### PR TITLE
introduce ffi_async_iter

### DIFF
--- a/boltffi/src/lib.rs
+++ b/boltffi/src/lib.rs
@@ -1,22 +1,17 @@
 pub use boltffi_core::{
-    CallbackForeignType, CallbackHandle, CustomFfiConvertible, CustomTypeConversionError, Data,
-    EventSubscription, FfiType, FromCallbackHandle, StreamProducer, UnexpectedFfiCallbackError,
-    custom_ffi, custom_type, data, default, error, export, ffi_stream, name, skip,
+    CallbackForeignType, CallbackHandle, CustomFfiConvertible, CustomTypeConversionError, Data, EventSubscription, FfiStream, FfiType, FromCallbackHandle, StreamProducer,
+    UnexpectedFfiCallbackError, custom_ffi, custom_type, data, default, error, export, ffi_async_iter, ffi_stream, name, skip,
 };
 
 #[doc(hidden)]
 pub mod __private {
     #[cfg(target_arch = "wasm32")]
     pub use boltffi_core::{
-        AsyncCallbackCompletionCode, CallbackRequestId, CompleteResult, CompletionPayload,
-        RequestGuard, WasmCallbackOutBuf, WasmCallbackOwner, allocate_request, cancel_request,
-        complete_request, complete_request_from_ffi, remove_request, rust_future_panic_message,
-        rust_future_poll_sync, set_request_waker, take_request_result, write_return_slot,
+        AsyncCallbackCompletionCode, CallbackRequestId, CompleteResult, CompletionPayload, RequestGuard, WasmCallbackOutBuf, WasmCallbackOwner, allocate_request, cancel_request,
+        complete_request, complete_request_from_ffi, remove_request, rust_future_panic_message, rust_future_poll_sync, set_request_waker, take_request_result, write_return_slot,
     };
     pub use boltffi_core::{
-        CallbackForeignType, CallbackHandle, EventSubscription, FfiBuf, FfiStatus,
-        FromCallbackHandle, RustFutureContinuationCallback, RustFutureHandle,
-        StreamContinuationCallback, StreamPollResult, SubscriptionHandle, WaitResult, rustfuture,
-        set_last_error, wire,
+        CallbackForeignType, CallbackHandle, EventSubscription, FfiBuf, FfiStatus, FromCallbackHandle, IteratorHandle, RustFutureContinuationCallback, RustFutureHandle,
+        StreamContinuationCallback, StreamPollResult, SubscriptionHandle, WaitResult, iterator_free, iterator_new, iterator_next, rustfuture, set_last_error, wire,
     };
 }

--- a/boltffi_bindgen/src/cheader/mod.rs
+++ b/boltffi_bindgen/src/cheader/mod.rs
@@ -1,11 +1,6 @@
-use std::collections::BTreeSet;
-
+use crate::model::{AsyncIteratorMethod, CallbackTrait, Class, Enumeration, Function, Method, Module, Parameter, Primitive, ReturnType, StreamMethod, TraitMethod, Type};
 use boltffi_ffi_rules::naming;
-
-use crate::model::{
-    CallbackTrait, Class, Enumeration, Function, Method, Module, Parameter, Primitive, ReturnType,
-    StreamMethod, TraitMethod, Type,
-};
+use std::collections::BTreeSet;
 
 pub struct CHeaderGenerator;
 
@@ -31,11 +26,7 @@ impl CHeaderGenerator {
         out.push_str(&Self::generate_enums(&module.enums));
         out.push_str(&Self::generate_ffi_named_buf_types(module));
         out.push_str(&Self::generate_ffi_named_option_types(module));
-        out.push_str(&Self::generate_traits(
-            &module.callback_traits,
-            prefix,
-            module,
-        ));
+        out.push_str(&Self::generate_traits(&module.callback_traits, prefix, module));
         out.push_str(&Self::generate_functions(&module.functions, module));
         out.push_str(&Self::generate_classes(&module.classes, prefix, module));
         out.push_str(&Self::generate_free_functions(prefix));
@@ -49,23 +40,16 @@ impl CHeaderGenerator {
             return String::new();
         }
 
-        let decls = names
-            .into_iter()
-            .map(|name| format!("struct {};\n", name))
-            .collect::<String>();
+        let decls = names.into_iter().map(|name| format!("struct {};\n", name)).collect::<String>();
         format!("\n{}\n", decls)
     }
 
     fn collect_forward_decl_struct_names(module: &Module) -> BTreeSet<String> {
         let mut names = BTreeSet::new();
 
-        module
-            .classes
-            .iter()
-            .map(|class| class.name.clone())
-            .for_each(|name| {
-                names.insert(name);
-            });
+        module.classes.iter().map(|class| class.name.clone()).for_each(|name| {
+            names.insert(name);
+        });
 
         module.functions.iter().for_each(|func| {
             func.inputs
@@ -114,23 +98,13 @@ impl CHeaderGenerator {
             Type::Object(name) => {
                 names.insert(name.clone());
             }
-            Type::Slice(inner) | Type::MutSlice(inner) | Type::Vec(inner) | Type::Option(inner) => {
-                Self::collect_forward_decl_names_from_type(inner, names)
-            }
+            Type::Slice(inner) | Type::MutSlice(inner) | Type::Vec(inner) | Type::Option(inner) => Self::collect_forward_decl_names_from_type(inner, names),
             Type::Result { ok, err } => {
                 Self::collect_forward_decl_names_from_type(ok, names);
                 Self::collect_forward_decl_names_from_type(err, names);
             }
             Type::Custom { repr, .. } => Self::collect_forward_decl_names_from_type(repr, names),
-            Type::Primitive(_)
-            | Type::String
-            | Type::Bytes
-            | Type::Builtin(_)
-            | Type::Closure(_)
-            | Type::Record(_)
-            | Type::Enum(_)
-            | Type::BoxedTrait(_)
-            | Type::Void => {}
+            Type::Primitive(_) | Type::String | Type::Bytes | Type::Builtin(_) | Type::Closure(_) | Type::Record(_) | Type::Enum(_) | Type::BoxedTrait(_) | Type::Void => {}
         }
     }
 
@@ -208,11 +182,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
         let mut primitive_option_types: HashSet<String> = HashSet::new();
         let mut named_option_types: HashSet<String> = HashSet::new();
 
-        fn insert_vec_buf_type(
-            inner: &Type,
-            primitive_buf: &mut HashSet<String>,
-            named_buf: &mut HashSet<String>,
-        ) {
+        fn insert_vec_buf_type(inner: &Type, primitive_buf: &mut HashSet<String>, named_buf: &mut HashSet<String>) {
             match inner {
                 Type::Primitive(p) => {
                     primitive_buf.insert(p.rust_name().to_string());
@@ -264,11 +234,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
                         match inner.as_ref() {
                             Type::Vec(vec_inner) => {
                                 insert_vec_buf_type(vec_inner, primitive_buf, named_buf);
-                                insert_vec_buf_type(
-                                    vec_inner,
-                                    option_primitive_buf,
-                                    option_named_buf,
-                                );
+                                insert_vec_buf_type(vec_inner, option_primitive_buf, option_named_buf);
                             }
                             Type::Primitive(p) => {
                                 prim_opts.insert(p.rust_name().to_string());
@@ -407,22 +373,11 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
     }
 
     fn generate_enums(enums: &[Enumeration]) -> String {
-        enums
-            .iter()
-            .filter(|e| !Self::is_internal_enum(&e.name))
-            .map(Self::generate_enum)
-            .collect()
+        enums.iter().filter(|e| !Self::is_internal_enum(&e.name)).map(Self::generate_enum).collect()
     }
 
     fn is_internal_enum(name: &str) -> bool {
-        matches!(
-            name,
-            "StreamPollResult"
-                | "ContinuationState"
-                | "WaitResult"
-                | "RustFuturePoll"
-                | "SchedulerStateTag"
-        )
+        matches!(name, "StreamPollResult" | "ContinuationState" | "WaitResult" | "RustFuturePoll" | "SchedulerStateTag")
     }
 
     fn generate_enum(e: &Enumeration) -> String {
@@ -436,10 +391,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
         let mut next_value: i64 = 0;
         for variant in &e.variants {
             let value = variant.discriminant.unwrap_or(next_value);
-            out.push_str(&format!(
-                "#define {}_{} {}\n",
-                hidden_name, variant.name, value
-            ));
+            out.push_str(&format!("#define {}_{} {}\n", hidden_name, variant.name, value));
             next_value = value + 1;
         }
         out.push('\n');
@@ -447,10 +399,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
     }
 
     fn generate_traits(traits: &[CallbackTrait], prefix: &str, module: &Module) -> String {
-        traits
-            .iter()
-            .map(|t| Self::generate_trait(t, prefix, module))
-            .collect()
+        traits.iter().map(|t| Self::generate_trait(t, prefix, module)).collect()
     }
 
     fn generate_trait(t: &CallbackTrait, prefix: &str, module: &Module) -> String {
@@ -458,10 +407,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
         let vtable_name = format!("{}VTable", trait_name);
         let snake_name = naming::to_snake_case(trait_name);
 
-        let mut vtable_fields = vec![
-            "  void (*free)(uint64_t handle);".to_string(),
-            "  uint64_t (*clone)(uint64_t handle);".to_string(),
-        ];
+        let mut vtable_fields = vec!["  void (*free)(uint64_t handle);".to_string(), "  uint64_t (*clone)(uint64_t handle);".to_string()];
 
         for method in &t.methods {
             vtable_fields.push(Self::generate_trait_method_field(method, module));
@@ -495,10 +441,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
 
         if method.is_async {
             let callback_return = Self::trait_callback_return_params(&method.returns);
-            params.push(format!(
-                "void (*callback)(uint64_t{}, FfiStatus)",
-                callback_return
-            ));
+            params.push(format!("void (*callback)(uint64_t{}, FfiStatus)", callback_return));
             params.push("uint64_t callback_data".to_string());
         } else {
             if let Some(ret_ty) = method.returns.ok_type() {
@@ -507,11 +450,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
             params.push("FfiStatus *status".to_string());
         }
 
-        format!(
-            "  void (*{})({});",
-            method_snake.as_str(),
-            params.join(", ")
-        )
+        format!("  void (*{})({});", method_snake.as_str(), params.join(", "))
     }
 
     fn trait_callback_return_params(returns: &ReturnType) -> String {
@@ -544,11 +483,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
                 vec![(name.to_string(), Self::type_to_c(ty))]
             }
             Type::Closure(signature) => {
-                let params_c: Vec<String> = signature
-                    .params
-                    .iter()
-                    .flat_map(Self::closure_param_to_c)
-                    .collect();
+                let params_c: Vec<String> = signature.params.iter().flat_map(Self::closure_param_to_c).collect();
                 let params_str = params_c.join(", ");
                 let ret_c = Self::closure_return_c_type(&signature.returns, module);
                 let callback_type = if params_str.is_empty() {
@@ -556,25 +491,16 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
                 } else {
                     format!("{} (*)(void*, {})", ret_c, params_str)
                 };
-                vec![
-                    (format!("{}_cb", name), callback_type),
-                    (format!("{}_ud", name), "void*".to_string()),
-                ]
+                vec![(format!("{}_cb", name), callback_type), (format!("{}_ud", name), "void*".to_string())]
             }
             _other => {
-                vec![
-                    (format!("{}_ptr", name), "const uint8_t*".to_string()),
-                    (format!("{}_len", name), "uintptr_t".to_string()),
-                ]
+                vec![(format!("{}_ptr", name), "const uint8_t*".to_string()), (format!("{}_len", name), "uintptr_t".to_string())]
             }
         }
     }
 
     fn generate_functions(functions: &[Function], module: &Module) -> String {
-        functions
-            .iter()
-            .map(|f| Self::generate_function(f, module))
-            .collect()
+        functions.iter().map(|f| Self::generate_function(f, module)).collect()
     }
 
     fn generate_function(func: &Function, module: &Module) -> String {
@@ -588,12 +514,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
         }
     }
 
-    fn generate_sync_function(
-        ffi_name: &str,
-        params: &[(String, String)],
-        returns: &ReturnType,
-        module: &Module,
-    ) -> String {
+    fn generate_sync_function(ffi_name: &str, params: &[(String, String)], returns: &ReturnType, module: &Module) -> String {
         let params_str = Self::format_params(params);
 
         match returns {
@@ -619,13 +540,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
 
     fn is_wire_encoded_type(ty: &Type, _module: &Module) -> bool {
         match ty {
-            Type::String
-            | Type::Vec(_)
-            | Type::Option(_)
-            | Type::Builtin(_)
-            | Type::Record(_)
-            | Type::Enum(_)
-            | Type::Custom { .. } => true,
+            Type::String | Type::Vec(_) | Type::Option(_) | Type::Builtin(_) | Type::Record(_) | Type::Enum(_) | Type::Custom { .. } => true,
             Type::Primitive(_) | Type::Void | Type::Object(_) => false,
             Type::Bytes => true,
             Type::Slice(_) | Type::MutSlice(_) => false,
@@ -644,11 +559,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
         }
     }
 
-    fn generate_async_function(
-        ffi_name: &str,
-        params: &[(String, String)],
-        returns: &ReturnType,
-    ) -> String {
+    fn generate_async_function(ffi_name: &str, params: &[(String, String)], returns: &ReturnType) -> String {
         let params_str = Self::format_params(params);
         let result_type = Self::async_result_type(returns);
 
@@ -662,11 +573,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
         )
     }
 
-    fn generate_vec_return_function(
-        ffi_name: &str,
-        params: &[(String, String)],
-        inner: &Type,
-    ) -> String {
+    fn generate_vec_return_function(ffi_name: &str, params: &[(String, String)], inner: &Type) -> String {
         let params_str = Self::format_params(params);
         let buf_type = format!("FfiBuf_{}", Self::primitive_to_cbindgen_name(inner));
         format!("{} {}({});\n", buf_type, ffi_name, params_str)
@@ -679,12 +586,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
         format!("FfiStatus {}({});\n", ffi_name, params_str)
     }
 
-    fn generate_result_return_function_with_err(
-        ffi_name: &str,
-        params: &[(String, String)],
-        ok_type: &Type,
-        err_type: Option<&Type>,
-    ) -> String {
+    fn generate_result_return_function_with_err(ffi_name: &str, params: &[(String, String)], ok_type: &Type, err_type: Option<&Type>) -> String {
         let err_out_type = err_type.and_then(Self::error_out_type);
 
         match ok_type {
@@ -698,11 +600,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
             }
             Type::String => {
                 let mut new_params = params.to_vec();
-                let out_name = if err_out_type.is_some() {
-                    "out_ok"
-                } else {
-                    "out"
-                };
+                let out_name = if err_out_type.is_some() { "out_ok" } else { "out" };
                 new_params.push((out_name.to_string(), "FfiString *".to_string()));
                 if let Some(err_type_str) = &err_out_type {
                     new_params.push(("out_err".to_string(), format!("{} *", err_type_str)));
@@ -712,15 +610,8 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
             }
             _ => {
                 let mut new_params = params.to_vec();
-                let out_name = if err_out_type.is_some() {
-                    "out_ok"
-                } else {
-                    "out"
-                };
-                new_params.push((
-                    out_name.to_string(),
-                    format!("{} *", Self::type_to_c(ok_type)),
-                ));
+                let out_name = if err_out_type.is_some() { "out_ok" } else { "out" };
+                new_params.push((out_name.to_string(), format!("{} *", Self::type_to_c(ok_type))));
                 if let Some(err_type_str) = &err_out_type {
                     new_params.push(("out_err".to_string(), format!("{} *", err_type_str)));
                 }
@@ -738,11 +629,7 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
         }
     }
 
-    fn generate_option_return_function(
-        ffi_name: &str,
-        params: &[(String, String)],
-        inner: &Type,
-    ) -> String {
+    fn generate_option_return_function(ffi_name: &str, params: &[(String, String)], inner: &Type) -> String {
         let option_type = Self::option_type_name(inner);
         let params_str = Self::format_params(params);
         format!("{} {}({});\n", option_type, ffi_name, params_str)
@@ -757,29 +644,19 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
         }
     }
 
-    fn generate_option_string_return_function(
-        ffi_name: &str,
-        params: &[(String, String)],
-    ) -> String {
+    fn generate_option_string_return_function(ffi_name: &str, params: &[(String, String)]) -> String {
         let params_str = Self::format_params(params);
         format!("FfiOption_FfiString {}({});\n", ffi_name, params_str)
     }
 
-    fn generate_option_vec_return_function(
-        ffi_name: &str,
-        params: &[(String, String)],
-        inner: &Type,
-    ) -> String {
+    fn generate_option_vec_return_function(ffi_name: &str, params: &[(String, String)], inner: &Type) -> String {
         let params_str = Self::format_params(params);
         let buf_type = format!("FfiBuf_{}", Self::primitive_to_cbindgen_name(inner));
         format!("FfiOption_{} {}({});\n", buf_type, ffi_name, params_str)
     }
 
     fn generate_classes(classes: &[Class], prefix: &str, module: &Module) -> String {
-        classes
-            .iter()
-            .map(|c| Self::generate_class(c, prefix, module))
-            .collect()
+        classes.iter().map(|c| Self::generate_class(c, prefix, module)).collect()
     }
 
     fn generate_class(class: &Class, prefix: &str, module: &Module) -> String {
@@ -802,41 +679,27 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
                     .flat_map(|p| Self::param_to_c(&p.name, &p.param_type, module))
                     .map(|(n, t)| format!("{} {}", t, n))
                     .collect();
-                out.push_str(&format!(
-                    "struct {} * {}({});\n",
-                    class.name,
-                    ffi_name,
-                    params.join(", ")
-                ));
+                out.push_str(&format!("struct {} * {}({});\n", class.name, ffi_name, params.join(", ")));
             }
         }
-        out.push_str(&format!(
-            "void {}_free(struct {} * handle);\n",
-            class_prefix, class.name
-        ));
+        out.push_str(&format!("void {}_free(struct {} * handle);\n", class_prefix, class.name));
 
         for method in &class.methods {
-            out.push_str(&Self::generate_method(
-                method,
-                &class.name,
-                &class_prefix,
-                module,
-            ));
+            out.push_str(&Self::generate_method(method, &class.name, &class_prefix, module));
         }
 
         for stream in &class.streams {
             out.push_str(&Self::generate_stream(stream, &class.name, &class_prefix));
         }
 
+        for iter in &class.async_iterators {
+            out.push_str(&Self::generate_async_iterator(iter, &class.name, &class_prefix));
+        }
+
         out
     }
 
-    fn generate_method(
-        method: &Method,
-        class_name: &str,
-        class_prefix: &str,
-        module: &Module,
-    ) -> String {
+    fn generate_method(method: &Method, class_name: &str, class_prefix: &str, module: &Module) -> String {
         let ffi_name = format!("{}_{}", class_prefix, method.name);
 
         let mut params: Vec<(String, String)> = if method.is_static() {
@@ -870,92 +733,68 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
         )
     }
 
+    fn generate_async_iterator(iter: &AsyncIteratorMethod, class_name: &str, class_prefix: &str) -> String {
+        let base_name = format!("{}_{}", class_prefix, iter.name);
+        let iter_handle_type = format!("struct {}_{}_Iterator", class_name, iter.name);
+
+        format!(
+            "{iter_handle_type}* {base_name}(const struct {class_name} *handle);\n\
+             RustFutureHandle {base_name}_next({iter_handle_type}* iter_handle);\n\
+             void {base_name}_next_poll(RustFutureHandle handle, uint64_t callback_data, RustFutureContinuationCallback callback);\n\
+             FfiBuf_u8 {base_name}_next_complete(RustFutureHandle handle, FfiStatus* out_status);\n\
+             void {base_name}_next_cancel(RustFutureHandle handle);\n\
+             void {base_name}_next_free(RustFutureHandle handle);\n\
+             void {base_name}_free({iter_handle_type}* iter_handle);\n",
+        )
+    }
+
     fn build_params(inputs: &[Parameter], module: &Module) -> Vec<(String, String)> {
-        inputs
-            .iter()
-            .flat_map(|p| Self::param_to_c(&p.name, &p.param_type, module))
-            .collect()
+        inputs.iter().flat_map(|p| Self::param_to_c(&p.name, &p.param_type, module)).collect()
     }
 
     fn param_to_c(name: &str, ty: &Type, module: &Module) -> Vec<(String, String)> {
         let name = naming::escape_c_keyword(name);
         match ty {
-            Type::String => vec![
-                (format!("{}_ptr", name), "const uint8_t*".to_string()),
-                (format!("{}_len", name), "uintptr_t".to_string()),
-            ],
-            Type::Builtin(_) => vec![
-                (format!("{}_ptr", name), "const uint8_t*".to_string()),
-                (format!("{}_len", name), "uintptr_t".to_string()),
-            ],
+            Type::String => vec![(format!("{}_ptr", name), "const uint8_t*".to_string()), (format!("{}_len", name), "uintptr_t".to_string())],
+            Type::Builtin(_) => vec![(format!("{}_ptr", name), "const uint8_t*".to_string()), (format!("{}_len", name), "uintptr_t".to_string())],
             Type::Slice(inner) => {
                 if matches!(inner.as_ref(), Type::Record(_) | Type::Builtin(_)) {
-                    vec![
-                        (format!("{}_ptr", name), "const uint8_t*".to_string()),
-                        (format!("{}_len", name), "uintptr_t".to_string()),
-                    ]
+                    vec![(format!("{}_ptr", name), "const uint8_t*".to_string()), (format!("{}_len", name), "uintptr_t".to_string())]
                 } else {
                     vec![
-                        (
-                            format!("{}_ptr", name),
-                            format!("const {}*", Self::type_to_c(inner)),
-                        ),
+                        (format!("{}_ptr", name), format!("const {}*", Self::type_to_c(inner))),
                         (format!("{}_len", name), "uintptr_t".to_string()),
                     ]
                 }
             }
             Type::MutSlice(inner) => {
                 if matches!(inner.as_ref(), Type::Record(_) | Type::Builtin(_)) {
-                    vec![
-                        (format!("{}_ptr", name), "uint8_t*".to_string()),
-                        (format!("{}_len", name), "uintptr_t".to_string()),
-                    ]
+                    vec![(format!("{}_ptr", name), "uint8_t*".to_string()), (format!("{}_len", name), "uintptr_t".to_string())]
                 } else {
                     vec![
-                        (
-                            format!("{}_ptr", name),
-                            format!("{}*", Self::type_to_c(inner)),
-                        ),
+                        (format!("{}_ptr", name), format!("{}*", Self::type_to_c(inner))),
                         (format!("{}_len", name), "uintptr_t".to_string()),
                     ]
                 }
             }
             Type::Vec(inner) => {
-                if matches!(
-                    inner.as_ref(),
-                    Type::Builtin(_) | Type::Record(_) | Type::Vec(_) | Type::Enum(_)
-                ) {
-                    vec![
-                        (format!("{}_ptr", name), "const uint8_t*".to_string()),
-                        (format!("{}_len", name), "uintptr_t".to_string()),
-                    ]
+                if matches!(inner.as_ref(), Type::Builtin(_) | Type::Record(_) | Type::Vec(_) | Type::Enum(_)) {
+                    vec![(format!("{}_ptr", name), "const uint8_t*".to_string()), (format!("{}_len", name), "uintptr_t".to_string())]
                 } else {
                     vec![
-                        (
-                            format!("{}_ptr", name),
-                            format!("const {}*", Self::type_to_c(inner)),
-                        ),
+                        (format!("{}_ptr", name), format!("const {}*", Self::type_to_c(inner))),
                         (format!("{}_len", name), "uintptr_t".to_string()),
                     ]
                 }
             }
             Type::Option(inner) => match inner.as_ref() {
-                Type::Object(_) | Type::BoxedTrait(_) | Type::Closure(_) => {
-                    Self::param_to_c(&name, inner, module)
-                }
+                Type::Object(_) | Type::BoxedTrait(_) | Type::Closure(_) => Self::param_to_c(&name, inner, module),
                 _ => {
-                    vec![
-                        (format!("{}_ptr", name), "const uint8_t*".to_string()),
-                        (format!("{}_len", name), "uintptr_t".to_string()),
-                    ]
+                    vec![(format!("{}_ptr", name), "const uint8_t*".to_string()), (format!("{}_len", name), "uintptr_t".to_string())]
                 }
             },
             Type::Closure(sig) => {
-                let params_c: Vec<String> = sig
-                    .params
-                    .iter()
-                    .flat_map(Self::closure_param_to_c)
-                    .collect();
+                let params_c: Vec<String> = sig.params.iter().flat_map(Self::closure_param_to_c).collect();
                 let params_str = params_c.join(", ");
                 let ret_c = Self::closure_return_c_type(&sig.returns, module);
                 let callback_type = if params_str.is_empty() {
@@ -963,19 +802,10 @@ static inline uint64_t {prefix}_atomic_u64_load(uint64_t* slot) {{
                 } else {
                     format!("{} (*)(void*, {})", ret_c, params_str)
                 };
-                vec![
-                    (format!("{}_cb", name), callback_type),
-                    (format!("{}_ud", name), "void*".to_string()),
-                ]
+                vec![(format!("{}_cb", name), callback_type), (format!("{}_ud", name), "void*".to_string())]
             }
-            Type::Record(_) => vec![
-                (format!("{}_ptr", name), "const uint8_t*".to_string()),
-                (format!("{}_len", name), "uintptr_t".to_string()),
-            ],
-            Type::Enum(_) => vec![
-                (format!("{}_ptr", name), "const uint8_t*".to_string()),
-                (format!("{}_len", name), "uintptr_t".to_string()),
-            ],
+            Type::Record(_) => vec![(format!("{}_ptr", name), "const uint8_t*".to_string()), (format!("{}_len", name), "uintptr_t".to_string())],
+            Type::Enum(_) => vec![(format!("{}_ptr", name), "const uint8_t*".to_string()), (format!("{}_len", name), "uintptr_t".to_string())],
             _ => vec![(name.to_string(), Self::type_to_c(ty))],
         }
     }
@@ -1089,11 +919,7 @@ mod tests {
     #[test]
     fn option_primitive_is_wire_encoded() {
         let module = empty_module();
-        let params = CHeaderGenerator::param_to_c(
-            "value",
-            &Type::Option(Box::new(Type::Primitive(Primitive::I32))),
-            &module,
-        );
+        let params = CHeaderGenerator::param_to_c("value", &Type::Option(Box::new(Type::Primitive(Primitive::I32))), &module);
         assert_eq!(params.len(), 2);
         assert_eq!(params[0].0, "value_ptr");
         assert_eq!(params[0].1, "const uint8_t*");
@@ -1104,8 +930,7 @@ mod tests {
     #[test]
     fn option_string_is_wire_encoded() {
         let module = empty_module();
-        let params =
-            CHeaderGenerator::param_to_c("name", &Type::Option(Box::new(Type::String)), &module);
+        let params = CHeaderGenerator::param_to_c("name", &Type::Option(Box::new(Type::String)), &module);
         assert_eq!(params.len(), 2);
         assert_eq!(params[0].1, "const uint8_t*");
     }
@@ -1113,11 +938,7 @@ mod tests {
     #[test]
     fn option_record_is_wire_encoded() {
         let module = empty_module();
-        let params = CHeaderGenerator::param_to_c(
-            "point",
-            &Type::Option(Box::new(Type::Record("Point".into()))),
-            &module,
-        );
+        let params = CHeaderGenerator::param_to_c("point", &Type::Option(Box::new(Type::Record("Point".into()))), &module);
         assert_eq!(params.len(), 2);
         assert_eq!(params[0].1, "const uint8_t*");
     }
@@ -1125,11 +946,7 @@ mod tests {
     #[test]
     fn option_enum_is_wire_encoded() {
         let module = empty_module();
-        let params = CHeaderGenerator::param_to_c(
-            "color",
-            &Type::Option(Box::new(Type::Enum("Color".into()))),
-            &module,
-        );
+        let params = CHeaderGenerator::param_to_c("color", &Type::Option(Box::new(Type::Enum("Color".into()))), &module);
         assert_eq!(params.len(), 2);
         assert_eq!(params[0].1, "const uint8_t*");
     }
@@ -1137,11 +954,7 @@ mod tests {
     #[test]
     fn option_object_is_nullable_pointer() {
         let module = empty_module();
-        let params = CHeaderGenerator::param_to_c(
-            "handle",
-            &Type::Option(Box::new(Type::Object("Player".into()))),
-            &module,
-        );
+        let params = CHeaderGenerator::param_to_c("handle", &Type::Option(Box::new(Type::Object("Player".into()))), &module);
         assert_eq!(params.len(), 1);
         assert_eq!(params[0].1, "struct Player*");
     }
@@ -1149,11 +962,7 @@ mod tests {
     #[test]
     fn option_boxed_trait_is_nullable_pointer() {
         let module = empty_module();
-        let params = CHeaderGenerator::param_to_c(
-            "listener",
-            &Type::Option(Box::new(Type::BoxedTrait("Listener".into()))),
-            &module,
-        );
+        let params = CHeaderGenerator::param_to_c("listener", &Type::Option(Box::new(Type::BoxedTrait("Listener".into()))), &module);
         assert_eq!(params.len(), 1);
         assert_eq!(params[0].1, "BoltFFICallbackHandle");
     }
@@ -1165,11 +974,7 @@ mod tests {
             params: vec![],
             returns: Box::new(Type::Void),
         };
-        let params = CHeaderGenerator::param_to_c(
-            "on_done",
-            &Type::Option(Box::new(Type::Closure(sig))),
-            &module,
-        );
+        let params = CHeaderGenerator::param_to_c("on_done", &Type::Option(Box::new(Type::Closure(sig))), &module);
         assert_eq!(params.len(), 2);
         assert!(params[0].0.contains("cb"));
         assert!(params[1].0.contains("ud"));
@@ -1178,65 +983,44 @@ mod tests {
     #[test]
     fn closure_return_void_is_void() {
         let module = empty_module();
-        assert_eq!(
-            CHeaderGenerator::closure_return_c_type(&Type::Void, &module),
-            "void"
-        );
+        assert_eq!(CHeaderGenerator::closure_return_c_type(&Type::Void, &module), "void");
     }
 
     #[test]
     fn closure_return_primitive_is_direct() {
         let module = empty_module();
-        assert_eq!(
-            CHeaderGenerator::closure_return_c_type(&Type::Primitive(Primitive::I32), &module),
-            "int32_t"
-        );
+        assert_eq!(CHeaderGenerator::closure_return_c_type(&Type::Primitive(Primitive::I32), &module), "int32_t");
     }
 
     #[test]
     fn closure_return_string_is_wire_encoded() {
         let module = empty_module();
-        assert_eq!(
-            CHeaderGenerator::closure_return_c_type(&Type::String, &module),
-            "FfiBuf_u8"
-        );
+        assert_eq!(CHeaderGenerator::closure_return_c_type(&Type::String, &module), "FfiBuf_u8");
     }
 
     #[test]
     fn closure_return_bytes_is_wire_encoded() {
         let module = empty_module();
-        assert_eq!(
-            CHeaderGenerator::closure_return_c_type(&Type::Bytes, &module),
-            "FfiBuf_u8"
-        );
+        assert_eq!(CHeaderGenerator::closure_return_c_type(&Type::Bytes, &module), "FfiBuf_u8");
     }
 
     #[test]
     fn closure_return_record_is_wire_encoded() {
         let module = empty_module();
-        assert_eq!(
-            CHeaderGenerator::closure_return_c_type(&Type::Record("Point".into()), &module),
-            "FfiBuf_u8"
-        );
+        assert_eq!(CHeaderGenerator::closure_return_c_type(&Type::Record("Point".into()), &module), "FfiBuf_u8");
     }
 
     #[test]
     fn closure_return_enum_is_wire_encoded() {
         let module = empty_module();
-        assert_eq!(
-            CHeaderGenerator::closure_return_c_type(&Type::Enum("Color".into()), &module),
-            "FfiBuf_u8"
-        );
+        assert_eq!(CHeaderGenerator::closure_return_c_type(&Type::Enum("Color".into()), &module), "FfiBuf_u8");
     }
 
     #[test]
     fn closure_return_vec_is_wire_encoded() {
         let module = empty_module();
         assert_eq!(
-            CHeaderGenerator::closure_return_c_type(
-                &Type::Vec(Box::new(Type::Primitive(Primitive::I32))),
-                &module
-            ),
+            CHeaderGenerator::closure_return_c_type(&Type::Vec(Box::new(Type::Primitive(Primitive::I32))), &module),
             "FfiBuf_u8"
         );
     }
@@ -1245,10 +1029,7 @@ mod tests {
     fn closure_return_option_is_wire_encoded() {
         let module = empty_module();
         assert_eq!(
-            CHeaderGenerator::closure_return_c_type(
-                &Type::Option(Box::new(Type::Primitive(Primitive::I32))),
-                &module
-            ),
+            CHeaderGenerator::closure_return_c_type(&Type::Option(Box::new(Type::Primitive(Primitive::I32))), &module),
             "FfiBuf_u8"
         );
     }
@@ -1256,10 +1037,7 @@ mod tests {
     #[test]
     fn closure_return_object_is_struct_pointer() {
         let module = empty_module();
-        assert_eq!(
-            CHeaderGenerator::closure_return_c_type(&Type::Object("Player".into()), &module),
-            "struct Player*"
-        );
+        assert_eq!(CHeaderGenerator::closure_return_c_type(&Type::Object("Player".into()), &module), "struct Player*");
     }
 
     #[test]

--- a/boltffi_bindgen/src/ir/abi.rs
+++ b/boltffi_bindgen/src/ir/abi.rs
@@ -1,16 +1,12 @@
-use boltffi_ffi_rules::naming::{
-    CreateFn, GlobalSymbol, Name, RegisterFn, VtableField, VtableType,
+use crate::ir::{
+    contract::PackageInfo,
+    definitions::StreamMode,
+    ids::{AsyncIteratorId, CallbackId, ClassId, EnumId, FieldName, FunctionId, MethodId, ParamName, RecordId, StreamId, VariantName},
+    ops::{ReadOp, ReadSeq, WriteOp, WriteSeq},
+    plan::{AbiType, CallbackStyle, Mutability},
+    types::TypeExpr,
 };
-
-use crate::ir::contract::PackageInfo;
-use crate::ir::definitions::StreamMode;
-use crate::ir::ids::{
-    CallbackId, ClassId, EnumId, FieldName, FunctionId, MethodId, ParamName, RecordId, StreamId,
-    VariantName,
-};
-use crate::ir::ops::{ReadOp, ReadSeq, WriteOp, WriteSeq};
-use crate::ir::plan::{AbiType, CallbackStyle, Mutability};
-use crate::ir::types::TypeExpr;
+use boltffi_ffi_rules::naming::{CreateFn, GlobalSymbol, Name, RegisterFn, VtableField, VtableType};
 
 /// The resolved FFI boundary for the whole crate.
 ///
@@ -24,6 +20,7 @@ pub struct AbiContract {
     pub calls: Vec<AbiCall>,
     pub callbacks: Vec<AbiCallbackInvocation>,
     pub streams: Vec<AbiStream>,
+    pub async_iterators: Vec<AbiAsyncIterator>,
     pub records: Vec<AbiRecord>,
     pub enums: Vec<AbiEnum>,
     pub free_buf: Name<GlobalSymbol>,
@@ -71,6 +68,27 @@ pub struct AbiEnumField {
 }
 
 #[derive(Debug, Clone)]
+pub struct AbiAsyncIterator {
+    pub class_id: ClassId,
+    pub iterator_id: AsyncIteratorId,
+    pub item: StreamItemTransport,
+    /// Creates the iterator handle: `{class}_{method}(handle) -> IteratorHandle`
+    pub entry: Name<GlobalSymbol>,
+    /// Starts one `next()` future: `{class}_{method}_next(iter) -> RustFutureHandle`
+    pub next: Name<GlobalSymbol>,
+    /// Polls the future
+    pub next_poll: Name<GlobalSymbol>,
+    /// Completes the future, returns wire-encoded `Option<T>`
+    pub next_complete: Name<GlobalSymbol>,
+    /// Cancels the future
+    pub next_cancel: Name<GlobalSymbol>,
+    /// Frees the future handle
+    pub next_free: Name<GlobalSymbol>,
+    /// Drops the iterator handle
+    pub free: Name<GlobalSymbol>,
+}
+
+#[derive(Debug, Clone)]
 pub enum StreamItemTransport {
     WireEncoded { decode_ops: ReadSeq },
 }
@@ -92,14 +110,8 @@ pub struct AbiStream {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CallId {
     Function(FunctionId),
-    Method {
-        class_id: ClassId,
-        method_id: MethodId,
-    },
-    Constructor {
-        class_id: ClassId,
-        index: usize,
-    },
+    Method { class_id: ClassId, method_id: MethodId },
+    Constructor { class_id: ClassId, index: usize },
 }
 
 #[derive(Debug, Clone)]
@@ -131,32 +143,11 @@ pub struct AsyncCall {
 #[derive(Debug, Clone)]
 pub enum ValueShape {
     Scalar(AbiType),
-    OptionScalar {
-        abi: AbiType,
-        read: ReadSeq,
-        write: WriteSeq,
-    },
-    ResultScalar {
-        ok: AbiType,
-        err: AbiType,
-        read: ReadSeq,
-        write: WriteSeq,
-    },
-    PrimitiveVec {
-        element_abi: AbiType,
-        read: ReadSeq,
-        write: WriteSeq,
-    },
-    BlittableRecord {
-        id: RecordId,
-        size: u32,
-        read: ReadSeq,
-        write: WriteSeq,
-    },
-    WireEncoded {
-        read: ReadSeq,
-        write: WriteSeq,
-    },
+    OptionScalar { abi: AbiType, read: ReadSeq, write: WriteSeq },
+    ResultScalar { ok: AbiType, err: AbiType, read: ReadSeq, write: WriteSeq },
+    PrimitiveVec { element_abi: AbiType, read: ReadSeq, write: WriteSeq },
+    BlittableRecord { id: RecordId, size: u32, read: ReadSeq, write: WriteSeq },
+    WireEncoded { read: ReadSeq, write: WriteSeq },
 }
 
 #[derive(Debug, Clone)]
@@ -201,14 +192,8 @@ pub enum InputShape {
 pub enum OutputShape {
     Unit,
     Value(ValueShape),
-    Handle {
-        class_id: ClassId,
-        nullable: bool,
-    },
-    Callback {
-        callback_id: CallbackId,
-        nullable: bool,
-    },
+    Handle { class_id: ClassId, nullable: bool },
+    Callback { callback_id: CallbackId, nullable: bool },
 }
 
 #[derive(Debug, Clone)]
@@ -222,10 +207,7 @@ pub struct AbiParam {
 pub enum ErrorTransport {
     None,
     StatusCode,
-    Encoded {
-        decode_ops: ReadSeq,
-        encode_ops: Option<WriteSeq>,
-    },
+    Encoded { decode_ops: ReadSeq, encode_ops: Option<WriteSeq> },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -307,20 +289,18 @@ impl FastOutputBinding<'_> {
     pub fn decode_ops(&self) -> Option<&ReadSeq> {
         match self {
             Self::Scalar { .. } => None,
-            Self::OptionScalar { decode_ops, .. }
-            | Self::ResultScalar { decode_ops, .. }
-            | Self::PrimitiveVec { decode_ops, .. }
-            | Self::BlittableRecord { decode_ops, .. } => Some(decode_ops),
+            Self::OptionScalar { decode_ops, .. } | Self::ResultScalar { decode_ops, .. } | Self::PrimitiveVec { decode_ops, .. } | Self::BlittableRecord { decode_ops, .. } => {
+                Some(decode_ops)
+            }
         }
     }
 
     pub fn encode_ops(&self) -> Option<&WriteSeq> {
         match self {
             Self::Scalar { .. } => None,
-            Self::OptionScalar { encode_ops, .. }
-            | Self::ResultScalar { encode_ops, .. }
-            | Self::PrimitiveVec { encode_ops, .. }
-            | Self::BlittableRecord { encode_ops, .. } => Some(encode_ops),
+            Self::OptionScalar { encode_ops, .. } | Self::ResultScalar { encode_ops, .. } | Self::PrimitiveVec { encode_ops, .. } | Self::BlittableRecord { encode_ops, .. } => {
+                Some(encode_ops)
+            }
         }
     }
 }
@@ -343,14 +323,8 @@ pub enum OutputBinding<'a> {
     Unit,
     Fast(FastOutputBinding<'a>),
     Wire(WireOutputBinding<'a>),
-    Handle {
-        class_id: &'a ClassId,
-        nullable: bool,
-    },
-    CallbackHandle {
-        callback_id: &'a CallbackId,
-        nullable: bool,
-    },
+    Handle { class_id: &'a ClassId, nullable: bool },
+    CallbackHandle { callback_id: &'a CallbackId, nullable: bool },
 }
 
 impl OutputBinding<'_> {
@@ -406,9 +380,7 @@ impl AbiParam {
     pub fn param_binding(&self) -> ParamBinding<'_> {
         match &self.input_shape {
             InputShape::Value(ValueShape::Scalar(_)) => ParamBinding::Input(InputBinding::Scalar),
-            InputShape::Utf8Slice { len_param } => {
-                ParamBinding::Input(InputBinding::Utf8Slice { len_param })
-            }
+            InputShape::Utf8Slice { len_param } => ParamBinding::Input(InputBinding::Utf8Slice { len_param }),
             InputShape::PrimitiveSlice {
                 len_param,
                 mutability,
@@ -418,55 +390,29 @@ impl AbiParam {
                 mutability: *mutability,
                 element_abi: *element_abi,
             }),
-            InputShape::WirePacket { len_param, value } => {
-                ParamBinding::Input(InputBinding::WirePacket {
-                    len_param,
-                    decode_ops: value.read_ops().unwrap_or_else(|| {
-                        panic!(
-                            "wire packet input shape missing decode ops for param {}",
-                            self.name.as_str()
-                        )
-                    }),
-                    encode_ops: value.write_ops().unwrap_or_else(|| {
-                        panic!(
-                            "wire packet input shape missing encode ops for param {}",
-                            self.name.as_str()
-                        )
-                    }),
-                })
-            }
-            InputShape::OutputBuffer { len_param, value } => {
-                ParamBinding::Input(InputBinding::OutputBuffer {
-                    len_param,
-                    decode_ops: value.read_ops().unwrap_or_else(|| {
-                        panic!(
-                            "output buffer input shape missing decode ops for param {}",
-                            self.name.as_str()
-                        )
-                    }),
-                })
-            }
-            InputShape::Handle { class_id, nullable } => {
-                ParamBinding::Input(InputBinding::Handle {
-                    class_id,
-                    nullable: *nullable,
-                })
-            }
-            InputShape::Callback {
-                callback_id,
-                nullable,
-                style,
-            } => ParamBinding::Input(InputBinding::CallbackHandle {
+            InputShape::WirePacket { len_param, value } => ParamBinding::Input(InputBinding::WirePacket {
+                len_param,
+                decode_ops: value
+                    .read_ops()
+                    .unwrap_or_else(|| panic!("wire packet input shape missing decode ops for param {}", self.name.as_str())),
+                encode_ops: value
+                    .write_ops()
+                    .unwrap_or_else(|| panic!("wire packet input shape missing encode ops for param {}", self.name.as_str())),
+            }),
+            InputShape::OutputBuffer { len_param, value } => ParamBinding::Input(InputBinding::OutputBuffer {
+                len_param,
+                decode_ops: value
+                    .read_ops()
+                    .unwrap_or_else(|| panic!("output buffer input shape missing decode ops for param {}", self.name.as_str())),
+            }),
+            InputShape::Handle { class_id, nullable } => ParamBinding::Input(InputBinding::Handle { class_id, nullable: *nullable }),
+            InputShape::Callback { callback_id, nullable, style } => ParamBinding::Input(InputBinding::CallbackHandle {
                 callback_id,
                 nullable: *nullable,
                 style: *style,
             }),
-            InputShape::HiddenSyntheticLen { for_param } => {
-                ParamBinding::Hidden(HiddenInputBinding::SyntheticLen { for_param })
-            }
-            InputShape::HiddenOutLen { for_param } => {
-                ParamBinding::Hidden(HiddenInputBinding::OutLen { for_param })
-            }
+            InputShape::HiddenSyntheticLen { for_param } => ParamBinding::Hidden(HiddenInputBinding::SyntheticLen { for_param }),
+            InputShape::HiddenOutLen { for_param } => ParamBinding::Hidden(HiddenInputBinding::OutLen { for_param }),
             InputShape::HiddenOutDirect => ParamBinding::Hidden(HiddenInputBinding::OutDirect),
             InputShape::HiddenStatusOut => ParamBinding::Hidden(HiddenInputBinding::StatusOut),
             InputShape::Value(_) => ParamBinding::UnsupportedValue,
@@ -485,65 +431,34 @@ impl OutputShape {
     pub fn output_binding(&self) -> OutputBinding<'_> {
         match self {
             OutputShape::Unit => OutputBinding::Unit,
-            OutputShape::Value(ValueShape::Scalar(abi_type)) => {
-                OutputBinding::Fast(FastOutputBinding::Scalar {
-                    abi_type: *abi_type,
-                })
-            }
-            OutputShape::Value(ValueShape::OptionScalar { abi, read, write }) => {
-                OutputBinding::Fast(FastOutputBinding::OptionScalar {
-                    abi_type: *abi,
-                    decode_ops: read,
-                    encode_ops: write,
-                })
-            }
-            OutputShape::Value(ValueShape::ResultScalar {
-                ok,
-                err,
-                read,
-                write,
-            }) => OutputBinding::Fast(FastOutputBinding::ResultScalar {
+            OutputShape::Value(ValueShape::Scalar(abi_type)) => OutputBinding::Fast(FastOutputBinding::Scalar { abi_type: *abi_type }),
+            OutputShape::Value(ValueShape::OptionScalar { abi, read, write }) => OutputBinding::Fast(FastOutputBinding::OptionScalar {
+                abi_type: *abi,
+                decode_ops: read,
+                encode_ops: write,
+            }),
+            OutputShape::Value(ValueShape::ResultScalar { ok, err, read, write }) => OutputBinding::Fast(FastOutputBinding::ResultScalar {
                 ok_abi: *ok,
                 err_abi: *err,
                 decode_ops: read,
                 encode_ops: write,
             }),
-            OutputShape::Value(ValueShape::PrimitiveVec {
-                element_abi,
-                read,
-                write,
-            }) => OutputBinding::Fast(FastOutputBinding::PrimitiveVec {
+            OutputShape::Value(ValueShape::PrimitiveVec { element_abi, read, write }) => OutputBinding::Fast(FastOutputBinding::PrimitiveVec {
                 element_abi: *element_abi,
                 decode_ops: read,
                 encode_ops: write,
             }),
-            OutputShape::Value(ValueShape::BlittableRecord {
-                id,
-                size,
-                read,
-                write,
-            }) => OutputBinding::Fast(FastOutputBinding::BlittableRecord {
+            OutputShape::Value(ValueShape::BlittableRecord { id, size, read, write }) => OutputBinding::Fast(FastOutputBinding::BlittableRecord {
                 record_id: id,
                 size: *size,
                 decode_ops: read,
                 encode_ops: write,
             }),
-            OutputShape::Handle { class_id, nullable } => OutputBinding::Handle {
-                class_id,
-                nullable: *nullable,
-            },
-            OutputShape::Callback {
-                callback_id,
-                nullable,
-            } => OutputBinding::CallbackHandle {
-                callback_id,
-                nullable: *nullable,
-            },
+            OutputShape::Handle { class_id, nullable } => OutputBinding::Handle { class_id, nullable: *nullable },
+            OutputShape::Callback { callback_id, nullable } => OutputBinding::CallbackHandle { callback_id, nullable: *nullable },
             OutputShape::Value(ValueShape::WireEncoded { read, write }) => {
                 let wire_shape = match (read.ops.first(), write.ops.first()) {
-                    (Some(ReadOp::String { .. }), Some(WriteOp::String { .. })) => {
-                        WireOutputKind::Utf8String
-                    }
+                    (Some(ReadOp::String { .. }), Some(WriteOp::String { .. })) => WireOutputKind::Utf8String,
                     _ => WireOutputKind::Encoded,
                 };
                 OutputBinding::Wire(WireOutputBinding {
@@ -595,6 +510,7 @@ mod tests {
             calls: vec![call],
             callbacks: Vec::new(),
             streams: Vec::new(),
+            async_iterators: Vec::new(),
             records: Vec::new(),
             enums: Vec::new(),
             free_buf: naming::free_buf_u8(),
@@ -661,10 +577,7 @@ mod tests {
         });
         contract.callbacks.iter().for_each(|callback| {
             callback.methods.iter().for_each(|method| {
-                method
-                    .params
-                    .iter()
-                    .for_each(assert_param_shape_consistency);
+                method.params.iter().for_each(assert_param_shape_consistency);
                 if let OutputShape::Value(value_shape) = &method.output_shape {
                     assert_value_shape_consistency(value_shape);
                 }

--- a/boltffi_bindgen/src/ir/build.rs
+++ b/boltffi_bindgen/src/ir/build.rs
@@ -1,16 +1,18 @@
-use crate::ir::contract::{FfiContract, PackageInfo, TypeCatalog};
-use crate::ir::definitions::{
-    CStyleVariant, CallbackKind, CallbackMethodDef, CallbackTraitDef, ClassDef, ConstructorDef,
-    CustomTypeDef, DataVariant, DefaultValue, DeprecationInfo, EnumDef, EnumRepr, FieldDef,
-    FunctionDef, MethodDef, ParamDef, ParamPassing, Receiver, RecordDef, ReturnDef, StreamDef,
-    StreamMode, VariantPayload,
+use crate::{
+    ir::{
+        contract::{FfiContract, PackageInfo, TypeCatalog},
+        definitions::{
+            AsyncIteratorDef, CStyleVariant, CallbackKind, CallbackMethodDef, CallbackTraitDef, ClassDef, ConstructorDef, CustomTypeDef, DataVariant, DefaultValue,
+            DeprecationInfo, EnumDef, EnumRepr, FieldDef, FunctionDef, MethodDef, ParamDef, ParamPassing, Receiver, RecordDef, ReturnDef, StreamDef, StreamMode, VariantPayload,
+        },
+        ids::{
+            AsyncIteratorId, BuiltinId, CallbackId, ClassId, ConverterPath, CustomTypeId, EnumId, FieldName, FunctionId, MethodId, ParamName, QualifiedName, RecordId, StreamId,
+            VariantName,
+        },
+        types::{BuiltinDef, BuiltinKind, PrimitiveType, TypeExpr},
+    },
+    model::{self, Module},
 };
-use crate::ir::ids::{
-    BuiltinId, CallbackId, ClassId, ConverterPath, CustomTypeId, EnumId, FieldName, FunctionId,
-    MethodId, ParamName, QualifiedName, RecordId, StreamId, VariantName,
-};
-use crate::ir::types::{BuiltinDef, BuiltinKind, PrimitiveType, TypeExpr};
-use crate::model::{self, Module};
 
 pub struct ContractBuilder<'m> {
     module: &'m Module,
@@ -24,23 +26,11 @@ impl<'m> ContractBuilder<'m> {
     pub fn build(&self) -> FfiContract {
         let mut catalog = TypeCatalog::new();
 
-        self.module
-            .records
-            .iter()
-            .map(|r| self.convert_record(r))
-            .for_each(|r| catalog.insert_record(r));
+        self.module.records.iter().map(|r| self.convert_record(r)).for_each(|r| catalog.insert_record(r));
 
-        self.module
-            .enums
-            .iter()
-            .map(|e| self.convert_enum(e))
-            .for_each(|e| catalog.insert_enum(e));
+        self.module.enums.iter().map(|e| self.convert_enum(e)).for_each(|e| catalog.insert_enum(e));
 
-        self.module
-            .classes
-            .iter()
-            .map(|c| self.convert_class(c))
-            .for_each(|c| catalog.insert_class(c));
+        self.module.classes.iter().map(|c| self.convert_class(c)).for_each(|c| catalog.insert_class(c));
 
         self.module
             .callback_traits
@@ -56,10 +46,7 @@ impl<'m> ContractBuilder<'m> {
 
         let mut builtin_ids: Vec<_> = self.module.used_builtins.iter().collect();
         builtin_ids.sort_by_key(|id| id.type_id());
-        builtin_ids
-            .into_iter()
-            .map(|id| convert_builtin_id(*id))
-            .for_each(|b| catalog.insert_builtin(b));
+        builtin_ids.into_iter().map(|id| convert_builtin_id(*id)).for_each(|b| catalog.insert_builtin(b));
 
         let mut closure_entries: Vec<_> = self.module.closures.iter().collect();
         closure_entries.sort_by_key(|(id, _)| *id);
@@ -68,12 +55,7 @@ impl<'m> ContractBuilder<'m> {
             .map(|(sig_id, sig)| self.convert_closure_to_callback(sig_id, sig))
             .for_each(|cb| catalog.insert_callback(cb));
 
-        let functions = self
-            .module
-            .functions
-            .iter()
-            .map(|f| self.convert_function(f))
-            .collect();
+        let functions = self.module.functions.iter().map(|f| self.convert_function(f)).collect();
 
         FfiContract {
             package: PackageInfo {
@@ -93,14 +75,11 @@ impl<'m> ContractBuilder<'m> {
                 .iter()
                 .map(|f| {
                     let type_expr = self.convert_type(&f.field_type);
-                    let default =
-                        f.default_value
-                            .as_deref()
-                            .map(parse_default_value)
-                            .or_else(|| {
-                                matches!(type_expr, TypeExpr::Option(_))
-                                    .then_some(DefaultValue::Null)
-                            });
+                    let default = f
+                        .default_value
+                        .as_deref()
+                        .map(parse_default_value)
+                        .or_else(|| matches!(type_expr, TypeExpr::Option(_)).then_some(DefaultValue::Null));
                     FieldDef {
                         name: FieldName::new(&f.name),
                         type_expr,
@@ -158,17 +137,8 @@ impl<'m> ContractBuilder<'m> {
     fn convert_variant_payload(&self, fields: &[model::RecordField]) -> VariantPayload {
         if fields.is_empty() {
             VariantPayload::Unit
-        } else if fields
-            .iter()
-            .enumerate()
-            .all(|(i, f)| f.name == format!("value_{i}"))
-        {
-            VariantPayload::Tuple(
-                fields
-                    .iter()
-                    .map(|f| self.convert_type(&f.field_type))
-                    .collect(),
-            )
+        } else if fields.iter().enumerate().all(|(i, f)| f.name == format!("value_{i}")) {
+            VariantPayload::Tuple(fields.iter().map(|f| self.convert_type(&f.field_type)).collect())
         } else {
             VariantPayload::Struct(
                 fields
@@ -187,11 +157,7 @@ impl<'m> ContractBuilder<'m> {
     fn convert_function(&self, func: &model::Function) -> FunctionDef {
         FunctionDef {
             id: FunctionId::new(&func.name),
-            params: func
-                .inputs
-                .iter()
-                .map(|p| self.convert_param(&p.name, &p.param_type))
-                .collect(),
+            params: func.inputs.iter().map(|p| self.convert_param(&p.name, &p.param_type)).collect(),
             returns: self.convert_return_type(&func.returns),
             is_async: func.is_async,
             doc: func.doc.clone(),
@@ -217,16 +183,9 @@ impl<'m> ContractBuilder<'m> {
                     })
                     .collect()
             },
-            methods: class
-                .methods
-                .iter()
-                .map(|m| self.convert_method(m))
-                .collect(),
-            streams: class
-                .streams
-                .iter()
-                .map(|s| self.convert_stream(s))
-                .collect(),
+            methods: class.methods.iter().map(|m| self.convert_method(m)).collect(),
+            streams: class.streams.iter().map(|s| self.convert_stream(s)).collect(),
+            async_iterators: class.async_iterators.iter().map(|a| self.convert_async_iterator(a)).collect(),
             doc: class.doc.clone(),
             deprecated: class.deprecated.as_ref().map(convert_deprecation),
         }
@@ -246,16 +205,17 @@ impl<'m> ContractBuilder<'m> {
         }
     }
 
-    fn convert_constructor(
-        &self,
-        ctor: &model::Constructor,
-        has_default_init: bool,
-    ) -> ConstructorDef {
-        let params: Vec<_> = ctor
-            .inputs
-            .iter()
-            .map(|p| self.convert_param(&p.name, &p.param_type))
-            .collect();
+    fn convert_async_iterator(&self, iter: &model::AsyncIteratorMethod) -> AsyncIteratorDef {
+        AsyncIteratorDef {
+            id: AsyncIteratorId::new(&iter.name),
+            item_type: self.convert_type(&iter.item_type),
+            doc: iter.doc.clone(),
+            deprecated: iter.deprecated.as_ref().map(convert_deprecation),
+        }
+    }
+
+    fn convert_constructor(&self, ctor: &model::Constructor, has_default_init: bool) -> ConstructorDef {
+        let params: Vec<_> = ctor.inputs.iter().map(|p| self.convert_param(&p.name, &p.param_type)).collect();
 
         // When there's no `new()`, a no-param named ctor like `with_defaults()`
         // would normally become a static factory (`static func withDefaults()`).
@@ -294,11 +254,7 @@ impl<'m> ContractBuilder<'m> {
         MethodDef {
             id: MethodId::new(&method.name),
             receiver: convert_receiver(method.receiver),
-            params: method
-                .inputs
-                .iter()
-                .map(|p| self.convert_param(&p.name, &p.param_type))
-                .collect(),
+            params: method.inputs.iter().map(|p| self.convert_param(&p.name, &p.param_type)).collect(),
             returns: self.convert_return_type(&method.returns),
             is_async: method.is_async,
             doc: method.doc.clone(),
@@ -314,11 +270,7 @@ impl<'m> ContractBuilder<'m> {
                 .iter()
                 .map(|m| CallbackMethodDef {
                     id: MethodId::new(&m.name),
-                    params: m
-                        .inputs
-                        .iter()
-                        .map(|p| self.convert_param(&p.name, &p.param_type))
-                        .collect(),
+                    params: m.inputs.iter().map(|p| self.convert_param(&p.name, &p.param_type)).collect(),
                     returns: self.convert_return_type(&m.returns),
                     is_async: m.is_async,
                     doc: m.doc.clone(),
@@ -342,11 +294,7 @@ impl<'m> ContractBuilder<'m> {
         }
     }
 
-    fn convert_closure_to_callback(
-        &self,
-        sig_id: &str,
-        sig: &model::ClosureSignature,
-    ) -> CallbackTraitDef {
+    fn convert_closure_to_callback(&self, sig_id: &str, sig: &model::ClosureSignature) -> CallbackTraitDef {
         let params = sig
             .params
             .iter()
@@ -394,24 +342,12 @@ impl<'m> ContractBuilder<'m> {
 
     fn convert_type_with_passing(&self, ty: &model::Type) -> (TypeExpr, ParamPassing) {
         match ty {
-            model::Type::Slice(inner) => (
-                TypeExpr::Vec(Box::new(self.convert_type(inner))),
-                ParamPassing::Ref,
-            ),
-            model::Type::MutSlice(inner) => (
-                TypeExpr::Vec(Box::new(self.convert_type(inner))),
-                ParamPassing::RefMut,
-            ),
-            model::Type::BoxedTrait(name) => (
-                TypeExpr::Callback(CallbackId::new(name)),
-                ParamPassing::BoxedDyn,
-            ),
+            model::Type::Slice(inner) => (TypeExpr::Vec(Box::new(self.convert_type(inner))), ParamPassing::Ref),
+            model::Type::MutSlice(inner) => (TypeExpr::Vec(Box::new(self.convert_type(inner))), ParamPassing::RefMut),
+            model::Type::BoxedTrait(name) => (TypeExpr::Callback(CallbackId::new(name)), ParamPassing::BoxedDyn),
             model::Type::Closure(sig) => {
                 let sig_id = format!("__Closure_{}", sig.signature_id());
-                (
-                    TypeExpr::Callback(CallbackId::new(&sig_id)),
-                    ParamPassing::ImplTrait,
-                )
+                (TypeExpr::Callback(CallbackId::new(&sig_id)), ParamPassing::ImplTrait)
             }
             _ => (self.convert_type(ty), ParamPassing::Value),
         }
@@ -438,9 +374,7 @@ impl<'m> ContractBuilder<'m> {
                 let sig_id = format!("__Closure_{}", sig.signature_id());
                 TypeExpr::Callback(CallbackId::new(&sig_id))
             }
-            model::Type::Slice(inner) | model::Type::MutSlice(inner) => {
-                TypeExpr::Vec(Box::new(self.convert_type(inner)))
-            }
+            model::Type::Slice(inner) | model::Type::MutSlice(inner) => TypeExpr::Vec(Box::new(self.convert_type(inner))),
             model::Type::Void => TypeExpr::Void,
         }
     }
@@ -468,9 +402,7 @@ fn parse_default_value(raw: &str) -> DefaultValue {
         "true" => DefaultValue::Bool(true),
         "false" => DefaultValue::Bool(false),
         "None" => DefaultValue::Null,
-        s if s.starts_with('"') && s.ends_with('"') => {
-            DefaultValue::String(s[1..s.len() - 1].to_string())
-        }
+        s if s.starts_with('"') && s.ends_with('"') => DefaultValue::String(s[1..s.len() - 1].to_string()),
         s if s.contains("::") => {
             let (enum_name, variant_name) = s.rsplit_once("::").expect("contains ::");
             DefaultValue::EnumVariant {
@@ -537,19 +469,14 @@ pub fn build_contract(module: &mut Module) -> FfiContract {
 
 #[cfg(test)]
 mod tests {
-    use crate::ir::definitions::{
-        CallbackKind, ConstructorDef, DefaultValue, EnumRepr, ParamPassing, Receiver as IrReceiver,
-        ReturnDef, VariantPayload,
+    use super::{ContractBuilder, parse_default_value};
+    use crate::{
+        ir::{
+            definitions::{CallbackKind, ConstructorDef, DefaultValue, EnumRepr, ParamPassing, Receiver as IrReceiver, ReturnDef, VariantPayload},
+            types::{PrimitiveType, TypeExpr},
+        },
+        model::{self, CallbackTrait, Enumeration, Module, Parameter, Primitive, Receiver, Record, RecordField, ReturnType, TraitMethod, TraitMethodParam, Type, Variant},
     };
-
-    use super::parse_default_value;
-    use crate::ir::types::{PrimitiveType, TypeExpr};
-    use crate::model::{
-        self, CallbackTrait, Enumeration, Module, Parameter, Primitive, Receiver, Record,
-        RecordField, ReturnType, TraitMethod, TraitMethodParam, Type, Variant,
-    };
-
-    use super::ContractBuilder;
 
     fn empty_module() -> Module {
         Module {
@@ -575,10 +502,7 @@ mod tests {
         module.records.push(
             Record::new("Location")
                 .with_doc("A geographic point.")
-                .with_field(
-                    RecordField::new("lat", Type::Primitive(Primitive::F64))
-                        .with_doc("Latitude in degrees."),
-                )
+                .with_field(RecordField::new("lat", Type::Primitive(Primitive::F64)).with_doc("Latitude in degrees."))
                 .with_field(RecordField::new("lng", Type::Primitive(Primitive::F64))),
         );
 
@@ -589,10 +513,7 @@ mod tests {
         assert_eq!(def.fields.len(), 2);
         assert_eq!(def.fields[0].name.as_str(), "lat");
         assert_eq!(def.fields[0].doc.as_deref(), Some("Latitude in degrees."));
-        assert!(matches!(
-            def.fields[0].type_expr,
-            TypeExpr::Primitive(PrimitiveType::F64)
-        ));
+        assert!(matches!(def.fields[0].type_expr, TypeExpr::Primitive(PrimitiveType::F64)));
         assert_eq!(def.fields[1].name.as_str(), "lng");
         assert!(def.fields[1].doc.is_none());
     }
@@ -640,13 +561,11 @@ mod tests {
     fn data_enum_with_variant_fields() {
         let mut module = empty_module();
         module.enums.push(
-            Enumeration::new("ApiResult")
-                .with_variant(Variant::new("Ok"))
-                .with_variant(
-                    Variant::new("Error")
-                        .with_field(RecordField::new("code", Type::Primitive(Primitive::I32)))
-                        .with_doc("Something went wrong."),
-                ),
+            Enumeration::new("ApiResult").with_variant(Variant::new("Ok")).with_variant(
+                Variant::new("Error")
+                    .with_field(RecordField::new("code", Type::Primitive(Primitive::I32)))
+                    .with_doc("Something went wrong."),
+            ),
         );
 
         let def = builder(&module).convert_enum(&module.enums[0]);
@@ -672,14 +591,8 @@ mod tests {
         let mut module = empty_module();
         module.enums.push(
             Enumeration::new("LocationBias")
-                .with_variant(
-                    Variant::new("Left")
-                        .with_field(RecordField::new("value_0", Type::Primitive(Primitive::F64))),
-                )
-                .with_variant(
-                    Variant::new("Right")
-                        .with_field(RecordField::new("value_0", Type::Primitive(Primitive::F64))),
-                ),
+                .with_variant(Variant::new("Left").with_field(RecordField::new("value_0", Type::Primitive(Primitive::F64))))
+                .with_variant(Variant::new("Right").with_field(RecordField::new("value_0", Type::Primitive(Primitive::F64)))),
         );
 
         let def = builder(&module).convert_enum(&module.enums[0]);
@@ -762,11 +675,7 @@ mod tests {
     #[test]
     fn error_enum_flag_propagates() {
         let mut module = empty_module();
-        module.enums.push(
-            Enumeration::new("ParseError")
-                .as_error()
-                .with_variant(Variant::new("InvalidSyntax")),
-        );
+        module.enums.push(Enumeration::new("ParseError").as_error().with_variant(Variant::new("InvalidSyntax")));
 
         let def = builder(&module).convert_enum(&module.enums[0]);
 
@@ -791,23 +700,15 @@ mod tests {
         assert!(!def.is_async);
         assert_eq!(def.params.len(), 2);
         assert_eq!(def.params[0].name.as_str(), "a");
-        assert!(matches!(
-            def.params[0].type_expr,
-            TypeExpr::Primitive(PrimitiveType::I32)
-        ));
+        assert!(matches!(def.params[0].type_expr, TypeExpr::Primitive(PrimitiveType::I32)));
         assert!(matches!(def.params[0].passing, ParamPassing::Value));
-        assert!(matches!(
-            def.returns,
-            ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::I64))
-        ));
+        assert!(matches!(def.returns, ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::I64))));
     }
 
     #[test]
     fn async_function_preserves_flag() {
         let mut module = empty_module();
-        module
-            .functions
-            .push(model::Function::new("fetch").make_async());
+        module.functions.push(model::Function::new("fetch").make_async());
 
         let def = builder(&module).convert_function(&module.functions[0]);
 
@@ -828,14 +729,12 @@ mod tests {
     fn class_method_with_receiver_and_doc() {
         let mut module = empty_module();
         module.classes.push(
-            model::Class::new("Counter")
-                .with_constructor(model::Constructor::new())
-                .with_method(
-                    model::Method::new("increment", Receiver::RefMut)
-                        .with_doc("Bumps the counter by one.")
-                        .with_param(Parameter::new("amount", Type::Primitive(Primitive::I32)))
-                        .with_return(ReturnType::value(Type::Primitive(Primitive::I64))),
-                ),
+            model::Class::new("Counter").with_constructor(model::Constructor::new()).with_method(
+                model::Method::new("increment", Receiver::RefMut)
+                    .with_doc("Bumps the counter by one.")
+                    .with_param(Parameter::new("amount", Type::Primitive(Primitive::I32)))
+                    .with_return(ReturnType::value(Type::Primitive(Primitive::I64))),
+            ),
         );
 
         let b = builder(&module);
@@ -847,18 +746,13 @@ mod tests {
         assert_eq!(method.doc.as_deref(), Some("Bumps the counter by one."));
         assert!(matches!(method.receiver, IrReceiver::RefMutSelf));
         assert_eq!(method.params.len(), 1);
-        assert!(matches!(
-            method.returns,
-            ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::I64))
-        ));
+        assert!(matches!(method.returns, ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::I64))));
     }
 
     #[test]
     fn class_doc_propagates() {
         let mut module = empty_module();
-        module
-            .classes
-            .push(model::Class::new("Store").with_doc("A persistent store."));
+        module.classes.push(model::Class::new("Store").with_doc("A persistent store."));
 
         let def = builder(&module).convert_class(&module.classes[0]);
 
@@ -869,22 +763,16 @@ mod tests {
     fn named_ctor_with_params_becomes_named_init() {
         let mut module = empty_module();
         module.classes.push(
-            model::Class::new("Buffer").with_constructor(
-                model::Constructor::new()
-                    .with_name("with_capacity")
-                    .with_param(model::ConstructorParam {
-                        name: "size".to_string(),
-                        param_type: Type::Primitive(Primitive::U32),
-                    }),
-            ),
+            model::Class::new("Buffer").with_constructor(model::Constructor::new().with_name("with_capacity").with_param(model::ConstructorParam {
+                name: "size".to_string(),
+                param_type: Type::Primitive(Primitive::U32),
+            })),
         );
 
         let def = builder(&module).convert_class(&module.classes[0]);
 
         assert_eq!(def.constructors.len(), 1);
-        assert!(
-            matches!(&def.constructors[0], ConstructorDef::NamedInit { name, .. } if name.as_str() == "with_capacity")
-        );
+        assert!(matches!(&def.constructors[0], ConstructorDef::NamedInit { name, .. } if name.as_str() == "with_capacity"));
     }
 
     #[test]
@@ -892,32 +780,24 @@ mod tests {
         let mut module = empty_module();
         module
             .classes
-            .push(model::Class::new("Db").with_constructor(
-                model::Constructor::new().with_doc("Opens a new database connection."),
-            ));
+            .push(model::Class::new("Db").with_constructor(model::Constructor::new().with_doc("Opens a new database connection.")));
 
         let def = builder(&module).convert_class(&module.classes[0]);
 
-        assert_eq!(
-            def.constructors[0].doc(),
-            Some("Opens a new database connection.")
-        );
+        assert_eq!(def.constructors[0].doc(), Some("Opens a new database connection."));
     }
 
     #[test]
     fn named_no_param_ctor_promoted_to_default_when_no_new() {
         let mut module = empty_module();
-        module.classes.push(
-            model::Class::new("Store")
-                .with_constructor(model::Constructor::new().with_name("with_defaults")),
-        );
+        module
+            .classes
+            .push(model::Class::new("Store").with_constructor(model::Constructor::new().with_name("with_defaults")));
 
         let def = builder(&module).convert_class(&module.classes[0]);
 
         assert_eq!(def.constructors.len(), 1);
-        assert!(
-            matches!(&def.constructors[0], ConstructorDef::Default { params, .. } if params.is_empty())
-        );
+        assert!(matches!(&def.constructors[0], ConstructorDef::Default { params, .. } if params.is_empty()));
     }
 
     #[test]
@@ -932,14 +812,8 @@ mod tests {
         let def = builder(&module).convert_class(&module.classes[0]);
 
         assert_eq!(def.constructors.len(), 2);
-        assert!(matches!(
-            &def.constructors[0],
-            ConstructorDef::Default { .. }
-        ));
-        assert!(matches!(
-            &def.constructors[1],
-            ConstructorDef::NamedFactory { .. }
-        ));
+        assert!(matches!(&def.constructors[0], ConstructorDef::Default { .. }));
+        assert!(matches!(&def.constructors[1], ConstructorDef::NamedFactory { .. }));
     }
 
     #[test]
@@ -954,14 +828,8 @@ mod tests {
         let def = builder(&module).convert_class(&module.classes[0]);
 
         assert_eq!(def.constructors.len(), 2);
-        assert!(matches!(
-            &def.constructors[0],
-            ConstructorDef::Default { .. }
-        ));
-        assert!(matches!(
-            &def.constructors[1],
-            ConstructorDef::NamedFactory { .. }
-        ));
+        assert!(matches!(&def.constructors[0], ConstructorDef::Default { .. }));
+        assert!(matches!(&def.constructors[1], ConstructorDef::NamedFactory { .. }));
     }
 
     #[test]
@@ -973,10 +841,7 @@ mod tests {
                 .with_method(
                     TraitMethod::new("fetch")
                         .with_doc("Fetches the next batch.")
-                        .with_param(TraitMethodParam::new(
-                            "count",
-                            Type::Primitive(Primitive::I32),
-                        ))
+                        .with_param(TraitMethodParam::new("count", Type::Primitive(Primitive::I32)))
                         .with_return(ReturnType::value(Type::Primitive(Primitive::Bool))),
                 )
                 .with_method(TraitMethod::new("reset").make_async()),
@@ -994,10 +859,7 @@ mod tests {
         assert_eq!(fetch.doc.as_deref(), Some("Fetches the next batch."));
         assert!(!fetch.is_async);
         assert_eq!(fetch.params.len(), 1);
-        assert!(matches!(
-            fetch.returns,
-            ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::Bool))
-        ));
+        assert!(matches!(fetch.returns, ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::Bool))));
 
         let reset = &def.methods[1];
         assert_eq!(reset.id.as_str(), "reset");
@@ -1030,9 +892,7 @@ mod tests {
                 .with_param(Parameter::new("b", Type::Record("Point".into())))
                 .with_return(ReturnType::value(Type::Primitive(Primitive::F64))),
         );
-        module
-            .callback_traits
-            .push(CallbackTrait::new("Renderer").with_method(TraitMethod::new("render")));
+        module.callback_traits.push(CallbackTrait::new("Renderer").with_method(TraitMethod::new("render")));
 
         let contract = builder(&module).build();
 
@@ -1045,18 +905,12 @@ mod tests {
 
     #[test]
     fn parse_default_bool_true() {
-        assert!(matches!(
-            parse_default_value("true"),
-            DefaultValue::Bool(true)
-        ));
+        assert!(matches!(parse_default_value("true"), DefaultValue::Bool(true)));
     }
 
     #[test]
     fn parse_default_bool_false() {
-        assert!(matches!(
-            parse_default_value("false"),
-            DefaultValue::Bool(false)
-        ));
+        assert!(matches!(parse_default_value("false"), DefaultValue::Bool(false)));
     }
 
     #[test]
@@ -1094,10 +948,7 @@ mod tests {
     #[test]
     fn parse_default_enum_variant() {
         match parse_default_value("Direction::North") {
-            DefaultValue::EnumVariant {
-                enum_name,
-                variant_name,
-            } => {
+            DefaultValue::EnumVariant { enum_name, variant_name } => {
                 assert_eq!(enum_name, "Direction");
                 assert_eq!(variant_name, "North");
             }
@@ -1116,10 +967,7 @@ mod tests {
         module.records.push(
             Record::new("Config")
                 .with_field(RecordField::new("name", Type::Primitive(Primitive::I32)))
-                .with_field(RecordField::new(
-                    "label",
-                    Type::Option(Box::new(Type::String)),
-                )),
+                .with_field(RecordField::new("label", Type::Option(Box::new(Type::String)))),
         );
 
         let def = builder(&module).convert_record(&module.records[0]);
@@ -1131,12 +979,9 @@ mod tests {
     #[test]
     fn explicit_default_overrides_option_auto() {
         let mut module = empty_module();
-        module.records.push(
-            Record::new("Config").with_field(
-                RecordField::new("label", Type::Option(Box::new(Type::String)))
-                    .with_default("\"unnamed\""),
-            ),
-        );
+        module
+            .records
+            .push(Record::new("Config").with_field(RecordField::new("label", Type::Option(Box::new(Type::String))).with_default("\"unnamed\"")));
 
         let def = builder(&module).convert_record(&module.records[0]);
 

--- a/boltffi_bindgen/src/ir/definitions.rs
+++ b/boltffi_bindgen/src/ir/definitions.rs
@@ -1,8 +1,7 @@
-use crate::ir::ids::{
-    CallbackId, ClassId, ConverterPath, CustomTypeId, EnumId, FieldName, FunctionId, MethodId,
-    ParamName, QualifiedName, RecordId, StreamId, VariantName,
+use crate::ir::{
+    ids::{AsyncIteratorId, CallbackId, ClassId, ConverterPath, CustomTypeId, EnumId, FieldName, FunctionId, MethodId, ParamName, QualifiedName, RecordId, StreamId, VariantName},
+    types::{PrimitiveType, TypeExpr},
 };
-use crate::ir::types::{PrimitiveType, TypeExpr};
 
 #[derive(Debug, Clone)]
 pub struct DeprecationInfo {
@@ -20,9 +19,7 @@ pub struct RecordDef {
 
 impl RecordDef {
     pub fn is_blittable(&self) -> bool {
-        self.fields
-            .iter()
-            .all(|f| matches!(f.type_expr, TypeExpr::Primitive(_)))
+        self.fields.iter().all(|f| matches!(f.type_expr, TypeExpr::Primitive(_)))
     }
 }
 
@@ -40,10 +37,7 @@ pub enum DefaultValue {
     Integer(i64),
     Float(f64),
     String(String),
-    EnumVariant {
-        enum_name: String,
-        variant_name: String,
-    },
+    EnumVariant { enum_name: String, variant_name: String },
     Null,
 }
 
@@ -67,14 +61,8 @@ impl EnumDef {
 
 #[derive(Debug, Clone)]
 pub enum EnumRepr {
-    CStyle {
-        tag_type: PrimitiveType,
-        variants: Vec<CStyleVariant>,
-    },
-    Data {
-        tag_type: PrimitiveType,
-        variants: Vec<DataVariant>,
-    },
+    CStyle { tag_type: PrimitiveType, variants: Vec<CStyleVariant> },
+    Data { tag_type: PrimitiveType, variants: Vec<DataVariant> },
 }
 
 #[derive(Debug, Clone)]
@@ -150,11 +138,20 @@ pub struct StreamDef {
 }
 
 #[derive(Debug, Clone)]
+pub struct AsyncIteratorDef {
+    pub id: AsyncIteratorId,
+    pub item_type: TypeExpr,
+    pub doc: Option<String>,
+    pub deprecated: Option<DeprecationInfo>,
+}
+
+#[derive(Debug, Clone)]
 pub struct ClassDef {
     pub id: ClassId,
     pub constructors: Vec<ConstructorDef>,
     pub methods: Vec<MethodDef>,
     pub streams: Vec<StreamDef>,
+    pub async_iterators: Vec<AsyncIteratorDef>,
     pub doc: Option<String>,
     pub deprecated: Option<DeprecationInfo>,
 }
@@ -188,19 +185,13 @@ impl ConstructorDef {
         match self {
             Self::Default { params, .. } => params.iter().collect(),
             Self::NamedFactory { .. } => vec![],
-            Self::NamedInit {
-                first_param,
-                rest_params,
-                ..
-            } => std::iter::once(first_param).chain(rest_params).collect(),
+            Self::NamedInit { first_param, rest_params, .. } => std::iter::once(first_param).chain(rest_params).collect(),
         }
     }
 
     pub fn is_fallible(&self) -> bool {
         match self {
-            Self::Default { is_fallible, .. }
-            | Self::NamedFactory { is_fallible, .. }
-            | Self::NamedInit { is_fallible, .. } => *is_fallible,
+            Self::Default { is_fallible, .. } | Self::NamedFactory { is_fallible, .. } | Self::NamedInit { is_fallible, .. } => *is_fallible,
         }
     }
 
@@ -213,9 +204,7 @@ impl ConstructorDef {
 
     pub fn doc(&self) -> Option<&str> {
         match self {
-            Self::Default { doc, .. }
-            | Self::NamedFactory { doc, .. }
-            | Self::NamedInit { doc, .. } => doc.as_deref(),
+            Self::Default { doc, .. } | Self::NamedFactory { doc, .. } | Self::NamedInit { doc, .. } => doc.as_deref(),
         }
     }
 }

--- a/boltffi_bindgen/src/ir/ids.rs
+++ b/boltffi_bindgen/src/ir/ids.rs
@@ -44,6 +44,7 @@ define_id!(CallbackId);
 define_id!(CustomTypeId);
 define_id!(BuiltinId);
 define_id!(StreamId);
+define_id!(AsyncIteratorId);
 define_id!(FieldName);
 define_id!(ParamName);
 define_id!(VariantName);

--- a/boltffi_bindgen/src/ir/lower.rs
+++ b/boltffi_bindgen/src/ir/lower.rs
@@ -1,35 +1,27 @@
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
-
+use crate::ir::{
+    abi::{
+        AbiAsyncIterator, AbiCall, AbiCallbackInvocation, AbiCallbackMethod, AbiContract, AbiEnum, AbiEnumField, AbiEnumPayload, AbiEnumVariant, AbiParam, AbiRecord, AbiStream,
+        AsyncCall, CallId, CallMode, ErrorTransport, InputShape, OutputShape, StreamItemTransport, ValueShape,
+    },
+    codec::{BlittableField, CodecPlan, EncodedField, EnumLayout, RecordLayout, VariantLayout, VariantPayloadLayout, VecLayout},
+    contract::FfiContract,
+    definitions::{
+        AsyncIteratorDef, CallbackMethodDef, CallbackTraitDef, ClassDef, ConstructorDef, EnumDef, EnumRepr, FunctionDef, MethodDef, ParamDef, ParamPassing, Receiver, RecordDef,
+        ReturnDef, StreamDef, VariantPayload,
+    },
+    ids::{AsyncIteratorId, BuiltinId, ClassId, EnumId, FieldName, FunctionId, MethodId, ParamName, RecordId},
+    ops::{FieldReadOp, FieldWriteOp, OffsetExpr, ReadOp, ReadSeq, SizeExpr, ValueExpr, WireShape, WriteOp, WriteSeq},
+    plan::{
+        AbiType, AsyncPlan, AsyncResult, CallPlan, CallPlanKind, CallTarget, CallbackStyle, CompletionCallback, DirectPlan, Mutability, ParamPlan, ParamStrategy, ReturnPlan,
+        ReturnValuePlan,
+    },
+    types::{PrimitiveType, TypeExpr},
+};
 use boltffi_ffi_rules::naming;
-
-use crate::ir::abi::{
-    AbiCall, AbiCallbackInvocation, AbiCallbackMethod, AbiContract, AbiEnum, AbiEnumField,
-    AbiEnumPayload, AbiEnumVariant, AbiParam, AbiRecord, AbiStream, AsyncCall, CallId, CallMode,
-    ErrorTransport, InputShape, OutputShape, StreamItemTransport, ValueShape,
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
 };
-use crate::ir::codec::{
-    BlittableField, CodecPlan, EncodedField, EnumLayout, RecordLayout, VariantLayout,
-    VariantPayloadLayout, VecLayout,
-};
-use crate::ir::contract::FfiContract;
-use crate::ir::definitions::{
-    CallbackMethodDef, CallbackTraitDef, ClassDef, ConstructorDef, EnumDef, EnumRepr, FunctionDef,
-    MethodDef, ParamDef, ParamPassing, Receiver, RecordDef, ReturnDef, StreamDef, VariantPayload,
-};
-use crate::ir::ids::{
-    BuiltinId, ClassId, EnumId, FieldName, FunctionId, MethodId, ParamName, RecordId,
-};
-use crate::ir::ops::{
-    FieldReadOp, FieldWriteOp, OffsetExpr, ReadOp, ReadSeq, SizeExpr, ValueExpr, WireShape,
-    WriteOp, WriteSeq,
-};
-use crate::ir::plan::{
-    AbiType, AsyncPlan, AsyncResult, CallPlan, CallPlanKind, CallTarget, CallbackStyle,
-    CompletionCallback, DirectPlan, Mutability, ParamPlan, ParamStrategy, ReturnPlan,
-    ReturnValuePlan,
-};
-use crate::ir::types::{PrimitiveType, TypeExpr};
 
 #[derive(Debug, Clone)]
 struct AbiCallbackParamPlan {
@@ -90,58 +82,34 @@ impl<'c> Lowerer<'c> {
 
 impl<'c> Lowerer<'c> {
     pub fn to_abi_contract(&self) -> AbiContract {
-        let function_calls = self
-            .contract
-            .functions
-            .iter()
-            .map(|func| self.abi_call_for_function(func));
+        let function_calls = self.contract.functions.iter().map(|func| self.abi_call_for_function(func));
 
         let class_calls = self.contract.catalog.all_classes().flat_map(|class| {
-            let ctor_calls = class
-                .constructors
-                .iter()
-                .enumerate()
-                .map(|(index, ctor)| self.abi_call_for_constructor(class, ctor, index));
-            let method_calls = class
-                .methods
-                .iter()
-                .map(|method| self.abi_call_for_method(class, method));
+            let ctor_calls = class.constructors.iter().enumerate().map(|(index, ctor)| self.abi_call_for_constructor(class, ctor, index));
+            let method_calls = class.methods.iter().map(|method| self.abi_call_for_method(class, method));
             ctor_calls.chain(method_calls)
         });
 
         let calls = function_calls.chain(class_calls).collect();
 
-        let callbacks = self
-            .contract
-            .catalog
-            .all_callbacks()
-            .map(|callback| self.abi_callback_invocation(callback))
-            .collect();
+        let callbacks = self.contract.catalog.all_callbacks().map(|callback| self.abi_callback_invocation(callback)).collect();
 
-        let records = self
-            .contract
-            .catalog
-            .all_records()
-            .map(|record| self.abi_record(record))
-            .collect();
+        let records = self.contract.catalog.all_records().map(|record| self.abi_record(record)).collect();
 
-        let enums = self
-            .contract
-            .catalog
-            .all_enums()
-            .map(|enumeration| self.abi_enum(enumeration))
-            .collect();
+        let enums = self.contract.catalog.all_enums().map(|enumeration| self.abi_enum(enumeration)).collect();
 
         let streams = self
             .contract
             .catalog
             .all_classes()
-            .flat_map(|class| {
-                class
-                    .streams
-                    .iter()
-                    .map(|stream| self.abi_stream(&class.id, stream))
-            })
+            .flat_map(|class| class.streams.iter().map(|stream| self.abi_stream(&class.id, stream)))
+            .collect();
+
+        let async_iterators = self
+            .contract
+            .catalog
+            .all_classes()
+            .flat_map(|class| class.async_iterators.iter().map(|iter| self.abi_async_iterator(&class.id, iter)))
             .collect();
 
         AbiContract {
@@ -149,6 +117,7 @@ impl<'c> Lowerer<'c> {
             calls,
             callbacks,
             streams,
+            async_iterators,
             records,
             enums,
             free_buf: naming::free_buf_u8(),
@@ -160,8 +129,7 @@ impl<'c> Lowerer<'c> {
         let plan = self.lower_function(func);
         let symbol = self.call_symbol(&plan);
         let params = self.abi_params_from_plan(&plan.params);
-        let (mode, output_shape, error) =
-            self.abi_mode_output_shape_error_for_function(func, &plan.kind);
+        let (mode, output_shape, error) = self.abi_mode_output_shape_error_for_function(func, &plan.kind);
 
         AbiCall {
             id: CallId::Function(func.id.clone()),
@@ -177,8 +145,7 @@ impl<'c> Lowerer<'c> {
         let plan = self.lower_method(class, method);
         let symbol = self.call_symbol(&plan);
         let params = self.abi_params_from_plan(&plan.params);
-        let (mode, output_shape, error) =
-            self.abi_mode_output_shape_error_for_method(class, method, &plan.kind);
+        let (mode, output_shape, error) = self.abi_mode_output_shape_error_for_method(class, method, &plan.kind);
 
         AbiCall {
             id: CallId::Method {
@@ -193,12 +160,7 @@ impl<'c> Lowerer<'c> {
         }
     }
 
-    fn abi_call_for_constructor(
-        &self,
-        class: &ClassDef,
-        ctor: &ConstructorDef,
-        index: usize,
-    ) -> AbiCall {
+    fn abi_call_for_constructor(&self, class: &ClassDef, ctor: &ConstructorDef, index: usize) -> AbiCall {
         let plan = self.lower_constructor(class, ctor);
         let symbol = self.call_symbol(&plan);
         let params = self.abi_params_from_plan(&plan.params);
@@ -268,6 +230,40 @@ impl<'c> Lowerer<'c> {
         }
     }
 
+    fn abi_async_iterator(&self, class_id: &ClassId, iter: &AsyncIteratorDef) -> AbiAsyncIterator {
+        let class_name = class_id.as_str();
+        let method_name = iter.id.as_str();
+
+        // The `_next_complete` returns wire-encoded `Option<T>`.
+        let option_codec = self.build_codec(&crate::ir::types::TypeExpr::Option(Box::new(iter.item_type.clone())));
+        let option_decode_ops = self.expand_decode(&option_codec);
+
+        AbiAsyncIterator {
+            class_id: class_id.clone(),
+            iterator_id: AsyncIteratorId::new(method_name),
+            item: StreamItemTransport::WireEncoded { decode_ops: option_decode_ops },
+            entry: naming::iterator_ffi_new(class_name, method_name),
+            next: naming::iterator_ffi_next(class_name, method_name),
+            next_poll: {
+                use boltffi_ffi_rules::naming::Name;
+                Name::new(format!("{}_poll", naming::iterator_ffi_next(class_name, method_name)))
+            },
+            next_complete: {
+                use boltffi_ffi_rules::naming::Name;
+                Name::new(format!("{}_complete", naming::iterator_ffi_next(class_name, method_name)))
+            },
+            next_cancel: {
+                use boltffi_ffi_rules::naming::Name;
+                Name::new(format!("{}_cancel", naming::iterator_ffi_next(class_name, method_name)))
+            },
+            next_free: {
+                use boltffi_ffi_rules::naming::Name;
+                Name::new(format!("{}_free", naming::iterator_ffi_next(class_name, method_name)))
+            },
+            free: naming::iterator_ffi_free(class_name, method_name),
+        }
+    }
+
     fn abi_record(&self, record: &RecordDef) -> AbiRecord {
         let codec = self.build_codec(&TypeExpr::Record(record.id.clone()));
         let decode_ops = self.expand_decode(&codec);
@@ -317,19 +313,13 @@ impl<'c> Lowerer<'c> {
             } => (
                 false,
                 match &enumeration.repr {
-                    EnumRepr::Data {
-                        variants: data_variants,
-                        ..
-                    } => {
+                    EnumRepr::Data { variants: data_variants, .. } => {
                         let layout_fields = variants
                             .iter()
                             .map(|variant| {
                                 let fields = match &variant.payload {
                                     VariantPayloadLayout::Unit => Vec::new(),
-                                    VariantPayloadLayout::Fields(fields) => fields
-                                        .iter()
-                                        .map(|field| self.abi_enum_field(field))
-                                        .collect(),
+                                    VariantPayloadLayout::Fields(fields) => fields.iter().map(|field| self.abi_enum_field(field)).collect(),
                                 };
                                 (variant.name.clone(), fields)
                             })
@@ -338,10 +328,7 @@ impl<'c> Lowerer<'c> {
                         data_variants
                             .iter()
                             .map(|variant| {
-                                let fields = layout_fields
-                                    .get(&variant.name)
-                                    .cloned()
-                                    .unwrap_or_default();
+                                let fields = layout_fields.get(&variant.name).cloned().unwrap_or_default();
                                 let payload = match &variant.payload {
                                     VariantPayload::Unit => AbiEnumPayload::Unit,
                                     VariantPayload::Tuple(_) => AbiEnumPayload::Tuple(fields),
@@ -372,10 +359,7 @@ impl<'c> Lowerer<'c> {
 
     fn abi_enum_field(&self, field: &EncodedField) -> AbiEnumField {
         let decode = self.expand_decode(&field.codec);
-        let encode = self.expand_encode(
-            &field.codec,
-            ValueExpr::Named(field.name.as_str().to_string()),
-        );
+        let encode = self.expand_encode(&field.codec, ValueExpr::Named(field.name.as_str().to_string()));
         AbiEnumField {
             name: field.name.clone(),
             type_expr: TypeExpr::from(&field.codec),
@@ -384,48 +368,28 @@ impl<'c> Lowerer<'c> {
         }
     }
 
-    fn abi_mode_output_shape_error_for_function(
-        &self,
-        func: &FunctionDef,
-        kind: &CallPlanKind,
-    ) -> (CallMode, OutputShape, ErrorTransport) {
+    fn abi_mode_output_shape_error_for_function(&self, func: &FunctionDef, kind: &CallPlanKind) -> (CallMode, OutputShape, ErrorTransport) {
         match kind {
             CallPlanKind::Sync { returns } => {
                 let (output_shape, error) = self.sync_output_shape_and_error(returns);
                 (CallMode::Sync, output_shape, error)
             }
             CallPlanKind::Async { async_plan } => {
-                let mode =
-                    CallMode::Async(Box::new(self.async_call_for_function(func, async_plan)));
-                (
-                    mode,
-                    OutputShape::Value(ValueShape::Scalar(AbiType::Pointer)),
-                    ErrorTransport::None,
-                )
+                let mode = CallMode::Async(Box::new(self.async_call_for_function(func, async_plan)));
+                (mode, OutputShape::Value(ValueShape::Scalar(AbiType::Pointer)), ErrorTransport::None)
             }
         }
     }
 
-    fn abi_mode_output_shape_error_for_method(
-        &self,
-        class: &ClassDef,
-        method: &MethodDef,
-        kind: &CallPlanKind,
-    ) -> (CallMode, OutputShape, ErrorTransport) {
+    fn abi_mode_output_shape_error_for_method(&self, class: &ClassDef, method: &MethodDef, kind: &CallPlanKind) -> (CallMode, OutputShape, ErrorTransport) {
         match kind {
             CallPlanKind::Sync { returns } => {
                 let (output_shape, error) = self.sync_output_shape_and_error(returns);
                 (CallMode::Sync, output_shape, error)
             }
             CallPlanKind::Async { async_plan } => {
-                let mode = CallMode::Async(Box::new(
-                    self.async_call_for_method(class, method, async_plan),
-                ));
-                (
-                    mode,
-                    OutputShape::Value(ValueShape::Scalar(AbiType::Pointer)),
-                    ErrorTransport::None,
-                )
+                let mode = CallMode::Async(Box::new(self.async_call_for_method(class, method, async_plan)));
+                (mode, OutputShape::Value(ValueShape::Scalar(AbiType::Pointer)), ErrorTransport::None)
             }
         }
     }
@@ -441,12 +405,7 @@ impl<'c> Lowerer<'c> {
         }
     }
 
-    fn async_call_for_method(
-        &self,
-        class: &ClassDef,
-        method: &MethodDef,
-        plan: &AsyncPlan,
-    ) -> AsyncCall {
+    fn async_call_for_method(&self, class: &ClassDef, method: &MethodDef, plan: &AsyncPlan) -> AsyncCall {
         AsyncCall {
             poll: naming::method_ffi_poll(class.id.as_str(), method.id.as_str()),
             complete: naming::method_ffi_complete(class.id.as_str(), method.id.as_str()),
@@ -525,10 +484,7 @@ impl<'c> Lowerer<'c> {
                 class_id: class_id.clone(),
                 nullable: *nullable,
             },
-            ReturnValuePlan::Callback {
-                callback_id,
-                nullable,
-            } => OutputShape::Callback {
+            ReturnValuePlan::Callback { callback_id, nullable } => OutputShape::Callback {
                 callback_id: callback_id.clone(),
                 nullable: *nullable,
             },
@@ -556,66 +512,29 @@ impl<'c> Lowerer<'c> {
         }
     }
 
-    fn merge_value_shape_classes(
-        &self,
-        read_class: ValueShapeClass,
-        write_class: ValueShapeClass,
-    ) -> ValueShapeClass {
+    fn merge_value_shape_classes(&self, read_class: ValueShapeClass, write_class: ValueShapeClass) -> ValueShapeClass {
         match (read_class, write_class) {
-            (ValueShapeClass::Scalar(read), ValueShapeClass::Scalar(write)) if read == write => {
-                ValueShapeClass::Scalar(read)
-            }
-            (ValueShapeClass::OptionScalar(read), ValueShapeClass::OptionScalar(write))
-                if read == write =>
+            (ValueShapeClass::Scalar(read), ValueShapeClass::Scalar(write)) if read == write => ValueShapeClass::Scalar(read),
+            (ValueShapeClass::OptionScalar(read), ValueShapeClass::OptionScalar(write)) if read == write => ValueShapeClass::OptionScalar(read),
+            (ValueShapeClass::ResultScalar { ok: read_ok, err: read_err }, ValueShapeClass::ResultScalar { ok: write_ok, err: write_err })
+                if read_ok == write_ok && read_err == write_err =>
             {
-                ValueShapeClass::OptionScalar(read)
+                ValueShapeClass::ResultScalar { ok: read_ok, err: read_err }
             }
-            (
-                ValueShapeClass::ResultScalar {
-                    ok: read_ok,
-                    err: read_err,
-                },
-                ValueShapeClass::ResultScalar {
-                    ok: write_ok,
-                    err: write_err,
-                },
-            ) if read_ok == write_ok && read_err == write_err => ValueShapeClass::ResultScalar {
-                ok: read_ok,
-                err: read_err,
-            },
-            (ValueShapeClass::PrimitiveVec(read), ValueShapeClass::PrimitiveVec(write))
-                if read == write =>
+            (ValueShapeClass::PrimitiveVec(read), ValueShapeClass::PrimitiveVec(write)) if read == write => ValueShapeClass::PrimitiveVec(read),
+            (ValueShapeClass::BlittableRecord { id: read_id, size: read_size }, ValueShapeClass::BlittableRecord { id: write_id, size: write_size })
+                if read_id == write_id && read_size == write_size =>
             {
-                ValueShapeClass::PrimitiveVec(read)
-            }
-            (
-                ValueShapeClass::BlittableRecord {
-                    id: read_id,
-                    size: read_size,
-                },
-                ValueShapeClass::BlittableRecord {
-                    id: write_id,
-                    size: write_size,
-                },
-            ) if read_id == write_id && read_size == write_size => {
-                ValueShapeClass::BlittableRecord {
-                    id: read_id,
-                    size: read_size,
-                }
+                ValueShapeClass::BlittableRecord { id: read_id, size: read_size }
             }
             (ValueShapeClass::Encoded, ValueShapeClass::Encoded) => ValueShapeClass::Encoded,
-            (read, write) => panic!(
-                "read/write value shape mismatch: read={:?}, write={:?}",
-                read, write
-            ),
+            (read, write) => panic!("read/write value shape mismatch: read={:?}, write={:?}", read, write),
         }
     }
 
     fn classify_value_shape_from_read_op(&self, op: &ReadOp) -> ValueShapeClass {
         match op {
-            ReadOp::Primitive { primitive, .. } => {
-                ValueShapeClass::Scalar(primitive_to_abi(*primitive))
-            }
+            ReadOp::Primitive { primitive, .. } => ValueShapeClass::Scalar(primitive_to_abi(*primitive)),
             ReadOp::Option { some, .. } => some
                 .ops
                 .first()
@@ -626,11 +545,7 @@ impl<'c> Lowerer<'c> {
                 .ops
                 .first()
                 .and_then(|ok_op| self.primitive_abi_from_read_op(ok_op))
-                .zip(
-                    err.ops
-                        .first()
-                        .and_then(|err_op| self.primitive_abi_from_read_op(err_op)),
-                )
+                .zip(err.ops.first().and_then(|err_op| self.primitive_abi_from_read_op(err_op)))
                 .map(|(ok, err)| ValueShapeClass::ResultScalar { ok, err })
                 .unwrap_or(ValueShapeClass::Encoded),
             ReadOp::Vec {
@@ -640,10 +555,7 @@ impl<'c> Lowerer<'c> {
             ReadOp::Vec { .. } => ValueShapeClass::Encoded,
             ReadOp::Record { id, .. } => self
                 .blittable_record_size_by_id(id)
-                .map(|size| ValueShapeClass::BlittableRecord {
-                    id: id.clone(),
-                    size,
-                })
+                .map(|size| ValueShapeClass::BlittableRecord { id: id.clone(), size })
                 .unwrap_or(ValueShapeClass::Encoded),
             _ => ValueShapeClass::Encoded,
         }
@@ -651,9 +563,7 @@ impl<'c> Lowerer<'c> {
 
     fn classify_value_shape_from_write_op(&self, op: &WriteOp) -> ValueShapeClass {
         match op {
-            WriteOp::Primitive { primitive, .. } => {
-                ValueShapeClass::Scalar(primitive_to_abi(*primitive))
-            }
+            WriteOp::Primitive { primitive, .. } => ValueShapeClass::Scalar(primitive_to_abi(*primitive)),
             WriteOp::Option { some, .. } => some
                 .ops
                 .first()
@@ -664,11 +574,7 @@ impl<'c> Lowerer<'c> {
                 .ops
                 .first()
                 .and_then(|ok_op| self.primitive_abi_from_write_op(ok_op))
-                .zip(
-                    err.ops
-                        .first()
-                        .and_then(|err_op| self.primitive_abi_from_write_op(err_op)),
-                )
+                .zip(err.ops.first().and_then(|err_op| self.primitive_abi_from_write_op(err_op)))
                 .map(|(ok, err)| ValueShapeClass::ResultScalar { ok, err })
                 .unwrap_or(ValueShapeClass::Encoded),
             WriteOp::Vec {
@@ -678,21 +584,13 @@ impl<'c> Lowerer<'c> {
             WriteOp::Vec { .. } => ValueShapeClass::Encoded,
             WriteOp::Record { id, .. } => self
                 .blittable_record_size_by_id(id)
-                .map(|size| ValueShapeClass::BlittableRecord {
-                    id: id.clone(),
-                    size,
-                })
+                .map(|size| ValueShapeClass::BlittableRecord { id: id.clone(), size })
                 .unwrap_or(ValueShapeClass::Encoded),
             _ => ValueShapeClass::Encoded,
         }
     }
 
-    fn materialize_value_shape(
-        &self,
-        shape_class: ValueShapeClass,
-        read: &ReadSeq,
-        write: &WriteSeq,
-    ) -> ValueShape {
+    fn materialize_value_shape(&self, shape_class: ValueShapeClass, read: &ReadSeq, write: &WriteSeq) -> ValueShape {
         match shape_class {
             ValueShapeClass::Scalar(abi) => ValueShape::Scalar(abi),
             ValueShapeClass::OptionScalar(abi) => ValueShape::OptionScalar {
@@ -797,10 +695,7 @@ impl<'c> Lowerer<'c> {
             },
             CodecPlan::Primitive(primitive) => ReadSeq {
                 size: SizeExpr::Fixed(primitive.wire_size_bytes()),
-                ops: vec![ReadOp::Primitive {
-                    primitive: *primitive,
-                    offset,
-                }],
+                ops: vec![ReadOp::Primitive { primitive: *primitive, offset }],
                 shape: WireShape::Value,
             },
             CodecPlan::String => ReadSeq {
@@ -814,16 +709,10 @@ impl<'c> Lowerer<'c> {
                 shape: WireShape::Value,
             },
             CodecPlan::Builtin(id) => {
-                let size = self
-                    .builtin_fixed_size(id)
-                    .map(SizeExpr::Fixed)
-                    .unwrap_or(SizeExpr::Runtime);
+                let size = self.builtin_fixed_size(id).map(SizeExpr::Fixed).unwrap_or(SizeExpr::Runtime);
                 ReadSeq {
                     size,
-                    ops: vec![ReadOp::Builtin {
-                        id: id.clone(),
-                        offset,
-                    }],
+                    ops: vec![ReadOp::Builtin { id: id.clone(), offset }],
                     shape: WireShape::Value,
                 }
             }
@@ -860,11 +749,7 @@ impl<'c> Lowerer<'c> {
                         fields
                             .iter()
                             .map(|field| {
-                                let offset_expr = if field.offset == 0 {
-                                    OffsetExpr::Base
-                                } else {
-                                    OffsetExpr::BasePlus(field.offset)
-                                };
+                                let offset_expr = if field.offset == 0 { OffsetExpr::Base } else { OffsetExpr::BasePlus(field.offset) };
                                 FieldReadOp {
                                     name: field.name.clone(),
                                     seq: ReadSeq {
@@ -894,11 +779,7 @@ impl<'c> Lowerer<'c> {
                 };
                 ReadSeq {
                     size,
-                    ops: vec![ReadOp::Record {
-                        id: id.clone(),
-                        offset,
-                        fields,
-                    }],
+                    ops: vec![ReadOp::Record { id: id.clone(), offset, fields }],
                     shape: WireShape::Value,
                 }
             }
@@ -945,38 +826,31 @@ impl<'c> Lowerer<'c> {
             },
             CodecPlan::String => WriteSeq {
                 size: SizeExpr::Sum(vec![SizeExpr::Fixed(4), SizeExpr::StringLen(value.clone())]),
-                ops: vec![WriteOp::String {
-                    value: value.clone(),
-                }],
+                ops: vec![WriteOp::String { value: value.clone() }],
                 shape: WireShape::Value,
             },
             CodecPlan::Bytes => WriteSeq {
                 size: SizeExpr::Sum(vec![SizeExpr::Fixed(4), SizeExpr::BytesLen(value.clone())]),
-                ops: vec![WriteOp::Bytes {
-                    value: value.clone(),
-                }],
+                ops: vec![WriteOp::Bytes { value: value.clone() }],
                 shape: WireShape::Value,
             },
             CodecPlan::Builtin(id) => WriteSeq {
-                size: self
-                    .builtin_fixed_size(id)
-                    .map(SizeExpr::Fixed)
-                    .unwrap_or_else(|| {
-                        if id.as_str() == "Url" {
-                            SizeExpr::Sum(vec![
-                                SizeExpr::Fixed(4),
-                                SizeExpr::BuiltinSize {
-                                    id: id.clone(),
-                                    value: value.clone(),
-                                },
-                            ])
-                        } else {
-                            SizeExpr::WireSize {
+                size: self.builtin_fixed_size(id).map(SizeExpr::Fixed).unwrap_or_else(|| {
+                    if id.as_str() == "Url" {
+                        SizeExpr::Sum(vec![
+                            SizeExpr::Fixed(4),
+                            SizeExpr::BuiltinSize {
+                                id: id.clone(),
                                 value: value.clone(),
-                                record_id: None,
-                            }
+                            },
+                        ])
+                    } else {
+                        SizeExpr::WireSize {
+                            value: value.clone(),
+                            record_id: None,
                         }
-                    }),
+                    }
+                }),
                 ops: vec![WriteOp::Builtin {
                     id: id.clone(),
                     value: value.clone(),
@@ -999,16 +873,15 @@ impl<'c> Lowerer<'c> {
             }
             CodecPlan::Vec { element, layout } => {
                 let element_seq = self.expand_encode(element, ValueExpr::Var("item".into()));
-                let size_expr =
-                    if matches!(element.as_ref(), CodecPlan::Primitive(PrimitiveType::U8)) {
-                        SizeExpr::Sum(vec![SizeExpr::Fixed(4), SizeExpr::BytesLen(value.clone())])
-                    } else {
-                        SizeExpr::VecSize {
-                            value: value.clone(),
-                            inner: Box::new(element_seq.size.clone()),
-                            layout: layout.clone(),
-                        }
-                    };
+                let size_expr = if matches!(element.as_ref(), CodecPlan::Primitive(PrimitiveType::U8)) {
+                    SizeExpr::Sum(vec![SizeExpr::Fixed(4), SizeExpr::BytesLen(value.clone())])
+                } else {
+                    SizeExpr::VecSize {
+                        value: value.clone(),
+                        inner: Box::new(element_seq.size.clone()),
+                        layout: layout.clone(),
+                    }
+                };
                 WriteSeq {
                     size: size_expr,
                     ops: vec![WriteOp::Vec {
@@ -1046,10 +919,7 @@ impl<'c> Lowerer<'c> {
                             FieldWriteOp {
                                 name: field.name.clone(),
                                 accessor: field_value.clone(),
-                                seq: self.expand_encode(
-                                    &CodecPlan::Primitive(field.primitive),
-                                    field_value,
-                                ),
+                                seq: self.expand_encode(&CodecPlan::Primitive(field.primitive), field_value),
                             }
                         })
                         .collect(),
@@ -1125,10 +995,7 @@ impl<'c> Lowerer<'c> {
     }
 
     fn abi_params_from_plan(&self, params: &[ParamPlan]) -> Vec<AbiParam> {
-        params
-            .iter()
-            .flat_map(|param| self.abi_param_from_plan(param))
-            .collect()
+        params.iter().flat_map(|param| self.abi_param_from_plan(param)).collect()
     }
 
     fn abi_param_from_plan(&self, param: &ParamPlan) -> Vec<AbiParam> {
@@ -1141,10 +1008,7 @@ impl<'c> Lowerer<'c> {
                 ffi_type: d.abi_type,
                 input_shape: InputShape::Value(ValueShape::Scalar(d.abi_type)),
             }],
-            ParamStrategy::Buffer {
-                mutability,
-                element_abi,
-            } => vec![
+            ParamStrategy::Buffer { mutability, element_abi } => vec![
                 AbiParam {
                     name: param.name.clone(),
                     ffi_type: AbiType::Pointer,
@@ -1157,31 +1021,24 @@ impl<'c> Lowerer<'c> {
                 AbiParam {
                     name: len_name,
                     ffi_type: AbiType::U64,
-                    input_shape: InputShape::HiddenSyntheticLen {
-                        for_param: param.name.clone(),
-                    },
+                    input_shape: InputShape::HiddenSyntheticLen { for_param: param.name.clone() },
                 },
             ],
             ParamStrategy::String { .. } => vec![
                 AbiParam {
                     name: param.name.clone(),
                     ffi_type: AbiType::Pointer,
-                    input_shape: InputShape::Utf8Slice {
-                        len_param: len_name.clone(),
-                    },
+                    input_shape: InputShape::Utf8Slice { len_param: len_name.clone() },
                 },
                 AbiParam {
                     name: len_name,
                     ffi_type: AbiType::U64,
-                    input_shape: InputShape::HiddenSyntheticLen {
-                        for_param: param.name.clone(),
-                    },
+                    input_shape: InputShape::HiddenSyntheticLen { for_param: param.name.clone() },
                 },
             ],
             ParamStrategy::Encoded { codec, mutability } => {
                 let decode_ops = self.expand_decode(codec);
-                let encode_ops =
-                    self.expand_encode(codec, ValueExpr::Named(param.name.as_str().to_string()));
+                let encode_ops = self.expand_encode(codec, ValueExpr::Named(param.name.as_str().to_string()));
                 let value_shape = self.value_shape_from_read_write(&decode_ops, &encode_ops);
                 let input_shape = match mutability {
                     Mutability::Mutable => InputShape::OutputBuffer {
@@ -1202,9 +1059,7 @@ impl<'c> Lowerer<'c> {
                     AbiParam {
                         name: len_name,
                         ffi_type: AbiType::U64,
-                        input_shape: InputShape::HiddenSyntheticLen {
-                            for_param: param.name.clone(),
-                        },
+                        input_shape: InputShape::HiddenSyntheticLen { for_param: param.name.clone() },
                     },
                 ]
             }
@@ -1216,11 +1071,7 @@ impl<'c> Lowerer<'c> {
                     nullable: *nullable,
                 },
             }],
-            ParamStrategy::Callback {
-                callback_id,
-                nullable,
-                style,
-            } => vec![AbiParam {
+            ParamStrategy::Callback { callback_id, nullable, style } => vec![AbiParam {
                 name: param.name.clone(),
                 ffi_type: AbiType::Pointer,
                 input_shape: InputShape::Callback {
@@ -1232,18 +1083,12 @@ impl<'c> Lowerer<'c> {
         }
     }
 
-    fn callback_output_shape_and_error(
-        &self,
-        returns: &ReturnDef,
-    ) -> (OutputShape, ErrorTransport) {
+    fn callback_output_shape_and_error(&self, returns: &ReturnDef) -> (OutputShape, ErrorTransport) {
         match returns {
             ReturnDef::Void => (OutputShape::Unit, ErrorTransport::None),
             ReturnDef::Value(ty) => {
                 let plan = self.lower_value_type(ty);
-                (
-                    self.output_shape_from_return_value(&plan),
-                    ErrorTransport::None,
-                )
+                (self.output_shape_from_return_value(&plan), ErrorTransport::None)
             }
             ReturnDef::Result { ok, err } => {
                 let ok_codec = self.build_codec(ok);
@@ -1258,20 +1103,14 @@ impl<'c> Lowerer<'c> {
                     OutputShape::Value(self.value_shape_from_read_write(&decode_ops, &encode_ops)),
                     ErrorTransport::Encoded {
                         decode_ops: self.expand_decode(&err_codec),
-                        encode_ops: Some(
-                            self.expand_encode(&err_codec, ValueExpr::Var("error".into())),
-                        ),
+                        encode_ops: Some(self.expand_encode(&err_codec, ValueExpr::Var("error".into()))),
                     },
                 )
             }
         }
     }
 
-    fn abi_callback_params<'a>(
-        &'a self,
-        callback: &'a CallbackTraitDef,
-        method: &'a CallbackMethodDef,
-    ) -> impl Iterator<Item = AbiParam> + 'a {
+    fn abi_callback_params<'a>(&'a self, callback: &'a CallbackTraitDef, method: &'a CallbackMethodDef) -> impl Iterator<Item = AbiParam> + 'a {
         let handle_param = AbiParam {
             name: ParamName::new("handle"),
             ffi_type: AbiType::Pointer,
@@ -1290,9 +1129,7 @@ impl<'c> Lowerer<'c> {
 
         let out_params = self.abi_callback_out_params(&method.returns, method.is_async);
 
-        std::iter::once(handle_param)
-            .chain(method_params)
-            .chain(out_params)
+        std::iter::once(handle_param).chain(method_params).chain(out_params)
     }
 
     fn abi_callback_param_from_plan(&self, param: AbiCallbackParamPlan) -> Vec<AbiParam> {
@@ -1307,8 +1144,7 @@ impl<'c> Lowerer<'c> {
             }],
             AbiCallbackParamStrategy::Encoded { codec } => {
                 let decode_ops = self.expand_decode(&codec);
-                let encode_ops =
-                    self.expand_encode(&codec, ValueExpr::Named(param.name.as_str().to_string()));
+                let encode_ops = self.expand_encode(&codec, ValueExpr::Named(param.name.as_str().to_string()));
                 let value_shape = self.value_shape_from_read_write(&decode_ops, &encode_ops);
                 vec![
                     AbiParam {
@@ -1322,9 +1158,7 @@ impl<'c> Lowerer<'c> {
                     AbiParam {
                         name: len_name,
                         ffi_type: AbiType::U64,
-                        input_shape: InputShape::HiddenSyntheticLen {
-                            for_param: param.name.clone(),
-                        },
+                        input_shape: InputShape::HiddenSyntheticLen { for_param: param.name.clone() },
                     },
                 ]
             }
@@ -1362,20 +1196,16 @@ impl<'c> Lowerer<'c> {
                     AbiParam {
                         name: out_len_name,
                         ffi_type: AbiType::U64,
-                        input_shape: InputShape::HiddenOutLen {
-                            for_param: out_ptr_name,
-                        },
+                        input_shape: InputShape::HiddenOutLen { for_param: out_ptr_name },
                     },
                 ]
             }
-            OutputShape::Handle { .. } | OutputShape::Callback { .. } | OutputShape::Unit => {
-                std::iter::once(AbiParam {
-                    name: out_ptr_name,
-                    ffi_type: AbiType::Pointer,
-                    input_shape: InputShape::HiddenOutDirect,
-                })
-                .collect()
-            }
+            OutputShape::Handle { .. } | OutputShape::Callback { .. } | OutputShape::Unit => std::iter::once(AbiParam {
+                name: out_ptr_name,
+                ffi_type: AbiType::Pointer,
+                input_shape: InputShape::HiddenOutDirect,
+            })
+            .collect(),
         }
     }
 }
@@ -1402,8 +1232,7 @@ impl<'c> Lowerer<'c> {
     }
 
     fn lower_method(&self, class: &ClassDef, method: &MethodDef) -> CallPlan {
-        let mut params: Vec<ParamPlan> =
-            method.params.iter().map(|p| self.lower_param(p)).collect();
+        let mut params: Vec<ParamPlan> = method.params.iter().map(|p| self.lower_param(p)).collect();
 
         if method.receiver != Receiver::Static {
             params.insert(
@@ -1436,11 +1265,7 @@ impl<'c> Lowerer<'c> {
     }
 
     fn lower_constructor(&self, class: &ClassDef, ctor: &ConstructorDef) -> CallPlan {
-        let params = ctor
-            .params()
-            .into_iter()
-            .map(|p| self.lower_param(p))
-            .collect();
+        let params = ctor.params().into_iter().map(|p| self.lower_param(p)).collect();
 
         let returns = if ctor.is_fallible() {
             ReturnPlan::Fallible {
@@ -1469,8 +1294,7 @@ impl<'c> Lowerer<'c> {
             .methods
             .iter()
             .map(|method| {
-                let mut params: Vec<ParamPlan> =
-                    method.params.iter().map(|p| self.lower_param(p)).collect();
+                let mut params: Vec<ParamPlan> = method.params.iter().map(|p| self.lower_param(p)).collect();
 
                 params.insert(
                     0,
@@ -1517,9 +1341,7 @@ impl<'c> Lowerer<'c> {
     }
 
     fn param_strategy(&self, type_expr: &TypeExpr, passing: &ParamPassing) -> ParamStrategy {
-        if let (ParamPassing::ImplTrait | ParamPassing::BoxedDyn, TypeExpr::Callback(id)) =
-            (passing, type_expr)
-        {
+        if let (ParamPassing::ImplTrait | ParamPassing::BoxedDyn, TypeExpr::Callback(id)) = (passing, type_expr) {
             let style = match passing {
                 ParamPassing::ImplTrait => CallbackStyle::ImplTrait,
                 ParamPassing::BoxedDyn => CallbackStyle::BoxedDyn,
@@ -1538,13 +1360,9 @@ impl<'c> Lowerer<'c> {
         };
 
         match type_expr {
-            TypeExpr::Void => ParamStrategy::Direct(DirectPlan {
-                abi_type: AbiType::Void,
-            }),
+            TypeExpr::Void => ParamStrategy::Direct(DirectPlan { abi_type: AbiType::Void }),
 
-            TypeExpr::Primitive(p) => ParamStrategy::Direct(DirectPlan {
-                abi_type: primitive_to_abi(*p),
-            }),
+            TypeExpr::Primitive(p) => ParamStrategy::Direct(DirectPlan { abi_type: primitive_to_abi(*p) }),
 
             TypeExpr::String => ParamStrategy::String { mutability },
 
@@ -1613,9 +1431,7 @@ impl<'c> Lowerer<'c> {
         match ty {
             TypeExpr::Void => ReturnValuePlan::Void,
 
-            TypeExpr::Primitive(p) => ReturnValuePlan::Direct(DirectPlan {
-                abi_type: primitive_to_abi(*p),
-            }),
+            TypeExpr::Primitive(p) => ReturnValuePlan::Direct(DirectPlan { abi_type: primitive_to_abi(*p) }),
 
             TypeExpr::Handle(class_id) => ReturnValuePlan::Handle {
                 class_id: class_id.clone(),
@@ -1636,14 +1452,10 @@ impl<'c> Lowerer<'c> {
                     callback_id: callback_id.clone(),
                     nullable: true,
                 },
-                _ => ReturnValuePlan::Encoded {
-                    codec: self.build_codec(ty),
-                },
+                _ => ReturnValuePlan::Encoded { codec: self.build_codec(ty) },
             },
 
-            _ => ReturnValuePlan::Encoded {
-                codec: self.build_codec(ty),
-            },
+            _ => ReturnValuePlan::Encoded { codec: self.build_codec(ty) },
         }
     }
 
@@ -1670,9 +1482,7 @@ impl<'c> Lowerer<'c> {
 impl<'c> Lowerer<'c> {
     fn lower_callback_param(&self, param: &ParamDef) -> AbiCallbackParamPlan {
         let strategy = match &param.type_expr {
-            TypeExpr::Primitive(p) => AbiCallbackParamStrategy::Direct(DirectPlan {
-                abi_type: primitive_to_abi(*p),
-            }),
+            TypeExpr::Primitive(p) => AbiCallbackParamStrategy::Direct(DirectPlan { abi_type: primitive_to_abi(*p) }),
             _ => AbiCallbackParamStrategy::Encoded {
                 codec: self.build_codec(&param.type_expr),
             },
@@ -1721,11 +1531,7 @@ impl<'c> Lowerer<'c> {
             },
 
             TypeExpr::Custom(id) => {
-                let def = self
-                    .contract
-                    .catalog
-                    .resolve_custom(id)
-                    .expect("custom type should be resolved");
+                let def = self.contract.catalog.resolve_custom(id).expect("custom type should be resolved");
                 CodecPlan::Custom {
                     id: id.clone(),
                     underlying: Box::new(self.build_codec(&def.repr)),
@@ -1745,11 +1551,7 @@ impl<'c> Lowerer<'c> {
 
         self.record_stack.borrow_mut().insert(id.clone());
 
-        let def = self
-            .contract
-            .catalog
-            .resolve_record(id)
-            .expect("record should be resolved");
+        let def = self.contract.catalog.resolve_record(id).expect("record should be resolved");
 
         let layout = if self.is_blittable_record(def) {
             self.build_blittable_record_layout(def)
@@ -1793,11 +1595,7 @@ impl<'c> Lowerer<'c> {
 
         self.enum_stack.borrow_mut().insert(id.clone());
 
-        let def = self
-            .contract
-            .catalog
-            .resolve_enum(id)
-            .expect("enum should be resolved");
+        let def = self.contract.catalog.resolve_enum(id).expect("enum should be resolved");
 
         let layout = match &def.repr {
             EnumRepr::CStyle { tag_type, .. } => EnumLayout::CStyle {
@@ -1883,19 +1681,11 @@ impl<'c> Lowerer<'c> {
         naming::function_ffi_name(id.as_str())
     }
 
-    fn method_symbol(
-        &self,
-        class_id: &ClassId,
-        method_id: &MethodId,
-    ) -> naming::Name<naming::GlobalSymbol> {
+    fn method_symbol(&self, class_id: &ClassId, method_id: &MethodId) -> naming::Name<naming::GlobalSymbol> {
         naming::method_ffi_name(class_id.as_str(), method_id.as_str())
     }
 
-    fn constructor_symbol(
-        &self,
-        class_id: &ClassId,
-        name: Option<&MethodId>,
-    ) -> naming::Name<naming::GlobalSymbol> {
+    fn constructor_symbol(&self, class_id: &ClassId, name: Option<&MethodId>) -> naming::Name<naming::GlobalSymbol> {
         match name {
             Some(n) => naming::method_ffi_name(class_id.as_str(), n.as_str()),
             None => naming::class_ffi_new(class_id.as_str()),
@@ -1937,30 +1727,23 @@ fn align_up(offset: usize, alignment: usize) -> usize {
 }
 
 fn compute_blittable_layout(def: &RecordDef) -> (usize, Vec<BlittableField>) {
-    let (final_offset, fields) =
-        def.fields
-            .iter()
-            .fold((0usize, Vec::new()), |(offset, mut fields), field| {
-                let TypeExpr::Primitive(p) = &field.type_expr else {
-                    panic!("blittable record should only have primitive fields");
-                };
+    let (final_offset, fields) = def.fields.iter().fold((0usize, Vec::new()), |(offset, mut fields), field| {
+        let TypeExpr::Primitive(p) = &field.type_expr else {
+            panic!("blittable record should only have primitive fields");
+        };
 
-                let alignment = p
-                    .alignment()
-                    .expect("blittable field must have fixed-size alignment");
-                let size = p
-                    .size_bytes()
-                    .expect("blittable field must have fixed size");
-                let aligned_offset = align_up(offset, alignment);
+        let alignment = p.alignment().expect("blittable field must have fixed-size alignment");
+        let size = p.size_bytes().expect("blittable field must have fixed size");
+        let aligned_offset = align_up(offset, alignment);
 
-                fields.push(BlittableField {
-                    name: field.name.clone(),
-                    offset: aligned_offset,
-                    primitive: *p,
-                });
+        fields.push(BlittableField {
+            name: field.name.clone(),
+            offset: aligned_offset,
+            primitive: *p,
+        });
 
-                (aligned_offset + size, fields)
-            });
+        (aligned_offset + size, fields)
+    });
 
     let max_align = def
         .fields
@@ -1983,15 +1766,12 @@ fn compute_blittable_layout(def: &RecordDef) -> (usize, Vec<BlittableField>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::contract::{FfiContract, PackageInfo, TypeCatalog};
-    use crate::ir::definitions::{
-        CallbackKind, CallbackMethodDef, ClassDef, ConstructorDef, FieldDef, FunctionDef,
-        MethodDef, ParamDef, ParamPassing, Receiver, RecordDef, ReturnDef,
+    use crate::ir::{
+        contract::{FfiContract, PackageInfo, TypeCatalog},
+        definitions::{CallbackKind, CallbackMethodDef, ClassDef, ConstructorDef, FieldDef, FunctionDef, MethodDef, ParamDef, ParamPassing, Receiver, RecordDef, ReturnDef},
+        ids::{CallbackId, ClassId, FieldName, FunctionId, MethodId, ParamName, RecordId},
+        types::{PrimitiveType, TypeExpr},
     };
-    use crate::ir::ids::{
-        CallbackId, ClassId, FieldName, FunctionId, MethodId, ParamName, RecordId,
-    };
-    use crate::ir::types::{PrimitiveType, TypeExpr};
     use boltffi_ffi_rules::naming;
 
     fn test_contract() -> FfiContract {
@@ -2014,17 +1794,9 @@ mod tests {
         let contract = test_contract();
         let lowerer = lowerer_for_contract(&contract);
 
-        let strategy = lowerer.param_strategy(
-            &TypeExpr::Primitive(PrimitiveType::I32),
-            &ParamPassing::Value,
-        );
+        let strategy = lowerer.param_strategy(&TypeExpr::Primitive(PrimitiveType::I32), &ParamPassing::Value);
 
-        assert!(matches!(
-            strategy,
-            ParamStrategy::Direct(DirectPlan {
-                abi_type: AbiType::I32
-            })
-        ));
+        assert!(matches!(strategy, ParamStrategy::Direct(DirectPlan { abi_type: AbiType::I32 })));
     }
 
     #[test]
@@ -2034,12 +1806,7 @@ mod tests {
 
         let strategy = lowerer.param_strategy(&TypeExpr::String, &ParamPassing::Ref);
 
-        assert!(matches!(
-            strategy,
-            ParamStrategy::String {
-                mutability: Mutability::Shared
-            }
-        ));
+        assert!(matches!(strategy, ParamStrategy::String { mutability: Mutability::Shared }));
     }
 
     #[test]
@@ -2047,10 +1814,7 @@ mod tests {
         let contract = test_contract();
         let lowerer = lowerer_for_contract(&contract);
 
-        let strategy = lowerer.param_strategy(
-            &TypeExpr::Vec(Box::new(TypeExpr::Primitive(PrimitiveType::F32))),
-            &ParamPassing::Ref,
-        );
+        let strategy = lowerer.param_strategy(&TypeExpr::Vec(Box::new(TypeExpr::Primitive(PrimitiveType::F32))), &ParamPassing::Ref);
 
         assert!(matches!(
             strategy,
@@ -2067,8 +1831,7 @@ mod tests {
         let lowerer = lowerer_for_contract(&contract);
 
         let class_id = ClassId::new("MyClass");
-        let strategy =
-            lowerer.param_strategy(&TypeExpr::Handle(class_id.clone()), &ParamPassing::Value);
+        let strategy = lowerer.param_strategy(&TypeExpr::Handle(class_id.clone()), &ParamPassing::Value);
 
         assert!(matches!(
             strategy,
@@ -2082,10 +1845,7 @@ mod tests {
         let lowerer = lowerer_for_contract(&contract);
 
         let class_id = ClassId::new("MyClass");
-        let strategy = lowerer.param_strategy(
-            &TypeExpr::Option(Box::new(TypeExpr::Handle(class_id.clone()))),
-            &ParamPassing::Value,
-        );
+        let strategy = lowerer.param_strategy(&TypeExpr::Option(Box::new(TypeExpr::Handle(class_id.clone()))), &ParamPassing::Value);
 
         assert!(matches!(
             strategy,
@@ -2099,10 +1859,7 @@ mod tests {
         let lowerer = lowerer_for_contract(&contract);
 
         let callback_id = CallbackId::new("OnComplete");
-        let strategy = lowerer.param_strategy(
-            &TypeExpr::Callback(callback_id.clone()),
-            &ParamPassing::ImplTrait,
-        );
+        let strategy = lowerer.param_strategy(&TypeExpr::Callback(callback_id.clone()), &ParamPassing::ImplTrait);
 
         assert!(matches!(
             strategy,
@@ -2120,10 +1877,7 @@ mod tests {
         let lowerer = lowerer_for_contract(&contract);
 
         let callback_id = CallbackId::new("OnComplete");
-        let strategy = lowerer.param_strategy(
-            &TypeExpr::Option(Box::new(TypeExpr::Callback(callback_id.clone()))),
-            &ParamPassing::Value,
-        );
+        let strategy = lowerer.param_strategy(&TypeExpr::Option(Box::new(TypeExpr::Callback(callback_id.clone()))), &ParamPassing::Value);
 
         assert!(matches!(
             strategy,
@@ -2150,15 +1904,9 @@ mod tests {
         let contract = test_contract();
         let lowerer = lowerer_for_contract(&contract);
 
-        let plan =
-            lowerer.lower_return(&ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::Bool)));
+        let plan = lowerer.lower_return(&ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::Bool)));
 
-        assert!(matches!(
-            plan,
-            ReturnPlan::Value(ReturnValuePlan::Direct(DirectPlan {
-                abi_type: AbiType::Bool
-            }))
-        ));
+        assert!(matches!(plan, ReturnPlan::Value(ReturnValuePlan::Direct(DirectPlan { abi_type: AbiType::Bool }))));
     }
 
     #[test]
@@ -2169,13 +1917,7 @@ mod tests {
         let class_id = ClassId::new("Connection");
         let plan = lowerer.lower_return(&ReturnDef::Value(TypeExpr::Handle(class_id)));
 
-        assert!(matches!(
-            plan,
-            ReturnPlan::Value(ReturnValuePlan::Handle {
-                nullable: false,
-                ..
-            })
-        ));
+        assert!(matches!(plan, ReturnPlan::Value(ReturnValuePlan::Handle { nullable: false, .. })));
     }
 
     #[test]
@@ -2184,14 +1926,9 @@ mod tests {
         let lowerer = lowerer_for_contract(&contract);
 
         let class_id = ClassId::new("Connection");
-        let plan = lowerer.lower_return(&ReturnDef::Value(TypeExpr::Option(Box::new(
-            TypeExpr::Handle(class_id),
-        ))));
+        let plan = lowerer.lower_return(&ReturnDef::Value(TypeExpr::Option(Box::new(TypeExpr::Handle(class_id)))));
 
-        assert!(matches!(
-            plan,
-            ReturnPlan::Value(ReturnValuePlan::Handle { nullable: true, .. })
-        ));
+        assert!(matches!(plan, ReturnPlan::Value(ReturnValuePlan::Handle { nullable: true, .. })));
     }
 
     #[test]
@@ -2208,10 +1945,7 @@ mod tests {
         assert!(matches!(
             plan,
             ReturnPlan::Fallible {
-                ok: ReturnValuePlan::Handle {
-                    nullable: false,
-                    ..
-                },
+                ok: ReturnValuePlan::Handle { nullable: false, .. },
                 ..
             }
         ));
@@ -2231,10 +1965,7 @@ mod tests {
         assert!(matches!(
             plan,
             ReturnPlan::Fallible {
-                ok: ReturnValuePlan::Callback {
-                    nullable: false,
-                    ..
-                },
+                ok: ReturnValuePlan::Callback { nullable: false, .. },
                 ..
             }
         ));
@@ -2275,9 +2006,7 @@ mod tests {
         let contract = test_contract();
         let lowerer = lowerer_for_contract(&contract);
 
-        let codec = lowerer.build_codec(&TypeExpr::Vec(Box::new(TypeExpr::Primitive(
-            PrimitiveType::I32,
-        ))));
+        let codec = lowerer.build_codec(&TypeExpr::Vec(Box::new(TypeExpr::Primitive(PrimitiveType::I32))));
 
         assert!(matches!(
             codec,
@@ -2295,13 +2024,7 @@ mod tests {
 
         let codec = lowerer.build_codec(&TypeExpr::Vec(Box::new(TypeExpr::String)));
 
-        assert!(matches!(
-            codec,
-            CodecPlan::Vec {
-                layout: VecLayout::Encoded,
-                ..
-            }
-        ));
+        assert!(matches!(codec, CodecPlan::Vec { layout: VecLayout::Encoded, .. }));
     }
 
     #[test]
@@ -2379,6 +2102,7 @@ mod tests {
             constructors: vec![],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2399,13 +2123,7 @@ mod tests {
         let plan = lowerer.lower_method(class, &method);
 
         assert_eq!(plan.params.len(), 1);
-        assert!(matches!(
-            &plan.params[0].strategy,
-            ParamStrategy::Handle {
-                nullable: false,
-                ..
-            }
-        ));
+        assert!(matches!(&plan.params[0].strategy, ParamStrategy::Handle { nullable: false, .. }));
         assert_eq!(plan.params[0].name.as_str(), "self");
     }
 
@@ -2418,6 +2136,7 @@ mod tests {
             constructors: vec![],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2449,6 +2168,7 @@ mod tests {
             constructors: vec![],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2468,10 +2188,7 @@ mod tests {
         assert!(matches!(
             plan.kind,
             CallPlanKind::Sync {
-                returns: ReturnPlan::Value(ReturnValuePlan::Handle {
-                    nullable: false,
-                    ..
-                })
+                returns: ReturnPlan::Value(ReturnValuePlan::Handle { nullable: false, .. })
             }
         ));
     }
@@ -2485,6 +2202,7 @@ mod tests {
             constructors: vec![],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2563,13 +2281,7 @@ mod tests {
 
         assert_eq!(plans[0].params.len(), 2);
         assert_eq!(plans[0].params[0].name.as_str(), "callback");
-        assert!(matches!(
-            &plans[0].params[0].strategy,
-            ParamStrategy::Callback {
-                nullable: false,
-                ..
-            }
-        ));
+        assert!(matches!(&plans[0].params[0].strategy, ParamStrategy::Callback { nullable: false, .. }));
     }
 
     #[test]
@@ -2646,10 +2358,7 @@ mod tests {
         match async_plan.result {
             AsyncResult::Fallible { ok, err_codec } => {
                 match ok {
-                    ReturnValuePlan::Handle {
-                        class_id: id,
-                        nullable,
-                    } => {
+                    ReturnValuePlan::Handle { class_id: id, nullable } => {
                         assert_eq!(id.as_str(), "Session");
                         assert!(!nullable);
                     }
@@ -2666,16 +2375,10 @@ mod tests {
         let contract = test_contract();
         let lowerer = lowerer_for_contract(&contract);
 
-        let strategy = lowerer.param_strategy(
-            &TypeExpr::Vec(Box::new(TypeExpr::Primitive(PrimitiveType::U8))),
-            &ParamPassing::Value,
-        );
+        let strategy = lowerer.param_strategy(&TypeExpr::Vec(Box::new(TypeExpr::Primitive(PrimitiveType::U8))), &ParamPassing::Value);
 
         match strategy {
-            ParamStrategy::Buffer {
-                element_abi,
-                mutability,
-            } => {
+            ParamStrategy::Buffer { element_abi, mutability } => {
                 assert_eq!(element_abi, AbiType::U8);
                 assert_eq!(mutability, Mutability::Shared);
             }
@@ -2706,10 +2409,7 @@ mod tests {
         let strategy = lowerer.param_strategy(&TypeExpr::Bytes, &ParamPassing::Ref);
 
         match strategy {
-            ParamStrategy::Buffer {
-                element_abi,
-                mutability,
-            } => {
+            ParamStrategy::Buffer { element_abi, mutability } => {
                 assert_eq!(element_abi, AbiType::U8);
                 assert_eq!(mutability, Mutability::Shared);
             }
@@ -2726,6 +2426,7 @@ mod tests {
             constructors: vec![],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2746,10 +2447,7 @@ mod tests {
                 returns: ReturnPlan::Fallible { ok, err_codec },
             } => {
                 match ok {
-                    ReturnValuePlan::Handle {
-                        class_id: id,
-                        nullable,
-                    } => {
+                    ReturnValuePlan::Handle { class_id: id, nullable } => {
                         assert_eq!(id.as_str(), "Connection");
                         assert!(!nullable);
                     }
@@ -2905,11 +2603,7 @@ mod tests {
         let plans = lowerer.lower_callback(&callback);
 
         match &plans[0].params[0].strategy {
-            ParamStrategy::Callback {
-                callback_id,
-                style,
-                nullable,
-            } => {
+            ParamStrategy::Callback { callback_id, style, nullable } => {
                 assert_eq!(callback_id.as_str(), "MyCallback");
                 assert_eq!(*style, CallbackStyle::BoxedDyn);
                 assert!(!nullable);
@@ -2924,17 +2618,10 @@ mod tests {
         let lowerer = lowerer_for_contract(&contract);
 
         let callback_id = CallbackId::new("Handler");
-        let strategy = lowerer.param_strategy(
-            &TypeExpr::Callback(callback_id.clone()),
-            &ParamPassing::BoxedDyn,
-        );
+        let strategy = lowerer.param_strategy(&TypeExpr::Callback(callback_id.clone()), &ParamPassing::BoxedDyn);
 
         match strategy {
-            ParamStrategy::Callback {
-                callback_id: id,
-                style,
-                nullable,
-            } => {
+            ParamStrategy::Callback { callback_id: id, style, nullable } => {
                 assert_eq!(id.as_str(), "Handler");
                 assert_eq!(style, CallbackStyle::BoxedDyn);
                 assert!(!nullable);
@@ -2952,6 +2639,7 @@ mod tests {
             constructors: vec![],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2972,10 +2660,7 @@ mod tests {
 
         match &plan.target {
             CallTarget::GlobalSymbol(s) => {
-                assert_eq!(
-                    s.as_str(),
-                    naming::method_ffi_name("Service", "start").as_str()
-                );
+                assert_eq!(s.as_str(), naming::method_ffi_name("Service", "start").as_str());
             }
             _ => panic!("expected GlobalSymbol"),
         }
@@ -2990,6 +2675,7 @@ mod tests {
             constructors: vec![],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
@@ -3020,10 +2706,7 @@ mod tests {
         let plan = lowerer.lower_constructor(class, &named_ctor);
         match &plan.target {
             CallTarget::GlobalSymbol(s) => {
-                assert_eq!(
-                    s.as_str(),
-                    naming::method_ffi_name("Factory", "with_config").as_str()
-                )
+                assert_eq!(s.as_str(), naming::method_ffi_name("Factory", "with_config").as_str())
             }
             _ => panic!("expected GlobalSymbol"),
         }
@@ -3066,10 +2749,7 @@ mod tests {
             RecordLayout::Encoded { fields } => {
                 assert_eq!(fields.len(), 3);
                 assert_eq!(fields[0].name.as_str(), "id");
-                assert!(matches!(
-                    fields[0].codec,
-                    CodecPlan::Primitive(PrimitiveType::U64)
-                ));
+                assert!(matches!(fields[0].codec, CodecPlan::Primitive(PrimitiveType::U64)));
                 assert_eq!(fields[1].name.as_str(), "body");
                 assert!(matches!(fields[1].codec, CodecPlan::String));
                 assert_eq!(fields[2].name.as_str(), "tags");
@@ -3101,10 +2781,7 @@ mod tests {
         let abi = lowerer.abi_call_for_function(&func);
 
         assert_eq!(abi.params.len(), 2);
-        assert!(matches!(
-            abi.params[0].input_shape,
-            InputShape::Utf8Slice { .. }
-        ));
+        assert!(matches!(abi.params[0].input_shape, InputShape::Utf8Slice { .. }));
         assert_eq!(abi.params[0].name.as_str(), "name");
         match &abi.params[1].input_shape {
             InputShape::HiddenSyntheticLen { for_param } => {
@@ -3157,10 +2834,7 @@ mod tests {
         let abi = lowerer.abi_call_for_function(&func);
 
         assert_eq!(abi.params.len(), 2);
-        assert!(matches!(
-            abi.params[0].input_shape,
-            InputShape::WirePacket { .. }
-        ));
+        assert!(matches!(abi.params[0].input_shape, InputShape::WirePacket { .. }));
         assert_eq!(abi.params[0].name.as_str(), "point");
         match &abi.params[1].input_shape {
             InputShape::HiddenSyntheticLen { for_param } => {
@@ -3189,6 +2863,7 @@ mod tests {
             }],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
@@ -3197,10 +2872,7 @@ mod tests {
         let class = contract.catalog.resolve_class(&class_id).unwrap();
         let abi = lowerer.abi_call_for_constructor(class, &class.constructors[0], 0);
 
-        assert!(matches!(
-            abi.output_shape,
-            OutputShape::Handle { nullable: true, .. }
-        ));
+        assert!(matches!(abi.output_shape, OutputShape::Handle { nullable: true, .. }));
         assert!(matches!(abi.error, ErrorTransport::Encoded { .. }));
     }
 }

--- a/boltffi_bindgen/src/model/callback_trait.rs
+++ b/boltffi_bindgen/src/model/callback_trait.rs
@@ -1,6 +1,5 @@
-use serde::{Deserialize, Serialize};
-
 use super::types::{Deprecation, ReturnType, Type};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CallbackTrait {
@@ -121,9 +120,6 @@ pub struct TraitMethodParam {
 
 impl TraitMethodParam {
     pub fn new(name: impl Into<String>, param_type: Type) -> Self {
-        Self {
-            name: name.into(),
-            param_type,
-        }
+        Self { name: name.into(), param_type }
     }
 }

--- a/boltffi_bindgen/src/model/class.rs
+++ b/boltffi_bindgen/src/model/class.rs
@@ -1,8 +1,9 @@
+use super::{
+    method::Method,
+    stream::{AsyncIteratorMethod, StreamMethod},
+    types::Deprecation,
+};
 use serde::{Deserialize, Serialize};
-
-use super::method::Method;
-use super::stream::StreamMethod;
-use super::types::Deprecation;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Class {
@@ -12,6 +13,7 @@ pub struct Class {
     pub constructors: Vec<Constructor>,
     pub methods: Vec<Method>,
     pub streams: Vec<StreamMethod>,
+    pub async_iterators: Vec<AsyncIteratorMethod>,
 }
 
 impl Class {
@@ -23,6 +25,7 @@ impl Class {
             constructors: Vec::new(),
             methods: Vec::new(),
             streams: Vec::new(),
+            async_iterators: Vec::new(),
         }
     }
 
@@ -55,6 +58,11 @@ impl Class {
 
     pub fn with_stream(mut self, stream: StreamMethod) -> Self {
         self.streams.push(stream);
+        self
+    }
+
+    pub fn with_async_iterator(mut self, iter: AsyncIteratorMethod) -> Self {
+        self.async_iterators.push(iter);
         self
     }
 
@@ -136,9 +144,6 @@ pub struct ConstructorParam {
 
 impl ConstructorParam {
     pub fn new(name: impl Into<String>, param_type: super::types::Type) -> Self {
-        Self {
-            name: name.into(),
-            param_type,
-        }
+        Self { name: name.into(), param_type }
     }
 }

--- a/boltffi_bindgen/src/model/custom_type.rs
+++ b/boltffi_bindgen/src/model/custom_type.rs
@@ -1,6 +1,5 @@
-use serde::{Deserialize, Serialize};
-
 use super::types::Type;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CustomType {
@@ -10,9 +9,6 @@ pub struct CustomType {
 
 impl CustomType {
     pub fn new(name: impl Into<String>, repr: Type) -> Self {
-        Self {
-            name: name.into(),
-            repr,
-        }
+        Self { name: name.into(), repr }
     }
 }

--- a/boltffi_bindgen/src/model/enum_layout.rs
+++ b/boltffi_bindgen/src/model/enum_layout.rs
@@ -44,12 +44,7 @@ impl DataEnumLayout {
                         payload_layout: Layout::new(0, 1),
                     }
                 } else {
-                    let struct_layout = StructLayout::from_layouts(
-                        variant
-                            .fields
-                            .iter()
-                            .map(|field| field.field_type.c_layout()),
-                    );
+                    let struct_layout = StructLayout::from_layouts(variant.fields.iter().map(|field| field.field_type.c_layout()));
 
                     DataEnumVariantLayout {
                         field_offsets: struct_layout.offsets().collect(),
@@ -67,17 +62,12 @@ impl DataEnumLayout {
             .map(|variant| variant.payload_layout.alignment)
             .fold(Alignment::new(1), |current, next| current.max(next));
 
-        let union_size_unpadded = variants
-            .iter()
-            .map(|variant| variant.payload_layout.size.as_usize())
-            .max()
-            .unwrap_or(0);
+        let union_size_unpadded = variants.iter().map(|variant| variant.payload_layout.size.as_usize()).max().unwrap_or(0);
 
         let union_size = Size::new(union_size_unpadded).padded_to(union_alignment);
         let payload_offset = (Offset::ZERO + tag_layout.size).aligned_to(union_alignment);
         let struct_alignment = tag_layout.alignment.max(union_alignment);
-        let struct_size = Size::new(payload_offset.as_usize() + union_size.as_usize())
-            .padded_to(struct_alignment);
+        let struct_size = Size::new(payload_offset.as_usize() + union_size.as_usize()).padded_to(struct_alignment);
 
         Some(Self {
             struct_size,
@@ -95,9 +85,6 @@ impl DataEnumLayout {
     }
 
     pub fn field_offset(&self, variant_index: usize, field_index: usize) -> Option<Offset> {
-        self.variants
-            .get(variant_index)
-            .and_then(|variant| variant.field_offsets.get(field_index))
-            .copied()
+        self.variants.get(variant_index).and_then(|variant| variant.field_offsets.get(field_index)).copied()
     }
 }

--- a/boltffi_bindgen/src/model/enumeration.rs
+++ b/boltffi_bindgen/src/model/enumeration.rs
@@ -1,7 +1,5 @@
+use super::{record::RecordField, types::Deprecation};
 use serde::{Deserialize, Serialize};
-
-use super::record::RecordField;
-use super::types::Deprecation;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Enumeration {

--- a/boltffi_bindgen/src/model/function.rs
+++ b/boltffi_bindgen/src/model/function.rs
@@ -1,7 +1,8 @@
+use super::{
+    method::Parameter,
+    types::{Deprecation, ReturnType, Type},
+};
 use serde::{Deserialize, Serialize};
-
-use super::method::Parameter;
-use super::types::{Deprecation, ReturnType, Type};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Function {
@@ -93,20 +94,14 @@ impl Function {
     }
 
     pub fn has_callbacks(&self) -> bool {
-        self.inputs
-            .iter()
-            .any(|p| matches!(p.param_type, Type::Closure(_)))
+        self.inputs.iter().any(|p| matches!(p.param_type, Type::Closure(_)))
     }
 
     pub fn callback_params(&self) -> impl Iterator<Item = &Parameter> {
-        self.inputs
-            .iter()
-            .filter(|p| matches!(p.param_type, Type::Closure(_)))
+        self.inputs.iter().filter(|p| matches!(p.param_type, Type::Closure(_)))
     }
 
     pub fn non_callback_params(&self) -> impl Iterator<Item = &Parameter> {
-        self.inputs
-            .iter()
-            .filter(|p| !matches!(p.param_type, Type::Closure(_)))
+        self.inputs.iter().filter(|p| !matches!(p.param_type, Type::Closure(_)))
     }
 }

--- a/boltffi_bindgen/src/model/layout.rs
+++ b/boltffi_bindgen/src/model/layout.rs
@@ -104,18 +104,13 @@ impl StructLayout {
     where
         I: IntoIterator<Item = Layout>,
     {
-        let (fields, final_offset, max_alignment) = layouts.into_iter().fold(
-            (Vec::new(), Offset::ZERO, Alignment::new(1)),
-            |(mut fields, offset, max_align), layout| {
+        let (fields, final_offset, max_alignment) = layouts
+            .into_iter()
+            .fold((Vec::new(), Offset::ZERO, Alignment::new(1)), |(mut fields, offset, max_align), layout| {
                 let aligned_offset = offset.aligned_to(layout.alignment);
                 fields.push(FieldLayout::new(aligned_offset, layout));
-                (
-                    fields,
-                    aligned_offset + layout.size,
-                    max_align.max(layout.alignment),
-                )
-            },
-        );
+                (fields, aligned_offset + layout.size, max_align.max(layout.alignment))
+            });
 
         let total_size = Size::new(final_offset.as_usize()).padded_to(max_alignment);
 

--- a/boltffi_bindgen/src/model/method.rs
+++ b/boltffi_bindgen/src/model/method.rs
@@ -1,6 +1,5 @@
-use serde::{Deserialize, Serialize};
-
 use super::types::{Deprecation, Receiver, ReturnType, Type};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Method {
@@ -95,21 +94,15 @@ impl Method {
     }
 
     pub fn has_callbacks(&self) -> bool {
-        self.inputs
-            .iter()
-            .any(|p| matches!(p.param_type, Type::Closure(_)))
+        self.inputs.iter().any(|p| matches!(p.param_type, Type::Closure(_)))
     }
 
     pub fn callback_params(&self) -> impl Iterator<Item = &Parameter> {
-        self.inputs
-            .iter()
-            .filter(|p| matches!(p.param_type, Type::Closure(_)))
+        self.inputs.iter().filter(|p| matches!(p.param_type, Type::Closure(_)))
     }
 
     pub fn non_callback_params(&self) -> impl Iterator<Item = &Parameter> {
-        self.inputs
-            .iter()
-            .filter(|p| !matches!(p.param_type, Type::Closure(_)))
+        self.inputs.iter().filter(|p| !matches!(p.param_type, Type::Closure(_)))
     }
 }
 
@@ -121,9 +114,6 @@ pub struct Parameter {
 
 impl Parameter {
     pub fn new(name: impl Into<String>, param_type: Type) -> Self {
-        Self {
-            name: name.into(),
-            param_type,
-        }
+        Self { name: name.into(), param_type }
     }
 }

--- a/boltffi_bindgen/src/model/mod.rs
+++ b/boltffi_bindgen/src/model/mod.rs
@@ -23,5 +23,5 @@ pub use method::{Method, Parameter};
 pub use module::Module;
 pub use option_info::OptionInfo;
 pub use record::{Record, RecordField};
-pub use stream::{StreamMethod, StreamMode};
+pub use stream::{AsyncIteratorMethod, StreamMethod, StreamMode};
 pub use types::{BuiltinId, ClosureSignature, Deprecation, Primitive, Receiver, ReturnType, Type};

--- a/boltffi_bindgen/src/model/module.rs
+++ b/boltffi_bindgen/src/model/module.rs
@@ -1,15 +1,15 @@
-use std::collections::{HashMap, HashSet};
-
+use super::{
+    callback_trait::CallbackTrait,
+    class::Class,
+    custom_type::CustomType,
+    enum_layout::DataEnumLayout,
+    enumeration::Enumeration,
+    function::Function,
+    record::Record,
+    types::{BuiltinId, ClosureSignature, ReturnType, Type},
+};
 use serde::{Deserialize, Serialize};
-
-use super::callback_trait::CallbackTrait;
-use super::class::Class;
-use super::custom_type::CustomType;
-use super::enum_layout::DataEnumLayout;
-use super::enumeration::Enumeration;
-use super::function::Function;
-use super::record::Record;
-use super::types::{BuiltinId, ClosureSignature, ReturnType, Type};
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Module {
@@ -71,9 +71,7 @@ impl Module {
     }
 
     pub fn find_enum(&self, name: &str) -> Option<&Enumeration> {
-        self.enums
-            .iter()
-            .find(|enumeration| enumeration.name == name)
+        self.enums.iter().find(|enumeration| enumeration.name == name)
     }
 
     pub fn with_callback_trait(mut self, callback_trait: CallbackTrait) -> Self {
@@ -87,31 +85,23 @@ impl Module {
     }
 
     pub fn find_callback_trait(&self, name: &str) -> Option<&CallbackTrait> {
-        self.callback_traits
-            .iter()
-            .find(|callback_trait| callback_trait.name == name)
+        self.callback_traits.iter().find(|callback_trait| callback_trait.name == name)
     }
 
     pub fn find_custom_type(&self, name: &str) -> Option<&CustomType> {
-        self.custom_types
-            .iter()
-            .find(|custom_type| custom_type.name == name)
+        self.custom_types.iter().find(|custom_type| custom_type.name == name)
     }
 
     pub fn has_exports(&self) -> bool {
-        !self.classes.is_empty()
-            || !self.functions.is_empty()
-            || !self.enums.is_empty()
-            || !self.callback_traits.is_empty()
-            || !self.custom_types.is_empty()
+        !self.classes.is_empty() || !self.functions.is_empty() || !self.enums.is_empty() || !self.callback_traits.is_empty() || !self.custom_types.is_empty()
     }
 
     pub fn has_async(&self) -> bool {
-        self.functions.iter().any(|f| f.is_async)
-            || self
-                .classes
-                .iter()
-                .any(|c| c.methods.iter().any(|m| m.is_async))
+        self.functions.iter().any(|f| f.is_async) || self.classes.iter().any(|c| c.methods.iter().any(|m| m.is_async)) || self.has_async_iterators()
+    }
+
+    pub fn has_async_iterators(&self) -> bool {
+        self.classes.iter().any(|c| !c.async_iterators.is_empty())
     }
 
     pub fn has_streams(&self) -> bool {
@@ -134,19 +124,13 @@ impl Module {
     }
 
     pub fn is_data_enum(&self, name: &str) -> bool {
-        self.enums
-            .iter()
-            .find(|e| e.name == name)
-            .is_some_and(|e| e.is_data_enum())
+        self.enums.iter().find(|e| e.name == name).is_some_and(|e| e.is_data_enum())
     }
 
     pub fn collect_derived_types(&mut self) {
         let mut collector = DerivedTypeCollector::new();
 
-        self.records
-            .iter()
-            .flat_map(|r| r.fields.iter().map(|f| &f.field_type))
-            .for_each(|ty| collector.visit(ty));
+        self.records.iter().flat_map(|r| r.fields.iter().map(|f| &f.field_type)).for_each(|ty| collector.visit(ty));
 
         self.enums
             .iter()
@@ -155,25 +139,16 @@ impl Module {
             .for_each(|ty| collector.visit(ty));
 
         self.functions.iter().for_each(|f| {
-            f.inputs
-                .iter()
-                .map(|p| &p.param_type)
-                .for_each(|ty| collector.visit(ty));
+            f.inputs.iter().map(|p| &p.param_type).for_each(|ty| collector.visit(ty));
             collector.visit_return_type(&f.returns);
         });
 
         self.classes.iter().for_each(|c| {
             c.constructors.iter().for_each(|ctor| {
-                ctor.inputs
-                    .iter()
-                    .map(|p| &p.param_type)
-                    .for_each(|ty| collector.visit(ty));
+                ctor.inputs.iter().map(|p| &p.param_type).for_each(|ty| collector.visit(ty));
             });
             c.methods.iter().for_each(|m| {
-                m.inputs
-                    .iter()
-                    .map(|p| &p.param_type)
-                    .for_each(|ty| collector.visit(ty));
+                m.inputs.iter().map(|p| &p.param_type).for_each(|ty| collector.visit(ty));
                 collector.visit_return_type(&m.returns);
             });
             c.streams.iter().for_each(|s| collector.visit(&s.item_type));
@@ -181,18 +156,12 @@ impl Module {
 
         self.callback_traits.iter().for_each(|cb| {
             cb.methods.iter().for_each(|m| {
-                m.inputs
-                    .iter()
-                    .map(|p| &p.param_type)
-                    .for_each(|ty| collector.visit(ty));
+                m.inputs.iter().map(|p| &p.param_type).for_each(|ty| collector.visit(ty));
                 collector.visit_return_type(&m.returns);
             });
         });
 
-        self.custom_types
-            .iter()
-            .map(|ct| &ct.repr)
-            .for_each(|ty| collector.visit(ty));
+        self.custom_types.iter().map(|ct| &ct.repr).for_each(|ty| collector.visit(ty));
 
         self.used_builtins = collector.builtins;
         self.closures = collector.closures;
@@ -233,14 +202,7 @@ impl DerivedTypeCollector {
             Type::Custom { repr, .. } => {
                 self.visit(repr);
             }
-            Type::Primitive(_)
-            | Type::String
-            | Type::Bytes
-            | Type::Record(_)
-            | Type::Enum(_)
-            | Type::Object(_)
-            | Type::BoxedTrait(_)
-            | Type::Void => {}
+            Type::Primitive(_) | Type::String | Type::Bytes | Type::Record(_) | Type::Enum(_) | Type::Object(_) | Type::BoxedTrait(_) | Type::Void => {}
         }
     }
 

--- a/boltffi_bindgen/src/model/option_info.rs
+++ b/boltffi_bindgen/src/model/option_info.rs
@@ -50,11 +50,7 @@ impl OptionInfo {
     }
 
     pub fn effective_inner(&self) -> &Type {
-        if self.is_vec {
-            self.inner.vec_inner().unwrap_or(&self.inner)
-        } else {
-            &self.inner
-        }
+        if self.is_vec { self.inner.vec_inner().unwrap_or(&self.inner) } else { &self.inner }
     }
 
     pub fn inner_name(&self) -> Option<&str> {
@@ -62,14 +58,10 @@ impl OptionInfo {
     }
 
     pub fn struct_size(&self, module: &Module) -> usize {
-        self.inner_name()
-            .map(|name| module.struct_size(name))
-            .unwrap_or(0)
+        self.inner_name().map(|name| module.struct_size(name)).unwrap_or(0)
     }
 
     pub fn is_data_enum(&self, module: &Module) -> bool {
-        self.inner_name()
-            .map(|name| module.is_data_enum(name))
-            .unwrap_or(false)
+        self.inner_name().map(|name| module.is_data_enum(name)).unwrap_or(false)
     }
 }

--- a/boltffi_bindgen/src/model/record.rs
+++ b/boltffi_bindgen/src/model/record.rs
@@ -1,7 +1,8 @@
+use super::{
+    layout::{CLayout, Size, StructLayout},
+    types::{Deprecation, Type},
+};
 use serde::{Deserialize, Serialize};
-
-use super::layout::{CLayout, Size, StructLayout};
-use super::types::{Deprecation, Type};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Record {
@@ -52,9 +53,7 @@ impl Record {
     }
 
     pub fn is_blittable(&self) -> bool {
-        self.fields
-            .iter()
-            .all(|field| field.field_type.is_primitive())
+        self.fields.iter().all(|field| field.field_type.is_primitive())
     }
 
     pub fn layout(&self) -> StructLayout {
@@ -66,10 +65,7 @@ impl Record {
     }
 
     pub fn field_offsets(&self) -> Vec<usize> {
-        self.layout()
-            .offsets()
-            .map(|offset| offset.as_usize())
-            .collect()
+        self.layout().offsets().map(|offset| offset.as_usize()).collect()
     }
 }
 

--- a/boltffi_bindgen/src/model/stream.rs
+++ b/boltffi_bindgen/src/model/stream.rs
@@ -1,6 +1,29 @@
+use super::types::{Deprecation, Type};
 use serde::{Deserialize, Serialize};
 
-use super::types::{Deprecation, Type};
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AsyncIteratorMethod {
+    pub name: String,
+    pub item_type: Type,
+    pub doc: Option<String>,
+    pub deprecated: Option<Deprecation>,
+}
+
+impl AsyncIteratorMethod {
+    pub fn new(name: impl Into<String>, item_type: Type) -> Self {
+        Self {
+            name: name.into(),
+            item_type,
+            doc: None,
+            deprecated: None,
+        }
+    }
+
+    pub fn maybe_doc(mut self, doc: Option<String>) -> Self {
+        self.doc = doc;
+        self
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum StreamMode {

--- a/boltffi_bindgen/src/model/types.rs
+++ b/boltffi_bindgen/src/model/types.rs
@@ -13,11 +13,7 @@ pub enum ReturnType {
 
 impl ReturnType {
     pub fn value(ty: Type) -> Self {
-        if ty.is_void() {
-            Self::Void
-        } else {
-            Self::Value(ty)
-        }
+        if ty.is_void() { Self::Void } else { Self::Value(ty) }
     }
 
     pub fn fallible(ok: Type, err: Type) -> Self {
@@ -26,10 +22,7 @@ impl ReturnType {
 
     pub fn from_output(ty: Type) -> Self {
         match ty.result_types() {
-            Some((ok, err)) => Self::Fallible {
-                ok: ok.clone(),
-                err: err.clone(),
-            },
+            Some((ok, err)) => Self::Fallible { ok: ok.clone(), err: err.clone() },
             None => Self::value(ty),
         }
     }
@@ -177,31 +170,15 @@ impl Primitive {
     }
 
     pub fn is_signed(self) -> bool {
-        matches!(
-            self,
-            Self::I8 | Self::I16 | Self::I32 | Self::I64 | Self::Isize
-        )
+        matches!(self, Self::I8 | Self::I16 | Self::I32 | Self::I64 | Self::Isize)
     }
 
     pub fn is_unsigned(self) -> bool {
-        matches!(
-            self,
-            Self::U8 | Self::U16 | Self::U32 | Self::U64 | Self::Usize
-        )
+        matches!(self, Self::U8 | Self::U16 | Self::U32 | Self::U64 | Self::Usize)
     }
 
     pub fn fits_in_32_bits(self) -> bool {
-        matches!(
-            self,
-            Self::Bool
-                | Self::I8
-                | Self::U8
-                | Self::I16
-                | Self::U16
-                | Self::I32
-                | Self::U32
-                | Self::F32
-        )
+        matches!(self, Self::Bool | Self::I8 | Self::U8 | Self::I16 | Self::U16 | Self::I32 | Self::U32 | Self::F32)
     }
 
     pub fn size_bytes(self) -> usize {
@@ -271,19 +248,10 @@ impl ClosureSignature {
     }
 
     pub fn signature_id(&self) -> String {
-        let params_id = self
-            .params
-            .iter()
-            .map(|p| p.type_id())
-            .collect::<Vec<_>>()
-            .join("_");
+        let params_id = self.params.iter().map(|p| p.type_id()).collect::<Vec<_>>().join("_");
         let ret_id = self.returns.type_id();
         if self.is_void_return() {
-            if params_id.is_empty() {
-                "Void".to_string()
-            } else {
-                params_id
-            }
+            if params_id.is_empty() { "Void".to_string() } else { params_id }
         } else if params_id.is_empty() {
             format!("To{}", ret_id)
         } else {
@@ -328,9 +296,7 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
 impl BuiltinId {
     pub fn from_rust_path(path: &str) -> Option<Self> {
         let trimmed = path.trim();
-        BUILTIN_SPECS
-            .iter()
-            .find_map(|spec| spec.rust_paths.contains(&trimmed).then_some(spec.id))
+        BUILTIN_SPECS.iter().find_map(|spec| spec.rust_paths.contains(&trimmed).then_some(spec.id))
     }
 
     pub fn type_id(self) -> &'static str {
@@ -405,10 +371,7 @@ impl Type {
 
     pub fn named_type(&self) -> Option<&str> {
         match self {
-            Self::Custom { name, .. }
-            | Self::Object(name)
-            | Self::Record(name)
-            | Self::Enum(name) => Some(name),
+            Self::Custom { name, .. } | Self::Object(name) | Self::Record(name) | Self::Enum(name) => Some(name),
             _ => None,
         }
     }
@@ -507,19 +470,12 @@ impl CLayout for Type {
     fn c_layout(&self) -> Layout {
         match self {
             Self::Primitive(primitive) => primitive.c_layout(),
-            Self::String | Self::Bytes | Self::Vec(_) | Self::Slice(_) | Self::MutSlice(_) => {
-                Layout::new(24, 8)
-            }
+            Self::String | Self::Bytes | Self::Vec(_) | Self::Slice(_) | Self::MutSlice(_) => Layout::new(24, 8),
             Self::Object(_) | Self::BoxedTrait(_) | Self::Closure(_) => Layout::new(8, 8),
-            Self::Builtin(_) | Self::Record(_) | Self::Enum(_) | Self::Custom { .. } => {
-                Layout::new(8, 8)
-            }
+            Self::Builtin(_) | Self::Record(_) | Self::Enum(_) | Self::Custom { .. } => Layout::new(8, 8),
             Self::Option(inner) => {
                 let inner_layout = inner.c_layout();
-                Layout::new(
-                    inner_layout.size.as_usize() + inner_layout.alignment.as_usize(),
-                    inner_layout.alignment.as_usize(),
-                )
+                Layout::new(inner_layout.size.as_usize() + inner_layout.alignment.as_usize(), inner_layout.alignment.as_usize())
             }
             Self::Result { ok, .. } => ok.c_layout(),
             Self::Void => Layout::new(0, 1),

--- a/boltffi_bindgen/src/render/swift/lower.rs
+++ b/boltffi_bindgen/src/render/swift/lower.rs
@@ -1,38 +1,30 @@
-use boltffi_ffi_rules::naming::{
-    self, snake_to_camel as camel_case, to_upper_camel_case as pascal_case,
+use super::{
+    emit,
+    plan::{
+        SwiftAsyncConversion, SwiftAsyncIterator, SwiftAsyncResult, SwiftCallMode, SwiftCallback, SwiftCallbackMethod, SwiftCallbackParam, SwiftClass, SwiftClosureTrampoline,
+        SwiftClosureTrampolineParam, SwiftConstructor, SwiftConversion, SwiftCustomType, SwiftEnum, SwiftEnumStyle, SwiftField, SwiftFunction, SwiftMethod, SwiftModule,
+        SwiftNativeConversion, SwiftNativeMapping, SwiftParam, SwiftRecord, SwiftReturn, SwiftStream, SwiftStreamMode, SwiftVariant, SwiftVariantPayload,
+    },
 };
+use crate::{
+    ir::{
+        FastOutputBinding, InputBinding, OutputBinding,
+        abi::{
+            AbiAsyncIterator, AbiCall, AbiCallbackInvocation, AbiContract, AbiEnum, AbiEnumField, AbiEnumPayload, AbiEnumVariant, AbiParam, AbiRecord, AbiStream, CallId, CallMode,
+            ErrorTransport, OutputShape, StreamItemTransport,
+        },
+        contract::FfiContract,
+        definitions::{AsyncIteratorDef, CallbackKind, ConstructorDef, DefaultValue, ParamDef, Receiver, ReturnDef, StreamDef, StreamMode},
+        ids::{CallbackId, ClassId, EnumId, FieldName, ParamName, RecordId},
+        ops::{FieldReadOp, OffsetExpr, ReadOp, ReadSeq, SizeExpr, ValueExpr, WireShape, WriteOp, WriteSeq, remap_root_in_seq},
+        plan::{AbiType, CallbackStyle, Mutability},
+        types::{PrimitiveType, TypeExpr},
+    },
+    render::{TypeConversion, TypeMappings},
+};
+use boltffi_ffi_rules::naming::{self, snake_to_camel as camel_case, to_upper_camel_case as pascal_case};
 use heck::ToLowerCamelCase;
-
 use std::collections::HashMap;
-
-use super::emit;
-use super::plan::{
-    SwiftAsyncConversion, SwiftAsyncResult, SwiftCallMode, SwiftCallback, SwiftCallbackMethod,
-    SwiftCallbackParam, SwiftClass, SwiftClosureTrampoline, SwiftClosureTrampolineParam,
-    SwiftConstructor, SwiftConversion, SwiftCustomType, SwiftEnum, SwiftEnumStyle, SwiftField,
-    SwiftFunction, SwiftMethod, SwiftModule, SwiftNativeConversion, SwiftNativeMapping, SwiftParam,
-    SwiftRecord, SwiftReturn, SwiftStream, SwiftStreamMode, SwiftVariant, SwiftVariantPayload,
-};
-use crate::ir::abi::{
-    AbiCall, AbiCallbackInvocation, AbiContract, AbiEnum, AbiEnumField, AbiEnumPayload,
-    AbiEnumVariant, AbiParam, AbiRecord, AbiStream, CallId, CallMode, ErrorTransport, OutputShape,
-    StreamItemTransport,
-};
-use crate::ir::contract::FfiContract;
-use crate::ir::definitions::{
-    CallbackKind, ConstructorDef, DefaultValue, ParamDef, Receiver, ReturnDef, StreamDef,
-    StreamMode,
-};
-use crate::ir::ids::{CallbackId, ClassId, EnumId, FieldName, ParamName, RecordId};
-use crate::ir::ops::{
-    FieldReadOp, OffsetExpr, ReadOp, ReadSeq, SizeExpr, ValueExpr, WireShape, WriteOp, WriteSeq,
-    remap_root_in_seq,
-};
-use crate::ir::plan::AbiType;
-use crate::ir::plan::{CallbackStyle, Mutability};
-use crate::ir::types::{PrimitiveType, TypeExpr};
-use crate::ir::{FastOutputBinding, InputBinding, OutputBinding};
-use crate::render::{TypeConversion, TypeMappings};
 
 struct AbiIndex {
     calls: HashMap<CallId, usize>,
@@ -43,37 +35,17 @@ struct AbiIndex {
 
 impl AbiIndex {
     fn new(contract: &AbiContract) -> Self {
-        let calls = contract
-            .calls
-            .iter()
-            .enumerate()
-            .map(|(index, call)| (call.id.clone(), index))
-            .collect();
+        let calls = contract.calls.iter().enumerate().map(|(index, call)| (call.id.clone(), index)).collect();
         let callbacks = contract
             .callbacks
             .iter()
             .enumerate()
             .map(|(index, callback)| (callback.callback_id.clone(), index))
             .collect();
-        let records = contract
-            .records
-            .iter()
-            .enumerate()
-            .map(|(index, record)| (record.id.clone(), index))
-            .collect();
-        let enums = contract
-            .enums
-            .iter()
-            .enumerate()
-            .map(|(index, enumeration)| (enumeration.id.clone(), index))
-            .collect();
+        let records = contract.records.iter().enumerate().map(|(index, record)| (record.id.clone(), index)).collect();
+        let enums = contract.enums.iter().enumerate().map(|(index, enumeration)| (enumeration.id.clone(), index)).collect();
 
-        Self {
-            calls,
-            callbacks,
-            records,
-            enums,
-        }
+        Self { calls, callbacks, records, enums }
     }
 
     fn call<'a>(&self, contract: &'a AbiContract, id: &CallId) -> &'a AbiCall {
@@ -81,11 +53,7 @@ impl AbiIndex {
         &contract.calls[*index]
     }
 
-    fn callback<'a>(
-        &self,
-        contract: &'a AbiContract,
-        id: &CallbackId,
-    ) -> &'a AbiCallbackInvocation {
+    fn callback<'a>(&self, contract: &'a AbiContract, id: &CallbackId) -> &'a AbiCallbackInvocation {
         let index = self.callbacks.get(id).expect("abi callback should exist");
         &contract.callbacks[*index]
     }
@@ -158,11 +126,7 @@ impl<'a> SwiftLowerer<'a> {
             TypeExpr::Option(inner) => format!("{}?", self.resolve_swift_type(inner)),
             TypeExpr::Vec(inner) => format!("[{}]", self.resolve_swift_type(inner)),
             TypeExpr::Result { ok, err } => {
-                format!(
-                    "Result<{}, {}>",
-                    self.resolve_swift_type(ok),
-                    self.resolve_swift_type(err)
-                )
+                format!("Result<{}, {}>", self.resolve_swift_type(ok), self.resolve_swift_type(err))
             }
             _ => emit::swift_type(type_expr),
         }
@@ -181,10 +145,7 @@ impl<'a> SwiftLowerer<'a> {
             .map(|def| {
                 let alias_name = pascal_case(def.id.as_str());
                 let target_type = emit::swift_type(&def.repr);
-                let native_mapping = self
-                    .type_mappings
-                    .get(def.id.as_str())
-                    .map(|mapping| self.build_native_mapping(mapping, &target_type));
+                let native_mapping = self.type_mappings.get(def.id.as_str()).map(|mapping| self.build_native_mapping(mapping, &target_type));
                 SwiftCustomType {
                     alias_name,
                     target_type,
@@ -194,20 +155,10 @@ impl<'a> SwiftLowerer<'a> {
             .collect()
     }
 
-    fn build_native_mapping(
-        &self,
-        mapping: &crate::render::TypeMapping,
-        _repr_type: &str,
-    ) -> SwiftNativeMapping {
+    fn build_native_mapping(&self, mapping: &crate::render::TypeMapping, _repr_type: &str) -> SwiftNativeMapping {
         let (decode_expr, encode_expr) = match mapping.conversion {
-            TypeConversion::UuidString => (
-                "UUID(uuidString: $0)!".to_string(),
-                "$0.uuidString".to_string(),
-            ),
-            TypeConversion::UrlString => (
-                "URL(string: $0)!".to_string(),
-                "$0.absoluteString".to_string(),
-            ),
+            TypeConversion::UuidString => ("UUID(uuidString: $0)!".to_string(), "$0.uuidString".to_string()),
+            TypeConversion::UrlString => ("URL(string: $0)!".to_string(), "$0.absoluteString".to_string()),
         };
 
         SwiftNativeMapping {
@@ -221,19 +172,10 @@ impl<'a> SwiftLowerer<'a> {
         match type_expr {
             TypeExpr::Custom(id) => self.type_mappings.get(id.as_str()).map(|mapping| {
                 let (decode_wrapper, encode_wrapper) = match mapping.conversion {
-                    TypeConversion::UuidString => (
-                        "UUID(uuidString: $0)!".to_string(),
-                        "$0.uuidString".to_string(),
-                    ),
-                    TypeConversion::UrlString => (
-                        "URL(string: $0)!".to_string(),
-                        "$0.absoluteString".to_string(),
-                    ),
+                    TypeConversion::UuidString => ("UUID(uuidString: $0)!".to_string(), "$0.uuidString".to_string()),
+                    TypeConversion::UrlString => ("URL(string: $0)!".to_string(), "$0.absoluteString".to_string()),
                 };
-                SwiftNativeConversion {
-                    decode_wrapper,
-                    encode_wrapper,
-                }
+                SwiftNativeConversion { decode_wrapper, encode_wrapper }
             }),
             _ => None,
         }
@@ -253,48 +195,39 @@ impl<'a> SwiftLowerer<'a> {
                 let abi_record = self.abi_index.record(self.abi, &def.id);
                 let decode_fields = self.record_decode_fields(abi_record);
                 let encode_fields = self.record_encode_fields(abi_record);
-                let fields =
-                    def.fields
-                        .iter()
-                        .map(|field| {
-                            let swift_name = camel_case(field.name.as_str());
-                            let decode =
-                                decode_fields.get(&field.name).cloned().unwrap_or_else(|| {
-                                    ReadSeq {
-                                        size: SizeExpr::Fixed(0),
-                                        ops: vec![],
-                                        shape: WireShape::Value,
-                                    }
-                                });
-                            let encode =
-                                encode_fields.get(&field.name).cloned().unwrap_or_else(|| {
-                                    WriteSeq {
-                                        size: SizeExpr::Fixed(0),
-                                        ops: vec![],
-                                        shape: WireShape::Value,
-                                    }
-                                });
-                            let c_offset = if abi_record.is_blittable {
-                                decode_fields
-                                    .get(&field.name)
-                                    .and_then(|seq| self.record_field_offset(seq))
-                            } else {
-                                None
-                            };
-                            let native_conversion =
-                                self.native_conversion_for_type(&field.type_expr);
-                            SwiftField {
-                                swift_name,
-                                swift_type: self.swift_type(&field.type_expr),
-                                default_expr: field.default.as_ref().map(swift_default_literal),
-                                decode,
-                                encode,
-                                doc: field.doc.clone(),
-                                c_offset,
-                                native_conversion,
-                            }
-                        })
-                        .collect();
+                let fields = def
+                    .fields
+                    .iter()
+                    .map(|field| {
+                        let swift_name = camel_case(field.name.as_str());
+                        let decode = decode_fields.get(&field.name).cloned().unwrap_or_else(|| ReadSeq {
+                            size: SizeExpr::Fixed(0),
+                            ops: vec![],
+                            shape: WireShape::Value,
+                        });
+                        let encode = encode_fields.get(&field.name).cloned().unwrap_or_else(|| WriteSeq {
+                            size: SizeExpr::Fixed(0),
+                            ops: vec![],
+                            shape: WireShape::Value,
+                        });
+                        let c_offset = if abi_record.is_blittable {
+                            decode_fields.get(&field.name).and_then(|seq| self.record_field_offset(seq))
+                        } else {
+                            None
+                        };
+                        let native_conversion = self.native_conversion_for_type(&field.type_expr);
+                        SwiftField {
+                            swift_name,
+                            swift_type: self.swift_type(&field.type_expr),
+                            default_expr: field.default.as_ref().map(swift_default_literal),
+                            decode,
+                            encode,
+                            doc: field.doc.clone(),
+                            c_offset,
+                            native_conversion,
+                        }
+                    })
+                    .collect();
 
                 SwiftRecord {
                     class_name: self.swift_name_for_record(&def.id),
@@ -325,20 +258,14 @@ impl<'a> SwiftLowerer<'a> {
                     .iter()
                     .enumerate()
                     .map(|(i, variant)| SwiftVariant {
-                        swift_name: emit::escape_swift_keyword(
-                            &variant.name.as_str().to_lower_camel_case(),
-                        ),
+                        swift_name: emit::escape_swift_keyword(&variant.name.as_str().to_lower_camel_case()),
                         discriminant: variant.discriminant,
                         payload: self.lower_variant_payload(variant),
                         doc: variant_docs.get(i).cloned().flatten(),
                     })
                     .collect();
 
-                let style = if abi_enum.is_c_style {
-                    SwiftEnumStyle::CStyle
-                } else {
-                    SwiftEnumStyle::Data
-                };
+                let style = if abi_enum.is_c_style { SwiftEnumStyle::CStyle } else { SwiftEnumStyle::Data };
                 SwiftEnum {
                     name: self.swift_name_for_enum(&def.id),
                     variants,
@@ -361,8 +288,7 @@ impl<'a> SwiftLowerer<'a> {
                     .iter()
                     .map(|field| {
                         let lowered = self.lower_enum_field(field);
-                        let encode =
-                            remap_root_in_seq(&lowered.encode, ValueExpr::Var("value".into()));
+                        let encode = remap_root_in_seq(&lowered.encode, ValueExpr::Var("value".into()));
                         SwiftField { encode, ..lowered }
                     })
                     .collect(),
@@ -375,8 +301,7 @@ impl<'a> SwiftLowerer<'a> {
                     .map(|field| {
                         let lowered = self.lower_enum_field(field);
                         if lowered.swift_name.chars().all(|c| c.is_ascii_digit()) {
-                            let encode =
-                                remap_root_in_seq(&lowered.encode, ValueExpr::Var("value".into()));
+                            let encode = remap_root_in_seq(&lowered.encode, ValueExpr::Var("value".into()));
                             SwiftField { encode, ..lowered }
                         } else {
                             lowered
@@ -428,24 +353,13 @@ impl<'a> SwiftLowerer<'a> {
                         });
 
                         match ctor {
-                            ConstructorDef::Default {
-                                is_fallible, doc, ..
-                            } => SwiftConstructor::Designated {
+                            ConstructorDef::Default { is_fallible, doc, .. } => SwiftConstructor::Designated {
                                 ffi_symbol: call.symbol.as_str().to_string(),
-                                params: ctor
-                                    .params()
-                                    .into_iter()
-                                    .map(|p| self.lower_param(p, call))
-                                    .collect(),
+                                params: ctor.params().into_iter().map(|p| self.lower_param(p, call)).collect(),
                                 is_fallible: *is_fallible,
                                 doc: doc.clone(),
                             },
-                            ConstructorDef::NamedFactory {
-                                name,
-                                is_fallible,
-                                doc,
-                                ..
-                            } => SwiftConstructor::Factory {
+                            ConstructorDef::NamedFactory { name, is_fallible, doc, .. } => SwiftConstructor::Factory {
                                 name: camel_case(name.as_str()),
                                 ffi_symbol: call.symbol.as_str().to_string(),
                                 is_fallible: *is_fallible,
@@ -475,41 +389,32 @@ impl<'a> SwiftLowerer<'a> {
                     })
                     .collect();
 
-                let methods =
-                    def.methods
-                        .iter()
-                        .map(|method| {
-                            let call = self.abi_call(&CallId::Method {
-                                class_id: def.id.clone(),
-                                method_id: method.id.clone(),
-                            });
-                            let mode = self.lower_call_mode(call, &method.returns);
-                            // we get the actual value back through poll/complete for async
-                            // so all we set up here is the error wrapping
-                            let returns = match &call.mode {
-                                CallMode::Async(async_call) => self
-                                    .lower_return_def_for_async(&async_call.error, &method.returns),
-                                CallMode::Sync => self.swift_return_from_abi(
-                                    &call.output_shape,
-                                    &call.error,
-                                    &method.returns,
-                                ),
-                            };
+                let methods = def
+                    .methods
+                    .iter()
+                    .map(|method| {
+                        let call = self.abi_call(&CallId::Method {
+                            class_id: def.id.clone(),
+                            method_id: method.id.clone(),
+                        });
+                        let mode = self.lower_call_mode(call, &method.returns);
+                        // we get the actual value back through poll/complete for async
+                        // so all we set up here is the error wrapping
+                        let returns = match &call.mode {
+                            CallMode::Async(async_call) => self.lower_return_def_for_async(&async_call.error, &method.returns),
+                            CallMode::Sync => self.swift_return_from_abi(&call.output_shape, &call.error, &method.returns),
+                        };
 
-                            SwiftMethod {
-                                name: camel_case(method.id.as_str()),
-                                mode,
-                                params: method
-                                    .params
-                                    .iter()
-                                    .map(|p| self.lower_param(p, call))
-                                    .collect(),
-                                returns,
-                                is_static: method.receiver == Receiver::Static,
-                                doc: method.doc.clone(),
-                            }
-                        })
-                        .collect();
+                        SwiftMethod {
+                            name: camel_case(method.id.as_str()),
+                            mode,
+                            params: method.params.iter().map(|p| self.lower_param(p, call)).collect(),
+                            returns,
+                            is_static: method.receiver == Receiver::Static,
+                            doc: method.doc.clone(),
+                        }
+                    })
+                    .collect();
 
                 let streams = def
                     .streams
@@ -519,11 +424,23 @@ impl<'a> SwiftLowerer<'a> {
                             .abi
                             .streams
                             .iter()
-                            .find(|stream| {
-                                stream.class_id == def.id && stream.stream_id == stream_def.id
-                            })
+                            .find(|stream| stream.class_id == def.id && stream.stream_id == stream_def.id)
                             .expect("abi stream");
                         self.lower_stream(stream_def, abi_stream, &class_name)
+                    })
+                    .collect();
+
+                let async_iterators = def
+                    .async_iterators
+                    .iter()
+                    .map(|iter_def| {
+                        let abi_iter = self
+                            .abi
+                            .async_iterators
+                            .iter()
+                            .find(|ai| ai.class_id == def.id && ai.iterator_id == iter_def.id)
+                            .expect("abi async iterator");
+                        self.lower_async_iterator(iter_def, abi_iter)
                     })
                     .collect();
 
@@ -533,18 +450,14 @@ impl<'a> SwiftLowerer<'a> {
                     constructors,
                     methods,
                     streams,
+                    async_iterators,
                     doc: def.doc.clone(),
                 }
             })
             .collect()
     }
 
-    fn lower_stream(
-        &self,
-        stream_def: &StreamDef,
-        stream: &AbiStream,
-        class_name: &str,
-    ) -> SwiftStream {
+    fn lower_stream(&self, stream_def: &StreamDef, stream: &AbiStream, class_name: &str) -> SwiftStream {
         let StreamItemTransport::WireEncoded { decode_ops } = &stream.item;
         let method_name_pascal = pascal_case(stream.stream_id.as_str());
 
@@ -577,6 +490,23 @@ impl<'a> SwiftLowerer<'a> {
             atomic_cas: self.abi.atomic_cas.to_string(),
         }
     }
+
+    fn lower_async_iterator(&self, iter_def: &AsyncIteratorDef, iter: &AbiAsyncIterator) -> SwiftAsyncIterator {
+        let StreamItemTransport::WireEncoded { decode_ops } = &iter.item;
+
+        SwiftAsyncIterator {
+            name: camel_case(iter.iterator_id.as_str()),
+            item_type: self.swift_type(&iter_def.item_type),
+            item_decode: self.rebase_read_seq(decode_ops, "pos", "0"),
+            entry: iter.entry.to_string(),
+            next: iter.next.to_string(),
+            next_poll: iter.next_poll.to_string(),
+            next_complete: iter.next_complete.to_string(),
+            next_cancel: iter.next_cancel.to_string(),
+            next_free: iter.next_free.to_string(),
+            free: iter.free.to_string(),
+        }
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -598,39 +528,19 @@ impl<'a> SwiftLowerer<'a> {
                     .methods
                     .iter()
                     .map(|method_def| {
-                        let abi_method = plan
-                            .methods
-                            .iter()
-                            .find(|m| m.id == method_def.id)
-                            .expect("callback method");
+                        let abi_method = plan.methods.iter().find(|m| m.id == method_def.id).expect("callback method");
                         // IR generates encode ops with self as root but we capture the
                         // callback return as result in the template so we need to rewrite
                         // the root before handing it off
-                        let returns = self.rebase_return_encode(
-                            self.swift_return_from_abi(
-                                &abi_method.output_shape,
-                                &abi_method.error,
-                                &method_def.returns,
-                            ),
-                            "result",
-                        );
+                        let returns = self.rebase_return_encode(self.swift_return_from_abi(&abi_method.output_shape, &abi_method.error, &method_def.returns), "result");
                         let has_out_param = !abi_method.is_async && !returns.is_void();
-                        let param_map = method_def
-                            .params
-                            .iter()
-                            .map(|param| (param.name.clone(), param))
-                            .collect::<HashMap<_, _>>();
+                        let param_map = method_def.params.iter().map(|param| (param.name.clone(), param)).collect::<HashMap<_, _>>();
                         // abi has extra params like context pointers for vtable machinery
                         // we only care about the ones the user declared in their trait
                         let params = abi_method
                             .params
                             .iter()
-                            .filter(|param| {
-                                matches!(
-                                    param.input_binding(),
-                                    Some(InputBinding::Scalar | InputBinding::WirePacket { .. })
-                                )
-                            })
+                            .filter(|param| matches!(param.input_binding(), Some(InputBinding::Scalar | InputBinding::WirePacket { .. })))
                             .map(|param| {
                                 let def = param_map.get(&param.name).unwrap_or_else(|| {
                                     unreachable!(
@@ -675,9 +585,7 @@ impl<'a> SwiftLowerer<'a> {
     fn lower_callback_param(&self, def: &ParamDef, param: &AbiParam) -> SwiftCallbackParam {
         let label = camel_case(param.name.as_str());
         let (swift_type, ffi_args, decode_prelude) = match param.input_binding() {
-            Some(InputBinding::Scalar) => {
-                (self.swift_type(&def.type_expr), vec![label.clone()], None)
-            }
+            Some(InputBinding::Scalar) => (self.swift_type(&def.type_expr), vec![label.clone()], None),
             Some(InputBinding::WirePacket { decode_ops, .. }) => {
                 let len_name = format!("{}Len", label);
                 let reader_decode = emit::emit_reader_read(decode_ops);
@@ -690,10 +598,7 @@ impl<'a> SwiftLowerer<'a> {
                     )),
                 )
             }
-            _ => unreachable!(
-                "unsupported ABI param input shape for Swift callback: {:?}",
-                param.input_shape
-            ),
+            _ => unreachable!("unsupported ABI param input shape for Swift callback: {:?}", param.input_shape),
         };
 
         SwiftCallbackParam {
@@ -719,22 +624,14 @@ impl<'a> SwiftLowerer<'a> {
                 let call = self.abi_call(&CallId::Function(def.id.clone()));
                 let mode = self.lower_call_mode(call, &def.returns);
                 let returns = match &call.mode {
-                    CallMode::Async(async_call) => {
-                        self.lower_return_def_for_async(&async_call.error, &def.returns)
-                    }
-                    CallMode::Sync => {
-                        self.swift_return_from_abi(&call.output_shape, &call.error, &def.returns)
-                    }
+                    CallMode::Async(async_call) => self.lower_return_def_for_async(&async_call.error, &def.returns),
+                    CallMode::Sync => self.swift_return_from_abi(&call.output_shape, &call.error, &def.returns),
                 };
 
                 SwiftFunction {
                     name: camel_case(def.id.as_str()),
                     mode,
-                    params: def
-                        .params
-                        .iter()
-                        .map(|p| self.lower_param(p, call))
-                        .collect(),
+                    params: def.params.iter().map(|p| self.lower_param(p, call)).collect(),
                     returns,
                     doc: def.doc.clone(),
                 }
@@ -752,14 +649,9 @@ impl<'a> SwiftLowerer<'a> {
         let abi_param = self.abi_param_for_semantic(call, &param.name);
         let swift_name = camel_case(param.name.as_str());
 
-        let (swift_type, conversion) = match abi_param.input_binding().expect("semantic param role")
-        {
+        let (swift_type, conversion) = match abi_param.input_binding().expect("semantic param role") {
             InputBinding::Scalar => (self.swift_type(&param.type_expr), SwiftConversion::Direct),
-            InputBinding::PrimitiveSlice {
-                element_abi,
-                mutability,
-                ..
-            } => {
+            InputBinding::PrimitiveSlice { element_abi, mutability, .. } => {
                 let element_type = self.abi_to_swift(element_abi);
                 if element_abi == AbiType::U8 && mutability == Mutability::Shared {
                     ("Data".to_string(), SwiftConversion::ToData)
@@ -776,53 +668,22 @@ impl<'a> SwiftLowerer<'a> {
                 }
             }
             InputBinding::Utf8Slice { .. } => ("String".to_string(), SwiftConversion::ToString),
-            InputBinding::WirePacket { encode_ops, .. } => (
-                self.swift_type(&param.type_expr),
-                SwiftConversion::ToWireBuffer {
-                    encode: encode_ops.clone(),
-                },
-            ),
+            InputBinding::WirePacket { encode_ops, .. } => (self.swift_type(&param.type_expr), SwiftConversion::ToWireBuffer { encode: encode_ops.clone() }),
             InputBinding::Handle { class_id, nullable } => {
                 let class_name = self.swift_name_for_class(class_id);
-                let swift_type = if nullable {
-                    format!("{}?", class_name)
-                } else {
-                    class_name.clone()
-                };
-                (
-                    swift_type,
-                    SwiftConversion::PassHandle {
-                        class_name,
-                        nullable,
-                    },
-                )
+                let swift_type = if nullable { format!("{}?", class_name) } else { class_name.clone() };
+                (swift_type, SwiftConversion::PassHandle { class_name, nullable })
             }
-            InputBinding::CallbackHandle {
-                callback_id,
-                nullable,
-                style,
-            } => match style {
+            InputBinding::CallbackHandle { callback_id, nullable, style } => match style {
                 CallbackStyle::BoxedDyn => {
                     let protocol = pascal_case(callback_id.as_str());
-                    let swift_type = if nullable {
-                        format!("(any {})?", protocol)
-                    } else {
-                        format!("any {}", protocol)
-                    };
-                    (
-                        swift_type,
-                        SwiftConversion::WrapCallback { protocol, nullable },
-                    )
+                    let swift_type = if nullable { format!("(any {})?", protocol) } else { format!("any {}", protocol) };
+                    (swift_type, SwiftConversion::WrapCallback { protocol, nullable })
                 }
                 CallbackStyle::ImplTrait => {
                     let closure_plan = self.build_closure_trampoline(callback_id, &swift_name);
                     let swift_type = format!("@escaping {}", closure_plan.swift_type);
-                    (
-                        swift_type,
-                        SwiftConversion::InlineClosure {
-                            closure: closure_plan,
-                        },
-                    )
+                    (swift_type, SwiftConversion::InlineClosure { closure: closure_plan })
                 }
             },
             InputBinding::OutputBuffer { .. } => {
@@ -857,37 +718,16 @@ impl<'a> SwiftLowerer<'a> {
 // ─────────────────────────────────────────────────────────────────────────────
 
 impl<'a> SwiftLowerer<'a> {
-    fn swift_return_from_abi(
-        &self,
-        output_shape: &OutputShape,
-        error: &ErrorTransport,
-        returns: &ReturnDef,
-    ) -> SwiftReturn {
+    fn swift_return_from_abi(&self, output_shape: &OutputShape, error: &ErrorTransport, returns: &ReturnDef) -> SwiftReturn {
         let base = match output_shape.output_binding() {
             OutputBinding::Unit => SwiftReturn::Void,
             OutputBinding::Fast(FastOutputBinding::Scalar { abi_type }) => SwiftReturn::Direct {
                 swift_type: self.abi_to_swift(abi_type),
             },
-            OutputBinding::Fast(FastOutputBinding::OptionScalar {
-                decode_ops,
-                encode_ops,
-                ..
-            })
-            | OutputBinding::Fast(FastOutputBinding::ResultScalar {
-                decode_ops,
-                encode_ops,
-                ..
-            })
-            | OutputBinding::Fast(FastOutputBinding::PrimitiveVec {
-                decode_ops,
-                encode_ops,
-                ..
-            })
-            | OutputBinding::Fast(FastOutputBinding::BlittableRecord {
-                decode_ops,
-                encode_ops,
-                ..
-            }) => SwiftReturn::FromWireBuffer {
+            OutputBinding::Fast(FastOutputBinding::OptionScalar { decode_ops, encode_ops, .. })
+            | OutputBinding::Fast(FastOutputBinding::ResultScalar { decode_ops, encode_ops, .. })
+            | OutputBinding::Fast(FastOutputBinding::PrimitiveVec { decode_ops, encode_ops, .. })
+            | OutputBinding::Fast(FastOutputBinding::BlittableRecord { decode_ops, encode_ops, .. }) => SwiftReturn::FromWireBuffer {
                 swift_type: self.swift_return_value_type(returns),
                 decode: decode_ops.clone(),
                 encode: encode_ops.clone(),
@@ -899,31 +739,18 @@ impl<'a> SwiftLowerer<'a> {
             },
             OutputBinding::Handle { class_id, nullable } => {
                 let class_name = self.swift_name_for_class(class_id);
-                SwiftReturn::Handle {
-                    class_name,
-                    nullable,
-                }
+                SwiftReturn::Handle { class_name, nullable }
             }
-            OutputBinding::CallbackHandle {
-                callback_id,
-                nullable,
-            } => {
+            OutputBinding::CallbackHandle { callback_id, nullable } => {
                 let protocol = pascal_case(callback_id.as_str());
-                let swift_type = if nullable {
-                    format!("(any {})?", protocol)
-                } else {
-                    format!("any {}", protocol)
-                };
+                let swift_type = if nullable { format!("(any {})?", protocol) } else { format!("any {}", protocol) };
                 SwiftReturn::Direct { swift_type }
             }
         };
 
         match error {
             ErrorTransport::None => base,
-            ErrorTransport::Encoded {
-                decode_ops,
-                encode_ops,
-            } => SwiftReturn::Throws {
+            ErrorTransport::Encoded { decode_ops, encode_ops } => SwiftReturn::Throws {
                 ok: Box::new(base),
                 err_type: self.swift_error_type(returns),
                 err_decode: decode_ops.clone(),
@@ -1020,11 +847,7 @@ impl<'a> SwiftLowerer<'a> {
                 _ => None,
             })
             .into_iter()
-            .flat_map(|fields| {
-                fields
-                    .iter()
-                    .map(|field| (field.name.clone(), field.seq.clone()))
-            })
+            .flat_map(|fields| fields.iter().map(|field| (field.name.clone(), field.seq.clone())))
             .collect()
     }
 
@@ -1038,11 +861,7 @@ impl<'a> SwiftLowerer<'a> {
                 _ => None,
             })
             .into_iter()
-            .flat_map(|fields| {
-                fields
-                    .iter()
-                    .map(|field| (field.name.clone(), field.seq.clone()))
-            })
+            .flat_map(|fields| fields.iter().map(|field| (field.name.clone(), field.seq.clone())))
             .collect()
     }
 
@@ -1061,11 +880,7 @@ impl<'a> SwiftLowerer<'a> {
     fn rebase_read_seq(&self, seq: &ReadSeq, old_base: &str, new_base: &str) -> ReadSeq {
         ReadSeq {
             size: seq.size.clone(),
-            ops: seq
-                .ops
-                .iter()
-                .map(|op| self.rebase_read_op(op, old_base, new_base))
-                .collect(),
+            ops: seq.ops.iter().map(|op| self.rebase_read_op(op, old_base, new_base)).collect(),
             shape: seq.shape,
         }
     }
@@ -1104,10 +919,7 @@ impl<'a> SwiftLowerer<'a> {
                     .iter()
                     .map(|field| {
                         let seq = self.rebase_read_seq(&field.seq, old_base, new_base);
-                        FieldReadOp {
-                            name: field.name.clone(),
-                            seq,
-                        }
+                        FieldReadOp { name: field.name.clone(), seq }
                     })
                     .collect(),
             },
@@ -1116,11 +928,7 @@ impl<'a> SwiftLowerer<'a> {
                 offset: self.rebase_offset_expr(offset, old_base, new_base),
                 layout: layout.clone(),
             },
-            ReadOp::Result {
-                tag_offset,
-                ok,
-                err,
-            } => ReadOp::Result {
+            ReadOp::Result { tag_offset, ok, err } => ReadOp::Result {
                 tag_offset: self.rebase_offset_expr(tag_offset, old_base, new_base),
                 ok: Box::new(self.rebase_read_seq(ok, old_base, new_base)),
                 err: Box::new(self.rebase_read_seq(err, old_base, new_base)),
@@ -1136,12 +944,7 @@ impl<'a> SwiftLowerer<'a> {
         }
     }
 
-    fn rebase_offset_expr(
-        &self,
-        offset: &OffsetExpr,
-        old_base: &str,
-        new_base: &str,
-    ) -> OffsetExpr {
+    fn rebase_offset_expr(&self, offset: &OffsetExpr, old_base: &str, new_base: &str) -> OffsetExpr {
         match offset {
             OffsetExpr::Fixed(value) => OffsetExpr::Fixed(*value),
             OffsetExpr::Base => OffsetExpr::Base,
@@ -1165,11 +968,7 @@ impl<'a> SwiftLowerer<'a> {
 
     fn rebase_return_encode(&self, returns: SwiftReturn, new_base: &str) -> SwiftReturn {
         match returns {
-            SwiftReturn::FromWireBuffer {
-                swift_type,
-                decode,
-                encode,
-            } => SwiftReturn::FromWireBuffer {
+            SwiftReturn::FromWireBuffer { swift_type, decode, encode } => SwiftReturn::FromWireBuffer {
                 swift_type,
                 decode,
                 encode: remap_root_in_seq(&encode, ValueExpr::Var(new_base.to_string())),
@@ -1185,8 +984,7 @@ impl<'a> SwiftLowerer<'a> {
                 err_type,
                 err_decode,
                 err_is_string,
-                err_encode: err_encode
-                    .map(|seq| remap_root_in_seq(&seq, ValueExpr::Var("error".to_string()))),
+                err_encode: err_encode.map(|seq| remap_root_in_seq(&seq, ValueExpr::Var("error".to_string()))),
             },
             other => other,
         }
@@ -1200,29 +998,13 @@ impl<'a> SwiftLowerer<'a> {
         }
     }
 
-    fn build_closure_trampoline(
-        &self,
-        callback_id: &CallbackId,
-        param_name: &str,
-    ) -> SwiftClosureTrampoline {
-        let callback_def = self
-            .contract
-            .catalog
-            .resolve_callback(callback_id)
-            .expect("closure callback should exist");
+    fn build_closure_trampoline(&self, callback_id: &CallbackId, param_name: &str) -> SwiftClosureTrampoline {
+        let callback_def = self.contract.catalog.resolve_callback(callback_id).expect("closure callback should exist");
         let method = &callback_def.methods[0];
         let abi_callback = self.abi_index.callback(self.abi, callback_id);
-        let abi_method = abi_callback
-            .methods
-            .iter()
-            .find(|m| m.id == method.id)
-            .expect("closure callback method");
+        let abi_method = abi_callback.methods.iter().find(|m| m.id == method.id).expect("closure callback method");
 
-        let param_types: Vec<String> = method
-            .params
-            .iter()
-            .map(|p| self.swift_type(&p.type_expr))
-            .collect();
+        let param_types: Vec<String> = method.params.iter().map(|p| self.swift_type(&p.type_expr)).collect();
         let return_type = match &method.returns {
             ReturnDef::Void => "Void".to_string(),
             ReturnDef::Value(ty) => self.swift_type(ty),
@@ -1242,21 +1024,14 @@ impl<'a> SwiftLowerer<'a> {
         let abi_params: Vec<&AbiParam> = abi_method
             .params
             .iter()
-            .filter(|param| {
-                matches!(
-                    param.input_binding(),
-                    Some(InputBinding::Scalar | InputBinding::WirePacket { .. })
-                )
-            })
+            .filter(|param| matches!(param.input_binding(), Some(InputBinding::Scalar | InputBinding::WirePacket { .. })))
             .collect();
         let trampoline_params: Vec<SwiftClosureTrampolineParam> = method
             .params
             .iter()
             .zip(abi_params.iter())
             .enumerate()
-            .map(|(idx, (param_def, abi_param))| {
-                self.build_closure_trampoline_param(idx, param_def, abi_param)
-            })
+            .map(|(idx, (param_def, abi_param))| self.build_closure_trampoline_param(idx, param_def, abi_param))
             .collect();
 
         SwiftClosureTrampoline {
@@ -1271,21 +1046,13 @@ impl<'a> SwiftLowerer<'a> {
         }
     }
 
-    fn build_closure_trampoline_param(
-        &self,
-        idx: usize,
-        param_def: &ParamDef,
-        abi_param: &AbiParam,
-    ) -> SwiftClosureTrampolineParam {
+    fn build_closure_trampoline_param(&self, idx: usize, param_def: &ParamDef, abi_param: &AbiParam) -> SwiftClosureTrampolineParam {
         match abi_param.input_binding().expect("closure param role") {
             InputBinding::WirePacket { decode_ops, .. } => {
                 let ptr_name = format!("ptr{}", idx);
                 let len_name = format!("len{}", idx);
                 let reader_decode = emit::emit_reader_read(decode_ops);
-                let decode_expr = format!(
-                    "{{ var reader = WireReader(ptr: {}!, len: Int({})); return {} }}()",
-                    ptr_name, len_name, reader_decode
-                );
+                let decode_expr = format!("{{ var reader = WireReader(ptr: {}!, len: Int({})); return {} }}()", ptr_name, len_name, reader_decode);
                 SwiftClosureTrampolineParam {
                     name: format!("{}, {}", ptr_name, len_name),
                     c_type: "UnsafePointer<UInt8>?, UInt".to_string(),
@@ -1300,10 +1067,7 @@ impl<'a> SwiftLowerer<'a> {
                     decode_expr: arg_name,
                 }
             }
-            _ => unreachable!(
-                "unsupported closure param role for {}",
-                param_def.name.as_str()
-            ),
+            _ => unreachable!("unsupported closure param role for {}", param_def.name.as_str()),
         }
     }
 
@@ -1351,41 +1115,26 @@ impl<'a> SwiftLowerer<'a> {
                 complete: async_call.complete.as_str().to_string(),
                 cancel: async_call.cancel.as_str().to_string(),
                 free: async_call.free.as_str().to_string(),
-                result: Box::new(self.lower_async_result(
-                    &async_call.result_shape,
-                    &async_call.error,
-                    returns,
-                )),
+                result: Box::new(self.lower_async_result(&async_call.result_shape, &async_call.error, returns)),
             },
         }
     }
 
-    fn lower_async_result(
-        &self,
-        result_shape: &OutputShape,
-        error: &ErrorTransport,
-        returns: &ReturnDef,
-    ) -> SwiftAsyncResult {
+    fn lower_async_result(&self, result_shape: &OutputShape, error: &ErrorTransport, returns: &ReturnDef) -> SwiftAsyncResult {
         let returns_is_result = matches!(returns, ReturnDef::Result { .. });
         let throws = returns_is_result || matches!(error, ErrorTransport::Encoded { .. });
 
         match result_shape.output_binding() {
             OutputBinding::Unit => SwiftAsyncResult::Void,
-            OutputBinding::Fast(FastOutputBinding::Scalar { abi_type }) => {
-                SwiftAsyncResult::Direct {
-                    swift_type: self.abi_to_swift(abi_type),
-                    conversion: SwiftAsyncConversion::None,
-                }
-            }
+            OutputBinding::Fast(FastOutputBinding::Scalar { abi_type }) => SwiftAsyncResult::Direct {
+                swift_type: self.abi_to_swift(abi_type),
+                conversion: SwiftAsyncConversion::None,
+            },
             OutputBinding::Fast(FastOutputBinding::OptionScalar { decode_ops, .. })
             | OutputBinding::Fast(FastOutputBinding::ResultScalar { decode_ops, .. })
             | OutputBinding::Fast(FastOutputBinding::PrimitiveVec { decode_ops, .. })
-            | OutputBinding::Fast(FastOutputBinding::BlittableRecord { decode_ops, .. }) => {
-                self.encoded_async_result(decode_ops.clone(), throws, error, returns)
-            }
-            OutputBinding::Wire(wire) => {
-                self.encoded_async_result(wire.decode_ops.clone(), throws, error, returns)
-            }
+            | OutputBinding::Fast(FastOutputBinding::BlittableRecord { decode_ops, .. }) => self.encoded_async_result(decode_ops.clone(), throws, error, returns),
+            OutputBinding::Wire(wire) => self.encoded_async_result(wire.decode_ops.clone(), throws, error, returns),
             OutputBinding::Handle { class_id, nullable } => SwiftAsyncResult::Direct {
                 swift_type: if nullable {
                     format!("{}?", self.swift_name_for_class(class_id))
@@ -1397,10 +1146,7 @@ impl<'a> SwiftLowerer<'a> {
                     nullable,
                 },
             },
-            OutputBinding::CallbackHandle {
-                callback_id,
-                nullable,
-            } => SwiftAsyncResult::Direct {
+            OutputBinding::CallbackHandle { callback_id, nullable } => SwiftAsyncResult::Direct {
                 swift_type: if nullable {
                     format!("(any {})?", pascal_case(callback_id.as_str()))
                 } else {
@@ -1414,13 +1160,7 @@ impl<'a> SwiftLowerer<'a> {
         }
     }
 
-    fn encoded_async_result(
-        &self,
-        decode_ops: ReadSeq,
-        throws: bool,
-        error: &ErrorTransport,
-        returns: &ReturnDef,
-    ) -> SwiftAsyncResult {
+    fn encoded_async_result(&self, decode_ops: ReadSeq, throws: bool, error: &ErrorTransport, returns: &ReturnDef) -> SwiftAsyncResult {
         let ok_type = if throws {
             match returns {
                 ReturnDef::Result { ok, .. } => Some(self.swift_type(ok)),
@@ -1436,9 +1176,7 @@ impl<'a> SwiftLowerer<'a> {
         };
         let err_decode = match error {
             ErrorTransport::Encoded { decode_ops, .. } => decode_ops.clone(),
-            ErrorTransport::None | ErrorTransport::StatusCode => {
-                self.error_decode_from_result_read(&decode_ops)
-            }
+            ErrorTransport::None | ErrorTransport::StatusCode => self.error_decode_from_result_read(&decode_ops),
         };
         SwiftAsyncResult::Encoded {
             swift_type,
@@ -1461,11 +1199,7 @@ impl<'a> SwiftLowerer<'a> {
         }
     }
 
-    fn lower_return_def_for_async(
-        &self,
-        error: &ErrorTransport,
-        returns: &ReturnDef,
-    ) -> SwiftReturn {
+    fn lower_return_def_for_async(&self, error: &ErrorTransport, returns: &ReturnDef) -> SwiftReturn {
         match error {
             ErrorTransport::None => SwiftReturn::Void,
             ErrorTransport::StatusCode => SwiftReturn::Throws {
@@ -1479,10 +1213,7 @@ impl<'a> SwiftLowerer<'a> {
                 err_is_string: false,
                 err_encode: None,
             },
-            ErrorTransport::Encoded {
-                decode_ops,
-                encode_ops,
-            } => SwiftReturn::Throws {
+            ErrorTransport::Encoded { decode_ops, encode_ops } => SwiftReturn::Throws {
                 ok: Box::new(SwiftReturn::Void),
                 err_type: self.swift_error_type(returns),
                 err_decode: decode_ops.clone(),
@@ -1508,29 +1239,22 @@ fn swift_default_literal(default: &DefaultValue) -> String {
 }
 
 fn lower_first_char(name: &str) -> String {
-    name.chars()
-        .enumerate()
-        .map(|(index, ch)| {
-            if index == 0 {
-                ch.to_ascii_lowercase()
-            } else {
-                ch
-            }
-        })
-        .collect()
+    name.chars().enumerate().map(|(index, ch)| if index == 0 { ch.to_ascii_lowercase() } else { ch }).collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::Lowerer as IrLowerer;
-    use crate::ir::contract::{FfiContract, PackageInfo};
-    use crate::ir::definitions::{
-        CStyleVariant, CallbackKind, CallbackMethodDef, CallbackTraitDef, DataVariant, EnumDef,
-        EnumRepr, FieldDef, ParamDef, ParamPassing, RecordDef, ReturnDef, VariantPayload,
+    use crate::ir::{
+        Lowerer as IrLowerer,
+        contract::{FfiContract, PackageInfo},
+        definitions::{
+            CStyleVariant, CallbackKind, CallbackMethodDef, CallbackTraitDef, DataVariant, EnumDef, EnumRepr, FieldDef, ParamDef, ParamPassing, RecordDef, ReturnDef,
+            VariantPayload,
+        },
+        ids::{CallbackId, FieldName, MethodId, ParamName, VariantName},
+        types::{PrimitiveType, TypeExpr},
     };
-    use crate::ir::ids::{CallbackId, FieldName, MethodId, ParamName, VariantName};
-    use crate::ir::types::{PrimitiveType, TypeExpr};
 
     fn empty_contract() -> FfiContract {
         FfiContract {
@@ -1575,10 +1299,7 @@ mod tests {
 
         assert_eq!(module.records.len(), 1);
         let record = &module.records[0];
-        assert!(
-            record.is_blittable,
-            "Point should be blittable (primitives only)"
-        );
+        assert!(record.is_blittable, "Point should be blittable (primitives only)");
         assert_eq!(record.blittable_size, Some(16));
     }
 
@@ -1609,10 +1330,7 @@ mod tests {
 
         assert_eq!(module.records.len(), 1);
         let record = &module.records[0];
-        assert!(
-            !record.is_blittable,
-            "User should NOT be blittable (has String)"
-        );
+        assert!(!record.is_blittable, "User should NOT be blittable (has String)");
         assert_eq!(record.blittable_size, None);
     }
 
@@ -1635,10 +1353,7 @@ mod tests {
 
         assert_eq!(module.records.len(), 1);
         let record = &module.records[0];
-        assert!(
-            !record.is_blittable,
-            "Scores should NOT be blittable (has Vec)"
-        );
+        assert!(!record.is_blittable, "Scores should NOT be blittable (has Vec)");
     }
 
     #[test]
@@ -1817,9 +1532,7 @@ mod tests {
                     DataVariant {
                         name: VariantName::new("Int"),
                         discriminant: 0,
-                        payload: VariantPayload::Tuple(vec![TypeExpr::Primitive(
-                            PrimitiveType::I64,
-                        )]),
+                        payload: VariantPayload::Tuple(vec![TypeExpr::Primitive(PrimitiveType::I64)]),
                         doc: None,
                     },
                     DataVariant {
@@ -1952,11 +1665,7 @@ mod tests {
 
         let module = lower_contract(&contract);
 
-        let outer = module
-            .records
-            .iter()
-            .find(|r| r.class_name == "Outer")
-            .unwrap();
+        let outer = module.records.iter().find(|r| r.class_name == "Outer").unwrap();
         assert_eq!(outer.fields[0].swift_type, "Inner");
     }
 
@@ -2009,10 +1718,7 @@ mod tests {
 
     #[test]
     fn swift_default_literal_string() {
-        assert_eq!(
-            swift_default_literal(&DefaultValue::String("hello".to_string())),
-            "\"hello\""
-        );
+        assert_eq!(swift_default_literal(&DefaultValue::String("hello".to_string())), "\"hello\"");
     }
 
     #[test]

--- a/boltffi_bindgen/src/render/swift/plan.rs
+++ b/boltffi_bindgen/src/render/swift/plan.rs
@@ -1,5 +1,7 @@
-use crate::ir::ops::{OffsetExpr, ReadOp, ReadSeq, WriteSeq};
-use crate::render::swift::emit;
+use crate::{
+    ir::ops::{OffsetExpr, ReadOp, ReadSeq, WriteSeq},
+    render::swift::emit,
+};
 
 #[derive(Debug, Clone)]
 pub enum SwiftCallMode {
@@ -64,9 +66,7 @@ impl SwiftAsyncResult {
             Self::Void => None,
             Self::Direct { swift_type, .. } => Some(swift_type),
             Self::Encoded {
-                throws: true,
-                ok_type: Some(ok),
-                ..
+                throws: true, ok_type: Some(ok), ..
             } => Some(ok),
             Self::Encoded { swift_type, .. } => Some(swift_type),
         }
@@ -77,9 +77,7 @@ impl SwiftAsyncResult {
             Self::Void => "Void",
             Self::Direct { swift_type, .. } => swift_type,
             Self::Encoded {
-                throws: true,
-                ok_type: Some(ok),
-                ..
+                throws: true, ok_type: Some(ok), ..
             } => ok,
             Self::Encoded { swift_type, .. } => swift_type,
         }
@@ -98,9 +96,7 @@ impl SwiftAsyncResult {
                 err_is_string,
                 ..
             } => match decode.ops.first() {
-                Some(ReadOp::Result { ok, .. }) => {
-                    Some(emit::emit_result_ok_throw(ok, err_decode, *err_is_string))
-                }
+                Some(ReadOp::Result { ok, .. }) => Some(emit::emit_result_ok_throw(ok, err_decode, *err_is_string)),
                 _ => Some(emit::emit_read_value_at(decode, "0")),
             },
             Self::Encoded { decode, .. } => Some(emit::emit_read_value_at(decode, "0")),
@@ -119,11 +115,7 @@ impl SwiftAsyncResult {
                 Some(ReadOp::Result { ok, err, .. }) => {
                     let ok_read = emit::emit_reader_read(ok);
                     let err_read = emit::emit_reader_read(err);
-                    let err_body = if *err_is_string {
-                        format!("FfiError(message: {})", err_read)
-                    } else {
-                        err_read
-                    };
+                    let err_body = if *err_is_string { format!("FfiError(message: {})", err_read) } else { err_read };
                     Some(format!(
                         "try {{ let tag = reader.readU8(); if tag == 0 {{ return {} }} else {{ throw {} }} }}()",
                         ok_read, err_body
@@ -171,15 +163,15 @@ pub struct SwiftNativeMapping {
 
 impl SwiftModule {
     pub fn has_async(&self) -> bool {
-        self.functions.iter().any(|f| f.mode.is_async())
-            || self
-                .classes
-                .iter()
-                .any(|c| c.methods.iter().any(|m| m.mode.is_async()))
+        self.functions.iter().any(|f| f.mode.is_async()) || self.classes.iter().any(|c| c.methods.iter().any(|m| m.mode.is_async())) || self.has_async_iterators()
     }
 
     pub fn has_streams(&self) -> bool {
         self.classes.iter().any(|c| !c.streams.is_empty())
+    }
+
+    pub fn has_async_iterators(&self) -> bool {
+        self.classes.iter().any(|c| !c.async_iterators.is_empty())
     }
 }
 
@@ -251,9 +243,7 @@ impl SwiftField {
     pub fn wire_writer_encode(&self) -> String {
         match &self.native_conversion {
             Some(conv) => {
-                let converted_value = conv
-                    .encode_wrapper
-                    .replace("$0", &format!("self.{}", self.swift_name));
+                let converted_value = conv.encode_wrapper.replace("$0", &format!("self.{}", self.swift_name));
                 let base_encode = emit::emit_writer_write(&self.encode);
                 base_encode.replace(&format!("self.{}", self.swift_name), &converted_value)
             }
@@ -299,9 +289,7 @@ impl SwiftVariant {
     pub fn is_single_tuple(&self) -> bool {
         match &self.payload {
             SwiftVariantPayload::Tuple(fields) => fields.len() == 1,
-            SwiftVariantPayload::Struct(fields) => {
-                fields.len() == 1 && fields[0].swift_name.chars().all(|c| c.is_ascii_digit())
-            }
+            SwiftVariantPayload::Struct(fields) => fields.len() == 1 && fields[0].swift_name.chars().all(|c| c.is_ascii_digit()),
             _ => false,
         }
     }
@@ -316,50 +304,33 @@ impl SwiftVariant {
     fn single_tuple_field(&self) -> Option<&SwiftField> {
         match &self.payload {
             SwiftVariantPayload::Tuple(fields) if fields.len() == 1 => Some(&fields[0]),
-            SwiftVariantPayload::Struct(fields)
-                if fields.len() == 1
-                    && fields[0].swift_name.chars().all(|c| c.is_ascii_digit()) =>
-            {
-                Some(&fields[0])
-            }
+            SwiftVariantPayload::Struct(fields) if fields.len() == 1 && fields[0].swift_name.chars().all(|c| c.is_ascii_digit()) => Some(&fields[0]),
             _ => None,
         }
     }
 
     pub fn tuple_value_decode(&self) -> String {
-        self.single_tuple_field()
-            .map(|f| f.wire_decode_inline())
-            .unwrap_or_default()
+        self.single_tuple_field().map(|f| f.wire_decode_inline()).unwrap_or_default()
     }
 
     pub fn tuple_value_size(&self) -> String {
-        self.single_tuple_field()
-            .map(|f| f.wire_size_expr())
-            .unwrap_or_default()
+        self.single_tuple_field().map(|f| f.wire_size_expr()).unwrap_or_default()
     }
 
     pub fn tuple_value_encode(&self) -> String {
-        self.single_tuple_field()
-            .map(|f| f.wire_encode())
-            .unwrap_or_default()
+        self.single_tuple_field().map(|f| f.wire_encode()).unwrap_or_default()
     }
 
     pub fn tuple_value_encode_bytes(&self) -> String {
-        self.single_tuple_field()
-            .map(|f| f.wire_encode_bytes())
-            .unwrap_or_default()
+        self.single_tuple_field().map(|f| f.wire_encode_bytes()).unwrap_or_default()
     }
 
     pub fn tuple_value_reader_decode(&self) -> String {
-        self.single_tuple_field()
-            .map(|f| f.wire_reader_decode())
-            .unwrap_or_default()
+        self.single_tuple_field().map(|f| f.wire_reader_decode()).unwrap_or_default()
     }
 
     pub fn tuple_value_writer_encode(&self) -> String {
-        self.single_tuple_field()
-            .map(|f| f.wire_writer_encode())
-            .unwrap_or_default()
+        self.single_tuple_field().map(|f| f.wire_writer_encode()).unwrap_or_default()
     }
 
     pub fn all_fields_fixed_size(&self) -> bool {
@@ -367,9 +338,7 @@ impl SwiftVariant {
     }
 
     pub fn tuple_value_fixed_size(&self) -> bool {
-        self.single_tuple_field()
-            .map(|f| f.has_fixed_size())
-            .unwrap_or(true)
+        self.single_tuple_field().map(|f| f.has_fixed_size()).unwrap_or(true)
     }
 }
 
@@ -381,12 +350,39 @@ pub enum SwiftVariantPayload {
 }
 
 #[derive(Debug, Clone)]
+pub struct SwiftAsyncIterator {
+    pub name: String,
+    pub item_type: String,
+    /// Wire decode for `Option<T>` — same reader machinery as async results
+    pub item_decode: ReadSeq,
+    /// `{class}_{method}(handle) -> IteratorHandle`
+    pub entry: String,
+    /// `{class}_{method}_next(iter) -> RustFutureHandle`
+    pub next: String,
+    pub next_poll: String,
+    pub next_complete: String,
+    pub next_cancel: String,
+    pub next_free: String,
+    /// `{class}_{method}_free(iter)`
+    pub free: String,
+}
+
+impl SwiftAsyncIterator {
+    /// The Swift reader decode expression for `Option<T>` from the wire buffer.
+    pub fn option_reader_decode_expr(&self) -> String {
+        use crate::render::swift::emit;
+        emit::emit_reader_read(&self.item_decode)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct SwiftClass {
     pub name: String,
     pub ffi_free: String,
     pub constructors: Vec<SwiftConstructor>,
     pub methods: Vec<SwiftMethod>,
     pub streams: Vec<SwiftStream>,
+    pub async_iterators: Vec<SwiftAsyncIterator>,
     pub doc: Option<String>,
 }
 
@@ -429,21 +425,11 @@ fn uses_offset_in_read_op(op: &ReadOp) -> bool {
         ReadOp::Primitive { offset, .. } => offset_uses(offset),
         ReadOp::String { offset } => offset_uses(offset),
         ReadOp::Bytes { offset } => offset_uses(offset),
-        ReadOp::Option { tag_offset, some } => {
-            offset_uses(tag_offset) || uses_offset_in_read_seq(some)
-        }
-        ReadOp::Vec {
-            len_offset,
-            element,
-            ..
-        } => offset_uses(len_offset) || uses_offset_in_read_seq(element),
+        ReadOp::Option { tag_offset, some } => offset_uses(tag_offset) || uses_offset_in_read_seq(some),
+        ReadOp::Vec { len_offset, element, .. } => offset_uses(len_offset) || uses_offset_in_read_seq(element),
         ReadOp::Record { offset, .. } => offset_uses(offset),
         ReadOp::Enum { offset, .. } => offset_uses(offset),
-        ReadOp::Result {
-            tag_offset,
-            ok,
-            err,
-        } => offset_uses(tag_offset) || uses_offset_in_read_seq(ok) || uses_offset_in_read_seq(err),
+        ReadOp::Result { tag_offset, ok, err } => offset_uses(tag_offset) || uses_offset_in_read_seq(ok) || uses_offset_in_read_seq(err),
         ReadOp::Builtin { offset, .. } => offset_uses(offset),
         ReadOp::Custom { underlying, .. } => uses_offset_in_read_seq(underlying),
     }
@@ -456,14 +442,8 @@ fn offset_uses(offset: &OffsetExpr) -> bool {
 #[derive(Debug, Clone)]
 pub enum SwiftStreamMode {
     Async,
-    Batch {
-        class_name: String,
-        method_name_pascal: String,
-    },
-    Callback {
-        class_name: String,
-        method_name_pascal: String,
-    },
+    Batch { class_name: String, method_name_pascal: String },
+    Callback { class_name: String, method_name_pascal: String },
 }
 
 #[derive(Debug, Clone)]
@@ -504,9 +484,7 @@ impl SwiftConstructor {
 
     pub fn ffi_symbol(&self) -> &str {
         match self {
-            Self::Designated { ffi_symbol, .. }
-            | Self::Factory { ffi_symbol, .. }
-            | Self::Convenience { ffi_symbol, .. } => ffi_symbol,
+            Self::Designated { ffi_symbol, .. } | Self::Factory { ffi_symbol, .. } | Self::Convenience { ffi_symbol, .. } => ffi_symbol,
         }
     }
 
@@ -519,9 +497,7 @@ impl SwiftConstructor {
 
     pub fn is_fallible(&self) -> bool {
         match self {
-            Self::Designated { is_fallible, .. }
-            | Self::Factory { is_fallible, .. }
-            | Self::Convenience { is_fallible, .. } => *is_fallible,
+            Self::Designated { is_fallible, .. } | Self::Factory { is_fallible, .. } | Self::Convenience { is_fallible, .. } => *is_fallible,
         }
     }
 
@@ -560,9 +536,7 @@ impl SwiftConstructor {
 
     pub fn doc(&self) -> &Option<String> {
         match self {
-            Self::Designated { doc, .. }
-            | Self::Factory { doc, .. }
-            | Self::Convenience { doc, .. } => doc,
+            Self::Designated { doc, .. } | Self::Factory { doc, .. } | Self::Convenience { doc, .. } => doc,
         }
     }
 }
@@ -595,36 +569,25 @@ impl SwiftMethod {
     }
 
     fn prefix_args(&self) -> Vec<&str> {
-        if self.needs_handle() {
-            vec!["handle"]
-        } else {
-            vec![]
-        }
+        if self.needs_handle() { vec!["handle"] } else { vec![] }
     }
 
     pub fn start_call_expr(&self) -> String {
         match &self.mode {
-            SwiftCallMode::Async { start, .. } => {
-                ffi_call_expr(start, &self.prefix_args(), &self.params)
-            }
+            SwiftCallMode::Async { start, .. } => ffi_call_expr(start, &self.prefix_args(), &self.params),
             SwiftCallMode::Sync { .. } => String::new(),
         }
     }
 
     pub fn sync_call_expr(&self) -> String {
         match &self.mode {
-            SwiftCallMode::Sync { symbol } => {
-                ffi_call_expr(symbol, &self.prefix_args(), &self.params)
-            }
+            SwiftCallMode::Sync { symbol } => ffi_call_expr(symbol, &self.prefix_args(), &self.params),
             SwiftCallMode::Async { .. } => String::new(),
         }
     }
 
     pub fn closure_depth(&self) -> usize {
-        self.params
-            .iter()
-            .filter(|p| p.needs_closure_wrap())
-            .count()
+        self.params.iter().filter(|p| p.needs_closure_wrap()).count()
     }
 
     pub fn method_body_indent(&self) -> String {
@@ -653,10 +616,7 @@ impl SwiftMethod {
 
     pub fn sync_closure_closes(&self) -> Vec<String> {
         let depth = self.closure_depth();
-        (0..depth)
-            .rev()
-            .map(|i| format!("{}}}", "    ".repeat(i + 2)))
-            .collect()
+        (0..depth).rev().map(|i| format!("{}}}", "    ".repeat(i + 2))).collect()
     }
 }
 
@@ -723,11 +683,7 @@ impl SwiftCallbackMethod {
     pub fn wire_return_encode(&self) -> Option<String> {
         self.encoded_return_encode().map(|encode| {
             let writer_body = emit::emit_writer_write(encode);
-            let discriminant = if self.throws() {
-                "writer.writeU8(0); "
-            } else {
-                ""
-            };
+            let discriminant = if self.throws() { "writer.writeU8(0); " } else { "" };
             format!(
                 "let encoded = ({{ var writer = WireWriter(); {}{}; return writer.finalize() }})()",
                 discriminant, writer_body
@@ -744,10 +700,7 @@ impl SwiftCallbackMethod {
 
     pub fn wire_err_encode(&self) -> Option<String> {
         match &self.returns {
-            SwiftReturn::Throws {
-                err_encode: Some(encode),
-                ..
-            } => {
+            SwiftReturn::Throws { err_encode: Some(encode), .. } => {
                 let writer_body = emit::emit_writer_write(encode);
                 Some(format!(
                     "let encoded = ({{ var writer = WireWriter(); writer.writeU8(1); {}; return writer.finalize() }})()",
@@ -780,18 +733,12 @@ pub struct SwiftFunction {
 }
 
 pub fn ffi_call_expr(symbol: &str, prefix_args: &[&str], params: &[SwiftParam]) -> String {
-    let args = prefix_args
-        .iter()
-        .map(|s| s.to_string())
-        .chain(params.iter().map(|p| p.ffi_arg()));
+    let args = prefix_args.iter().map(|s| s.to_string()).chain(params.iter().map(|p| p.ffi_arg()));
     format!("{}({})", symbol, args.collect::<Vec<_>>().join(", "))
 }
 
 pub fn closure_wrappers(params: &[SwiftParam]) -> Vec<String> {
-    params
-        .iter()
-        .filter_map(|p| p.closure_wrap_open())
-        .collect()
+    params.iter().filter_map(|p| p.closure_wrap_open()).collect()
 }
 
 impl SwiftFunction {
@@ -822,10 +769,7 @@ impl SwiftFunction {
     }
 
     pub fn closure_depth(&self) -> usize {
-        self.params
-            .iter()
-            .filter(|p| p.needs_closure_wrap())
-            .count()
+        self.params.iter().filter(|p| p.needs_closure_wrap()).count()
     }
 
     pub fn body_indent(&self) -> String {
@@ -854,10 +798,7 @@ impl SwiftFunction {
 
     pub fn sync_closure_closes(&self) -> Vec<String> {
         let depth = self.closure_depth();
-        (0..depth)
-            .rev()
-            .map(|i| format!("{}}}", "    ".repeat(i + 1)))
-            .collect()
+        (0..depth).rev().map(|i| format!("{}}}", "    ".repeat(i + 1))).collect()
     }
 }
 
@@ -878,10 +819,7 @@ impl SwiftParam {
         };
         match &self.label {
             Some(label) if label != &self.name => {
-                format!(
-                    "{} {}: {}{}",
-                    label, self.name, inout_prefix, self.swift_type
-                )
+                format!("{} {}: {}{}", label, self.name, inout_prefix, self.swift_type)
             }
             _ => format!("{}: {}{}", self.name, inout_prefix, self.swift_type),
         }
@@ -890,10 +828,7 @@ impl SwiftParam {
     pub fn ffi_arg(&self) -> String {
         match &self.conversion {
             SwiftConversion::Direct => self.name.clone(),
-            SwiftConversion::ToString => format!(
-                "{}Buf.baseAddress!, UInt({}Buf.count)",
-                self.name, self.name
-            ),
+            SwiftConversion::ToString => format!("{}Buf.baseAddress!, UInt({}Buf.count)", self.name, self.name),
             SwiftConversion::ToData => {
                 format!("{}Ptr.baseAddress, UInt({}Ptr.count)", self.name, self.name)
             }
@@ -908,10 +843,7 @@ impl SwiftParam {
             }
             SwiftConversion::WrapCallback { protocol, nullable } => {
                 if *nullable {
-                    format!(
-                        "{}.map {{ {}Bridge.create($0) }} ?? BoltFFICallbackHandle(handle: 0, vtable: nil)",
-                        self.name, protocol
-                    )
+                    format!("{}.map {{ {}Bridge.create($0) }} ?? BoltFFICallbackHandle(handle: 0, vtable: nil)", self.name, protocol)
                 } else {
                     format!("{}Bridge.create({})", protocol, self.name)
                 }
@@ -939,11 +871,7 @@ impl SwiftParam {
             SwiftConversion::InlineClosure { closure } => Some(closure.render()),
             SwiftConversion::ToWireBuffer { encode } => {
                 let writer_body = emit::emit_writer_write(encode);
-                Some(format!(
-                    "let {name}Bytes = boltffiEncode {{ writer in {body} }}",
-                    name = self.name,
-                    body = writer_body
-                ))
+                Some(format!("let {name}Bytes = boltffiEncode {{ writer in {body} }}", name = self.name, body = writer_body))
             }
             _ => None,
         }
@@ -952,28 +880,16 @@ impl SwiftParam {
     pub fn needs_closure_wrap(&self) -> bool {
         matches!(
             &self.conversion,
-            SwiftConversion::ToString
-                | SwiftConversion::ToData
-                | SwiftConversion::PrimitiveBuffer { .. }
-                | SwiftConversion::MutableBuffer { .. }
+            SwiftConversion::ToString | SwiftConversion::ToData | SwiftConversion::PrimitiveBuffer { .. } | SwiftConversion::MutableBuffer { .. }
         )
     }
 
     pub fn closure_wrap_open(&self) -> Option<String> {
         match &self.conversion {
             SwiftConversion::ToString => Some(format!("{n}.withUTF8 {{ {n}Buf in", n = self.name)),
-            SwiftConversion::ToData => Some(format!(
-                "{}.withUnsafeBytes {{ {}Ptr in",
-                self.name, self.name
-            )),
-            SwiftConversion::PrimitiveBuffer { .. } => Some(format!(
-                "{}.withUnsafeBufferPointer {{ {}Ptr in",
-                self.name, self.name
-            )),
-            SwiftConversion::MutableBuffer { .. } => Some(format!(
-                "{}.withUnsafeMutableBufferPointer {{ {}Ptr in",
-                self.name, self.name
-            )),
+            SwiftConversion::ToData => Some(format!("{}.withUnsafeBytes {{ {}Ptr in", self.name, self.name)),
+            SwiftConversion::PrimitiveBuffer { .. } => Some(format!("{}.withUnsafeBufferPointer {{ {}Ptr in", self.name, self.name)),
+            SwiftConversion::MutableBuffer { .. } => Some(format!("{}.withUnsafeMutableBufferPointer {{ {}Ptr in", self.name, self.name)),
             _ => None,
         }
     }
@@ -981,9 +897,7 @@ impl SwiftParam {
     pub fn closure_wrap_close(&self) -> Option<&'static str> {
         match &self.conversion {
             SwiftConversion::ToString | SwiftConversion::ToData => Some("}"),
-            SwiftConversion::PrimitiveBuffer { .. } | SwiftConversion::MutableBuffer { .. } => {
-                Some("}")
-            }
+            SwiftConversion::PrimitiveBuffer { .. } | SwiftConversion::MutableBuffer { .. } => Some("}"),
             _ => None,
         }
     }
@@ -991,26 +905,11 @@ impl SwiftParam {
 
 impl SwiftClosureTrampoline {
     pub fn render(&self) -> String {
-        let c_params: String = self
-            .trampoline_params
-            .iter()
-            .map(|p| p.c_type.as_str())
-            .collect::<Vec<_>>()
-            .join(", ");
+        let c_params: String = self.trampoline_params.iter().map(|p| p.c_type.as_str()).collect::<Vec<_>>().join(", ");
 
-        let param_names: String = self
-            .trampoline_params
-            .iter()
-            .map(|p| p.name.as_str())
-            .collect::<Vec<_>>()
-            .join(", ");
+        let param_names: String = self.trampoline_params.iter().map(|p| p.name.as_str()).collect::<Vec<_>>().join(", ");
 
-        let decode_args: String = self
-            .trampoline_params
-            .iter()
-            .map(|p| p.decode_expr.as_str())
-            .collect::<Vec<_>>()
-            .join(", ");
+        let decode_args: String = self.trampoline_params.iter().map(|p| p.decode_expr.as_str()).collect::<Vec<_>>().join(", ");
 
         format!(
             r#"typealias {type_alias} = {swift_type}
@@ -1097,10 +996,7 @@ impl SwiftReturn {
             SwiftReturn::Void => None,
             SwiftReturn::Direct { swift_type } => Some(swift_type.clone()),
             SwiftReturn::FromWireBuffer { swift_type, .. } => Some(swift_type.clone()),
-            SwiftReturn::Handle {
-                class_name,
-                nullable,
-            } => {
+            SwiftReturn::Handle { class_name, nullable } => {
                 if *nullable {
                     Some(format!("{}?", class_name))
                 } else {
@@ -1133,29 +1029,19 @@ impl SwiftReturn {
 
     pub fn handle_info(&self) -> Option<(&str, bool)> {
         match self {
-            SwiftReturn::Handle {
-                class_name,
-                nullable,
-            } => Some((class_name.as_str(), *nullable)),
+            SwiftReturn::Handle { class_name, nullable } => Some((class_name.as_str(), *nullable)),
             _ => None,
         }
     }
 
     pub fn decode_expr(&self) -> Option<String> {
         match self {
-            SwiftReturn::FromWireBuffer { decode, .. } => {
-                Some(emit::emit_read_value_at(decode, "0"))
-            }
+            SwiftReturn::FromWireBuffer { decode, .. } => Some(emit::emit_read_value_at(decode, "0")),
             SwiftReturn::Throws {
-                ok,
-                err_decode,
-                err_is_string,
-                ..
+                ok, err_decode, err_is_string, ..
             } => match ok.as_ref() {
                 SwiftReturn::FromWireBuffer { decode, .. } => match decode.ops.first() {
-                    Some(ReadOp::Result { ok, .. }) => {
-                        Some(emit::emit_result_ok_throw(ok, err_decode, *err_is_string))
-                    }
+                    Some(ReadOp::Result { ok, .. }) => Some(emit::emit_result_ok_throw(ok, err_decode, *err_is_string)),
                     _ => ok.decode_expr(),
                 },
                 _ => ok.decode_expr(),
@@ -1167,18 +1053,12 @@ impl SwiftReturn {
     pub fn reader_decode_expr(&self) -> Option<String> {
         match self {
             SwiftReturn::FromWireBuffer { decode, .. } => Some(emit::emit_reader_read(decode)),
-            SwiftReturn::Throws {
-                ok, err_is_string, ..
-            } => match ok.as_ref() {
+            SwiftReturn::Throws { ok, err_is_string, .. } => match ok.as_ref() {
                 SwiftReturn::FromWireBuffer { decode, .. } => match decode.ops.first() {
                     Some(ReadOp::Result { ok, err, .. }) => {
                         let ok_read = emit::emit_reader_read(ok);
                         let err_read = emit::emit_reader_read(err);
-                        let err_body = if *err_is_string {
-                            format!("FfiError(message: {})", err_read)
-                        } else {
-                            err_read
-                        };
+                        let err_body = if *err_is_string { format!("FfiError(message: {})", err_read) } else { err_read };
                         Some(format!(
                             "try {{ let tag = reader.readU8(); if tag == 0 {{ return {} }} else {{ throw {} }} }}()",
                             ok_read, err_body

--- a/boltffi_bindgen/src/render/swift/snapshots/boltffi_bindgen__render__swift__templates__tests__snapshot_class_with_async_iterator.snap
+++ b/boltffi_bindgen/src/render/swift/snapshots/boltffi_bindgen__render__swift__templates__tests__snapshot_class_with_async_iterator.snap
@@ -1,0 +1,30 @@
+---
+source: boltffi_bindgen/src/render/swift/templates.rs
+expression: "render_class(&cls, \"boltffi\")"
+---
+public final class NumberIterator {
+    let handle: OpaquePointer
+
+    init(handle: OpaquePointer) {
+        self.handle = handle
+    }
+
+    deinit {
+        boltffi_number_iterator_free(handle)
+    }
+
+
+    public func countToThree() -> BoltFFIAsyncSequence<Int32> {
+        let iterHandle = boltffi_number_iterator_count_to_three(self.handle)!
+        return BoltFFIAsyncSequence<Int32>(
+            iterHandle: iterHandle,
+            nextFn: boltffi_number_iterator_count_to_three_next,
+            pollFn: boltffi_number_iterator_count_to_three_next_poll,
+            completeFn: boltffi_number_iterator_count_to_three_next_complete,
+            cancelFn: boltffi_number_iterator_count_to_three_next_cancel,
+            freeFutureFn: boltffi_number_iterator_count_to_three_next_free,
+            freeIterFn: boltffi_number_iterator_count_to_three_free,
+            decode: { reader in reader.readOptional { reader in reader.readI32() } }
+        )
+    }
+}

--- a/boltffi_bindgen/src/render/swift/templates.rs
+++ b/boltffi_bindgen/src/render/swift/templates.rs
@@ -1,22 +1,12 @@
+use super::plan::{SwiftCallMode, SwiftCallback, SwiftClass, SwiftEnum, SwiftField, SwiftFunction, SwiftRecord, SwiftStreamMode, SwiftVariant};
 use askama::Template;
-
-use super::plan::{
-    SwiftCallMode, SwiftCallback, SwiftClass, SwiftEnum, SwiftField, SwiftFunction, SwiftRecord,
-    SwiftStreamMode, SwiftVariant,
-};
 
 pub fn swift_doc_block(doc: &Option<String>, indent: &str) -> String {
     match doc {
         Some(text) => {
             let lines: String = text
                 .lines()
-                .map(|line| {
-                    if line.is_empty() {
-                        format!("{indent}///\n")
-                    } else {
-                        format!("{indent}/// {line}\n")
-                    }
-                })
+                .map(|line| if line.is_empty() { format!("{indent}///\n") } else { format!("{indent}/// {line}\n") })
                 .collect();
             lines
         }
@@ -36,17 +26,19 @@ pub struct PreambleFooterTemplate<'a> {
     pub prefix: &'a str,
     pub has_async: bool,
     pub has_streams: bool,
+    pub has_async_iterators: bool,
 }
 
 pub fn render_preamble_header(ffi_module_name: Option<&str>) -> String {
     PreambleHeaderTemplate { ffi_module_name }.render().unwrap()
 }
 
-pub fn render_preamble_footer(prefix: &str, has_async: bool, has_streams: bool) -> String {
+pub fn render_preamble_footer(prefix: &str, has_async: bool, has_streams: bool, has_async_iterators: bool) -> String {
     PreambleFooterTemplate {
         prefix,
         has_async,
         has_streams,
+        has_async_iterators,
     }
     .render()
     .unwrap()
@@ -211,17 +203,10 @@ impl SwiftEmitter {
 
         module.custom_types.iter().for_each(|ct| {
             if ct.native_mapping.is_none() {
-                output.push_str(&format!(
-                    "public typealias {} = {}\n",
-                    ct.alias_name, ct.target_type
-                ));
+                output.push_str(&format!("public typealias {} = {}\n", ct.alias_name, ct.target_type));
             }
         });
-        if module
-            .custom_types
-            .iter()
-            .any(|ct| ct.native_mapping.is_none())
-        {
+        if module.custom_types.iter().any(|ct| ct.native_mapping.is_none()) {
             output.push('\n');
         }
 
@@ -254,6 +239,7 @@ impl SwiftEmitter {
             &self.prefix,
             module.has_async(),
             module.has_streams(),
+            module.has_async_iterators(),
         ));
         output.push('\n');
 
@@ -270,16 +256,17 @@ impl Default for SwiftEmitter {
 #[cfg(all(test, not(miri)))]
 mod tests {
     use super::*;
-    use crate::ir::codec::VecLayout;
-    use crate::ir::ids::RecordId;
-    use crate::ir::ops::{
-        OffsetExpr, ReadOp, ReadSeq, SizeExpr, ValueExpr, WireShape, WriteOp, WriteSeq,
-    };
-    use crate::ir::types::{PrimitiveType, TypeExpr};
-    use crate::render::swift::plan::{
-        SwiftAsyncResult, SwiftCallback, SwiftCallbackMethod, SwiftCallbackParam, SwiftClass,
-        SwiftConstructor, SwiftConversion, SwiftEnumStyle, SwiftFunction, SwiftMethod, SwiftParam,
-        SwiftReturn, SwiftStream, SwiftStreamMode, SwiftVariantPayload,
+    use crate::{
+        ir::{
+            codec::VecLayout,
+            ids::RecordId,
+            ops::{OffsetExpr, ReadOp, ReadSeq, SizeExpr, ValueExpr, WireShape, WriteOp, WriteSeq},
+            types::{PrimitiveType, TypeExpr},
+        },
+        render::swift::plan::{
+            SwiftAsyncIterator, SwiftAsyncResult, SwiftCallback, SwiftCallbackMethod, SwiftCallbackParam, SwiftClass, SwiftConstructor, SwiftConversion, SwiftEnumStyle,
+            SwiftFunction, SwiftMethod, SwiftParam, SwiftReturn, SwiftStream, SwiftStreamMode, SwiftVariantPayload,
+        },
     };
 
     fn val(name: &str) -> ValueExpr {
@@ -301,10 +288,7 @@ mod tests {
     fn read_primitive(primitive: PrimitiveType, offset_expr: OffsetExpr) -> ReadSeq {
         ReadSeq {
             size: SizeExpr::Fixed(primitive.wire_size_bytes()),
-            ops: vec![ReadOp::Primitive {
-                primitive,
-                offset: offset_expr,
-            }],
+            ops: vec![ReadOp::Primitive { primitive, offset: offset_expr }],
             shape: WireShape::Value,
         }
     }
@@ -320,10 +304,7 @@ mod tests {
     fn write_primitive(primitive: PrimitiveType, value: &str) -> WriteSeq {
         WriteSeq {
             size: SizeExpr::Fixed(primitive.wire_size_bytes()),
-            ops: vec![WriteOp::Primitive {
-                primitive,
-                value: val(value),
-            }],
+            ops: vec![WriteOp::Primitive { primitive, value: val(value) }],
             shape: WireShape::Value,
         }
     }
@@ -331,9 +312,7 @@ mod tests {
     fn read_string(offset_expr: OffsetExpr) -> ReadSeq {
         ReadSeq {
             size: SizeExpr::Runtime,
-            ops: vec![ReadOp::String {
-                offset: offset_expr,
-            }],
+            ops: vec![ReadOp::String { offset: offset_expr }],
             shape: WireShape::Value,
         }
     }
@@ -349,9 +328,7 @@ mod tests {
     fn read_bytes(offset_expr: OffsetExpr) -> ReadSeq {
         ReadSeq {
             size: SizeExpr::Runtime,
-            ops: vec![ReadOp::Bytes {
-                offset: offset_expr,
-            }],
+            ops: vec![ReadOp::Bytes { offset: offset_expr }],
             shape: WireShape::Value,
         }
     }
@@ -389,12 +366,7 @@ mod tests {
         }
     }
 
-    fn read_vec(
-        offset_expr: OffsetExpr,
-        element_type: TypeExpr,
-        element: ReadSeq,
-        layout: VecLayout,
-    ) -> ReadSeq {
+    fn read_vec(offset_expr: OffsetExpr, element_type: TypeExpr, element: ReadSeq, layout: VecLayout) -> ReadSeq {
         ReadSeq {
             size: SizeExpr::Runtime,
             ops: vec![ReadOp::Vec {
@@ -407,12 +379,7 @@ mod tests {
         }
     }
 
-    fn write_vec(
-        value: &str,
-        element: WriteSeq,
-        element_type: &TypeExpr,
-        layout: VecLayout,
-    ) -> WriteSeq {
+    fn write_vec(value: &str, element: WriteSeq, element_type: &TypeExpr, layout: VecLayout) -> WriteSeq {
         let size = if matches!(element_type, TypeExpr::Primitive(PrimitiveType::U8)) {
             SizeExpr::Sum(vec![SizeExpr::Fixed(4), SizeExpr::BytesLen(val(value))])
         } else {
@@ -458,14 +425,7 @@ mod tests {
         }
     }
 
-    fn field(
-        name: &str,
-        swift_type: &str,
-        decode: ReadSeq,
-        encode: WriteSeq,
-        c_offset: Option<usize>,
-        default_expr: Option<&str>,
-    ) -> SwiftField {
+    fn field(name: &str, swift_type: &str, decode: ReadSeq, encode: WriteSeq, c_offset: Option<usize>, default_expr: Option<&str>) -> SwiftField {
         SwiftField {
             swift_name: name.to_string(),
             swift_type: swift_type.to_string(),
@@ -557,14 +517,7 @@ mod tests {
                     None,
                     None,
                 ),
-                field(
-                    "name",
-                    "String",
-                    read_string(offset("pos")),
-                    write_string("name"),
-                    None,
-                    None,
-                ),
+                field("name", "String", read_string(offset("pos")), write_string("name"), None, None),
             ],
             is_blittable: false,
             blittable_size: None,
@@ -742,14 +695,7 @@ mod tests {
                 SwiftVariant {
                     swift_name: "text".to_string(),
                     discriminant: 1,
-                    payload: SwiftVariantPayload::Tuple(vec![field(
-                        "value",
-                        "String",
-                        read_string(offset("pos")),
-                        write_string("value"),
-                        None,
-                        None,
-                    )]),
+                    payload: SwiftVariantPayload::Tuple(vec![field("value", "String", read_string(offset("pos")), write_string("value"), None, None)]),
                     doc: None,
                 },
                 SwiftVariant {
@@ -841,9 +787,7 @@ mod tests {
                     conversion: SwiftConversion::Direct,
                 },
             ],
-            returns: SwiftReturn::Direct {
-                swift_type: "Int32".to_string(),
-            },
+            returns: SwiftReturn::Direct { swift_type: "Int32".to_string() },
             doc: None,
         };
         insta::assert_snapshot!(render_function(&func, "boltffi"));
@@ -946,9 +890,7 @@ mod tests {
                     swift_type: "Data".to_string(),
                     call_arg: "data".to_string(),
                     ffi_args: vec!["dataPtr".to_string(), "dataLen".to_string()],
-                    decode_prelude: Some(
-                        "let data = Data(bytes: dataPtr!, count: Int(dataLen))".to_string(),
-                    ),
+                    decode_prelude: Some("let data = Data(bytes: dataPtr!, count: Int(dataLen))".to_string()),
                 }],
                 returns: SwiftReturn::Void,
                 is_async: false,
@@ -978,13 +920,9 @@ mod tests {
                     swift_type: "String".to_string(),
                     call_arg: "input".to_string(),
                     ffi_args: vec!["inputPtr".to_string(), "inputLen".to_string()],
-                    decode_prelude: Some(
-                        "let input = String(decoding: UnsafeBufferPointer(start: inputPtr, count: Int(inputLen)), as: UTF8.self)".to_string(),
-                    ),
+                    decode_prelude: Some("let input = String(decoding: UnsafeBufferPointer(start: inputPtr, count: Int(inputLen)), as: UTF8.self)".to_string()),
                 }],
-                returns: SwiftReturn::Direct {
-                    swift_type: "Bool".to_string(),
-                },
+                returns: SwiftReturn::Direct { swift_type: "Bool".to_string() },
                 is_async: false,
                 has_out_param: true,
                 doc: None,
@@ -1034,6 +972,7 @@ mod tests {
                 doc: Some("Inserts a value into the store by key.".to_string()),
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: Some("A persistent key-value data store.".to_string()),
         };
         insta::assert_snapshot!(render_class(&cls, "boltffi"));
@@ -1075,6 +1014,7 @@ mod tests {
                 doc: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
         };
         insta::assert_snapshot!(render_class(&cls, "boltffi"));
@@ -1100,6 +1040,34 @@ mod tests {
                 free: "boltffi_event_source_events_free".to_string(),
                 free_buf: "boltffi_free_buf_u8".to_string(),
                 atomic_cas: "boltffi_atomic_u8_cas".to_string(),
+            }],
+            async_iterators: vec![],
+            doc: None,
+        };
+        insta::assert_snapshot!(render_class(&cls, "boltffi"));
+    }
+
+    #[test]
+    fn snapshot_class_with_async_iterator() {
+        let item_decode = read_primitive(PrimitiveType::I32, OffsetExpr::Var("pos".to_string()));
+        let option_decode = read_option(OffsetExpr::Var("pos".to_string()), item_decode);
+        let cls = SwiftClass {
+            name: "NumberIterator".to_string(),
+            ffi_free: "boltffi_number_iterator_free".to_string(),
+            constructors: vec![],
+            methods: vec![],
+            streams: vec![],
+            async_iterators: vec![SwiftAsyncIterator {
+                name: "countToThree".to_string(),
+                item_type: "Int32".to_string(),
+                item_decode: option_decode,
+                entry: "boltffi_number_iterator_count_to_three".to_string(),
+                next: "boltffi_number_iterator_count_to_three_next".to_string(),
+                next_poll: "boltffi_number_iterator_count_to_three_next_poll".to_string(),
+                next_complete: "boltffi_number_iterator_count_to_three_next_complete".to_string(),
+                next_cancel: "boltffi_number_iterator_count_to_three_next_cancel".to_string(),
+                next_free: "boltffi_number_iterator_count_to_three_next_free".to_string(),
+                free: "boltffi_number_iterator_count_to_three_free".to_string(),
             }],
             doc: None,
         };
@@ -1140,6 +1108,7 @@ mod tests {
                 doc: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
         };
         insta::assert_snapshot!(render_class(&cls, "boltffi"));
@@ -1163,6 +1132,7 @@ mod tests {
             }],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
         };
         insta::assert_snapshot!(render_class(&cls, "boltffi"));
@@ -1219,6 +1189,7 @@ mod tests {
                 doc: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
         };
         insta::assert_snapshot!(render_class(&cls, "boltffi"));
@@ -1242,9 +1213,7 @@ mod tests {
                     swift_type: "String".to_string(),
                     call_arg: "result".to_string(),
                     ffi_args: vec!["resultPtr".to_string(), "resultLen".to_string()],
-                    decode_prelude: Some(
-                        "let result = String(decoding: UnsafeBufferPointer(start: resultPtr, count: Int(resultLen)), as: UTF8.self)".to_string(),
-                    ),
+                    decode_prelude: Some("let result = String(decoding: UnsafeBufferPointer(start: resultPtr, count: Int(resultLen)), as: UTF8.self)".to_string()),
                 }],
                 returns: SwiftReturn::Void,
                 is_async: true,
@@ -1261,14 +1230,7 @@ mod tests {
         let record = SwiftRecord {
             class_name: "UserProfile".to_string(),
             fields: vec![
-                field(
-                    "name",
-                    "String",
-                    read_string(offset("pos")),
-                    write_string("name"),
-                    None,
-                    None,
-                ),
+                field("name", "String", read_string(offset("pos")), write_string("name"), None, None),
                 field(
                     "bio",
                     "String?",
@@ -1290,29 +1252,12 @@ mod tests {
         let record = SwiftRecord {
             class_name: "Team".to_string(),
             fields: vec![
-                field(
-                    "name",
-                    "String",
-                    read_string(offset("pos")),
-                    write_string("name"),
-                    None,
-                    None,
-                ),
+                field("name", "String", read_string(offset("pos")), write_string("name"), None, None),
                 field(
                     "members",
                     "[String]",
-                    read_vec(
-                        offset("pos"),
-                        TypeExpr::String,
-                        read_string(offset("pos")),
-                        VecLayout::Encoded,
-                    ),
-                    write_vec(
-                        "members",
-                        write_string("item"),
-                        &TypeExpr::String,
-                        VecLayout::Encoded,
-                    ),
+                    read_vec(offset("pos"), TypeExpr::String, read_string(offset("pos")), VecLayout::Encoded),
+                    write_vec("members", write_string("item"), &TypeExpr::String, VecLayout::Encoded),
                     None,
                     None,
                 ),
@@ -1372,6 +1317,7 @@ mod tests {
                 doc: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
         };
         insta::assert_snapshot!(render_class(&cls, "boltffi"));
@@ -1385,14 +1331,7 @@ mod tests {
                 SwiftVariant {
                     swift_name: "found".to_string(),
                     discriminant: 0,
-                    payload: SwiftVariantPayload::Tuple(vec![field(
-                        "0",
-                        "String",
-                        read_string(offset("pos")),
-                        write_string("0"),
-                        None,
-                        None,
-                    )]),
+                    payload: SwiftVariantPayload::Tuple(vec![field("0", "String", read_string(offset("pos")), write_string("0"), None, None)]),
                     doc: None,
                 },
                 SwiftVariant {

--- a/boltffi_bindgen/src/render/swift/templates/class.txt
+++ b/boltffi_bindgen/src/render/swift/templates/class.txt
@@ -295,6 +295,22 @@
     }
 {%- endmatch %}
 {%- endfor %}
+{%- for iter in cls.async_iterators %}
+
+    public func {{ iter.name }}() -> BoltFFIAsyncSequence<{{ iter.item_type }}> {
+        let iterHandle = {{ iter.entry }}(self.handle)!
+        return BoltFFIAsyncSequence<{{ iter.item_type }}>(
+            iterHandle: iterHandle,
+            nextFn: {{ iter.next }},
+            pollFn: {{ iter.next_poll }},
+            completeFn: {{ iter.next_complete }},
+            cancelFn: {{ iter.next_cancel }},
+            freeFutureFn: {{ iter.next_free }},
+            freeIterFn: {{ iter.free }},
+            decode: { reader in {{ iter.option_reader_decode_expr() }} }
+        )
+    }
+{%- endfor %}
 }
 {%- for stream in cls.streams %}
 {%- match stream.mode %}

--- a/boltffi_bindgen/src/render/swift/templates/preamble_footer.txt
+++ b/boltffi_bindgen/src/render/swift/templates/preamble_footer.txt
@@ -27,7 +27,7 @@ private func ensureOk(_ status: FfiStatus, context: StaticString = #function) {
 }
 {%- if has_async %}
 
-final class FfiFutureState<T>: @unchecked Sendable {
+final class FfiFutureState<T: Sendable>: @unchecked Sendable {
     typealias Continuation = CheckedContinuation<T, Error>
 
     enum FinishDecision {
@@ -307,14 +307,14 @@ final class FfiFutureState<T>: @unchecked Sendable {
 private final class BoltFFIAsyncPollDriver: @unchecked Sendable {
     let futureHandle: RustFutureHandle?
     let pollFn: (RustFutureHandle?, UInt64, (@convention(c) (UInt64, Int8) -> Void)?) -> Void
-    let onReady: () -> Void
-    let canContinuePolling: () -> Bool
+    let onReady: @Sendable () -> Void
+    let canContinuePolling: @Sendable () -> Bool
 
     init(
         futureHandle: RustFutureHandle?,
         pollFn: @escaping (RustFutureHandle?, UInt64, (@convention(c) (UInt64, Int8) -> Void)?) -> Void,
-        onReady: @escaping () -> Void,
-        canContinuePolling: @escaping () -> Bool
+        onReady: @escaping @Sendable () -> Void,
+        canContinuePolling: @escaping @Sendable () -> Bool
     ) {
         self.futureHandle = futureHandle; self.pollFn = pollFn
         self.onReady = onReady; self.canContinuePolling = canContinuePolling
@@ -343,14 +343,15 @@ private let boltffiAsyncPollCallback: @convention(c) (UInt64, Int8) -> Void = { 
     Unmanaged<BoltFFIAsyncPollDriver>.fromOpaque(UnsafeRawPointer(bitPattern: UInt(callbackData))!).takeRetainedValue().handlePollResult(pollResult)
 }
 
-func boltffiAsyncCall<T>(
+func boltffiAsyncCall<T: Sendable>(
     futureHandle: RustFutureHandle?,
-    pollFn: @escaping (RustFutureHandle?, UInt64, (@convention(c) (UInt64, Int8) -> Void)?) -> Void,
-    completeFn: @escaping (RustFutureHandle?, UnsafeMutablePointer<FfiStatus>?) -> FfiBuf_u8,
-    cancelFn: @escaping (RustFutureHandle?) -> Void,
-    freeFn: @escaping (RustFutureHandle?) -> Void,
-    transform: @escaping (FfiBuf_u8, FfiStatus) throws -> T
+    pollFn: @escaping @Sendable (RustFutureHandle?, UInt64, (@convention(c) (UInt64, Int8) -> Void)?) -> Void,
+    completeFn: @escaping @Sendable (RustFutureHandle?, UnsafeMutablePointer<FfiStatus>?) -> FfiBuf_u8,
+    cancelFn: @escaping @Sendable (RustFutureHandle?) -> Void,
+    freeFn: @escaping @Sendable (RustFutureHandle?) -> Void,
+    transform: @escaping @Sendable (FfiBuf_u8, FfiStatus) throws -> T
 ) async throws -> T {
+    nonisolated(unsafe) let futureHandle = futureHandle
     typealias Ctx = FfiFutureState<T>
     let state = Ctx(handle: futureHandle)
 
@@ -404,13 +405,14 @@ func boltffiAsyncCall<T>(
     }
 }
 
-func boltffiAsyncCallDirect<T>(
+func boltffiAsyncCallDirect<T: Sendable>(
     futureHandle: RustFutureHandle?,
-    pollFn: @escaping (RustFutureHandle?, UInt64, (@convention(c) (UInt64, Int8) -> Void)?) -> Void,
-    completeFn: @escaping (RustFutureHandle?, UnsafeMutablePointer<FfiStatus>?) -> T,
-    cancelFn: @escaping (RustFutureHandle?) -> Void,
-    freeFn: @escaping (RustFutureHandle?) -> Void
+    pollFn: @escaping @Sendable (RustFutureHandle?, UInt64, (@convention(c) (UInt64, Int8) -> Void)?) -> Void,
+    completeFn: @escaping @Sendable (RustFutureHandle?, UnsafeMutablePointer<FfiStatus>?) -> T,
+    cancelFn: @escaping @Sendable (RustFutureHandle?) -> Void,
+    freeFn: @escaping @Sendable (RustFutureHandle?) -> Void
 ) async throws -> T {
+    nonisolated(unsafe) let futureHandle = futureHandle
     typealias Ctx = FfiFutureState<T>
     let state = Ctx(handle: futureHandle)
 
@@ -457,6 +459,121 @@ func boltffiAsyncCallDirect<T>(
             cancelFn(state.handle)
             freeFn(state.handle)
             continuation.resume(throwing: CancellationError())
+        }
+    }
+}
+{%- endif %}
+{%- if has_async_iterators %}
+
+/// A lazy pull-based async sequence wrapping a BoltFFI async iterator.
+///
+/// Each element is produced by calling `next()` on the Rust side via the
+/// standard `RustFutureHandle` poll/complete machinery. No background `Task`
+/// is spawned — iteration is driven entirely by Swift's `for await` loop.
+public struct BoltFFIAsyncSequence<T: Sendable>: AsyncSequence, Sendable {
+    public typealias Element = T
+
+    private let iterHandle: OpaquePointer
+    private let nextFn: @Sendable (OpaquePointer?) -> RustFutureHandle?
+    private let pollFn: @Sendable (RustFutureHandle?, UInt64, (@convention(c) (UInt64, Int8) -> Void)?) -> Void
+    private let completeFn: @Sendable (RustFutureHandle?, UnsafeMutablePointer<FfiStatus>?) -> FfiBuf_u8
+    private let cancelFn: @Sendable (RustFutureHandle?) -> Void
+    private let freeFutureFn: @Sendable (RustFutureHandle?) -> Void
+    private let freeIterFn: @Sendable (OpaquePointer?) -> Void
+    private let decode: @Sendable (inout WireReader) -> T?
+
+    init(
+        iterHandle: OpaquePointer,
+        nextFn: @escaping @Sendable (OpaquePointer?) -> RustFutureHandle?,
+        pollFn: @escaping @Sendable (RustFutureHandle?, UInt64, (@convention(c) (UInt64, Int8) -> Void)?) -> Void,
+        completeFn: @escaping @Sendable (RustFutureHandle?, UnsafeMutablePointer<FfiStatus>?) -> FfiBuf_u8,
+        cancelFn: @escaping @Sendable (RustFutureHandle?) -> Void,
+        freeFutureFn: @escaping @Sendable (RustFutureHandle?) -> Void,
+        freeIterFn: @escaping @Sendable (OpaquePointer?) -> Void,
+        decode: @escaping @Sendable (inout WireReader) -> T?
+    ) {
+        self.iterHandle = iterHandle
+        self.nextFn = nextFn
+        self.pollFn = pollFn
+        self.completeFn = completeFn
+        self.cancelFn = cancelFn
+        self.freeFutureFn = freeFutureFn
+        self.freeIterFn = freeIterFn
+        self.decode = decode
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(
+            iterHandle: iterHandle,
+            nextFn: nextFn,
+            pollFn: pollFn,
+            completeFn: completeFn,
+            cancelFn: cancelFn,
+            freeFutureFn: freeFutureFn,
+            freeIterFn: freeIterFn,
+            decode: decode
+        )
+    }
+
+    public final class AsyncIterator: AsyncIteratorProtocol, @unchecked Sendable {
+        private let iterHandle: OpaquePointer
+        private let nextFn: @Sendable (OpaquePointer?) -> RustFutureHandle?
+        private let pollFn: @Sendable (RustFutureHandle?, UInt64, (@convention(c) (UInt64, Int8) -> Void)?) -> Void
+        private let completeFn: @Sendable (RustFutureHandle?, UnsafeMutablePointer<FfiStatus>?) -> FfiBuf_u8
+        private let cancelFn: @Sendable (RustFutureHandle?) -> Void
+        private let freeFutureFn: @Sendable (RustFutureHandle?) -> Void
+        private let freeIterFn: @Sendable (OpaquePointer?) -> Void
+        private let decode: @Sendable (inout WireReader) -> T?
+        private var done = false
+
+        fileprivate init(
+            iterHandle: OpaquePointer,
+            nextFn: @escaping @Sendable (OpaquePointer?) -> RustFutureHandle?,
+            pollFn: @escaping @Sendable (RustFutureHandle?, UInt64, (@convention(c) (UInt64, Int8) -> Void)?) -> Void,
+            completeFn: @escaping @Sendable (RustFutureHandle?, UnsafeMutablePointer<FfiStatus>?) -> FfiBuf_u8,
+            cancelFn: @escaping @Sendable (RustFutureHandle?) -> Void,
+            freeFutureFn: @escaping @Sendable (RustFutureHandle?) -> Void,
+            freeIterFn: @escaping @Sendable (OpaquePointer?) -> Void,
+            decode: @escaping @Sendable (inout WireReader) -> T?
+        ) {
+            self.iterHandle = iterHandle
+            self.nextFn = nextFn
+            self.pollFn = pollFn
+            self.completeFn = completeFn
+            self.cancelFn = cancelFn
+            self.freeFutureFn = freeFutureFn
+            self.freeIterFn = freeIterFn
+            self.decode = decode
+        }
+
+        deinit {
+            freeIterFn(iterHandle)
+        }
+
+        public func next() async -> T? {
+            guard !done else { return nil }
+            let futureHandle = nextFn(iterHandle)
+            do {
+                return try await boltffiAsyncCall(
+                    futureHandle: futureHandle,
+                    pollFn: pollFn,
+                    completeFn: completeFn,
+                    cancelFn: cancelFn,
+                    freeFn: freeFutureFn
+                ) { [self] buf, status in
+                    guard status.code == 0 else {
+                        {{ prefix }}_free_buf_u8(buf)
+                        throw FfiError(message: "iterator next failed")
+                    }
+                    defer { {{ prefix }}_free_buf_u8(buf) }
+                    return boltffiDecodeOwnedBuf(buf.ptr, Int(buf.len)) { reader in
+                        self.decode(&reader)
+                    }
+                }
+            } catch {
+                done = true
+                return nil
+            }
         }
     }
 }

--- a/boltffi_bindgen/src/render/typescript/lower.rs
+++ b/boltffi_bindgen/src/render/typescript/lower.rs
@@ -1,27 +1,21 @@
+use crate::{
+    ir::{
+        FastOutputBinding, InputBinding, OutputBinding,
+        abi::{AbiCall, AbiCallbackInvocation, AbiContract, AbiEnum, AbiEnumPayload, AbiParam, AbiRecord, CallId, CallMode, ErrorTransport, OutputShape},
+        contract::FfiContract,
+        definitions::{CallbackKind, CallbackTraitDef, ClassDef, ConstructorDef, EnumDef, FunctionDef, MethodDef, ParamDef, Receiver, RecordDef, ReturnDef},
+        ids::{CallbackId, EnumId, FieldName, RecordId},
+        ops::{FieldWriteOp, ReadOp, ReadSeq, SizeExpr, ValueExpr, WireShape, WriteOp, WriteSeq},
+        plan::AbiType,
+        types::{PrimitiveType, TypeExpr},
+    },
+    render::typescript::{emit, plan::*},
+};
+use boltffi_ffi_rules::{
+    callback as cb_naming,
+    naming::{self, ffi_prefix, snake_to_camel as camel_case},
+};
 use std::collections::{HashMap, HashSet};
-
-use boltffi_ffi_rules::callback as cb_naming;
-use boltffi_ffi_rules::naming::{self, snake_to_camel as camel_case};
-
-use crate::ir::abi::{
-    AbiCall, AbiCallbackInvocation, AbiContract, AbiEnum, AbiEnumPayload, AbiParam, AbiRecord,
-    CallId, CallMode, ErrorTransport, OutputShape,
-};
-use crate::ir::contract::FfiContract;
-use crate::ir::definitions::{
-    CallbackKind, CallbackTraitDef, ClassDef, ConstructorDef, EnumDef, FunctionDef, MethodDef,
-    ParamDef, Receiver, RecordDef, ReturnDef,
-};
-use crate::ir::ids::{CallbackId, EnumId, FieldName, RecordId};
-use crate::ir::ops::{
-    FieldWriteOp, ReadOp, ReadSeq, SizeExpr, ValueExpr, WireShape, WriteOp, WriteSeq,
-};
-use crate::ir::plan::AbiType;
-use crate::ir::types::{PrimitiveType, TypeExpr};
-use crate::ir::{FastOutputBinding, InputBinding, OutputBinding};
-use crate::render::typescript::emit;
-use crate::render::typescript::plan::*;
-use boltffi_ffi_rules::naming::ffi_prefix;
 
 struct AbiIndex {
     calls: HashMap<CallId, usize>,
@@ -32,44 +26,15 @@ struct AbiIndex {
 
 impl AbiIndex {
     fn new(contract: &AbiContract) -> Self {
-        let calls = contract
-            .calls
-            .iter()
-            .enumerate()
-            .map(|(index, call)| (call.id.clone(), index))
-            .collect();
-        let callbacks = contract
-            .callbacks
-            .iter()
-            .enumerate()
-            .map(|(index, cb)| (cb.callback_id.clone(), index))
-            .collect();
-        let records = contract
-            .records
-            .iter()
-            .enumerate()
-            .map(|(index, record)| (record.id.clone(), index))
-            .collect();
-        let enums = contract
-            .enums
-            .iter()
-            .enumerate()
-            .map(|(index, enumeration)| (enumeration.id.clone(), index))
-            .collect();
+        let calls = contract.calls.iter().enumerate().map(|(index, call)| (call.id.clone(), index)).collect();
+        let callbacks = contract.callbacks.iter().enumerate().map(|(index, cb)| (cb.callback_id.clone(), index)).collect();
+        let records = contract.records.iter().enumerate().map(|(index, record)| (record.id.clone(), index)).collect();
+        let enums = contract.enums.iter().enumerate().map(|(index, enumeration)| (enumeration.id.clone(), index)).collect();
 
-        Self {
-            calls,
-            callbacks,
-            records,
-            enums,
-        }
+        Self { calls, callbacks, records, enums }
     }
 
-    fn callback<'a>(
-        &self,
-        contract: &'a AbiContract,
-        id: &CallbackId,
-    ) -> &'a AbiCallbackInvocation {
+    fn callback<'a>(&self, contract: &'a AbiContract, id: &CallbackId) -> &'a AbiCallbackInvocation {
         &contract.callbacks[self.callbacks[id]]
     }
 
@@ -105,12 +70,7 @@ pub struct TypeScriptLowerer<'a> {
 }
 
 impl<'a> TypeScriptLowerer<'a> {
-    pub fn new(
-        contract: &'a FfiContract,
-        abi: &'a AbiContract,
-        module_name: String,
-        experimental: TypeScriptExperimental,
-    ) -> Self {
+    pub fn new(contract: &'a FfiContract, abi: &'a AbiContract, module_name: String, experimental: TypeScriptExperimental) -> Self {
         Self {
             contract,
             abi,
@@ -122,49 +82,19 @@ impl<'a> TypeScriptLowerer<'a> {
     pub fn lower(&self) -> TsModule {
         let index = AbiIndex::new(self.abi);
 
-        let records = self
-            .contract
-            .catalog
-            .all_records()
-            .map(|def| self.lower_record(def, &index))
-            .collect();
+        let records = self.contract.catalog.all_records().map(|def| self.lower_record(def, &index)).collect();
 
-        let enums = self
-            .contract
-            .catalog
-            .all_enums()
-            .map(|def| self.lower_enum(def, &index))
-            .collect();
+        let enums = self.contract.catalog.all_enums().map(|def| self.lower_enum(def, &index)).collect();
 
-        let functions: Vec<TsFunction> = self
-            .contract
-            .functions
-            .iter()
-            .filter_map(|def| self.lower_function(def, &index))
-            .collect();
+        let functions: Vec<TsFunction> = self.contract.functions.iter().filter_map(|def| self.lower_function(def, &index)).collect();
 
-        let async_functions: Vec<TsAsyncFunction> = self
-            .contract
-            .functions
-            .iter()
-            .filter_map(|def| self.lower_async_function(def, &index))
-            .collect();
+        let async_functions: Vec<TsAsyncFunction> = self.contract.functions.iter().filter_map(|def| self.lower_async_function(def, &index)).collect();
 
-        let classes = self
-            .contract
-            .catalog
-            .all_classes()
-            .map(|def| self.lower_class(def, &index))
-            .collect();
+        let classes = self.contract.catalog.all_classes().map(|def| self.lower_class(def, &index)).collect();
 
         let wasm_imports = self.collect_wasm_imports(&index);
 
-        let callbacks = self
-            .contract
-            .catalog
-            .all_callbacks()
-            .map(|def| self.lower_callback(def, &index))
-            .collect();
+        let callbacks = self.contract.catalog.all_callbacks().map(|def| self.lower_callback(def, &index)).collect();
 
         let error_exceptions = self.collect_error_exceptions(&functions, &async_functions, &index);
 
@@ -182,12 +112,7 @@ impl<'a> TypeScriptLowerer<'a> {
         }
     }
 
-    fn collect_error_exceptions(
-        &self,
-        functions: &[TsFunction],
-        async_functions: &[TsAsyncFunction],
-        index: &AbiIndex,
-    ) -> Vec<TsErrorException> {
+    fn collect_error_exceptions(&self, functions: &[TsFunction], async_functions: &[TsAsyncFunction], index: &AbiIndex) -> Vec<TsErrorException> {
         let mut error_types: HashSet<String> = HashSet::new();
 
         for func in functions {
@@ -239,22 +164,16 @@ impl<'a> TypeScriptLowerer<'a> {
                 let ts_type_str = emit::ts_type(&field.type_expr);
                 let field_name = camel_case(field.name.as_str());
 
-                let decode = decode_fields
-                    .get(&field.name)
-                    .cloned()
-                    .unwrap_or_else(|| ReadSeq {
-                        size: SizeExpr::Fixed(0),
-                        ops: vec![],
-                        shape: WireShape::Value,
-                    });
-                let encode = encode_fields
-                    .get(&field.name)
-                    .cloned()
-                    .unwrap_or_else(|| WriteSeq {
-                        size: SizeExpr::Fixed(0),
-                        ops: vec![],
-                        shape: WireShape::Value,
-                    });
+                let decode = decode_fields.get(&field.name).cloned().unwrap_or_else(|| ReadSeq {
+                    size: SizeExpr::Fixed(0),
+                    ops: vec![],
+                    shape: WireShape::Value,
+                });
+                let encode = encode_fields.get(&field.name).cloned().unwrap_or_else(|| WriteSeq {
+                    size: SizeExpr::Fixed(0),
+                    ops: vec![],
+                    shape: WireShape::Value,
+                });
 
                 TsField {
                     name: emit::escape_ts_keyword(&field_name),
@@ -293,11 +212,7 @@ impl<'a> TypeScriptLowerer<'a> {
         let abi_enum = index.enumeration(self.abi, &def.id);
         let name = naming::to_upper_camel_case(def.id.as_str());
 
-        let kind = if abi_enum.is_c_style {
-            TsEnumKind::CStyle
-        } else {
-            TsEnumKind::Data
-        };
+        let kind = if abi_enum.is_c_style { TsEnumKind::CStyle } else { TsEnumKind::Data };
 
         let variant_docs = def.variant_docs();
         let variants = abi_enum
@@ -343,16 +258,10 @@ impl<'a> TypeScriptLowerer<'a> {
             .constructors
             .iter()
             .enumerate()
-            .map(|(constructor_index, constructor)| {
-                self.lower_class_constructor(def, constructor, constructor_index, index)
-            })
+            .map(|(constructor_index, constructor)| self.lower_class_constructor(def, constructor, constructor_index, index))
             .collect();
 
-        let methods = def
-            .methods
-            .iter()
-            .map(|method| self.lower_class_method(def, method, index))
-            .collect();
+        let methods = def.methods.iter().map(|method| self.lower_class_method(def, method, index)).collect();
 
         TsClass {
             class_name,
@@ -363,13 +272,7 @@ impl<'a> TypeScriptLowerer<'a> {
         }
     }
 
-    fn lower_class_constructor(
-        &self,
-        class_def: &ClassDef,
-        constructor: &ConstructorDef,
-        constructor_index: usize,
-        index: &AbiIndex,
-    ) -> TsClassConstructor {
+    fn lower_class_constructor(&self, class_def: &ClassDef, constructor: &ConstructorDef, constructor_index: usize, index: &AbiIndex) -> TsClassConstructor {
         let call_id = CallId::Constructor {
             class_id: class_def.id.clone(),
             index: constructor_index,
@@ -381,11 +284,7 @@ impl<'a> TypeScriptLowerer<'a> {
             .map(|method_id| emit::escape_ts_keyword(&camel_case(method_id.as_str())))
             .unwrap_or_else(|| "new".to_string());
 
-        let param_defs: HashMap<&str, &ParamDef> = constructor
-            .params()
-            .into_iter()
-            .map(|param| (param.name.as_str(), param))
-            .collect();
+        let param_defs: HashMap<&str, &ParamDef> = constructor.params().into_iter().map(|param| (param.name.as_str(), param)).collect();
 
         let params = abi_call
             .params
@@ -402,20 +301,12 @@ impl<'a> TypeScriptLowerer<'a> {
             ffi_name: abi_call.symbol.as_str().to_string(),
             is_default: constructor.name().is_none(),
             params,
-            returns_nullable_handle: matches!(
-                abi_call.output_binding(),
-                OutputBinding::Handle { nullable: true, .. }
-            ),
+            returns_nullable_handle: matches!(abi_call.output_binding(), OutputBinding::Handle { nullable: true, .. }),
             doc: constructor.doc().map(String::from),
         }
     }
 
-    fn lower_class_method(
-        &self,
-        class_def: &ClassDef,
-        method_def: &MethodDef,
-        index: &AbiIndex,
-    ) -> TsClassMethod {
+    fn lower_class_method(&self, class_def: &ClassDef, method_def: &MethodDef, index: &AbiIndex) -> TsClassMethod {
         let call_id = CallId::Method {
             class_id: class_def.id.clone(),
             method_id: method_def.id.clone(),
@@ -423,11 +314,7 @@ impl<'a> TypeScriptLowerer<'a> {
         let abi_call = index.call(self.abi, &call_id);
         let is_static = method_def.receiver == Receiver::Static;
 
-        let param_defs: HashMap<&str, &ParamDef> = method_def
-            .params
-            .iter()
-            .map(|param| (param.name.as_str(), param))
-            .collect();
+        let param_defs: HashMap<&str, &ParamDef> = method_def.params.iter().map(|param| (param.name.as_str(), param)).collect();
 
         let params = abi_call
             .params
@@ -437,10 +324,7 @@ impl<'a> TypeScriptLowerer<'a> {
                 let Some(input_abi) = parameter.input_binding() else {
                     return false;
                 };
-                if !is_static
-                    && *param_index == 0
-                    && matches!(input_abi, InputBinding::Handle { .. })
-                {
+                if !is_static && *param_index == 0 && matches!(input_abi, InputBinding::Handle { .. }) {
                     return false;
                 }
                 true
@@ -453,8 +337,7 @@ impl<'a> TypeScriptLowerer<'a> {
 
         let (return_type, return_handle, mode) = match &abi_call.mode {
             CallMode::Sync => {
-                let (return_type, return_route) =
-                    self.select_output_route(&abi_call.output_shape, TsExecutionModel::Sync);
+                let (return_type, return_route) = self.select_output_route(&abi_call.output_shape, TsExecutionModel::Sync);
                 let return_handle = match abi_call.output_binding() {
                     OutputBinding::Handle { class_id, nullable } => Some(TsHandleReturn {
                         class_name: naming::to_upper_camel_case(class_id.as_str()),
@@ -462,16 +345,11 @@ impl<'a> TypeScriptLowerer<'a> {
                     }),
                     _ => None,
                 };
-                (
-                    return_type,
-                    return_handle,
-                    TsClassMethodMode::Sync(TsClassSyncMethod { return_route }),
-                )
+                (return_type, return_handle, TsClassMethodMode::Sync(TsClassSyncMethod { return_route }))
             }
             CallMode::Async(async_call) => {
                 let entry_ffi_name = abi_call.symbol.as_str().to_string();
-                let (return_type, return_route) =
-                    self.select_output_route(&async_call.result_shape, TsExecutionModel::Async);
+                let (return_type, return_route) = self.select_output_route(&async_call.result_shape, TsExecutionModel::Async);
                 let return_handle = match async_call.result_binding() {
                     OutputBinding::Handle { class_id, nullable } => Some(TsHandleReturn {
                         class_name: naming::to_upper_camel_case(class_id.as_str()),
@@ -517,16 +395,9 @@ impl<'a> TypeScriptLowerer<'a> {
             .iter()
             .filter(|m| !m.is_async)
             .filter_map(|method_def| {
-                let abi_method = abi_callback
-                    .methods
-                    .iter()
-                    .find(|am| am.id == method_def.id)?;
+                let abi_method = abi_callback.methods.iter().find(|am| am.id == method_def.id)?;
                 let ts_name = camel_case(method_def.id.as_str());
-                let import_name = format!(
-                    "__boltffi_callback_{}_{}",
-                    trait_name_snake,
-                    naming::to_snake_case(method_def.id.as_str())
-                );
+                let import_name = format!("__boltffi_callback_{}_{}", trait_name_snake, naming::to_snake_case(method_def.id.as_str()));
 
                 let params = method_def
                     .params
@@ -535,10 +406,7 @@ impl<'a> TypeScriptLowerer<'a> {
                         let ts_type = emit::ts_type(&p.type_expr);
                         let param_name = p.name.as_str();
                         let callback_param_name = camel_case(param_name);
-                        let abi_param = abi_method
-                            .params
-                            .iter()
-                            .find(|ap| ap.name.as_str() == param_name);
+                        let abi_param = abi_method.params.iter().find(|ap| ap.name.as_str() == param_name);
 
                         let kind = match abi_param {
                             Some(abi_param) => match abi_param.input_binding() {
@@ -546,14 +414,9 @@ impl<'a> TypeScriptLowerer<'a> {
                                     let decode_expr = emit::emit_reader_read(decode_ops);
                                     TsCallbackParamKind::WireEncoded { decode_expr }
                                 }
-                                _ => callback_primitive_param_kind(
-                                    callback_param_name.as_str(),
-                                    Some(abi_param.ffi_type),
-                                ),
+                                _ => callback_primitive_param_kind(callback_param_name.as_str(), Some(abi_param.ffi_type)),
                             },
-                            None => {
-                                callback_primitive_param_kind(callback_param_name.as_str(), None)
-                            }
+                            None => callback_primitive_param_kind(callback_param_name.as_str(), None),
                         };
 
                         TsCallbackParam {
@@ -582,17 +445,9 @@ impl<'a> TypeScriptLowerer<'a> {
                         let encode_ops = binding.encode_ops().expect("encoded callback return");
                         let encode_expr = emit::emit_writer_write(encode_ops, "writer", "result");
                         let size_expr = emit::emit_size_expr(&encode_ops.size, "result");
-                        TsCallbackReturnKind::WireEncoded {
-                            ts_type,
-                            encode_expr,
-                            size_expr,
-                        }
+                        TsCallbackReturnKind::WireEncoded { ts_type, encode_expr, size_expr }
                     }
-                    OutputBinding::Handle { .. } | OutputBinding::CallbackHandle { .. } => {
-                        TsCallbackReturnKind::Primitive {
-                            ts_type: "number".to_string(),
-                        }
-                    }
+                    OutputBinding::Handle { .. } | OutputBinding::CallbackHandle { .. } => TsCallbackReturnKind::Primitive { ts_type: "number".to_string() },
                 };
 
                 Some(TsCallbackMethod {
@@ -610,20 +465,11 @@ impl<'a> TypeScriptLowerer<'a> {
             .iter()
             .filter(|m| m.is_async)
             .filter_map(|method_def| {
-                let abi_method = abi_callback
-                    .methods
-                    .iter()
-                    .find(|am| am.id == method_def.id)?;
+                let abi_method = abi_callback.methods.iter().find(|am| am.id == method_def.id)?;
                 let ts_name = camel_case(method_def.id.as_str());
                 let method_name_snake = naming::to_snake_case(method_def.id.as_str());
-                let start_import_name = format!(
-                    "__boltffi_callback_{}_{}_start",
-                    trait_name_snake, method_name_snake
-                );
-                let complete_export_name = format!(
-                    "boltffi_callback_{}_{}_complete",
-                    trait_name_snake, method_name_snake
-                );
+                let start_import_name = format!("__boltffi_callback_{}_{}_start", trait_name_snake, method_name_snake);
+                let complete_export_name = format!("boltffi_callback_{}_{}_complete", trait_name_snake, method_name_snake);
 
                 let params = method_def
                     .params
@@ -632,10 +478,7 @@ impl<'a> TypeScriptLowerer<'a> {
                         let ts_type = emit::ts_type(&p.type_expr);
                         let param_name = p.name.as_str();
                         let callback_param_name = camel_case(param_name);
-                        let abi_param = abi_method
-                            .params
-                            .iter()
-                            .find(|ap| ap.name.as_str() == param_name);
+                        let abi_param = abi_method.params.iter().find(|ap| ap.name.as_str() == param_name);
 
                         let kind = match abi_param {
                             Some(abi_param) => match abi_param.input_binding() {
@@ -643,14 +486,9 @@ impl<'a> TypeScriptLowerer<'a> {
                                     let decode_expr = emit::emit_reader_read(decode_ops);
                                     TsCallbackParamKind::WireEncoded { decode_expr }
                                 }
-                                _ => callback_primitive_param_kind(
-                                    callback_param_name.as_str(),
-                                    Some(abi_param.ffi_type),
-                                ),
+                                _ => callback_primitive_param_kind(callback_param_name.as_str(), Some(abi_param.ffi_type)),
                             },
-                            None => {
-                                callback_primitive_param_kind(callback_param_name.as_str(), None)
-                            }
+                            None => callback_primitive_param_kind(callback_param_name.as_str(), None),
                         };
 
                         TsCallbackParam {
@@ -661,14 +499,7 @@ impl<'a> TypeScriptLowerer<'a> {
                     })
                     .collect();
 
-                let (
-                    return_type,
-                    encode_expr,
-                    size_expr,
-                    direct_write_method,
-                    direct_write_value_expr,
-                    direct_size,
-                ) = match abi_method.output_shape.output_binding() {
+                let (return_type, encode_expr, size_expr, direct_write_method, direct_write_value_expr, direct_size) = match abi_method.output_shape.output_binding() {
                     OutputBinding::Unit => (None, None, None, None, None, None),
                     OutputBinding::Fast(FastOutputBinding::Scalar { abi_type: abi }) => {
                         let ts_type = match &method_def.returns {
@@ -694,23 +525,11 @@ impl<'a> TypeScriptLowerer<'a> {
                         let encode_ops = binding.encode_ops().expect("encoded callback return");
                         let encode_expr = emit::emit_writer_write(encode_ops, "writer", "result");
                         let size_expr = emit::emit_size_expr(&encode_ops.size, "result");
-                        (
-                            Some(ts_type),
-                            Some(encode_expr),
-                            Some(size_expr),
-                            None,
-                            None,
-                            None,
-                        )
+                        (Some(ts_type), Some(encode_expr), Some(size_expr), None, None, None)
                     }
-                    OutputBinding::Handle { .. } | OutputBinding::CallbackHandle { .. } => (
-                        Some("number".to_string()),
-                        None,
-                        None,
-                        Some("writeU32".to_string()),
-                        Some("result".to_string()),
-                        Some(4),
-                    ),
+                    OutputBinding::Handle { .. } | OutputBinding::CallbackHandle { .. } => {
+                        (Some("number".to_string()), None, None, Some("writeU32".to_string()), Some("result".to_string()), Some(4))
+                    }
                 };
 
                 Some(TsAsyncCallbackMethod {
@@ -771,8 +590,7 @@ impl<'a> TypeScriptLowerer<'a> {
         let func_name = camel_case(def.id.as_str());
         let ffi_name = abi_call.symbol.as_str().to_string();
 
-        let param_defs: HashMap<&str, &ParamDef> =
-            def.params.iter().map(|p| (p.name.as_str(), p)).collect();
+        let param_defs: HashMap<&str, &ParamDef> = def.params.iter().map(|p| (p.name.as_str(), p)).collect();
 
         let params = abi_call
             .params
@@ -784,8 +602,7 @@ impl<'a> TypeScriptLowerer<'a> {
             })
             .collect();
 
-        let (return_type, return_route) =
-            self.select_output_route(&abi_call.output_shape, TsExecutionModel::Sync);
+        let (return_type, return_route) = self.select_output_route(&abi_call.output_shape, TsExecutionModel::Sync);
         let (throws, err_type) = self.lower_error(&abi_call.error);
 
         Some(TsFunction {
@@ -813,8 +630,7 @@ impl<'a> TypeScriptLowerer<'a> {
         let fn_name_snake = naming::to_snake_case(def.id.as_str());
         let base_ffi_name = format!("{}_{}", ffi_prefix(), fn_name_snake);
 
-        let param_defs: HashMap<&str, &ParamDef> =
-            def.params.iter().map(|p| (p.name.as_str(), p)).collect();
+        let param_defs: HashMap<&str, &ParamDef> = def.params.iter().map(|p| (p.name.as_str(), p)).collect();
 
         let params = abi_call
             .params
@@ -826,8 +642,7 @@ impl<'a> TypeScriptLowerer<'a> {
             })
             .collect();
 
-        let (return_type, return_route) =
-            self.select_output_route(&async_call.result_shape, TsExecutionModel::Async);
+        let (return_type, return_route) = self.select_output_route(&async_call.result_shape, TsExecutionModel::Async);
         let (throws, err_type) = self.lower_error(&async_call.error);
 
         Some(TsAsyncFunction {
@@ -864,9 +679,7 @@ impl<'a> TypeScriptLowerer<'a> {
                 let (ts_type, input_route) = match element_abi {
                     AbiType::U8 => ("Uint8Array".to_string(), TsInputRoute::Bytes),
                     _ => (
-                        param_def
-                            .map(|p| emit::ts_type(&p.type_expr))
-                            .unwrap_or_else(|| primitive_buffer_ts_type(element_abi)),
+                        param_def.map(|p| emit::ts_type(&p.type_expr)).unwrap_or_else(|| primitive_buffer_ts_type(element_abi)),
                         TsInputRoute::PrimitiveBuffer { element_abi },
                     ),
                 };
@@ -877,20 +690,12 @@ impl<'a> TypeScriptLowerer<'a> {
                 }
             }
             Some(InputBinding::WirePacket { encode_ops, .. }) => {
-                let ts_type = param_def
-                    .map(|p| emit::ts_type(&p.type_expr))
-                    .unwrap_or_else(|| "unknown".to_string());
-                let has_codec = param_def
-                    .map(|p| matches!(&p.type_expr, TypeExpr::Record(_) | TypeExpr::Enum(_)))
-                    .unwrap_or(false);
+                let ts_type = param_def.map(|p| emit::ts_type(&p.type_expr)).unwrap_or_else(|| "unknown".to_string());
+                let has_codec = param_def.map(|p| matches!(&p.type_expr, TypeExpr::Record(_) | TypeExpr::Enum(_))).unwrap_or(false);
                 let input_route = if has_codec {
-                    TsInputRoute::CodecEncoded {
-                        codec_name: ts_type.clone(),
-                    }
+                    TsInputRoute::CodecEncoded { codec_name: ts_type.clone() }
                 } else {
-                    TsInputRoute::OtherEncoded {
-                        encode: encode_ops.clone(),
-                    }
+                    TsInputRoute::OtherEncoded { encode: encode_ops.clone() }
                 };
                 TsParam {
                     name: emit::escape_ts_keyword(&name),
@@ -908,11 +713,7 @@ impl<'a> TypeScriptLowerer<'a> {
             }
             Some(InputBinding::Handle { class_id, nullable }) => {
                 let class_name = naming::to_upper_camel_case(class_id.as_str());
-                let ts_type = if nullable {
-                    format!("{class_name} | null")
-                } else {
-                    class_name
-                };
+                let ts_type = if nullable { format!("{class_name} | null") } else { class_name };
                 TsParam {
                     name: emit::escape_ts_keyword(&name),
                     ts_type,
@@ -932,26 +733,16 @@ impl<'a> TypeScriptLowerer<'a> {
         }
     }
 
-    fn select_output_route(
-        &self,
-        output_shape: &OutputShape,
-        execution_model: TsExecutionModel,
-    ) -> (Option<String>, TsOutputRoute) {
+    fn select_output_route(&self, output_shape: &OutputShape, execution_model: TsExecutionModel) -> (Option<String>, TsOutputRoute) {
         match output_shape.output_binding() {
             OutputBinding::Unit => (None, TsOutputRoute::void()),
-            OutputBinding::Fast(FastOutputBinding::Scalar { abi_type }) => {
-                self.scalar_output_route(abi_type, execution_model)
-            }
+            OutputBinding::Fast(FastOutputBinding::Scalar { abi_type }) => self.scalar_output_route(abi_type, execution_model),
             OutputBinding::Fast(fast) => {
                 let decode_ops = fast.decode_ops().expect("encoded fast return");
                 self.encoded_output_route(decode_ops, execution_model)
             }
-            OutputBinding::Wire(wire) => {
-                self.encoded_output_route(wire.decode_ops, execution_model)
-            }
-            OutputBinding::Handle { class_id, nullable } => {
-                self.handle_output_route(class_id.as_str(), nullable, execution_model)
-            }
+            OutputBinding::Wire(wire) => self.encoded_output_route(wire.decode_ops, execution_model),
+            OutputBinding::Handle { class_id, nullable } => self.handle_output_route(class_id.as_str(), nullable, execution_model),
             OutputBinding::CallbackHandle { .. } => match execution_model {
                 TsExecutionModel::Sync => (Some("unknown".to_string()), TsOutputRoute::void()),
                 TsExecutionModel::Async => (None, TsOutputRoute::void()),
@@ -970,50 +761,24 @@ impl<'a> TypeScriptLowerer<'a> {
         }
     }
 
-    fn scalar_output_route(
-        &self,
-        abi_type: AbiType,
-        execution_model: TsExecutionModel,
-    ) -> (Option<String>, TsOutputRoute) {
+    fn scalar_output_route(&self, abi_type: AbiType, execution_model: TsExecutionModel) -> (Option<String>, TsOutputRoute) {
         let ts_type = ts_abi_type(&abi_type);
         match execution_model {
-            TsExecutionModel::Sync => (
-                Some(ts_type),
-                TsOutputRoute::direct(ts_direct_cast(&abi_type)),
-            ),
-            TsExecutionModel::Async => (
-                Some(ts_type),
-                TsOutputRoute::async_scalar(ts_direct_cast(&abi_type)),
-            ),
+            TsExecutionModel::Sync => (Some(ts_type), TsOutputRoute::direct(ts_direct_cast(&abi_type))),
+            TsExecutionModel::Async => (Some(ts_type), TsOutputRoute::async_scalar(ts_direct_cast(&abi_type))),
         }
     }
 
-    fn handle_output_route(
-        &self,
-        class_id: &str,
-        nullable: bool,
-        execution_model: TsExecutionModel,
-    ) -> (Option<String>, TsOutputRoute) {
+    fn handle_output_route(&self, class_id: &str, nullable: bool, execution_model: TsExecutionModel) -> (Option<String>, TsOutputRoute) {
         let class_name = naming::to_upper_camel_case(class_id);
-        let ts_type = if nullable {
-            format!("{class_name} | null")
-        } else {
-            class_name
-        };
+        let ts_type = if nullable { format!("{class_name} | null") } else { class_name };
         match execution_model {
             TsExecutionModel::Sync => (Some(ts_type), TsOutputRoute::direct(String::new())),
-            TsExecutionModel::Async => (
-                Some(ts_type),
-                TsOutputRoute::packed("reader.readU32()".to_string()),
-            ),
+            TsExecutionModel::Async => (Some(ts_type), TsOutputRoute::packed("reader.readU32()".to_string())),
         }
     }
 
-    fn encoded_output_route(
-        &self,
-        decode_ops: &ReadSeq,
-        execution_model: TsExecutionModel,
-    ) -> (Option<String>, TsOutputRoute) {
+    fn encoded_output_route(&self, decode_ops: &ReadSeq, execution_model: TsExecutionModel) -> (Option<String>, TsOutputRoute) {
         match execution_model {
             TsExecutionModel::Sync => self.sync_encoded_output_route(decode_ops),
             TsExecutionModel::Async => self.async_encoded_output_route(decode_ops),
@@ -1023,10 +788,7 @@ impl<'a> TypeScriptLowerer<'a> {
     fn sync_encoded_output_route(&self, decode_ops: &ReadSeq) -> (Option<String>, TsOutputRoute) {
         let ts_type_str = infer_ts_type_from_read_ops(decode_ops);
         if let Some(optional_decode) = emit_raw_optional_primitive_read(decode_ops) {
-            return (
-                Some(ts_type_str),
-                TsOutputRoute::f64_optional(optional_decode),
-            );
+            return (Some(ts_type_str), TsOutputRoute::f64_optional(optional_decode));
         }
         match decode_ops.ops.first() {
             Some(ReadOp::Vec {
@@ -1043,10 +805,7 @@ impl<'a> TypeScriptLowerer<'a> {
                     _ => None,
                 };
                 if let Some(decode) = slot_decode {
-                    (
-                        Some(ts_type_str),
-                        TsOutputRoute::void_slot(decode.to_string()),
-                    )
+                    (Some(ts_type_str), TsOutputRoute::void_slot(decode.to_string()))
                 } else {
                     let decode = emit::emit_reader_read(decode_ops);
                     (Some(ts_type_str), TsOutputRoute::packed(decode))
@@ -1086,16 +845,13 @@ impl<'a> TypeScriptLowerer<'a> {
                 })
                 .collect();
 
-            let (_, return_route) =
-                self.select_output_route(&call.output_shape, TsExecutionModel::Sync);
+            let (_, return_route) = self.select_output_route(&call.output_shape, TsExecutionModel::Sync);
             let return_output = call.output_binding();
             let return_wasm_type = if return_route.is_void() {
                 None
             } else if return_route.is_direct() {
                 match return_output {
-                    OutputBinding::Fast(FastOutputBinding::Scalar { abi_type }) => {
-                        Some(abi_type_to_wasm(&abi_type))
-                    }
+                    OutputBinding::Fast(FastOutputBinding::Scalar { abi_type }) => Some(abi_type_to_wasm(&abi_type)),
                     OutputBinding::Handle { .. } => Some("number".to_string()),
                     _ => None,
                 }
@@ -1121,10 +877,7 @@ impl<'a> TypeScriptLowerer<'a> {
 }
 
 fn is_excluded_error_type(err_type: &str) -> bool {
-    matches!(
-        err_type,
-        "String" | "string" | "FfiError" | "Error" | "unknown"
-    )
+    matches!(err_type, "String" | "string" | "FfiError" | "Error" | "unknown")
 }
 
 fn ts_abi_type(abi_type: &AbiType) -> String {
@@ -1169,9 +922,7 @@ fn scalar_async_decode_expr(abi_type: &AbiType) -> String {
 fn abi_type_to_wasm(abi_type: &AbiType) -> String {
     match abi_type {
         AbiType::Void => "void".to_string(),
-        AbiType::Bool | AbiType::I8 | AbiType::U8 | AbiType::I16 | AbiType::U16 => {
-            "number".to_string()
-        }
+        AbiType::Bool | AbiType::I8 | AbiType::U8 | AbiType::I16 | AbiType::U16 => "number".to_string(),
         AbiType::I32 | AbiType::U32 | AbiType::ISize | AbiType::USize => "number".to_string(),
         AbiType::I64 | AbiType::U64 => "bigint".to_string(),
         AbiType::F32 | AbiType::F64 => "number".to_string(),
@@ -1179,23 +930,14 @@ fn abi_type_to_wasm(abi_type: &AbiType) -> String {
     }
 }
 
-fn callback_primitive_param_kind(
-    param_name: &str,
-    abi_type: Option<AbiType>,
-) -> TsCallbackParamKind {
-    let import_ts_type = abi_type
-        .as_ref()
-        .map(abi_type_to_wasm)
-        .unwrap_or_else(|| "number".to_string());
+fn callback_primitive_param_kind(param_name: &str, abi_type: Option<AbiType>) -> TsCallbackParamKind {
+    let import_ts_type = abi_type.as_ref().map(abi_type_to_wasm).unwrap_or_else(|| "number".to_string());
     let call_expr = match abi_type {
         Some(AbiType::Bool) => format!("{param_name} !== 0"),
         _ => param_name.to_string(),
     };
 
-    TsCallbackParamKind::Primitive {
-        import_ts_type,
-        call_expr,
-    }
+    TsCallbackParamKind::Primitive { import_ts_type, call_expr }
 }
 
 struct DirectWriteInfo {
@@ -1205,10 +947,7 @@ struct DirectWriteInfo {
 
 fn direct_write_info(abi_type: &AbiType) -> DirectWriteInfo {
     match abi_type {
-        AbiType::Void => DirectWriteInfo {
-            method_name: "",
-            byte_width: 0,
-        },
+        AbiType::Void => DirectWriteInfo { method_name: "", byte_width: 0 },
         AbiType::Bool => DirectWriteInfo {
             method_name: "writeBool",
             byte_width: 1,
@@ -1279,16 +1018,9 @@ fn primitive_buffer_ts_type(abi_type: AbiType) -> String {
     match abi_type {
         AbiType::Bool => "boolean[]".to_string(),
         AbiType::I64 | AbiType::U64 => "bigint[]".to_string(),
-        AbiType::I8
-        | AbiType::U8
-        | AbiType::I16
-        | AbiType::U16
-        | AbiType::I32
-        | AbiType::U32
-        | AbiType::ISize
-        | AbiType::USize
-        | AbiType::F32
-        | AbiType::F64 => "number[]".to_string(),
+        AbiType::I8 | AbiType::U8 | AbiType::I16 | AbiType::U16 | AbiType::I32 | AbiType::U32 | AbiType::ISize | AbiType::USize | AbiType::F32 | AbiType::F64 => {
+            "number[]".to_string()
+        }
         AbiType::Void | AbiType::Pointer => "unknown[]".to_string(),
     }
 }
@@ -1354,11 +1086,7 @@ fn record_decode_fields(record: &AbiRecord) -> HashMap<FieldName, ReadSeq> {
             _ => None,
         })
         .into_iter()
-        .flat_map(|fields| {
-            fields
-                .iter()
-                .map(|field| (field.name.clone(), field.seq.clone()))
-        })
+        .flat_map(|fields| fields.iter().map(|field| (field.name.clone(), field.seq.clone())))
         .collect()
 }
 
@@ -1372,11 +1100,7 @@ fn record_encode_fields(record: &AbiRecord) -> HashMap<FieldName, WriteSeq> {
             _ => None,
         })
         .into_iter()
-        .flat_map(|fields| {
-            fields
-                .iter()
-                .map(|field| (field.name.clone(), field.seq.clone()))
-        })
+        .flat_map(|fields| fields.iter().map(|field| (field.name.clone(), field.seq.clone())))
         .collect()
 }
 
@@ -1391,9 +1115,7 @@ fn remap_named_to_field(seq: &WriteSeq) -> WriteSeq {
 fn remap_named_in_value(expr: &ValueExpr) -> ValueExpr {
     match expr {
         ValueExpr::Named(name) => ValueExpr::Instance.field(FieldName::new(name)),
-        ValueExpr::Field(parent, field) => {
-            ValueExpr::Field(Box::new(remap_named_in_value(parent)), field.clone())
-        }
+        ValueExpr::Field(parent, field) => ValueExpr::Field(Box::new(remap_named_in_value(parent)), field.clone()),
         other => other.clone(),
     }
 }
@@ -1416,11 +1138,7 @@ fn remap_named_in_size(size: &SizeExpr) -> SizeExpr {
             value: remap_named_in_value(value),
             inner: Box::new(remap_named_in_size(inner)),
         },
-        SizeExpr::VecSize {
-            value,
-            inner,
-            layout,
-        } => SizeExpr::VecSize {
+        SizeExpr::VecSize { value, inner, layout } => SizeExpr::VecSize {
             value: remap_named_in_value(value),
             inner: Box::new(remap_named_in_size(inner)),
             layout: layout.clone(),
@@ -1487,11 +1205,7 @@ fn remap_named_in_write_op(op: &WriteOp) -> WriteOp {
             id: id.clone(),
             value: remap_named_in_value(value),
         },
-        WriteOp::Custom {
-            id,
-            value,
-            underlying,
-        } => WriteOp::Custom {
+        WriteOp::Custom { id, value, underlying } => WriteOp::Custom {
             id: id.clone(),
             value: remap_named_in_value(value),
             underlying: Box::new(remap_named_to_field(underlying)),
@@ -1502,13 +1216,12 @@ fn remap_named_in_write_op(op: &WriteOp) -> WriteOp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::Lowerer as IrLowerer;
-    use crate::ir::contract::{FfiContract, PackageInfo};
-    use crate::ir::definitions::{
-        ClassDef, ConstructorDef, FunctionDef, MethodDef, ParamDef, ParamPassing, Receiver,
-        ReturnDef,
+    use crate::ir::{
+        Lowerer as IrLowerer,
+        contract::{FfiContract, PackageInfo},
+        definitions::{ClassDef, ConstructorDef, FunctionDef, MethodDef, ParamDef, ParamPassing, Receiver, ReturnDef},
+        ids::{ClassId, FunctionId, MethodId, ParamName},
     };
-    use crate::ir::ids::{ClassId, FunctionId, MethodId, ParamName};
 
     fn empty_contract() -> FfiContract {
         FfiContract {
@@ -1539,12 +1252,7 @@ mod tests {
         }
     }
 
-    fn function(
-        name: &str,
-        params: Vec<ParamDef>,
-        returns: ReturnDef,
-        is_async: bool,
-    ) -> FunctionDef {
+    fn function(name: &str, params: Vec<ParamDef>, returns: ReturnDef, is_async: bool) -> FunctionDef {
         FunctionDef {
             id: FunctionId::new(name),
             params,
@@ -1557,13 +1265,7 @@ mod tests {
 
     fn lower_contract(contract: &FfiContract) -> TsModule {
         let abi = IrLowerer::new(contract).to_abi_contract();
-        TypeScriptLowerer::new(
-            contract,
-            &abi,
-            "Test".to_string(),
-            TypeScriptExperimental::default(),
-        )
-        .lower()
+        TypeScriptLowerer::new(contract, &abi, "Test".to_string(), TypeScriptExperimental::default()).lower()
     }
 
     fn class_with_sync_and_async_methods() -> ClassDef {
@@ -1596,6 +1298,7 @@ mod tests {
                 },
             ],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         }
@@ -1629,10 +1332,7 @@ mod tests {
         let mut contract = empty_contract();
         contract.functions.push(function(
             "add",
-            vec![
-                primitive_param("left", PrimitiveType::I32),
-                primitive_param("right", PrimitiveType::I32),
-            ],
+            vec![primitive_param("left", PrimitiveType::I32), primitive_param("right", PrimitiveType::I32)],
             ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::I32)),
             false,
         ));
@@ -1645,31 +1345,16 @@ mod tests {
             .expect("wasm import for direct return");
 
         assert_eq!(import.return_wasm_type.as_deref(), Some("number"));
-        assert_eq!(
-            import
-                .params
-                .iter()
-                .map(|param| param.name.as_str())
-                .collect::<Vec<_>>(),
-            vec!["left", "right"]
-        );
+        assert_eq!(import.params.iter().map(|param| param.name.as_str()).collect::<Vec<_>>(), vec!["left", "right"]);
     }
 
     #[test]
     fn wasm_imports_skip_async_calls() {
         let mut contract = empty_contract();
-        contract.functions.push(function(
-            "sync_value",
-            vec![],
-            ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::I32)),
-            false,
-        ));
-        contract.functions.push(function(
-            "async_value",
-            vec![],
-            ReturnDef::Value(TypeExpr::String),
-            true,
-        ));
+        contract
+            .functions
+            .push(function("sync_value", vec![], ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::I32)), false));
+        contract.functions.push(function("async_value", vec![], ReturnDef::Value(TypeExpr::String), true));
 
         let module = lower_contract(&contract);
 
@@ -1683,39 +1368,24 @@ mod tests {
         contract.functions.push(function(
             "find_even",
             vec![primitive_param("value", PrimitiveType::I32)],
-            ReturnDef::Value(TypeExpr::Option(Box::new(TypeExpr::Primitive(
-                PrimitiveType::I32,
-            )))),
+            ReturnDef::Value(TypeExpr::Option(Box::new(TypeExpr::Primitive(PrimitiveType::I32)))),
             false,
         ));
 
         let module = lower_contract(&contract);
-        let function = module
-            .functions
-            .iter()
-            .find(|function| function.name == "findEven")
-            .expect("findEven should be lowered");
+        let function = module.functions.iter().find(|function| function.name == "findEven").expect("findEven should be lowered");
 
         assert!(function.return_route.is_f64_optional());
-        assert_eq!(
-            function.return_route.decode_expr(),
-            "_module.unpackOptionI32(packed)"
-        );
+        assert_eq!(function.return_route.decode_expr(), "_module.unpackOptionI32(packed)");
     }
 
     #[test]
     fn class_instance_methods_exclude_receiver_from_public_params() {
         let mut contract = empty_contract();
-        contract
-            .catalog
-            .insert_class(class_with_sync_and_async_methods());
+        contract.catalog.insert_class(class_with_sync_and_async_methods());
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|class| class.class_name == "Counter")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|class| class.class_name == "Counter").expect("class should be lowered");
         let method = class
             .methods
             .iter()
@@ -1730,37 +1400,18 @@ mod tests {
     #[test]
     fn class_async_methods_generate_wasm_poll_sync_symbol_names() {
         let mut contract = empty_contract();
-        contract
-            .catalog
-            .insert_class(class_with_sync_and_async_methods());
+        contract.catalog.insert_class(class_with_sync_and_async_methods());
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|class| class.class_name == "Counter")
-            .expect("class should be lowered");
-        let method = class
-            .methods
-            .iter()
-            .find(|method| method.ts_name == "nextValue")
-            .expect("async method should be lowered");
+        let class = module.classes.iter().find(|class| class.class_name == "Counter").expect("class should be lowered");
+        let method = class.methods.iter().find(|method| method.ts_name == "nextValue").expect("async method should be lowered");
 
         match &method.mode {
             TsClassMethodMode::Async(async_method) => {
                 assert_eq!(method.ffi_name, "boltffi_counter_next_value");
-                assert_eq!(
-                    async_method.poll_sync_ffi_name,
-                    "boltffi_counter_next_value_poll_sync"
-                );
-                assert_eq!(
-                    async_method.complete_ffi_name,
-                    "boltffi_counter_next_value_complete"
-                );
-                assert_eq!(
-                    async_method.panic_message_ffi_name,
-                    "boltffi_counter_next_value_panic_message"
-                );
+                assert_eq!(async_method.poll_sync_ffi_name, "boltffi_counter_next_value_poll_sync");
+                assert_eq!(async_method.complete_ffi_name, "boltffi_counter_next_value_complete");
+                assert_eq!(async_method.panic_message_ffi_name, "boltffi_counter_next_value_panic_message");
             }
             TsClassMethodMode::Sync(_) => panic!("expected async class method mode"),
         }
@@ -1769,12 +1420,9 @@ mod tests {
     #[test]
     fn vec_i32_param_uses_number_array_conversion() {
         let mut contract = empty_contract();
-        contract.functions.push(function(
-            "process_values",
-            vec![vec_param("values", PrimitiveType::I32)],
-            ReturnDef::Void,
-            false,
-        ));
+        contract
+            .functions
+            .push(function("process_values", vec![vec_param("values", PrimitiveType::I32)], ReturnDef::Void, false));
 
         let module = lower_contract(&contract);
         let function = module
@@ -1782,30 +1430,18 @@ mod tests {
             .iter()
             .find(|function| function.name == "processValues")
             .expect("function should be lowered");
-        let param = function
-            .params
-            .iter()
-            .find(|param| param.name == "values")
-            .expect("vec parameter should exist");
+        let param = function.params.iter().find(|param| param.name == "values").expect("vec parameter should exist");
 
         assert_eq!(param.ts_type, "number[]");
-        assert!(matches!(
-            param.input_route,
-            TsInputRoute::PrimitiveBuffer {
-                element_abi: AbiType::I32
-            }
-        ));
+        assert!(matches!(param.input_route, TsInputRoute::PrimitiveBuffer { element_abi: AbiType::I32 }));
     }
 
     #[test]
     fn vec_i32_param_builds_primitive_buffer_wrapper_sequence() {
         let mut contract = empty_contract();
-        contract.functions.push(function(
-            "process_values",
-            vec![vec_param("values", PrimitiveType::I32)],
-            ReturnDef::Void,
-            false,
-        ));
+        contract
+            .functions
+            .push(function("process_values", vec![vec_param("values", PrimitiveType::I32)], ReturnDef::Void, false));
 
         let module = lower_contract(&contract);
         let function = module
@@ -1813,38 +1449,19 @@ mod tests {
             .iter()
             .find(|function| function.name == "processValues")
             .expect("function should be lowered");
-        let param = function
-            .params
-            .iter()
-            .find(|param| param.name == "values")
-            .expect("vec parameter should exist");
+        let param = function.params.iter().find(|param| param.name == "values").expect("vec parameter should exist");
 
-        assert_eq!(
-            param.wrapper_code(),
-            Some("const values_alloc = _module.allocI32Array(values);".to_string())
-        );
-        assert_eq!(
-            param.ffi_args(),
-            vec![
-                "values_alloc.ptr".to_string(),
-                "values_alloc.len".to_string()
-            ]
-        );
-        assert_eq!(
-            param.cleanup_code(),
-            Some("_module.freePrimitiveBuffer(values_alloc);".to_string())
-        );
+        assert_eq!(param.wrapper_code(), Some("const values_alloc = _module.allocI32Array(values);".to_string()));
+        assert_eq!(param.ffi_args(), vec!["values_alloc.ptr".to_string(), "values_alloc.len".to_string()]);
+        assert_eq!(param.cleanup_code(), Some("_module.freePrimitiveBuffer(values_alloc);".to_string()));
     }
 
     #[test]
     fn vec_u8_param_remains_uint8_array() {
         let mut contract = empty_contract();
-        contract.functions.push(function(
-            "process_bytes",
-            vec![vec_param("values", PrimitiveType::U8)],
-            ReturnDef::Void,
-            false,
-        ));
+        contract
+            .functions
+            .push(function("process_bytes", vec![vec_param("values", PrimitiveType::U8)], ReturnDef::Void, false));
 
         let module = lower_contract(&contract);
         let function = module
@@ -1852,29 +1469,13 @@ mod tests {
             .iter()
             .find(|function| function.name == "processBytes")
             .expect("function should be lowered");
-        let param = function
-            .params
-            .iter()
-            .find(|param| param.name == "values")
-            .expect("vec parameter should exist");
+        let param = function.params.iter().find(|param| param.name == "values").expect("vec parameter should exist");
 
         assert_eq!(param.ts_type, "Uint8Array");
         assert!(matches!(param.input_route, TsInputRoute::Bytes));
-        assert_eq!(
-            param.wrapper_code(),
-            Some("const values_alloc = _module.allocBytes(values);".to_string())
-        );
-        assert_eq!(
-            param.ffi_args(),
-            vec![
-                "values_alloc.ptr".to_string(),
-                "values_alloc.len".to_string()
-            ]
-        );
-        assert_eq!(
-            param.cleanup_code(),
-            Some("_module.freeAlloc(values_alloc);".to_string())
-        );
+        assert_eq!(param.wrapper_code(), Some("const values_alloc = _module.allocBytes(values);".to_string()));
+        assert_eq!(param.ffi_args(), vec!["values_alloc.ptr".to_string(), "values_alloc.len".to_string()]);
+        assert_eq!(param.cleanup_code(), Some("_module.freeAlloc(values_alloc);".to_string()));
     }
 
     #[test]
@@ -1882,10 +1483,7 @@ mod tests {
         let info = direct_write_info(&AbiType::Bool);
         assert_eq!(info.method_name, "writeBool");
         assert_eq!(info.byte_width, 1);
-        assert_eq!(
-            direct_write_argument_expr(&AbiType::Bool, "result"),
-            "result"
-        );
+        assert_eq!(direct_write_argument_expr(&AbiType::Bool, "result"), "result");
     }
 
     #[test]
@@ -1900,24 +1498,15 @@ mod tests {
 
     #[test]
     fn direct_write_argument_expr_casts_pointer_sized_scalars_to_bigint() {
-        assert_eq!(
-            direct_write_argument_expr(&AbiType::ISize, "result"),
-            "BigInt(result)"
-        );
-        assert_eq!(
-            direct_write_argument_expr(&AbiType::USize, "result"),
-            "BigInt(result)"
-        );
+        assert_eq!(direct_write_argument_expr(&AbiType::ISize, "result"), "BigInt(result)");
+        assert_eq!(direct_write_argument_expr(&AbiType::USize, "result"), "BigInt(result)");
     }
 
     #[test]
     fn callback_primitive_param_kind_uses_bigint_for_i64() {
         let kind = callback_primitive_param_kind("count", Some(AbiType::I64));
         match kind {
-            TsCallbackParamKind::Primitive {
-                import_ts_type,
-                call_expr,
-            } => {
+            TsCallbackParamKind::Primitive { import_ts_type, call_expr } => {
                 assert_eq!(import_ts_type, "bigint");
                 assert_eq!(call_expr, "count");
             }
@@ -1931,10 +1520,7 @@ mod tests {
     fn callback_primitive_param_kind_coerces_bool_to_boolean_expression() {
         let kind = callback_primitive_param_kind("isActive", Some(AbiType::Bool));
         match kind {
-            TsCallbackParamKind::Primitive {
-                import_ts_type,
-                call_expr,
-            } => {
+            TsCallbackParamKind::Primitive { import_ts_type, call_expr } => {
                 assert_eq!(import_ts_type, "number");
                 assert_eq!(call_expr, "isActive !== 0");
             }
@@ -1957,16 +1543,13 @@ mod tests {
             }],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Counter")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Counter").expect("class should be lowered");
 
         assert_eq!(class.constructors.len(), 1);
         let constructor = &class.constructors[0];
@@ -1996,16 +1579,13 @@ mod tests {
             ],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Connection")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Connection").expect("class should be lowered");
 
         assert_eq!(class.constructors.len(), 2);
         assert_eq!(class.constructors[0].ffi_name, "boltffi_connection_new");
@@ -2030,16 +1610,13 @@ mod tests {
                 deprecated: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Factory")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Factory").expect("class should be lowered");
 
         let method = &class.methods[0];
         assert!(method.is_static);
@@ -2062,16 +1639,13 @@ mod tests {
                 deprecated: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Buffer")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Buffer").expect("class should be lowered");
 
         let method = &class.methods[0];
         assert!(!method.is_static);
@@ -2099,16 +1673,13 @@ mod tests {
                 deprecated: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Database")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Database").expect("class should be lowered");
 
         let method = &class.methods[0];
         assert_eq!(method.ffi_name, "boltffi_database_query");
@@ -2125,16 +1696,13 @@ mod tests {
             constructors: vec![],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Resource")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Resource").expect("class should be lowered");
 
         assert_eq!(class.ffi_free, "boltffi_resource_free");
     }
@@ -2150,11 +1718,7 @@ mod tests {
         ));
 
         let module = lower_contract(&contract);
-        let import = module
-            .wasm_imports
-            .iter()
-            .find(|i| i.ffi_name == "boltffi_use_default")
-            .expect("wasm import should exist");
+        let import = module.wasm_imports.iter().find(|i| i.ffi_name == "boltffi_use_default").expect("wasm import should exist");
 
         assert_eq!(import.params[0].name, "default_");
     }
@@ -2175,16 +1739,13 @@ mod tests {
                 deprecated: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Counter")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Counter").expect("class should be lowered");
 
         let method = &class.methods[0];
         assert_eq!(method.ts_name, "incrementAsync");
@@ -2194,10 +1755,7 @@ mod tests {
 
         match &method.mode {
             TsClassMethodMode::Async(async_method) => {
-                assert_eq!(
-                    async_method.poll_sync_ffi_name,
-                    "boltffi_counter_increment_async_poll_sync"
-                );
+                assert_eq!(async_method.poll_sync_ffi_name, "boltffi_counter_increment_async_poll_sync");
             }
             TsClassMethodMode::Sync(_) => panic!("expected async method mode"),
         }
@@ -2211,6 +1769,7 @@ mod tests {
             constructors: vec![],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2246,16 +1805,13 @@ mod tests {
                 deprecated: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Logger")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Logger").expect("class should be lowered");
 
         let method = &class.methods[0];
         assert_eq!(method.params[0].name, "message");
@@ -2281,16 +1837,13 @@ mod tests {
             }],
             methods: vec![],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Connection")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Connection").expect("class should be lowered");
 
         let ctor = &class.constructors[0];
         assert_eq!(ctor.params[0].name, "url");
@@ -2314,16 +1867,13 @@ mod tests {
                 deprecated: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Printer")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Printer").expect("class should be lowered");
 
         let method = &class.methods[0];
         assert!(method.return_type.is_none());
@@ -2338,27 +1888,25 @@ mod tests {
     #[test]
     fn class_method_with_record_param_uses_codec_conversion() {
         let mut contract = empty_contract();
-        contract
-            .catalog
-            .insert_record(crate::ir::definitions::RecordDef {
-                id: crate::ir::ids::RecordId::new("Point"),
-                fields: vec![
-                    crate::ir::definitions::FieldDef {
-                        name: FieldName::new("x"),
-                        type_expr: TypeExpr::Primitive(PrimitiveType::F64),
-                        doc: None,
-                        default: None,
-                    },
-                    crate::ir::definitions::FieldDef {
-                        name: FieldName::new("y"),
-                        type_expr: TypeExpr::Primitive(PrimitiveType::F64),
-                        doc: None,
-                        default: None,
-                    },
-                ],
-                doc: None,
-                deprecated: None,
-            });
+        contract.catalog.insert_record(crate::ir::definitions::RecordDef {
+            id: crate::ir::ids::RecordId::new("Point"),
+            fields: vec![
+                crate::ir::definitions::FieldDef {
+                    name: FieldName::new("x"),
+                    type_expr: TypeExpr::Primitive(PrimitiveType::F64),
+                    doc: None,
+                    default: None,
+                },
+                crate::ir::definitions::FieldDef {
+                    name: FieldName::new("y"),
+                    type_expr: TypeExpr::Primitive(PrimitiveType::F64),
+                    doc: None,
+                    default: None,
+                },
+            ],
+            doc: None,
+            deprecated: None,
+        });
         contract.catalog.insert_class(ClassDef {
             id: ClassId::new("Canvas"),
             constructors: vec![],
@@ -2377,16 +1925,13 @@ mod tests {
                 deprecated: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Canvas")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Canvas").expect("class should be lowered");
 
         let method = &class.methods[0];
         assert_eq!(method.params[0].name, "point");
@@ -2415,16 +1960,13 @@ mod tests {
                 deprecated: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Counter")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Counter").expect("class should be lowered");
 
         let method = &class.methods[0];
         assert_eq!(method.return_type.as_deref(), Some("number"));
@@ -2452,16 +1994,13 @@ mod tests {
                 deprecated: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "Service")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "Service").expect("class should be lowered");
 
         let method = &class.methods[0];
         assert_eq!(method.ts_name, "getUserById");
@@ -2505,42 +2044,24 @@ mod tests {
                 deprecated: None,
             }],
             streams: vec![],
+            async_iterators: vec![],
             doc: None,
             deprecated: None,
         });
 
         let module = lower_contract(&contract);
-        let class = module
-            .classes
-            .iter()
-            .find(|c| c.class_name == "NetworkClient")
-            .expect("class should be lowered");
+        let class = module.classes.iter().find(|c| c.class_name == "NetworkClient").expect("class should be lowered");
 
         let method = &class.methods[0];
         assert_eq!(method.ffi_name, "boltffi_network_client_fetch_data");
 
         match &method.mode {
             TsClassMethodMode::Async(async_method) => {
-                assert_eq!(
-                    async_method.poll_sync_ffi_name,
-                    "boltffi_network_client_fetch_data_poll_sync"
-                );
-                assert_eq!(
-                    async_method.complete_ffi_name,
-                    "boltffi_network_client_fetch_data_complete"
-                );
-                assert_eq!(
-                    async_method.panic_message_ffi_name,
-                    "boltffi_network_client_fetch_data_panic_message"
-                );
-                assert_eq!(
-                    async_method.cancel_ffi_name,
-                    "boltffi_network_client_fetch_data_cancel"
-                );
-                assert_eq!(
-                    async_method.free_ffi_name,
-                    "boltffi_network_client_fetch_data_free"
-                );
+                assert_eq!(async_method.poll_sync_ffi_name, "boltffi_network_client_fetch_data_poll_sync");
+                assert_eq!(async_method.complete_ffi_name, "boltffi_network_client_fetch_data_complete");
+                assert_eq!(async_method.panic_message_ffi_name, "boltffi_network_client_fetch_data_panic_message");
+                assert_eq!(async_method.cancel_ffi_name, "boltffi_network_client_fetch_data_cancel");
+                assert_eq!(async_method.free_ffi_name, "boltffi_network_client_fetch_data_free");
             }
             _ => panic!("expected async method"),
         }

--- a/boltffi_bindgen/src/scan/compiler_type_resolution.rs
+++ b/boltffi_bindgen/src/scan/compiler_type_resolution.rs
@@ -1,17 +1,16 @@
-use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
-
 use proc_macro2::Span;
 use quote::quote;
 use serde::Deserialize;
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 use syn::{LitStr, Type};
 
 fn runner_dir(crate_path: &Path) -> PathBuf {
-    crate_path
-        .join("target")
-        .join("boltffi_bindgen_type_resolution")
+    crate_path.join("target").join("boltffi_bindgen_type_resolution")
 }
 
 fn write_if_changed(path: &Path, contents: &str) -> Result<(), String> {
@@ -23,9 +22,7 @@ fn write_if_changed(path: &Path, contents: &str) -> Result<(), String> {
 }
 
 fn rewrite_crate_prefix(spelling: &str) -> Option<String> {
-    spelling
-        .strip_prefix("crate::")
-        .map(|rest| format!("target_crate::{}", rest))
+    spelling.strip_prefix("crate::").map(|rest| format!("target_crate::{}", rest))
 }
 
 fn generate_main_rs(spellings: &[(String, Type)]) -> String {
@@ -82,29 +79,15 @@ fn load_cargo_metadata(crate_path: &Path) -> Result<CargoMetadataJson, String> {
     serde_json::from_slice(&output.stdout).map_err(|e| format!("parse cargo metadata: {}", e))
 }
 
-fn select_target_package(
-    crate_path: &Path,
-    package_hint: &str,
-    metadata: &CargoMetadataJson,
-) -> Result<CargoPackage, String> {
-    let canonical_manifest_path = crate_path
-        .join("Cargo.toml")
-        .canonicalize()
-        .ok()
-        .and_then(|path| path.to_str().map(str::to_string));
+fn select_target_package(crate_path: &Path, package_hint: &str, metadata: &CargoMetadataJson) -> Result<CargoPackage, String> {
+    let canonical_manifest_path = crate_path.join("Cargo.toml").canonicalize().ok().and_then(|path| path.to_str().map(str::to_string));
 
     metadata
         .packages
         .iter()
         .find(|package| Some(package.manifest_path.as_str()) == canonical_manifest_path.as_deref())
         .cloned()
-        .or_else(|| {
-            metadata
-                .packages
-                .iter()
-                .find(|package| package.name == package_hint)
-                .cloned()
-        })
+        .or_else(|| metadata.packages.iter().find(|package| package.name == package_hint).cloned())
         .ok_or_else(|| {
             let available = metadata
                 .packages
@@ -112,10 +95,7 @@ fn select_target_package(
                 .map(|package| format!("{} ({})", package.name, package.manifest_path))
                 .collect::<Vec<_>>()
                 .join(", ");
-            format!(
-                "could not select target package (hint: {}) from cargo metadata: {}",
-                package_hint, available
-            )
+            format!("could not select target package (hint: {}) from cargo metadata: {}", package_hint, available)
         })
 }
 
@@ -126,11 +106,7 @@ fn cargo_manifest_dir(manifest_path: &str) -> Result<PathBuf, String> {
         .ok_or_else(|| format!("invalid manifest path: {}", manifest_path))
 }
 
-pub fn resolve(
-    crate_path: &Path,
-    package_hint: &str,
-    spellings: impl IntoIterator<Item = String>,
-) -> Result<HashMap<String, String>, String> {
+pub fn resolve(crate_path: &Path, package_hint: &str, spellings: impl IntoIterator<Item = String>) -> Result<HashMap<String, String>, String> {
     let mut unique = HashSet::<String>::new();
     let mut targets = spellings
         .into_iter()

--- a/boltffi_bindgen/src/scan/mod.rs
+++ b/boltffi_bindgen/src/scan/mod.rs
@@ -1,19 +1,16 @@
-use indexmap::IndexMap;
-use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::path::Path;
-use syn::{
-    Attribute, Fields, FnArg, ImplItem, Item, ItemEnum, ItemImpl, ItemStruct, ItemTrait, Type,
-};
-use walkdir::WalkDir;
-
 use crate::model::{
-    BuiltinId, CallbackTrait, Class, ClosureSignature as MClosureSignature, Constructor,
-    ConstructorParam, CustomType, Enumeration, Function, Method, Module, Parameter, Primitive,
-    Receiver, Record, RecordField, ReturnType, StreamMethod, StreamMode, TraitMethod,
-    TraitMethodParam, Type as MType, Variant,
+    AsyncIteratorMethod, BuiltinId, CallbackTrait, Class, ClosureSignature as MClosureSignature, Constructor, ConstructorParam, CustomType, Enumeration, Function, Method, Module,
+    Parameter, Primitive, Receiver, Record, RecordField, ReturnType, StreamMethod, StreamMode, TraitMethod, TraitMethodParam, Type as MType, Variant,
 };
+use indexmap::IndexMap;
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+    fs,
+    path::Path,
+};
+use syn::{Attribute, Fields, FnArg, ImplItem, Item, ItemEnum, ItemImpl, ItemStruct, ItemTrait, Type};
+use walkdir::WalkDir;
 
 mod compiler_type_resolution;
 
@@ -37,6 +34,7 @@ pub enum TypeShape {
         constructors: Vec<Constructor>,
         methods: Vec<Method>,
         streams: Vec<StreamMethod>,
+        async_iterators: Vec<AsyncIteratorMethod>,
     },
     Custom {
         repr: MType,
@@ -55,12 +53,9 @@ pub struct TypeRegistry {
 
 impl TypeRegistry {
     pub fn is_enum(&self, name: &str) -> bool {
-        self.types.get(name).is_some_and(|meta| {
-            matches!(
-                meta.shape,
-                TypeShape::Pending(PendingKind::Enum) | TypeShape::Enum { .. }
-            )
-        })
+        self.types
+            .get(name)
+            .is_some_and(|meta| matches!(meta.shape, TypeShape::Pending(PendingKind::Enum) | TypeShape::Enum { .. }))
     }
 
     pub fn contains(&self, name: &str) -> bool {
@@ -94,15 +89,9 @@ impl TypeRegistry {
     pub fn classify_named_type(&self, name: &str) -> Option<MType> {
         let meta = self.types.get(name)?;
         Some(match &meta.shape {
-            TypeShape::Pending(PendingKind::Record) | TypeShape::Record { .. } => {
-                MType::Record(name.to_string())
-            }
-            TypeShape::Pending(PendingKind::Enum) | TypeShape::Enum { .. } => {
-                MType::Enum(name.to_string())
-            }
-            TypeShape::Pending(PendingKind::Class) | TypeShape::Class { .. } => {
-                MType::Object(name.to_string())
-            }
+            TypeShape::Pending(PendingKind::Record) | TypeShape::Record { .. } => MType::Record(name.to_string()),
+            TypeShape::Pending(PendingKind::Enum) | TypeShape::Enum { .. } => MType::Enum(name.to_string()),
+            TypeShape::Pending(PendingKind::Class) | TypeShape::Class { .. } => MType::Object(name.to_string()),
             TypeShape::Pending(PendingKind::Callback) => MType::BoxedTrait(name.to_string()),
             TypeShape::Custom { repr } => MType::Custom {
                 name: name.to_string(),
@@ -122,9 +111,7 @@ impl TypeRegistry {
     }
 
     pub fn has_callback(&self, name: &str) -> bool {
-        self.types
-            .get(name)
-            .is_some_and(|m| matches!(m.shape, TypeShape::Pending(PendingKind::Callback)))
+        self.types.get(name).is_some_and(|m| matches!(m.shape, TypeShape::Pending(PendingKind::Callback)))
     }
 }
 
@@ -181,18 +168,10 @@ impl AliasResolver {
 
     fn resolve_type_spelling<'a>(&self, spelling: &'a str) -> Cow<'a, str> {
         let stripped = spelling.trim().trim_start_matches("::");
-        let parts: Vec<String> = stripped
-            .split("::")
-            .filter(|p| !p.is_empty())
-            .map(|p| p.to_string())
-            .collect();
+        let parts: Vec<String> = stripped.split("::").filter(|p| !p.is_empty()).map(|p| p.to_string()).collect();
 
         let resolved = self.resolve_segments(parts);
-        let resolved_spelling = resolved
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>()
-            .join("::");
+        let resolved_spelling = resolved.iter().map(String::as_str).collect::<Vec<_>>().join("::");
 
         if resolved_spelling != stripped {
             Cow::Owned(resolved_spelling)
@@ -205,31 +184,18 @@ impl AliasResolver {
         let expanded = std::iter::successors(Some(segments), |current| {
             let first = current.first()?;
             let replacement = self.use_aliases.get(first)?;
-            let next = replacement
-                .iter()
-                .cloned()
-                .chain(current.iter().skip(1).cloned())
-                .collect::<Vec<_>>();
+            let next = replacement.iter().cloned().chain(current.iter().skip(1).cloned()).collect::<Vec<_>>();
             (next != *current).then_some(next)
         })
         .take(16)
         .last()
         .unwrap_or_default();
 
-        expanded
-            .last()
-            .and_then(|last| self.type_aliases.get(last))
-            .cloned()
-            .unwrap_or(expanded)
+        expanded.last().and_then(|last| self.type_aliases.get(last)).cloned().unwrap_or(expanded)
     }
 
     fn segments_from_path(type_path: &syn::TypePath) -> Vec<String> {
-        type_path
-            .path
-            .segments
-            .iter()
-            .map(|seg| seg.ident.to_string())
-            .collect()
+        type_path.path.segments.iter().map(|seg| seg.ident.to_string()).collect()
     }
 
     fn collect_use_tree(&mut self, prefix: Vec<String>, tree: &syn::UseTree) {
@@ -249,10 +215,7 @@ impl AliasResolver {
                 target.push(rename.ident.to_string());
                 self.use_aliases.insert(rename.rename.to_string(), target);
             }
-            syn::UseTree::Group(group) => group
-                .items
-                .iter()
-                .for_each(|item| self.collect_use_tree(prefix.clone(), item)),
+            syn::UseTree::Group(group) => group.items.iter().for_each(|item| self.collect_use_tree(prefix.clone(), item)),
             syn::UseTree::Glob(_) => {}
         }
     }
@@ -292,37 +255,27 @@ impl SourceScanner {
 
         self.global_aliases = Self::collect_global_aliases(&files)?;
         let compiler_targets = Self::collect_compiler_type_targets(&files, &self.global_aliases)?;
-        self.compiler_canonical_types =
-            compiler_type_resolution::resolve(crate_path, &self.module_name, compiler_targets)?;
-        files
-            .iter()
-            .try_for_each(|path| self.collect_type_names(path))?;
-        files
-            .iter()
-            .try_for_each(|path| self.collect_custom_types(path))?;
+        self.compiler_canonical_types = compiler_type_resolution::resolve(crate_path, &self.module_name, compiler_targets)?;
+        files.iter().try_for_each(|path| self.collect_type_names(path))?;
+        files.iter().try_for_each(|path| self.collect_custom_types(path))?;
         files.iter().try_for_each(|path| self.scan_file(path))?;
         Ok(())
     }
 
-    fn collect_compiler_type_targets(
-        files: &[std::path::PathBuf],
-        global_aliases: &HashMap<String, Vec<String>>,
-    ) -> Result<Vec<String>, String> {
+    fn collect_compiler_type_targets(files: &[std::path::PathBuf], global_aliases: &HashMap<String, Vec<String>>) -> Result<Vec<String>, String> {
         let mut targets = Vec::<String>::new();
         let mut seen = HashSet::<String>::new();
 
         files.iter().try_for_each(|path| {
-            let content = fs::read_to_string(path)
-                .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+            let content = fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
 
-            let syntax = syn::parse_file(&content)
-                .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+            let syntax = syn::parse_file(&content).map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
 
-            let alias_resolver =
-                AliasResolver::from_items(&syntax.items).with_global(global_aliases);
-            syntax.items.iter().for_each(|item| {
-                Self::collect_item_type_targets(item, &alias_resolver, &mut targets, &mut seen)
-            });
+            let alias_resolver = AliasResolver::from_items(&syntax.items).with_global(global_aliases);
+            syntax
+                .items
+                .iter()
+                .for_each(|item| Self::collect_item_type_targets(item, &alias_resolver, &mut targets, &mut seen));
 
             Ok::<(), String>(())
         })?;
@@ -330,43 +283,30 @@ impl SourceScanner {
         Ok(targets)
     }
 
-    fn collect_item_type_targets(
-        item: &Item,
-        alias_resolver: &AliasResolver,
-        out: &mut Vec<String>,
-        seen: &mut HashSet<String>,
-    ) {
+    fn collect_item_type_targets(item: &Item, alias_resolver: &AliasResolver, out: &mut Vec<String>, seen: &mut HashSet<String>) {
         match item {
             Item::Struct(item_struct) => {
                 let is_record = has_attribute(&item_struct.attrs, "ffi_record")
                     || has_attribute(&item_struct.attrs, "data")
                     || has_repr_c(&item_struct.attrs)
-                    || (has_attribute(&item_struct.attrs, "derive")
-                        && has_ffi_type_derive(&item_struct.attrs));
+                    || (has_attribute(&item_struct.attrs, "derive") && has_ffi_type_derive(&item_struct.attrs));
                 if is_record {
-                    item_struct.fields.iter().for_each(|field| {
-                        Self::collect_type_targets(&field.ty, alias_resolver, out, seen)
-                    });
+                    item_struct.fields.iter().for_each(|field| Self::collect_type_targets(&field.ty, alias_resolver, out, seen));
                 }
             }
             Item::Enum(item_enum) => {
                 let is_error = has_attribute(&item_enum.attrs, "error");
-                let is_data_enum = has_repr_int(&item_enum.attrs)
-                    || has_attribute(&item_enum.attrs, "data")
-                    || is_error;
+                let is_data_enum = has_repr_int(&item_enum.attrs) || has_attribute(&item_enum.attrs, "data") || is_error;
                 if is_data_enum {
                     item_enum
                         .variants
                         .iter()
                         .flat_map(|variant| variant.fields.iter())
-                        .for_each(|field| {
-                            Self::collect_type_targets(&field.ty, alias_resolver, out, seen)
-                        });
+                        .for_each(|field| Self::collect_type_targets(&field.ty, alias_resolver, out, seen));
                 }
             }
             Item::Impl(item_impl) => {
-                let is_exported = has_attribute(&item_impl.attrs, "ffi_class")
-                    || has_attribute(&item_impl.attrs, "export");
+                let is_exported = has_attribute(&item_impl.attrs, "ffi_class") || has_attribute(&item_impl.attrs, "export");
                 if is_exported {
                     item_impl
                         .items
@@ -386,27 +326,19 @@ impl SourceScanner {
                                     FnArg::Typed(pat_type) => Some(pat_type.ty.as_ref()),
                                     FnArg::Receiver(_) => None,
                                 })
-                                .for_each(|ty| {
-                                    Self::collect_type_targets(ty, alias_resolver, out, seen)
-                                });
+                                .for_each(|ty| Self::collect_type_targets(ty, alias_resolver, out, seen));
 
                             match &method.sig.output {
                                 syn::ReturnType::Default => {}
                                 syn::ReturnType::Type(_, ty) => {
-                                    Self::collect_type_targets(
-                                        ty.as_ref(),
-                                        alias_resolver,
-                                        out,
-                                        seen,
-                                    );
+                                    Self::collect_type_targets(ty.as_ref(), alias_resolver, out, seen);
                                 }
                             }
                         });
                 }
             }
             Item::Trait(item_trait) => {
-                let is_exported = has_attribute(&item_trait.attrs, "ffi_trait")
-                    || has_attribute(&item_trait.attrs, "export");
+                let is_exported = has_attribute(&item_trait.attrs, "ffi_trait") || has_attribute(&item_trait.attrs, "export");
                 if is_exported {
                     item_trait
                         .items
@@ -424,27 +356,19 @@ impl SourceScanner {
                                     FnArg::Typed(pat_type) => Some(pat_type.ty.as_ref()),
                                     FnArg::Receiver(_) => None,
                                 })
-                                .for_each(|ty| {
-                                    Self::collect_type_targets(ty, alias_resolver, out, seen)
-                                });
+                                .for_each(|ty| Self::collect_type_targets(ty, alias_resolver, out, seen));
 
                             match &method.sig.output {
                                 syn::ReturnType::Default => {}
                                 syn::ReturnType::Type(_, ty) => {
-                                    Self::collect_type_targets(
-                                        ty.as_ref(),
-                                        alias_resolver,
-                                        out,
-                                        seen,
-                                    );
+                                    Self::collect_type_targets(ty.as_ref(), alias_resolver, out, seen);
                                 }
                             }
                         });
                 }
             }
             Item::Fn(item_fn) => {
-                let is_exported = has_attribute(&item_fn.attrs, "ffi_export")
-                    || has_attribute(&item_fn.attrs, "export");
+                let is_exported = has_attribute(&item_fn.attrs, "ffi_export") || has_attribute(&item_fn.attrs, "export");
                 if is_exported {
                     item_fn
                         .sig
@@ -468,19 +392,10 @@ impl SourceScanner {
         }
     }
 
-    fn collect_type_targets(
-        ty: &Type,
-        alias_resolver: &AliasResolver,
-        out: &mut Vec<String>,
-        seen: &mut HashSet<String>,
-    ) {
+    fn collect_type_targets(ty: &Type, alias_resolver: &AliasResolver, out: &mut Vec<String>, seen: &mut HashSet<String>) {
         match ty {
             Type::Path(type_path) => {
-                let all_segments_plain = type_path
-                    .path
-                    .segments
-                    .iter()
-                    .all(|seg| matches!(seg.arguments, syn::PathArguments::None));
+                let all_segments_plain = type_path.path.segments.iter().all(|seg| matches!(seg.arguments, syn::PathArguments::None));
 
                 type_path
                     .path
@@ -495,9 +410,7 @@ impl SourceScanner {
                         syn::GenericArgument::Type(inner_ty) => Some(inner_ty),
                         _ => None,
                     })
-                    .for_each(|inner_ty| {
-                        Self::collect_type_targets(inner_ty, alias_resolver, out, seen)
-                    });
+                    .for_each(|inner_ty| Self::collect_type_targets(inner_ty, alias_resolver, out, seen));
 
                 type_path
                     .path
@@ -508,30 +421,17 @@ impl SourceScanner {
                         _ => None,
                     })
                     .for_each(|args| {
-                        args.inputs.iter().for_each(|inner_ty| {
-                            Self::collect_type_targets(inner_ty, alias_resolver, out, seen)
-                        });
+                        args.inputs.iter().for_each(|inner_ty| Self::collect_type_targets(inner_ty, alias_resolver, out, seen));
                         match &args.output {
                             syn::ReturnType::Default => {}
                             syn::ReturnType::Type(_, out_ty) => {
-                                Self::collect_type_targets(
-                                    out_ty.as_ref(),
-                                    alias_resolver,
-                                    out,
-                                    seen,
-                                );
+                                Self::collect_type_targets(out_ty.as_ref(), alias_resolver, out, seen);
                             }
                         }
                     });
 
                 if all_segments_plain {
-                    let path_str = type_path
-                        .path
-                        .segments
-                        .iter()
-                        .map(|seg| seg.ident.to_string())
-                        .collect::<Vec<_>>()
-                        .join("::");
+                    let path_str = type_path.path.segments.iter().map(|seg| seg.ident.to_string()).collect::<Vec<_>>().join("::");
 
                     let resolved = alias_resolver.resolve_type_spelling(&path_str).into_owned();
                     if resolved.starts_with("crate::") && seen.insert(resolved.clone()) {
@@ -548,9 +448,7 @@ impl SourceScanner {
             Type::Array(array) => {
                 Self::collect_type_targets(array.elem.as_ref(), alias_resolver, out, seen);
             }
-            Type::Tuple(tuple) => tuple.elems.iter().for_each(|inner_ty| {
-                Self::collect_type_targets(inner_ty, alias_resolver, out, seen)
-            }),
+            Type::Tuple(tuple) => tuple.elems.iter().for_each(|inner_ty| Self::collect_type_targets(inner_ty, alias_resolver, out, seen)),
             Type::Group(group) => {
                 Self::collect_type_targets(group.elem.as_ref(), alias_resolver, out, seen);
             }
@@ -561,18 +459,14 @@ impl SourceScanner {
         }
     }
 
-    fn collect_global_aliases(
-        files: &[std::path::PathBuf],
-    ) -> Result<HashMap<String, Vec<String>>, String> {
+    fn collect_global_aliases(files: &[std::path::PathBuf]) -> Result<HashMap<String, Vec<String>>, String> {
         let mut aliases = HashMap::<String, Vec<String>>::new();
         let mut conflicts = HashSet::<String>::new();
 
         files.iter().try_for_each(|path| {
-            let content = fs::read_to_string(path)
-                .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+            let content = fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
 
-            let syntax = syn::parse_file(&content)
-                .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+            let syntax = syn::parse_file(&content).map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
 
             let local = AliasResolver::from_items(&syntax.items);
             syntax
@@ -584,18 +478,12 @@ impl SourceScanner {
                 })
                 .filter_map(|item_type| {
                     let target_path = match item_type.ty.as_ref() {
-                        Type::Path(type_path) => {
-                            Some(AliasResolver::segments_from_path(type_path).join("::"))
-                        }
+                        Type::Path(type_path) => Some(AliasResolver::segments_from_path(type_path).join("::")),
                         _ => None,
                     }?;
 
                     let resolved = local.resolve_type_spelling(&target_path).into_owned();
-                    let segments = resolved
-                        .split("::")
-                        .filter(|p| !p.is_empty())
-                        .map(|p| p.to_string())
-                        .collect::<Vec<_>>();
+                    let segments = resolved.split("::").filter(|p| !p.is_empty()).map(|p| p.to_string()).collect::<Vec<_>>();
                     Some((item_type.ident.to_string(), segments))
                 })
                 .for_each(|(alias_name, target)| match aliases.get(&alias_name) {
@@ -619,76 +507,40 @@ impl SourceScanner {
     }
 
     fn collect_custom_types(&mut self, path: &Path) -> Result<(), String> {
-        let content = fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+        let content = fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
 
-        let syntax = syn::parse_file(&content)
-            .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+        let syntax = syn::parse_file(&content).map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
 
-        let alias_resolver =
-            AliasResolver::from_items(&syntax.items).with_global(&self.global_aliases);
+        let alias_resolver = AliasResolver::from_items(&syntax.items).with_global(&self.global_aliases);
         syntax
             .items
             .iter()
             .filter_map(|item| match item {
-                Item::Macro(item_macro)
-                    if item_macro
-                        .mac
-                        .path
-                        .segments
-                        .last()
-                        .is_some_and(|segment| segment.ident == "custom_type") =>
-                {
-                    Some(item_macro)
-                }
+                Item::Macro(item_macro) if item_macro.mac.path.segments.last().is_some_and(|segment| segment.ident == "custom_type") => Some(item_macro),
                 _ => None,
             })
-            .try_for_each(|item_macro| {
-                self.collect_custom_type_macro(item_macro, &alias_resolver)
-            })?;
+            .try_for_each(|item_macro| self.collect_custom_type_macro(item_macro, &alias_resolver))?;
         syntax
             .items
             .iter()
             .filter_map(|item| match item {
-                Item::Impl(item_impl) if has_attribute(&item_impl.attrs, "custom_ffi") => {
-                    Some(item_impl)
-                }
+                Item::Impl(item_impl) if has_attribute(&item_impl.attrs, "custom_ffi") => Some(item_impl),
                 _ => None,
             })
             .try_for_each(|item_impl| self.collect_custom_type(item_impl, &alias_resolver))
     }
 
-    fn collect_custom_type_macro(
-        &mut self,
-        item_macro: &syn::ItemMacro,
-        alias_resolver: &AliasResolver,
-    ) -> Result<(), String> {
-        let spec: CustomTypeMacroSpec = syn::parse2(item_macro.mac.tokens.clone())
-            .map_err(|e| format!("custom_type!: failed to parse: {e}"))?;
+    fn collect_custom_type_macro(&mut self, item_macro: &syn::ItemMacro, alias_resolver: &AliasResolver) -> Result<(), String> {
+        let spec: CustomTypeMacroSpec = syn::parse2(item_macro.mac.tokens.clone()).map_err(|e| format!("custom_type!: failed to parse: {e}"))?;
 
         let name = spec.name.to_string();
         if self.type_registry.contains(&name) {
-            return Err(format!(
-                "custom_type!: `{}` conflicts with an existing record/enum/class name",
-                name
-            ));
+            return Err(format!("custom_type!: `{}` conflicts with an existing record/enum/class name", name));
         }
 
         let repr_syn_type = &spec.repr;
-        let repr = rust_type_to_ffi_type(
-            repr_syn_type,
-            &self.type_registry,
-            alias_resolver,
-            &self.compiler_canonical_types,
-            None,
-        )
-        .ok_or_else(|| {
-            format!(
-                "custom_type!: `{}` has an unsupported repr type: {}",
-                name,
-                quote::quote!(#repr_syn_type)
-            )
-        })?;
+        let repr = rust_type_to_ffi_type(repr_syn_type, &self.type_registry, alias_resolver, &self.compiler_canonical_types, None)
+            .ok_or_else(|| format!("custom_type!: `{}` has an unsupported repr type: {}", name, quote::quote!(#repr_syn_type)))?;
 
         self.type_registry.register(
             name.clone(),
@@ -700,20 +552,13 @@ impl SourceScanner {
         Ok(())
     }
 
-    fn collect_custom_type(
-        &mut self,
-        item_impl: &ItemImpl,
-        alias_resolver: &AliasResolver,
-    ) -> Result<(), String> {
+    fn collect_custom_type(&mut self, item_impl: &ItemImpl, alias_resolver: &AliasResolver) -> Result<(), String> {
         let Some(name) = impl_self_type_ident(item_impl) else {
             return Err("custom_ffi: unsupported self type".to_string());
         };
 
         if self.type_registry.contains(&name) {
-            return Err(format!(
-                "custom_ffi: `{}` conflicts with an existing record/enum/class name",
-                name
-            ));
+            return Err(format!("custom_ffi: `{}` conflicts with an existing record/enum/class name", name));
         }
 
         let repr_syn_type = item_impl
@@ -726,20 +571,8 @@ impl SourceScanner {
             .next()
             .ok_or_else(|| format!("custom_ffi: `{}` is missing `type FfiRepr = ...;`", name))?;
 
-        let repr = rust_type_to_ffi_type(
-            repr_syn_type,
-            &self.type_registry,
-            alias_resolver,
-            &self.compiler_canonical_types,
-            None,
-        )
-        .ok_or_else(|| {
-            format!(
-                "custom_ffi: `{}` has an unsupported FfiRepr type: {}",
-                name,
-                quote::quote!(#repr_syn_type)
-            )
-        })?;
+        let repr = rust_type_to_ffi_type(repr_syn_type, &self.type_registry, alias_resolver, &self.compiler_canonical_types, None)
+            .ok_or_else(|| format!("custom_ffi: `{}` has an unsupported FfiRepr type: {}", name, quote::quote!(#repr_syn_type)))?;
 
         self.type_registry.register(
             name.clone(),
@@ -753,11 +586,9 @@ impl SourceScanner {
     }
 
     fn collect_type_names(&mut self, path: &Path) -> Result<(), String> {
-        let content = fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+        let content = fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
 
-        let syntax = syn::parse_file(&content)
-            .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+        let syntax = syn::parse_file(&content).map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
 
         for item in &syntax.items {
             match item {
@@ -765,8 +596,7 @@ impl SourceScanner {
                     if has_attribute(&item_struct.attrs, "ffi_record")
                         || has_attribute(&item_struct.attrs, "data")
                         || has_repr_c(&item_struct.attrs)
-                        || (has_attribute(&item_struct.attrs, "derive")
-                            && has_ffi_type_derive(&item_struct.attrs))
+                        || (has_attribute(&item_struct.attrs, "derive") && has_ffi_type_derive(&item_struct.attrs))
                     {
                         self.type_registry.register(
                             item_struct.ident.to_string(),
@@ -778,10 +608,7 @@ impl SourceScanner {
                     }
                 }
                 Item::Enum(item_enum) => {
-                    if has_repr_int(&item_enum.attrs)
-                        || has_attribute(&item_enum.attrs, "data")
-                        || has_attribute(&item_enum.attrs, "error")
-                    {
+                    if has_repr_int(&item_enum.attrs) || has_attribute(&item_enum.attrs, "data") || has_attribute(&item_enum.attrs, "error") {
                         self.type_registry.register(
                             item_enum.ident.to_string(),
                             TypeMeta {
@@ -792,8 +619,7 @@ impl SourceScanner {
                     }
                 }
                 Item::Impl(item_impl) => {
-                    if (has_attribute(&item_impl.attrs, "ffi_class")
-                        || has_attribute(&item_impl.attrs, "export"))
+                    if (has_attribute(&item_impl.attrs, "ffi_class") || has_attribute(&item_impl.attrs, "export"))
                         && let Type::Path(type_path) = item_impl.self_ty.as_ref()
                         && let Some(seg) = type_path.path.segments.last()
                     {
@@ -814,14 +640,11 @@ impl SourceScanner {
     }
 
     pub fn scan_file(&mut self, path: &Path) -> Result<(), String> {
-        let content = fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+        let content = fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
 
-        let syntax = syn::parse_file(&content)
-            .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+        let syntax = syn::parse_file(&content).map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
 
-        self.alias_resolver =
-            AliasResolver::from_items(&syntax.items).with_global(&self.global_aliases);
+        self.alias_resolver = AliasResolver::from_items(&syntax.items).with_global(&self.global_aliases);
         syntax.items.iter().for_each(|item| self.process_item(item));
 
         Ok(())
@@ -831,45 +654,34 @@ impl SourceScanner {
         match item {
             Item::Struct(item_struct) => {
                 if let Some(doc) = extract_doc_string(&item_struct.attrs) {
-                    self.type_registry
-                        .set_doc(&item_struct.ident.to_string(), doc);
+                    self.type_registry.set_doc(&item_struct.ident.to_string(), doc);
                 }
                 if has_attribute(&item_struct.attrs, "ffi_record")
                     || has_attribute(&item_struct.attrs, "data")
                     || has_repr_c(&item_struct.attrs)
-                    || (has_attribute(&item_struct.attrs, "derive")
-                        && has_ffi_type_derive(&item_struct.attrs))
+                    || (has_attribute(&item_struct.attrs, "derive") && has_ffi_type_derive(&item_struct.attrs))
                 {
                     self.process_record(item_struct);
                 }
             }
             Item::Impl(item_impl) => {
-                if has_attribute(&item_impl.attrs, "ffi_class")
-                    || has_attribute(&item_impl.attrs, "export")
-                {
+                if has_attribute(&item_impl.attrs, "ffi_class") || has_attribute(&item_impl.attrs, "export") {
                     self.process_class(item_impl);
                 }
             }
             Item::Trait(item_trait) => {
-                if has_attribute(&item_trait.attrs, "ffi_trait")
-                    || has_attribute(&item_trait.attrs, "export")
-                {
+                if has_attribute(&item_trait.attrs, "ffi_trait") || has_attribute(&item_trait.attrs, "export") {
                     self.process_callback_trait(item_trait);
                 }
             }
             Item::Fn(item_fn) => {
-                if has_attribute(&item_fn.attrs, "ffi_export")
-                    || has_attribute(&item_fn.attrs, "export")
-                {
+                if has_attribute(&item_fn.attrs, "ffi_export") || has_attribute(&item_fn.attrs, "export") {
                     self.process_function(item_fn);
                 }
             }
             Item::Enum(item_enum) => {
                 let is_error = has_attribute(&item_enum.attrs, "error");
-                if has_repr_int(&item_enum.attrs)
-                    || has_attribute(&item_enum.attrs, "data")
-                    || is_error
-                {
+                if has_repr_int(&item_enum.attrs) || has_attribute(&item_enum.attrs, "data") || is_error {
                     self.process_enum(item_enum, is_error);
                 }
             }
@@ -877,11 +689,7 @@ impl SourceScanner {
         }
     }
 
-    fn resolve_typed_params(
-        &self,
-        inputs: &syn::punctuated::Punctuated<FnArg, syn::token::Comma>,
-        self_type: Option<&str>,
-    ) -> Option<Vec<(String, MType)>> {
+    fn resolve_typed_params(&self, inputs: &syn::punctuated::Punctuated<FnArg, syn::token::Comma>, self_type: Option<&str>) -> Option<Vec<(String, MType)>> {
         let typed: Vec<_> = inputs
             .iter()
             .filter_map(|arg| match arg {
@@ -897,13 +705,7 @@ impl SourceScanner {
                     syn::Pat::Ident(ident) => ident.ident.to_string(),
                     _ => return None,
                 };
-                let ty = rust_type_to_ffi_type(
-                    &pat_type.ty,
-                    &self.type_registry,
-                    &self.alias_resolver,
-                    &self.compiler_canonical_types,
-                    self_type,
-                )?;
+                let ty = rust_type_to_ffi_type(&pat_type.ty, &self.type_registry, &self.alias_resolver, &self.compiler_canonical_types, self_type)?;
                 Some((name, ty))
             })
             .collect();
@@ -914,13 +716,7 @@ impl SourceScanner {
     fn resolve_output(&self, output: &syn::ReturnType, self_type: Option<&str>) -> Option<MType> {
         match output {
             syn::ReturnType::Default => None,
-            syn::ReturnType::Type(_, ty) => rust_type_to_ffi_type(
-                ty,
-                &self.type_registry,
-                &self.alias_resolver,
-                &self.compiler_canonical_types,
-                self_type,
-            ),
+            syn::ReturnType::Type(_, ty) => rust_type_to_ffi_type(ty, &self.type_registry, &self.alias_resolver, &self.compiler_canonical_types, self_type),
         }
     }
 
@@ -928,11 +724,7 @@ impl SourceScanner {
         sig.inputs
             .first()
             .and_then(|arg| match arg {
-                syn::FnArg::Receiver(r) => Some(if r.mutability.is_some() {
-                    Receiver::RefMut
-                } else {
-                    Receiver::Ref
-                }),
+                syn::FnArg::Receiver(r) => Some(if r.mutability.is_some() { Receiver::RefMut } else { Receiver::Ref }),
                 _ => None,
             })
             .unwrap_or(Receiver::None)
@@ -946,13 +738,7 @@ impl SourceScanner {
                 .iter()
                 .filter_map(|f| {
                     let field_name = f.ident.as_ref()?.to_string();
-                    let field_type = rust_type_to_ffi_type(
-                        &f.ty,
-                        &self.type_registry,
-                        &self.alias_resolver,
-                        &self.compiler_canonical_types,
-                        None,
-                    )?;
+                    let field_type = rust_type_to_ffi_type(&f.ty, &self.type_registry, &self.alias_resolver, &self.compiler_canonical_types, None)?;
                     let mut record_field = RecordField::new(&field_name, field_type);
                     if let Some(doc) = extract_doc_string(&f.attrs) {
                         record_field = record_field.with_doc(doc);
@@ -978,11 +764,7 @@ impl SourceScanner {
             .iter()
             .map(|v| {
                 let variant_name = v.ident.to_string();
-                let discriminant = v
-                    .discriminant
-                    .as_ref()
-                    .and_then(|(_, expr)| parse_discriminant_expr(expr))
-                    .unwrap_or(next_discriminant);
+                let discriminant = v.discriminant.as_ref().and_then(|(_, expr)| parse_discriminant_expr(expr)).unwrap_or(next_discriminant);
                 next_discriminant = discriminant + 1;
 
                 let fields: Vec<RecordField> = match &v.fields {
@@ -991,13 +773,7 @@ impl SourceScanner {
                         .iter()
                         .filter_map(|f| {
                             let field_name = f.ident.as_ref()?.to_string();
-                            let field_type = rust_type_to_ffi_type(
-                                &f.ty,
-                                &self.type_registry,
-                                &self.alias_resolver,
-                                &self.compiler_canonical_types,
-                                None,
-                            )?;
+                            let field_type = rust_type_to_ffi_type(&f.ty, &self.type_registry, &self.alias_resolver, &self.compiler_canonical_types, None)?;
                             let mut record_field = RecordField::new(&field_name, field_type);
                             if let Some(doc) = extract_doc_string(&f.attrs) {
                                 record_field = record_field.with_doc(doc);
@@ -1010,30 +786,19 @@ impl SourceScanner {
                         .iter()
                         .enumerate()
                         .filter_map(|(i, f)| {
-                            let field_type = rust_type_to_ffi_type(
-                                &f.ty,
-                                &self.type_registry,
-                                &self.alias_resolver,
-                                &self.compiler_canonical_types,
-                                None,
-                            )?;
+                            let field_type = rust_type_to_ffi_type(&f.ty, &self.type_registry, &self.alias_resolver, &self.compiler_canonical_types, None)?;
                             Some(RecordField::new(format!("value_{i}"), field_type))
                         })
                         .collect(),
                     Fields::Unit => Vec::new(),
                 };
 
-                let variant = Variant::new(&variant_name)
-                    .with_discriminant(discriminant)
-                    .maybe_doc(extract_doc_string(&v.attrs));
-                fields
-                    .into_iter()
-                    .fold(variant, |v, field| v.with_field(field))
+                let variant = Variant::new(&variant_name).with_discriminant(discriminant).maybe_doc(extract_doc_string(&v.attrs));
+                fields.into_iter().fold(variant, |v, field| v.with_field(field))
             })
             .collect();
 
-        self.type_registry
-            .fill(&name, TypeShape::Enum { variants, is_error });
+        self.type_registry.fill(&name, TypeShape::Enum { variants, is_error });
     }
 
     fn process_function(&mut self, item_fn: &syn::ItemFn) {
@@ -1048,9 +813,7 @@ impl SourceScanner {
 
         let function = params
             .into_iter()
-            .fold(Function::new(sig.ident.to_string()), |f, (name, ty)| {
-                f.with_param(Parameter::new(&name, ty))
-            })
+            .fold(Function::new(sig.ident.to_string()), |f, (name, ty)| f.with_param(Parameter::new(&name, ty)))
             .maybe_doc(extract_doc_string(&item_fn.attrs))
             .maybe_return(output.map(ReturnType::from_output))
             .maybe_async(sig.asyncness.is_some());
@@ -1083,9 +846,7 @@ impl SourceScanner {
         Some(
             params
                 .into_iter()
-                .fold(TraitMethod::new(sig.ident.to_string()), |tm, (name, ty)| {
-                    tm.with_param(TraitMethodParam::new(&name, ty))
-                })
+                .fold(TraitMethod::new(sig.ident.to_string()), |tm, (name, ty)| tm.with_param(TraitMethodParam::new(&name, ty)))
                 .maybe_doc(extract_doc_string(&method.attrs))
                 .maybe_return(output.map(ReturnType::from_output))
                 .maybe_async(sig.asyncness.is_some()),
@@ -1100,6 +861,7 @@ impl SourceScanner {
         let mut constructors = Vec::new();
         let mut methods = Vec::new();
         let mut streams = Vec::new();
+        let mut async_iterators = Vec::new();
 
         item_impl
             .items
@@ -1114,6 +876,13 @@ impl SourceScanner {
                 if has_attribute(&method.attrs, "ffi_stream") {
                     if let Some(stream) = self.build_stream(method) {
                         streams.push(stream);
+                    }
+                    return;
+                }
+
+                if has_attribute(&method.attrs, "ffi_async_iter") {
+                    if let Some(iter) = self.build_async_iterator(method) {
+                        async_iterators.push(iter);
                     }
                     return;
                 }
@@ -1136,6 +905,7 @@ impl SourceScanner {
                 constructors,
                 methods,
                 streams,
+                async_iterators,
             },
         );
     }
@@ -1149,10 +919,7 @@ impl SourceScanner {
         Some(
             params
                 .into_iter()
-                .fold(
-                    Method::new(sig.ident.to_string(), receiver),
-                    |m, (name, ty)| m.with_param(Parameter::new(&name, ty)),
-                )
+                .fold(Method::new(sig.ident.to_string(), receiver), |m, (name, ty)| m.with_param(Parameter::new(&name, ty)))
                 .maybe_doc(extract_doc_string(&method.attrs))
                 .maybe_return(output.map(ReturnType::from_output))
                 .maybe_async(sig.asyncness.is_some()),
@@ -1162,44 +929,30 @@ impl SourceScanner {
     fn build_stream(&self, method: &syn::ImplItemFn) -> Option<StreamMethod> {
         let name = method.sig.ident.to_string();
 
-        let (item_type, mode) = extract_stream_attr(
-            &method.attrs,
-            &self.type_registry,
-            &self.alias_resolver,
-            &self.compiler_canonical_types,
-        )?;
+        let (item_type, mode) = extract_stream_attr(&method.attrs, &self.type_registry, &self.alias_resolver, &self.compiler_canonical_types)?;
 
-        Some(
-            StreamMethod::new(&name, item_type)
-                .with_mode(mode)
-                .maybe_doc(extract_doc_string(&method.attrs)),
-        )
+        Some(StreamMethod::new(&name, item_type).with_mode(mode).maybe_doc(extract_doc_string(&method.attrs)))
+    }
+
+    fn build_async_iterator(&self, method: &syn::ImplItemFn) -> Option<AsyncIteratorMethod> {
+        let name = method.sig.ident.to_string();
+        let item_type = extract_async_iter_attr(&method.attrs, &self.type_registry, &self.alias_resolver, &self.compiler_canonical_types)?;
+        Some(AsyncIteratorMethod::new(&name, item_type).maybe_doc(extract_doc_string(&method.attrs)))
     }
 
     fn is_constructor(&self, method: &syn::ImplItemFn, class_name: &str) -> bool {
-        let has_self_receiver = method
-            .sig
-            .inputs
-            .iter()
-            .any(|arg| matches!(arg, syn::FnArg::Receiver(_)));
+        let has_self_receiver = method.sig.inputs.iter().any(|arg| matches!(arg, syn::FnArg::Receiver(_)));
         if has_self_receiver {
             return false;
         }
 
         match &method.sig.output {
             syn::ReturnType::Default => false,
-            syn::ReturnType::Type(_, ty) => {
-                return_type_is_self(ty.as_ref(), class_name)
-                    || return_type_is_result_self(ty.as_ref(), class_name)
-            }
+            syn::ReturnType::Type(_, ty) => return_type_is_self(ty.as_ref(), class_name) || return_type_is_result_self(ty.as_ref(), class_name),
         }
     }
 
-    fn build_constructor(
-        &self,
-        method: &syn::ImplItemFn,
-        self_type_name: &str,
-    ) -> Option<Constructor> {
+    fn build_constructor(&self, method: &syn::ImplItemFn, self_type_name: &str) -> Option<Constructor> {
         let sig = &method.sig;
         let is_fallible = match &sig.output {
             syn::ReturnType::Default => false,
@@ -1210,12 +963,9 @@ impl SourceScanner {
         Some(
             params
                 .into_iter()
-                .fold(
-                    Constructor::new()
-                        .with_name(sig.ident.to_string())
-                        .with_fallible(is_fallible),
-                    |c, (name, ty)| c.with_param(ConstructorParam::new(&name, ty)),
-                )
+                .fold(Constructor::new().with_name(sig.ident.to_string()).with_fallible(is_fallible), |c, (name, ty)| {
+                    c.with_param(ConstructorParam::new(&name, ty))
+                })
                 .maybe_doc(extract_doc_string(&method.attrs)),
         )
     }
@@ -1226,17 +976,11 @@ impl SourceScanner {
         for (name, entry) in self.type_registry.drain() {
             match entry.shape {
                 TypeShape::Record { fields } => {
-                    let record = fields
-                        .into_iter()
-                        .fold(Record::new(&name), |r, f| r.with_field(f))
-                        .maybe_doc(entry.doc);
+                    let record = fields.into_iter().fold(Record::new(&name), |r, f| r.with_field(f)).maybe_doc(entry.doc);
                     module = module.with_record(record);
                 }
                 TypeShape::Enum { variants, is_error } => {
-                    let mut enumeration = variants
-                        .into_iter()
-                        .fold(Enumeration::new(&name), |e, v| e.with_variant(v))
-                        .maybe_doc(entry.doc);
+                    let mut enumeration = variants.into_iter().fold(Enumeration::new(&name), |e, v| e.with_variant(v)).maybe_doc(entry.doc);
                     if is_error {
                         enumeration = enumeration.as_error();
                     }
@@ -1246,15 +990,12 @@ impl SourceScanner {
                     constructors,
                     methods,
                     streams,
+                    async_iterators,
                 } => {
-                    let class = constructors
-                        .into_iter()
-                        .fold(Class::new(&name), |c, ctor| c.with_constructor(ctor));
+                    let class = constructors.into_iter().fold(Class::new(&name), |c, ctor| c.with_constructor(ctor));
                     let class = methods.into_iter().fold(class, |c, m| c.with_method(m));
-                    let class = streams
-                        .into_iter()
-                        .fold(class, |c, s| c.with_stream(s))
-                        .maybe_doc(entry.doc);
+                    let class = streams.into_iter().fold(class, |c, s| c.with_stream(s));
+                    let class = async_iterators.into_iter().fold(class, |c, a| c.with_async_iterator(a)).maybe_doc(entry.doc);
                     module = module.with_class(class);
                 }
                 TypeShape::Custom { repr } => {
@@ -1321,22 +1062,15 @@ impl syn::parse::Parse for CustomTypeMacroSpec {
 }
 
 fn has_attribute(attrs: &[Attribute], name: &str) -> bool {
-    attrs.iter().any(|attr| {
-        attr.path().is_ident(name)
-            || attr
-                .path()
-                .segments
-                .last()
-                .is_some_and(|segment| segment.ident == name)
-    })
+    attrs
+        .iter()
+        .any(|attr| attr.path().is_ident(name) || attr.path().segments.last().is_some_and(|segment| segment.ident == name))
 }
 
 fn extract_default_value(attrs: &[Attribute]) -> Option<String> {
     attrs.iter().find_map(|attr| {
         let path = attr.path();
-        let is_boltffi_default = path.segments.len() == 2
-            && path.segments[0].ident == "boltffi"
-            && path.segments[1].ident == "default";
+        let is_boltffi_default = path.segments.len() == 2 && path.segments[0].ident == "boltffi" && path.segments[1].ident == "default";
         if !is_boltffi_default {
             return None;
         }
@@ -1354,11 +1088,7 @@ fn extract_doc_string(attrs: &[Attribute]) -> Option<String> {
         .filter(|attr| attr.path().is_ident("doc"))
         .filter_map(|attr| match &attr.meta {
             syn::Meta::NameValue(nv) => {
-                if let syn::Expr::Lit(syn::ExprLit {
-                    lit: syn::Lit::Str(s),
-                    ..
-                }) = &nv.value
-                {
+                if let syn::Expr::Lit(syn::ExprLit { lit: syn::Lit::Str(s), .. }) = &nv.value {
                     Some(s.value())
                 } else {
                     None
@@ -1372,41 +1102,24 @@ fn extract_doc_string(attrs: &[Attribute]) -> Option<String> {
         return None;
     }
 
-    let joined = lines
-        .iter()
-        .map(|line| line.strip_prefix(' ').unwrap_or(line))
-        .collect::<Vec<_>>()
-        .join("\n");
+    let joined = lines.iter().map(|line| line.strip_prefix(' ').unwrap_or(line)).collect::<Vec<_>>().join("\n");
 
     let trimmed = joined.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
+    if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
 }
 
 fn return_type_is_self(ty: &Type, class_name: &str) -> bool {
     let Type::Path(type_path) = ty else {
         return false;
     };
-    type_path
-        .path
-        .segments
-        .last()
-        .is_some_and(|segment| segment.ident == "Self" || segment.ident == class_name)
+    type_path.path.segments.last().is_some_and(|segment| segment.ident == "Self" || segment.ident == class_name)
 }
 
 fn return_type_is_result_self(ty: &Type, class_name: &str) -> bool {
     let Type::Path(type_path) = ty else {
         return false;
     };
-    let Some(result_segment) = type_path
-        .path
-        .segments
-        .last()
-        .filter(|segment| segment.ident == "Result")
-    else {
+    let Some(result_segment) = type_path.path.segments.last().filter(|segment| segment.ident == "Result") else {
         return false;
     };
     let syn::PathArguments::AngleBracketed(args) = &result_segment.arguments else {
@@ -1415,26 +1128,14 @@ fn return_type_is_result_self(ty: &Type, class_name: &str) -> bool {
     let Some(syn::GenericArgument::Type(Type::Path(ok_ty))) = args.args.first() else {
         return false;
     };
-    ok_ty
-        .path
-        .segments
-        .last()
-        .is_some_and(|segment| segment.ident == "Self" || segment.ident == class_name)
+    ok_ty.path.segments.last().is_some_and(|segment| segment.ident == "Self" || segment.ident == class_name)
 }
 
 fn impl_self_type_ident(item_impl: &ItemImpl) -> Option<String> {
     match item_impl.self_ty.as_ref() {
-        Type::Path(type_path) => type_path
-            .path
-            .segments
-            .last()
-            .map(|segment| segment.ident.to_string()),
+        Type::Path(type_path) => type_path.path.segments.last().map(|segment| segment.ident.to_string()),
         Type::Group(group) => match group.elem.as_ref() {
-            Type::Path(type_path) => type_path
-                .path
-                .segments
-                .last()
-                .map(|segment| segment.ident.to_string()),
+            Type::Path(type_path) => type_path.path.segments.last().map(|segment| segment.ident.to_string()),
             _ => None,
         },
         _ => None,
@@ -1462,9 +1163,7 @@ fn has_repr_int(attrs: &[Attribute]) -> bool {
             return false;
         };
         let tokens = meta.tokens.to_string();
-        ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64"]
-            .iter()
-            .any(|ty| tokens.contains(ty))
+        ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64"].iter().any(|ty| tokens.contains(ty))
     })
 }
 
@@ -1516,8 +1215,7 @@ fn extract_stream_attr(
         };
 
         let tokens = meta.tokens.to_string();
-        let item_type =
-            extract_item_type(&tokens, registry, alias_resolver, compiler_canonical_types)?;
+        let item_type = extract_item_type(&tokens, registry, alias_resolver, compiler_canonical_types)?;
         let mode = extract_stream_mode(&tokens);
 
         return Some((item_type, mode));
@@ -1525,20 +1223,29 @@ fn extract_stream_attr(
     None
 }
 
-fn extract_item_type(
-    tokens: &str,
-    registry: &TypeRegistry,
-    alias_resolver: &AliasResolver,
-    compiler_canonical_types: &HashMap<String, String>,
-) -> Option<MType> {
+fn extract_async_iter_attr(attrs: &[Attribute], registry: &TypeRegistry, alias_resolver: &AliasResolver, compiler_canonical_types: &HashMap<String, String>) -> Option<MType> {
+    for attr in attrs {
+        if !attr.path().is_ident("ffi_async_iter") {
+            continue;
+        }
+
+        let Ok(meta) = attr.meta.require_list() else {
+            continue;
+        };
+
+        let tokens = meta.tokens.to_string();
+        return extract_item_type(&tokens, registry, alias_resolver, compiler_canonical_types);
+    }
+    None
+}
+
+fn extract_item_type(tokens: &str, registry: &TypeRegistry, alias_resolver: &AliasResolver, compiler_canonical_types: &HashMap<String, String>) -> Option<MType> {
     let item_start = tokens.find("item")? + 4;
     let rest = &tokens[item_start..];
     let eq_pos = rest.find('=')?;
     let after_eq = rest[eq_pos + 1..].trim();
 
-    let type_end = after_eq
-        .find(',')
-        .unwrap_or(after_eq.find(')').unwrap_or(after_eq.len()));
+    let type_end = after_eq.find(',').unwrap_or(after_eq.find(')').unwrap_or(after_eq.len()));
     let type_str = after_eq[..type_end].trim();
 
     string_to_ffi_type(type_str, registry, alias_resolver, compiler_canonical_types)
@@ -1576,8 +1283,7 @@ fn rust_type_to_ffi_type(
 
             if ident == "Box"
                 && let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments
-                && let Some(syn::GenericArgument::Type(Type::TraitObject(trait_obj))) =
-                    args.args.first()
+                && let Some(syn::GenericArgument::Type(Type::TraitObject(trait_obj))) = args.args.first()
                 && let Some(syn::TypeParamBound::Trait(trait_bound)) = trait_obj.bounds.first()
                 && let Some(seg) = trait_bound.path.segments.last()
             {
@@ -1586,8 +1292,7 @@ fn rust_type_to_ffi_type(
 
             if ident == "Arc"
                 && let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments
-                && let Some(syn::GenericArgument::Type(Type::TraitObject(trait_obj))) =
-                    args.args.first()
+                && let Some(syn::GenericArgument::Type(Type::TraitObject(trait_obj))) = args.args.first()
                 && let Some(syn::TypeParamBound::Trait(trait_bound)) = trait_obj.bounds.first()
                 && let Some(seg) = trait_bound.path.segments.last()
             {
@@ -1598,26 +1303,14 @@ fn rust_type_to_ffi_type(
                 && let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments
                 && let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first()
             {
-                return rust_type_to_ffi_type(
-                    inner_ty,
-                    registry,
-                    alias_resolver,
-                    compiler_canonical_types,
-                    self_type_name,
-                );
+                return rust_type_to_ffi_type(inner_ty, registry, alias_resolver, compiler_canonical_types, self_type_name);
             }
 
             if ident == "Vec" {
                 if let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments
                     && let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first()
                 {
-                    let inner = rust_type_to_ffi_type(
-                        inner_ty,
-                        registry,
-                        alias_resolver,
-                        compiler_canonical_types,
-                        self_type_name,
-                    )?;
+                    let inner = rust_type_to_ffi_type(inner_ty, registry, alias_resolver, compiler_canonical_types, self_type_name)?;
                     return Some(MType::Vec(Box::new(inner)));
                 }
                 return None;
@@ -1627,13 +1320,7 @@ fn rust_type_to_ffi_type(
                 if let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments
                     && let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first()
                 {
-                    let inner = rust_type_to_ffi_type(
-                        inner_ty,
-                        registry,
-                        alias_resolver,
-                        compiler_canonical_types,
-                        self_type_name,
-                    )?;
+                    let inner = rust_type_to_ffi_type(inner_ty, registry, alias_resolver, compiler_canonical_types, self_type_name)?;
                     return Some(MType::Option(Box::new(inner)));
                 }
                 return None;
@@ -1643,24 +1330,12 @@ fn rust_type_to_ffi_type(
                 if let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments {
                     let mut args_iter = args.args.iter();
                     if let Some(syn::GenericArgument::Type(ok_ty)) = args_iter.next() {
-                        let ok = rust_type_to_ffi_type(
-                            ok_ty,
-                            registry,
-                            alias_resolver,
-                            compiler_canonical_types,
-                            self_type_name,
-                        )?;
+                        let ok = rust_type_to_ffi_type(ok_ty, registry, alias_resolver, compiler_canonical_types, self_type_name)?;
                         let err = args_iter
                             .next()
                             .and_then(|arg| {
                                 if let syn::GenericArgument::Type(err_ty) = arg {
-                                    rust_type_to_ffi_type(
-                                        err_ty,
-                                        registry,
-                                        alias_resolver,
-                                        compiler_canonical_types,
-                                        self_type_name,
-                                    )
+                                    rust_type_to_ffi_type(err_ty, registry, alias_resolver, compiler_canonical_types, self_type_name)
                                 } else {
                                     None
                                 }
@@ -1675,20 +1350,9 @@ fn rust_type_to_ffi_type(
                 return None;
             }
 
-            let path_str = type_path
-                .path
-                .segments
-                .iter()
-                .map(|s| s.ident.to_string())
-                .collect::<Vec<_>>()
-                .join("::");
+            let path_str = type_path.path.segments.iter().map(|s| s.ident.to_string()).collect::<Vec<_>>().join("::");
 
-            string_to_ffi_type(
-                &path_str,
-                registry,
-                alias_resolver,
-                compiler_canonical_types,
-            )
+            string_to_ffi_type(&path_str, registry, alias_resolver, compiler_canonical_types)
         }
         Type::Reference(type_ref) => {
             if let Type::Path(inner) = &*type_ref.elem {
@@ -1698,74 +1362,36 @@ fn rust_type_to_ffi_type(
                 }
             }
             if let Type::Slice(slice) = &*type_ref.elem {
-                let inner = rust_type_to_ffi_type(
-                    &slice.elem,
-                    registry,
-                    alias_resolver,
-                    compiler_canonical_types,
-                    self_type_name,
-                )?;
+                let inner = rust_type_to_ffi_type(&slice.elem, registry, alias_resolver, compiler_canonical_types, self_type_name)?;
                 return if type_ref.mutability.is_some() {
                     Some(MType::MutSlice(Box::new(inner)))
                 } else {
                     Some(MType::Slice(Box::new(inner)))
                 };
             }
-            rust_type_to_ffi_type(
-                &type_ref.elem,
-                registry,
-                alias_resolver,
-                compiler_canonical_types,
-                self_type_name,
-            )
+            rust_type_to_ffi_type(&type_ref.elem, registry, alias_resolver, compiler_canonical_types, self_type_name)
         }
         Type::Slice(slice) => {
-            let inner = rust_type_to_ffi_type(
-                &slice.elem,
-                registry,
-                alias_resolver,
-                compiler_canonical_types,
-                self_type_name,
-            )?;
+            let inner = rust_type_to_ffi_type(&slice.elem, registry, alias_resolver, compiler_canonical_types, self_type_name)?;
             Some(MType::Slice(Box::new(inner)))
         }
         Type::ImplTrait(impl_trait) => {
             for bound in &impl_trait.bounds {
                 if let syn::TypeParamBound::Trait(trait_bound) = bound {
-                    let trait_name = trait_bound
-                        .path
-                        .segments
-                        .last()
-                        .map(|s| s.ident.to_string())?;
+                    let trait_name = trait_bound.path.segments.last().map(|s| s.ident.to_string())?;
 
                     if (trait_name == "FnMut" || trait_name == "Fn" || trait_name == "FnOnce")
-                        && let syn::PathArguments::Parenthesized(args) =
-                            &trait_bound.path.segments.last()?.arguments
+                        && let syn::PathArguments::Parenthesized(args) = &trait_bound.path.segments.last()?.arguments
                     {
                         let params: Vec<MType> = args
                             .inputs
                             .iter()
-                            .filter_map(|t| {
-                                rust_type_to_ffi_type(
-                                    t,
-                                    registry,
-                                    alias_resolver,
-                                    compiler_canonical_types,
-                                    self_type_name,
-                                )
-                            })
+                            .filter_map(|t| rust_type_to_ffi_type(t, registry, alias_resolver, compiler_canonical_types, self_type_name))
                             .collect();
 
                         let returns = match &args.output {
                             syn::ReturnType::Default => MType::Void,
-                            syn::ReturnType::Type(_, ty) => rust_type_to_ffi_type(
-                                ty,
-                                registry,
-                                alias_resolver,
-                                compiler_canonical_types,
-                                self_type_name,
-                            )
-                            .unwrap_or(MType::Void),
+                            syn::ReturnType::Type(_, ty) => rust_type_to_ffi_type(ty, registry, alias_resolver, compiler_canonical_types, self_type_name).unwrap_or(MType::Void),
                         };
 
                         return Some(MType::Closure(MClosureSignature::new(params, returns)));
@@ -1790,12 +1416,7 @@ fn rust_type_to_ffi_type(
     }
 }
 
-fn string_to_ffi_type(
-    s: &str,
-    registry: &TypeRegistry,
-    alias_resolver: &AliasResolver,
-    compiler_canonical_types: &HashMap<String, String>,
-) -> Option<MType> {
+fn string_to_ffi_type(s: &str, registry: &TypeRegistry, alias_resolver: &AliasResolver, compiler_canonical_types: &HashMap<String, String>) -> Option<MType> {
     let trimmed = s.trim();
     match trimmed {
         "i8" => Some(MType::Primitive(Primitive::I8)),
@@ -1814,36 +1435,19 @@ fn string_to_ffi_type(
         "String" | "str" | "std::string::String" | "alloc::string::String" => Some(MType::String),
         s if s.starts_with("Vec<") => {
             let inner = &s[4..s.len() - 1];
-            Some(MType::Vec(Box::new(string_to_ffi_type(
-                inner,
-                registry,
-                alias_resolver,
-                compiler_canonical_types,
-            )?)))
+            Some(MType::Vec(Box::new(string_to_ffi_type(inner, registry, alias_resolver, compiler_canonical_types)?)))
         }
         s if s.starts_with("Option<") => {
             let inner = &s[7..s.len() - 1];
-            Some(MType::Option(Box::new(string_to_ffi_type(
-                inner,
-                registry,
-                alias_resolver,
-                compiler_canonical_types,
-            )?)))
+            Some(MType::Option(Box::new(string_to_ffi_type(inner, registry, alias_resolver, compiler_canonical_types)?)))
         }
         s if s.starts_with("Result<") => {
             let inner = &s[7..s.len() - 1];
             let parts: Vec<&str> = inner.splitn(2, ',').map(|p| p.trim()).collect();
-            let ok = string_to_ffi_type(
-                parts.first()?,
-                registry,
-                alias_resolver,
-                compiler_canonical_types,
-            )?;
+            let ok = string_to_ffi_type(parts.first()?, registry, alias_resolver, compiler_canonical_types)?;
             let err = parts
                 .get(1)
-                .and_then(|e| {
-                    string_to_ffi_type(e, registry, alias_resolver, compiler_canonical_types)
-                })
+                .and_then(|e| string_to_ffi_type(e, registry, alias_resolver, compiler_canonical_types))
                 .unwrap_or(MType::String);
             Some(MType::Result {
                 ok: Box::new(ok),
@@ -1856,20 +1460,12 @@ fn string_to_ffi_type(
             }
 
             let resolved = alias_resolver.resolve_type_spelling(s);
-            let canonical = compiler_canonical_types
-                .get(resolved.as_ref())
-                .map(String::as_str)
-                .unwrap_or(resolved.as_ref());
+            let canonical = compiler_canonical_types.get(resolved.as_ref()).map(String::as_str).unwrap_or(resolved.as_ref());
 
             BuiltinId::from_rust_path(canonical)
                 .map(MType::Builtin)
                 .or_else(|| registry.classify_named_type(canonical))
-                .or_else(|| {
-                    canonical
-                        .rsplit("::")
-                        .next()
-                        .and_then(|name| registry.classify_named_type(name))
-                })
+                .or_else(|| canonical.rsplit("::").next().and_then(|name| registry.classify_named_type(name)))
         }
     }
 }
@@ -1895,10 +1491,7 @@ mod tests {
             Item::Struct(s) => &s.attrs,
             _ => panic!("expected struct"),
         };
-        assert_eq!(
-            extract_doc_string(attrs),
-            Some("A point in 2D space.".to_string())
-        );
+        assert_eq!(extract_doc_string(attrs), Some("A point in 2D space.".to_string()));
     }
 
     #[test]
@@ -1913,10 +1506,7 @@ mod tests {
             Item::Struct(s) => &s.attrs,
             _ => panic!("expected struct"),
         };
-        assert_eq!(
-            extract_doc_string(attrs),
-            Some("First line.\nSecond line.\nThird line.".to_string())
-        );
+        assert_eq!(extract_doc_string(attrs), Some("First line.\nSecond line.\nThird line.".to_string()));
     }
 
     #[test]
@@ -1977,22 +1567,10 @@ mod tests {
             },
         );
 
-        assert!(matches!(
-            reg.classify_named_type("Point"),
-            Some(MType::Record(_))
-        ));
-        assert!(matches!(
-            reg.classify_named_type("Color"),
-            Some(MType::Enum(_))
-        ));
-        assert!(matches!(
-            reg.classify_named_type("Sensor"),
-            Some(MType::Object(_))
-        ));
-        assert!(matches!(
-            reg.classify_named_type("UtcDateTime"),
-            Some(MType::Custom { .. })
-        ));
+        assert!(matches!(reg.classify_named_type("Point"), Some(MType::Record(_))));
+        assert!(matches!(reg.classify_named_type("Color"), Some(MType::Enum(_))));
+        assert!(matches!(reg.classify_named_type("Sensor"), Some(MType::Object(_))));
+        assert!(matches!(reg.classify_named_type("UtcDateTime"), Some(MType::Custom { .. })));
         assert!(reg.classify_named_type("Unknown").is_none());
     }
 
@@ -2019,10 +1597,7 @@ mod tests {
     #[test]
     fn type_registry_doc_at_registration() {
         let mut reg = TypeRegistry::default();
-        reg.register(
-            "Sensor".into(),
-            pending_with_doc(PendingKind::Class, "A hardware sensor."),
-        );
+        reg.register("Sensor".into(), pending_with_doc(PendingKind::Class, "A hardware sensor."));
 
         assert_eq!(reg.doc("Sensor"), Some("A hardware sensor."));
     }
@@ -2057,10 +1632,7 @@ mod tests {
             },
         );
 
-        assert!(matches!(
-            reg.classify_named_type("Timestamp"),
-            Some(MType::Custom { .. })
-        ));
+        assert!(matches!(reg.classify_named_type("Timestamp"), Some(MType::Custom { .. })));
         assert!(!reg.is_enum("Timestamp"));
     }
 
@@ -2075,10 +1647,7 @@ mod tests {
             },
         );
 
-        assert!(matches!(
-            reg.classify_named_type("Point"),
-            Some(MType::Record(_))
-        ));
+        assert!(matches!(reg.classify_named_type("Point"), Some(MType::Record(_))));
         assert!(matches!(
             reg.types.get("Point").unwrap().shape,
             TypeShape::Record { ref fields } if fields.len() == 1
@@ -2116,10 +1685,7 @@ mod tests {
             },
             _ => panic!("expected struct"),
         };
-        assert_eq!(
-            extract_doc_string(&fields[0].attrs),
-            Some("Unique identifier for this location.".to_string())
-        );
+        assert_eq!(extract_doc_string(&fields[0].attrs), Some("Unique identifier for this location.".to_string()));
         assert_eq!(extract_doc_string(&fields[1].attrs), None);
     }
 
@@ -2136,10 +1702,7 @@ mod tests {
             Item::Enum(e) => &e.variants,
             _ => panic!("expected enum"),
         };
-        assert_eq!(
-            extract_doc_string(&variants[0].attrs),
-            Some("Pointing north.".to_string())
-        );
+        assert_eq!(extract_doc_string(&variants[0].attrs), Some("Pointing north.".to_string()));
         assert_eq!(extract_doc_string(&variants[1].attrs), None);
     }
 
@@ -2161,10 +1724,7 @@ mod tests {
             },
             _ => panic!("expected enum"),
         };
-        assert_eq!(
-            extract_doc_string(&fields[0].attrs),
-            Some("Error code describing the failure.".to_string())
-        );
+        assert_eq!(extract_doc_string(&fields[0].attrs), Some("Error code describing the failure.".to_string()));
         assert_eq!(extract_doc_string(&fields[1].attrs), None);
     }
 }

--- a/boltffi_core/src/async_callback.rs
+++ b/boltffi_core/src/async_callback.rs
@@ -1,6 +1,4 @@
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::task::Waker;
+use std::{cell::RefCell, collections::HashMap, task::Waker};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
@@ -70,13 +68,7 @@ impl RequestRegistry {
         if self.next_id == 0 {
             self.next_id = 1;
         }
-        self.pending.insert(
-            id,
-            PendingRequest {
-                waker: None,
-                result: None,
-            },
-        );
+        self.pending.insert(id, PendingRequest { waker: None, result: None });
         CallbackRequestId(id)
     }
 
@@ -86,12 +78,7 @@ impl RequestRegistry {
         }
     }
 
-    fn complete(
-        &mut self,
-        id: CallbackRequestId,
-        code: AsyncCallbackCompletionCode,
-        data: Vec<u8>,
-    ) -> CompleteResult {
+    fn complete(&mut self, id: CallbackRequestId, code: AsyncCallbackCompletionCode, data: Vec<u8>) -> CompleteResult {
         let Some(request) = self.pending.get_mut(&id.0) else {
             return CompleteResult::UnknownOrAlreadyCompleted;
         };
@@ -151,11 +138,7 @@ pub fn set_request_waker(id: CallbackRequestId, waker: Waker) {
     REGISTRY.with(|r| r.borrow_mut().set_waker(id, waker));
 }
 
-pub fn complete_request(
-    id: CallbackRequestId,
-    code: AsyncCallbackCompletionCode,
-    data: Vec<u8>,
-) -> CompleteResult {
+pub fn complete_request(id: CallbackRequestId, code: AsyncCallbackCompletionCode, data: Vec<u8>) -> CompleteResult {
     REGISTRY.with(|r| r.borrow_mut().complete(id, code, data))
 }
 
@@ -180,13 +163,7 @@ impl Drop for RequestGuard {
 }
 
 #[cfg(target_arch = "wasm32")]
-pub unsafe fn complete_request_from_ffi(
-    request_id: u32,
-    completion_code: i32,
-    data_ptr: u32,
-    data_len: u32,
-    data_cap: u32,
-) -> i32 {
+pub unsafe fn complete_request_from_ffi(request_id: u32, completion_code: i32, data_ptr: u32, data_len: u32, data_cap: u32) -> i32 {
     let id = CallbackRequestId(request_id);
     let code = AsyncCallbackCompletionCode::from_i32(completion_code);
 
@@ -200,7 +177,7 @@ pub unsafe fn complete_request_from_ffi(
     };
 
     if data_ptr != 0 && data_cap > 0 {
-        crate::wasm::boltffi_wasm_free_impl(data_ptr as usize, data_cap as usize);
+        crate::wasm::boltffi_wasm_free_impl(data_ptr as *mut u8, data_cap as usize);
     }
 
     complete_request(id, code, data) as i32

--- a/boltffi_core/src/async_iterator.rs
+++ b/boltffi_core/src/async_iterator.rs
@@ -1,0 +1,99 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// Minimal pull-based stream trait. Mirrors `futures::Stream` without the dependency.
+/// Implement this on your type, or use [`stream_from_fn`] for simple cases.
+pub trait Stream {
+    type Item;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>>;
+}
+
+pub type IteratorHandle = *mut core::ffi::c_void;
+
+/// Vtable header stored at offset 0 of every iterator allocation (`repr(C)`).
+#[repr(C)]
+struct IteratorHeader<T> {
+    poll_next: unsafe fn(IteratorHandle, &mut Context<'_>) -> Poll<Option<T>>,
+    drop_in_place: unsafe fn(IteratorHandle),
+}
+
+/// Single heap allocation: vtable header followed by the concrete stream data.
+/// `repr(C)` guarantees `header` sits at offset 0 so a pointer to this struct
+/// can be safely cast to `*const IteratorHeader<T>`.
+#[repr(C)]
+struct IteratorAlloc<T: Send + 'static, S> {
+    header: IteratorHeader<T>,
+    stream: S,
+}
+
+/// Create a new iterator handle from a concrete stream.
+///
+/// Performs a **single** heap allocation that stores both the vtable and the
+/// stream data contiguously.
+pub fn iterator_new<T: Send + 'static, S: Stream<Item = T> + Send + 'static>(stream: S) -> IteratorHandle {
+    unsafe fn poll_impl<T: Send + 'static, S: Stream<Item = T> + Send + 'static>(handle: IteratorHandle, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        let alloc = unsafe { &mut *(handle as *mut IteratorAlloc<T, S>) };
+        // SAFETY: The IteratorAlloc lives on the heap (Box) and is never moved
+        // after creation, so the stream field is structurally pinned.
+        unsafe { Pin::new_unchecked(&mut alloc.stream) }.poll_next(cx)
+    }
+
+    unsafe fn drop_impl<T: Send + 'static, S>(handle: IteratorHandle) {
+        drop(unsafe { Box::from_raw(handle as *mut IteratorAlloc<T, S>) });
+    }
+
+    let alloc = Box::new(IteratorAlloc {
+        header: IteratorHeader {
+            poll_next: poll_impl::<T, S>,
+            drop_in_place: drop_impl::<T, S>,
+        },
+        stream,
+    });
+    Box::into_raw(alloc) as IteratorHandle
+}
+
+/// Wraps `IteratorHandle` so it can be captured by a `Send` future.
+///
+/// # Safety
+/// The caller must guarantee the pointee is actually safe to send across threads.
+struct SendHandle(IteratorHandle);
+// SAFETY: IteratorAlloc<T, S> requires T: Send + S: Send, so the data behind
+// the handle is Send. The raw pointer itself is just an address; we document
+// that callers must not alias it unsafely.
+unsafe impl Send for SendHandle {}
+
+impl SendHandle {
+    fn get(&self) -> IteratorHandle {
+        self.0
+    }
+}
+
+/// Return a [`Future`] that polls the next item from the iterator behind `handle`.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer previously returned by [`iterator_new`], and
+/// the handle must remain valid for the lifetime of the returned future.
+pub unsafe fn iterator_next<T: Send + 'static>(handle: IteratorHandle) -> impl std::future::Future<Output = Option<T>> + Send {
+    let send_handle = SendHandle(handle);
+    std::future::poll_fn(move |cx| {
+        let handle = send_handle.get();
+        let header = unsafe { &*(handle as *const IteratorHeader<T>) };
+        unsafe { (header.poll_next)(handle, cx) }
+    })
+}
+
+/// Drop the iterator, freeing all resources.
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer previously returned by [`iterator_new`] and
+/// must not be used again after this call.
+pub unsafe fn iterator_free<T: Send + 'static>(handle: IteratorHandle) {
+    if !handle.is_null() {
+        let header = unsafe { &*(handle as *const IteratorHeader<T>) };
+        unsafe { (header.drop_in_place)(handle) };
+    }
+}

--- a/boltffi_core/src/callback.rs
+++ b/boltffi_core/src/callback.rs
@@ -1,5 +1,4 @@
-use std::ffi::c_void;
-use std::sync::Arc;
+use std::{ffi::c_void, sync::Arc};
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -64,10 +63,7 @@ impl Default for CallbackHandle {
 
 impl std::fmt::Debug for CallbackHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CallbackHandle")
-            .field("handle", &self.handle)
-            .field("vtable", &self.vtable)
-            .finish()
+        f.debug_struct("CallbackHandle").field("handle", &self.handle).field("vtable", &self.vtable).finish()
     }
 }
 

--- a/boltffi_core/src/lib.rs
+++ b/boltffi_core/src/lib.rs
@@ -6,6 +6,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[cfg(target_arch = "wasm32")]
 pub mod async_callback;
+pub mod async_iterator;
 pub mod callback;
 pub mod custom_ffi;
 pub mod handle;
@@ -21,14 +22,11 @@ pub mod wire;
 
 #[cfg(target_arch = "wasm32")]
 pub use async_callback::{
-    AsyncCallbackCompletionCode, CallbackRequestId, CompleteResult, CompletionPayload,
-    RequestGuard, allocate_request, cancel_request, complete_request, complete_request_from_ffi,
+    AsyncCallbackCompletionCode, CallbackRequestId, CompleteResult, CompletionPayload, RequestGuard, allocate_request, cancel_request, complete_request, complete_request_from_ffi,
     remove_request, set_request_waker, take_request_result,
 };
-pub use boltffi_macros::{
-    Data, FfiType, custom_ffi, custom_type, data, default, error, export, ffi_class, ffi_export,
-    ffi_stream, ffi_trait, name, skip,
-};
+pub use async_iterator::{IteratorHandle, Stream as FfiStream, iterator_free, iterator_new, iterator_next};
+pub use boltffi_macros::{Data, FfiType, custom_ffi, custom_type, data, default, error, export, ffi_async_iter, ffi_class, ffi_export, ffi_stream, ffi_trait, name, skip};
 #[cfg(target_arch = "wasm32")]
 pub use callback::WasmCallbackOwner;
 pub use callback::{CallbackForeignType, CallbackHandle, FromCallbackHandle};
@@ -36,17 +34,12 @@ pub use custom_ffi::CustomFfiConvertible;
 pub use handle::HandleBox;
 pub use pending::{CancellationToken, PendingHandle};
 pub use ringbuffer::SpscRingBuffer;
-pub use rustfuture::{
-    RustFuture, RustFutureContinuationCallback, RustFutureHandle, RustFuturePoll,
-};
+pub use rustfuture::{RustFuture, RustFutureContinuationCallback, RustFutureHandle, RustFuturePoll};
 #[cfg(target_arch = "wasm32")]
 pub use rustfuture::{WasmPollStatus, rust_future_panic_message, rust_future_poll_sync};
 pub use safety::catch_ffi_panic;
 pub use status::{FfiStatus, clear_last_error, set_last_error, take_last_error};
-pub use subscription::{
-    EventSubscription, StreamContinuationCallback, StreamPollResult, StreamProducer,
-    SubscriptionHandle, WaitResult,
-};
+pub use subscription::{EventSubscription, StreamContinuationCallback, StreamPollResult, StreamProducer, SubscriptionHandle, WaitResult};
 pub use types::{FfiBuf, FfiError, FfiOption, FfiSlice, FfiString};
 pub use wasm::WASM_ABI_VERSION;
 #[cfg(target_arch = "wasm32")]

--- a/boltffi_core/src/pending.rs
+++ b/boltffi_core/src/pending.rs
@@ -1,5 +1,7 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 pub struct PendingHandle {
     cancelled: Arc<AtomicBool>,
@@ -58,12 +60,6 @@ pub unsafe extern "C" fn boltffi_pending_free(handle: *mut PendingHandle) {
     }
 }
 
-pub type AsyncCallback<T> =
-    extern "C" fn(user_data: *mut core::ffi::c_void, status: crate::FfiStatus, result: T);
-pub type AsyncCallbackVoid =
-    extern "C" fn(user_data: *mut core::ffi::c_void, status: crate::FfiStatus);
-pub type AsyncCallbackString = extern "C" fn(
-    user_data: *mut core::ffi::c_void,
-    status: crate::FfiStatus,
-    result: crate::FfiString,
-);
+pub type AsyncCallback<T> = extern "C" fn(user_data: *mut core::ffi::c_void, status: crate::FfiStatus, result: T);
+pub type AsyncCallbackVoid = extern "C" fn(user_data: *mut core::ffi::c_void, status: crate::FfiStatus);
+pub type AsyncCallbackString = extern "C" fn(user_data: *mut core::ffi::c_void, status: crate::FfiStatus, result: crate::FfiString);

--- a/boltffi_core/src/ringbuffer.rs
+++ b/boltffi_core/src/ringbuffer.rs
@@ -1,6 +1,8 @@
-use std::cell::UnsafeCell;
-use std::mem::MaybeUninit;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{
+    cell::UnsafeCell,
+    mem::MaybeUninit,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 #[repr(align(64))]
 struct CacheLinePadded<T>(T);
@@ -29,10 +31,7 @@ unsafe impl<T: Send> Sync for SpscRingBuffer<T> {}
 impl<T> SpscRingBuffer<T> {
     pub fn new(capacity: usize) -> Self {
         let capacity = capacity.next_power_of_two();
-        let buffer = (0..capacity)
-            .map(|_| UnsafeCell::new(MaybeUninit::uninit()))
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
+        let buffer = (0..capacity).map(|_| UnsafeCell::new(MaybeUninit::uninit())).collect::<Vec<_>>().into_boxed_slice();
 
         Self {
             buffer,
@@ -62,9 +61,7 @@ impl<T> SpscRingBuffer<T> {
             (*self.buffer[slot_index].get()).write(value);
         }
 
-        self.producer_index
-            .get()
-            .store(producer_position + 1, Ordering::Release);
+        self.producer_index.get().store(producer_position + 1, Ordering::Release);
 
         Ok(())
     }
@@ -80,9 +77,7 @@ impl<T> SpscRingBuffer<T> {
         let slot_index = self.slot_index(consumer_position);
         let value = unsafe { (*self.buffer[slot_index].get()).assume_init_read() };
 
-        self.consumer_index
-            .get()
-            .store(consumer_position + 1, Ordering::Release);
+        self.consumer_index.get().store(consumer_position + 1, Ordering::Release);
 
         Some(value)
     }
@@ -98,19 +93,13 @@ impl<T> SpscRingBuffer<T> {
             return 0;
         }
 
-        output_buffer
-            .iter_mut()
-            .take(batch_size)
-            .enumerate()
-            .for_each(|(offset, output_slot)| {
-                let slot_index = self.slot_index(consumer_position + offset);
-                let value = unsafe { (*self.buffer[slot_index].get()).assume_init_read() };
-                output_slot.write(value);
-            });
+        output_buffer.iter_mut().take(batch_size).enumerate().for_each(|(offset, output_slot)| {
+            let slot_index = self.slot_index(consumer_position + offset);
+            let value = unsafe { (*self.buffer[slot_index].get()).assume_init_read() };
+            output_slot.write(value);
+        });
 
-        self.consumer_index
-            .get()
-            .store(consumer_position + batch_size, Ordering::Release);
+        self.consumer_index.get().store(consumer_position + batch_size, Ordering::Release);
 
         batch_size
     }
@@ -184,18 +173,13 @@ mod tests {
             ring_buffer.push(index).unwrap();
         });
 
-        let mut batch_buffer: [MaybeUninit<i32>; 4] =
-            unsafe { MaybeUninit::uninit().assume_init() };
+        let mut batch_buffer: [MaybeUninit<i32>; 4] = unsafe { MaybeUninit::uninit().assume_init() };
         let popped_count = ring_buffer.pop_batch_into(&mut batch_buffer);
         assert_eq!(popped_count, 4);
 
-        batch_buffer
-            .iter()
-            .take(popped_count)
-            .enumerate()
-            .for_each(|(index, slot)| {
-                assert_eq!(unsafe { slot.assume_init() }, index as i32);
-            });
+        batch_buffer.iter().take(popped_count).enumerate().for_each(|(index, slot)| {
+            assert_eq!(unsafe { slot.assume_init() }, index as i32);
+        });
 
         assert_eq!(ring_buffer.available_count(), 6);
     }

--- a/boltffi_core/src/rustfuture.rs
+++ b/boltffi_core/src/rustfuture.rs
@@ -1,9 +1,14 @@
-use std::future::Future;
-use std::pin::Pin;
-use std::ptr;
-use std::sync::atomic::{AtomicPtr, AtomicU8, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::{
+    cell::UnsafeCell,
+    future::Future,
+    pin::Pin,
+    ptr,
+    sync::{
+        Arc,
+        atomic::{AtomicPtr, AtomicU8, AtomicU64, Ordering},
+    },
+    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+};
 
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -33,9 +38,7 @@ struct ContinuationCallback(RustFutureContinuationCallback);
 
 impl ContinuationCallback {
     fn from_raw_ptr(ptr: *mut ()) -> Option<Self> {
-        (!ptr.is_null()).then(|| {
-            Self(unsafe { std::mem::transmute::<*mut (), RustFutureContinuationCallback>(ptr) })
-        })
+        (!ptr.is_null()).then(|| Self(unsafe { std::mem::transmute::<*mut (), RustFutureContinuationCallback>(ptr) }))
     }
 
     fn into_raw_ptr(self) -> *mut () {
@@ -105,31 +108,18 @@ impl AtomicContinuationScheduler {
     }
 
     fn try_transition(&self, from: SchedulerStateTag, to: SchedulerStateTag) -> bool {
-        self.state_tag
-            .compare_exchange(
-                from.into_raw(),
-                to.into_raw(),
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            )
-            .is_ok()
+        self.state_tag.compare_exchange(from.into_raw(), to.into_raw(), Ordering::AcqRel, Ordering::Acquire).is_ok()
     }
 
     fn load_stored_continuation(&self) -> (Option<ContinuationCallback>, ContinuationData) {
         let callback_ptr = self.stored_callback_ptr.load(Ordering::Acquire);
-        let callback_data =
-            ContinuationData::from_raw(self.stored_callback_data.load(Ordering::Acquire));
-        (
-            ContinuationCallback::from_raw_ptr(callback_ptr),
-            callback_data,
-        )
+        let callback_data = ContinuationData::from_raw(self.stored_callback_data.load(Ordering::Acquire));
+        (ContinuationCallback::from_raw_ptr(callback_ptr), callback_data)
     }
 
     fn write_continuation(&self, callback: ContinuationCallback, callback_data: ContinuationData) {
-        self.stored_callback_data
-            .store(callback_data.into_raw(), Ordering::Release);
-        self.stored_callback_ptr
-            .store(callback.into_raw_ptr(), Ordering::Release);
+        self.stored_callback_data.store(callback_data.into_raw(), Ordering::Release);
+        self.stored_callback_ptr.store(callback.into_raw_ptr(), Ordering::Release);
     }
 
     fn invoke_stored_continuation(&self, poll_result: RustFuturePoll) {
@@ -139,19 +129,12 @@ impl AtomicContinuationScheduler {
         }
     }
 
-    fn store_continuation(
-        &self,
-        continuation_callback: ContinuationCallback,
-        callback_data: ContinuationData,
-    ) {
+    fn store_continuation(&self, continuation_callback: ContinuationCallback, callback_data: ContinuationData) {
         loop {
             match self.current_state() {
                 SchedulerStateTag::Empty => {
                     self.write_continuation(continuation_callback, callback_data);
-                    if self.try_transition(
-                        SchedulerStateTag::Empty,
-                        SchedulerStateTag::ContinuationStored,
-                    ) {
+                    if self.try_transition(SchedulerStateTag::Empty, SchedulerStateTag::ContinuationStored) {
                         return;
                     }
                 }
@@ -178,10 +161,7 @@ impl AtomicContinuationScheduler {
         loop {
             match self.current_state() {
                 SchedulerStateTag::ContinuationStored => {
-                    if self.try_transition(
-                        SchedulerStateTag::ContinuationStored,
-                        SchedulerStateTag::Empty,
-                    ) {
+                    if self.try_transition(SchedulerStateTag::ContinuationStored, SchedulerStateTag::Empty) {
                         self.invoke_stored_continuation(RustFuturePoll::MaybeReady);
                         return;
                     }
@@ -201,10 +181,7 @@ impl AtomicContinuationScheduler {
             let current_state = self.current_state();
             match current_state {
                 SchedulerStateTag::ContinuationStored => {
-                    if self.try_transition(
-                        SchedulerStateTag::ContinuationStored,
-                        SchedulerStateTag::Cancelled,
-                    ) {
+                    if self.try_transition(SchedulerStateTag::ContinuationStored, SchedulerStateTag::Cancelled) {
                         self.invoke_stored_continuation(RustFuturePoll::Ready);
                         return;
                     }
@@ -234,14 +211,14 @@ pub enum TerminalState {
 }
 
 #[allow(dead_code)]
-enum FutureExecutionState<T> {
-    Running(Pin<Box<dyn Future<Output = T> + Send + 'static>>),
+enum CompletionState<T> {
+    Running,
     Complete(T),
     Panicked(String),
     Consumed,
 }
 
-impl<T> FutureExecutionState<T> {
+impl<T> CompletionState<T> {
     fn is_finished(&self) -> bool {
         matches!(self, Self::Complete(_) | Self::Panicked(_) | Self::Consumed)
     }
@@ -272,166 +249,153 @@ impl<T> FutureExecutionState<T> {
     }
 }
 
+/// Type-erased header containing vtable function pointers, scheduler, and
+/// completion state. The handle points to this struct.
+#[repr(C)]
 pub struct RustFuture<T: Send + 'static> {
-    future_execution_state: Mutex<FutureExecutionState<T>>,
+    poll_future: unsafe fn(*const RustFuture<T>, &Waker) -> bool,
+    drop_future: unsafe fn(*const RustFuture<T>),
+    arc_clone: unsafe fn(*const RustFuture<T>),
+    arc_drop: unsafe fn(*const RustFuture<T>),
     continuation_scheduler: AtomicContinuationScheduler,
+    completion_state: UnsafeCell<CompletionState<T>>,
 }
+
+/// Single heap allocation: vtable header followed by the concrete future.
+/// `repr(C)` guarantees `header` sits at offset 0 so a pointer to this struct
+/// can be safely cast to `*const RustFuture<T>`.
+#[repr(C)]
+struct RustFutureAlloc<T: Send + 'static, F> {
+    header: RustFuture<T>,
+    future: UnsafeCell<Option<F>>,
+}
+
+// SAFETY: The UnsafeCell<Option<F>> (future) is accessed exclusively:
+// 1. During poll — the scheduler guarantees sequential polling
+// 2. During drop_future — called after completion or from the panic handler
+// 3. During Drop of RustFutureAlloc — when Arc refcount reaches 0
+unsafe impl<T: Send + 'static, F: Send> Sync for RustFutureAlloc<T, F> {}
+
+// ---------------------------------------------------------------------------
+// Vtable function implementations
+// ---------------------------------------------------------------------------
+
+unsafe fn poll_impl<T: Send + 'static, F: Future<Output = T> + Send + 'static>(header_ptr: *const RustFuture<T>, waker: &Waker) -> bool {
+    let alloc_ptr = header_ptr as *const RustFutureAlloc<T, F>;
+    let alloc = unsafe { &*alloc_ptr };
+
+    let future_cell = unsafe { &mut *alloc.future.get() };
+    let Some(future) = future_cell.as_mut() else {
+        return true;
+    };
+
+    // SAFETY: The future lives inside Arc<RustFutureAlloc> on the heap and is
+    // never moved after creation. We only set it to None after completion.
+    let pinned = unsafe { Pin::new_unchecked(future) };
+    let mut cx = Context::from_waker(waker);
+
+    match pinned.poll(&mut cx) {
+        Poll::Pending => false,
+        Poll::Ready(result) => {
+            // Drop the future immediately — it's done.
+            *future_cell = None;
+            unsafe { *alloc.header.completion_state.get() = CompletionState::Complete(result) };
+            true
+        }
+    }
+}
+
+unsafe fn drop_impl<T: Send + 'static, F>(header_ptr: *const RustFuture<T>) {
+    let alloc_ptr = header_ptr as *const RustFutureAlloc<T, F>;
+    let alloc = unsafe { &*alloc_ptr };
+    let future_cell = unsafe { &mut *alloc.future.get() };
+    *future_cell = None;
+}
+
+unsafe fn arc_clone_impl<T: Send + 'static, F>(header_ptr: *const RustFuture<T>) {
+    unsafe { Arc::increment_strong_count(header_ptr as *const RustFutureAlloc<T, F>) };
+}
+
+unsafe fn arc_drop_impl<T: Send + 'static, F>(header_ptr: *const RustFuture<T>) {
+    unsafe { Arc::decrement_strong_count(header_ptr as *const RustFutureAlloc<T, F>) };
+}
+
+// ---------------------------------------------------------------------------
+// Waker vtable — delegates Arc ops through header function pointers
+// ---------------------------------------------------------------------------
 
 impl<T: Send + 'static> RustFuture<T> {
-    pub fn new<F>(future: F) -> Arc<Self>
-    where
-        F: Future<Output = T> + Send + 'static,
-    {
-        Arc::new(Self {
-            future_execution_state: Mutex::new(FutureExecutionState::Running(Box::pin(future))),
-            continuation_scheduler: AtomicContinuationScheduler::new(),
-        })
+    const WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(Self::waker_clone, Self::waker_wake, Self::waker_wake_by_ref, Self::waker_drop);
+    #[cfg(target_arch = "wasm32")]
+    const WASM_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(Self::wasm_waker_clone, Self::wasm_waker_wake, Self::wasm_waker_wake_by_ref, Self::wasm_waker_drop);
+
+    unsafe fn waker_clone(data: *const ()) -> RawWaker {
+        let header = data as *const RustFuture<T>;
+        unsafe { ((*header).arc_clone)(header) };
+        RawWaker::new(data, &Self::WAKER_VTABLE)
     }
 
-    fn poll_future_once(&self, waker: &Waker) -> bool {
-        let mut execution_state_guard = self.future_execution_state.lock().unwrap();
-
-        if execution_state_guard.is_finished() {
-            return true;
-        }
-
-        let FutureExecutionState::Running(pinned_future) = &mut *execution_state_guard else {
-            return true;
-        };
-
-        let mut poll_context = Context::from_waker(waker);
-        match pinned_future.as_mut().poll(&mut poll_context) {
-            Poll::Pending => false,
-            Poll::Ready(result) => {
-                *execution_state_guard = FutureExecutionState::Complete(result);
-                true
-            }
-        }
+    unsafe fn waker_wake(data: *const ()) {
+        let header = data as *const RustFuture<T>;
+        unsafe { (*header).continuation_scheduler.wake_continuation() };
+        // Consume the waker's Arc ref.
+        unsafe { ((*header).arc_drop)(header) };
     }
 
-    pub fn poll(
-        self: &Arc<Self>,
-        continuation_callback: RustFutureContinuationCallback,
-        callback_data: u64,
-    ) {
-        let is_cancelled = self.continuation_scheduler.is_cancelled();
-
-        let is_ready = is_cancelled || {
-            let waker = self.clone().create_waker();
-            self.poll_future_once(&waker)
-        };
-
-        if is_ready {
-            continuation_callback(callback_data, RustFuturePoll::Ready);
-        } else {
-            self.continuation_scheduler.store_continuation(
-                ContinuationCallback(continuation_callback),
-                ContinuationData::from_raw(callback_data),
-            );
-        }
+    unsafe fn waker_wake_by_ref(data: *const ()) {
+        let header = data as *const RustFuture<T>;
+        unsafe { (*header).continuation_scheduler.wake_continuation() };
     }
 
-    pub fn complete(&self) -> Option<T> {
-        self.future_execution_state.lock().unwrap().take_result()
-    }
-
-    pub fn panic_message(&self) -> Option<String> {
-        self.future_execution_state
-            .lock()
-            .unwrap()
-            .take_panic_message()
-    }
-
-    pub fn cancel(&self) {
-        self.continuation_scheduler.mark_cancelled();
-    }
-
-    pub fn free(self: Arc<Self>) {
-        self.continuation_scheduler.mark_cancelled();
+    unsafe fn waker_drop(data: *const ()) {
+        let header = data as *const RustFuture<T>;
+        unsafe { ((*header).arc_drop)(header) };
     }
 
     #[cfg(target_arch = "wasm32")]
-    pub fn poll_sync(self: &Arc<Self>) -> WasmPollStatus {
-        if self.continuation_scheduler.is_cancelled() {
-            return WasmPollStatus::Cancelled;
-        }
-
-        let waker = self.clone().create_wasm_waker();
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            self.poll_future_once(&waker)
-        }));
-
-        match result {
-            Ok(true) => {
-                let state = self.future_execution_state.lock().unwrap();
-                if state.is_panicked() {
-                    WasmPollStatus::Panicked
-                } else {
-                    WasmPollStatus::Ready
-                }
-            }
-            Ok(false) => WasmPollStatus::Pending,
-            Err(panic_payload) => {
-                let message = panic_payload_to_string(panic_payload);
-                *self.future_execution_state.lock().unwrap() =
-                    FutureExecutionState::Panicked(message);
-                WasmPollStatus::Panicked
-            }
-        }
+    unsafe fn wasm_waker_clone(data: *const ()) -> RawWaker {
+        let header = data as *const RustFuture<T>;
+        unsafe { ((*header).arc_clone)(header) };
+        RawWaker::new(data, &Self::WASM_WAKER_VTABLE)
     }
 
     #[cfg(target_arch = "wasm32")]
-    fn create_wasm_waker(self: Arc<Self>) -> Waker {
-        let handle = Arc::into_raw(self) as u32;
-        let raw_waker = RawWaker::new(handle as *const (), &WASM_WAKER_VTABLE);
-        unsafe { Waker::from_raw(raw_waker) }
+    unsafe fn wasm_waker_wake(data: *const ()) {
+        let handle = data as u32;
+        unsafe { __boltffi_wake(handle) };
+        let header = data as *const RustFuture<T>;
+        unsafe { ((*header).arc_drop)(header) };
     }
 
-    fn create_waker(self: Arc<Self>) -> Waker {
-        let raw_waker = RawWaker::new(Arc::into_raw(self) as *const (), &RUST_FUTURE_WAKER_VTABLE);
-        unsafe { Waker::from_raw(raw_waker) }
+    #[cfg(target_arch = "wasm32")]
+    unsafe fn wasm_waker_wake_by_ref(data: *const ()) {
+        let handle = data as u32;
+        unsafe { __boltffi_wake(handle) };
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    unsafe fn wasm_waker_drop(data: *const ()) {
+        let header = data as *const RustFuture<T>;
+        unsafe { ((*header).arc_drop)(header) };
     }
 }
 
-const RUST_FUTURE_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-    waker_clone_fn::<()>,
-    waker_wake_fn::<()>,
-    waker_wake_by_ref_fn::<()>,
-    waker_drop_fn::<()>,
-);
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-#[cfg(target_arch = "wasm32")]
-const WASM_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-    wasm_waker_clone,
-    wasm_waker_wake,
-    wasm_waker_wake_by_ref,
-    wasm_waker_drop,
-);
-
-#[cfg(target_arch = "wasm32")]
-fn wasm_waker_clone(data: *const ()) -> RawWaker {
-    let handle = data as u32;
-    unsafe { Arc::increment_strong_count(handle as *const RustFuture<()>) };
-    RawWaker::new(data, &WASM_WAKER_VTABLE)
+fn create_waker_from_header<T: Send + 'static>(header: *const RustFuture<T>) -> Waker {
+    // Clone the Arc for the waker's ownership.
+    unsafe { ((*header).arc_clone)(header) };
+    let raw_waker = RawWaker::new(header as *const (), &RustFuture::<T>::WAKER_VTABLE);
+    unsafe { Waker::from_raw(raw_waker) }
 }
 
 #[cfg(target_arch = "wasm32")]
-fn wasm_waker_wake(data: *const ()) {
-    let handle = data as u32;
-    unsafe { __boltffi_wake(handle) };
-    unsafe { Arc::decrement_strong_count(handle as *const RustFuture<()>) };
-}
-
-#[cfg(target_arch = "wasm32")]
-fn wasm_waker_wake_by_ref(data: *const ()) {
-    let handle = data as u32;
-    unsafe { __boltffi_wake(handle) };
-}
-
-#[cfg(target_arch = "wasm32")]
-fn wasm_waker_drop(data: *const ()) {
-    let handle = data as u32;
-    unsafe { Arc::decrement_strong_count(handle as *const RustFuture<()>) };
+fn create_wasm_waker_from_header<T: Send + 'static>(header: *const RustFuture<T>) -> Waker {
+    unsafe { ((*header).arc_clone)(header) };
+    let raw_waker = RawWaker::new(header as *const (), &RustFuture::<T>::WASM_WAKER_VTABLE);
+    unsafe { Waker::from_raw(raw_waker) }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -445,28 +409,9 @@ fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
     "unknown panic".to_string()
 }
 
-fn waker_clone_fn<T: Send + 'static>(waker_data_ptr: *const ()) -> RawWaker {
-    unsafe { Arc::increment_strong_count(waker_data_ptr as *const RustFuture<T>) };
-    RawWaker::new(waker_data_ptr, &RUST_FUTURE_WAKER_VTABLE)
-}
-
-fn waker_wake_fn<T: Send + 'static>(waker_data_ptr: *const ()) {
-    let rust_future_arc = unsafe { Arc::from_raw(waker_data_ptr as *const RustFuture<T>) };
-    rust_future_arc.continuation_scheduler.wake_continuation();
-}
-
-fn waker_wake_by_ref_fn<T: Send + 'static>(waker_data_ptr: *const ()) {
-    let rust_future_ptr = waker_data_ptr as *const RustFuture<T>;
-    unsafe {
-        (*rust_future_ptr)
-            .continuation_scheduler
-            .wake_continuation()
-    };
-}
-
-fn waker_drop_fn<T: Send + 'static>(waker_data_ptr: *const ()) {
-    drop(unsafe { Arc::from_raw(waker_data_ptr as *const RustFuture<T>) });
-}
+// ---------------------------------------------------------------------------
+// Public handle type and free functions
+// ---------------------------------------------------------------------------
 
 pub type RustFutureHandle = *const core::ffi::c_void;
 
@@ -475,51 +420,92 @@ where
     F: Future<Output = T> + Send + 'static,
     T: Send + 'static,
 {
-    Arc::into_raw(RustFuture::new(future)) as RustFutureHandle
+    let alloc = Arc::new(RustFutureAlloc {
+        header: RustFuture {
+            poll_future: poll_impl::<T, F>,
+            drop_future: drop_impl::<T, F>,
+            arc_clone: arc_clone_impl::<T, F>,
+            arc_drop: arc_drop_impl::<T, F>,
+            continuation_scheduler: AtomicContinuationScheduler::new(),
+            completion_state: UnsafeCell::new(CompletionState::Running),
+        },
+        future: UnsafeCell::new(Some(future)),
+    });
+    Arc::into_raw(alloc) as RustFutureHandle
 }
 
-pub unsafe fn rust_future_poll<T: Send + 'static>(
-    handle: RustFutureHandle,
-    continuation_callback: RustFutureContinuationCallback,
-    callback_data: u64,
-) {
-    let rust_future_arc = unsafe { Arc::from_raw(handle as *const RustFuture<T>) };
-    rust_future_arc.poll(continuation_callback, callback_data);
-    std::mem::forget(rust_future_arc);
+pub unsafe fn rust_future_poll<T: Send + 'static>(handle: RustFutureHandle, continuation_callback: RustFutureContinuationCallback, callback_data: u64) {
+    let header = handle as *const RustFuture<T>;
+
+    let is_cancelled = unsafe { (*header).continuation_scheduler.is_cancelled() };
+
+    let is_ready = is_cancelled || {
+        let waker = create_waker_from_header(header);
+        unsafe { ((*header).poll_future)(header, &waker) }
+    };
+
+    if is_ready {
+        continuation_callback(callback_data, RustFuturePoll::Ready);
+    } else {
+        unsafe {
+            (*header)
+                .continuation_scheduler
+                .store_continuation(ContinuationCallback(continuation_callback), ContinuationData::from_raw(callback_data));
+        }
+    }
 }
 
 pub unsafe fn rust_future_complete<T: Send + 'static>(handle: RustFutureHandle) -> Option<T> {
-    let rust_future_arc = unsafe { Arc::from_raw(handle as *const RustFuture<T>) };
-    let result = rust_future_arc.complete();
-    std::mem::forget(rust_future_arc);
-    result
+    let header = handle as *const RustFuture<T>;
+    unsafe { (*(*header).completion_state.get()).take_result() }
 }
 
 pub unsafe fn rust_future_cancel<T: Send + 'static>(handle: RustFutureHandle) {
-    let rust_future_arc = unsafe { Arc::from_raw(handle as *const RustFuture<T>) };
-    rust_future_arc.cancel();
-    std::mem::forget(rust_future_arc);
+    let header = handle as *const RustFuture<T>;
+    unsafe { (*header).continuation_scheduler.mark_cancelled() };
 }
 
 pub unsafe fn rust_future_free<T: Send + 'static>(handle: RustFutureHandle) {
-    let rust_future_arc = unsafe { Arc::from_raw(handle as *const RustFuture<T>) };
-    rust_future_arc.free();
+    let header = handle as *const RustFuture<T>;
+    unsafe {
+        (*header).continuation_scheduler.mark_cancelled();
+        ((*header).arc_drop)(header);
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
 pub unsafe fn rust_future_poll_sync<T: Send + 'static>(handle: RustFutureHandle) -> i32 {
-    let rust_future_arc = unsafe { Arc::from_raw(handle as *const RustFuture<T>) };
-    let status = rust_future_arc.poll_sync();
-    std::mem::forget(rust_future_arc);
-    status as i32
+    let header = handle as *const RustFuture<T>;
+
+    if unsafe { (*header).continuation_scheduler.is_cancelled() } {
+        return WasmPollStatus::Cancelled as i32;
+    }
+
+    let waker = create_wasm_waker_from_header(header);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe { ((*header).poll_future)(header, &waker) }));
+
+    match result {
+        Ok(true) => {
+            let state = unsafe { &*(*header).completion_state.get() };
+            if state.is_panicked() {
+                WasmPollStatus::Panicked as i32
+            } else {
+                WasmPollStatus::Ready as i32
+            }
+        }
+        Ok(false) => WasmPollStatus::Pending as i32,
+        Err(panic_payload) => {
+            let message = panic_payload_to_string(panic_payload);
+            // Drop the future to prevent further access after panic.
+            unsafe { ((*header).drop_future)(header) };
+            unsafe { *(*header).completion_state.get() = CompletionState::Panicked(message) };
+            WasmPollStatus::Panicked as i32
+        }
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
-pub unsafe fn rust_future_panic_message<T: Send + 'static>(
-    handle: RustFutureHandle,
-) -> Option<String> {
-    let rust_future_arc = unsafe { Arc::from_raw(handle as *const RustFuture<T>) };
-    let message = rust_future_arc.panic_message();
-    std::mem::forget(rust_future_arc);
-    message
+pub unsafe fn rust_future_panic_message<T: Send + 'static>(handle: RustFutureHandle) -> Option<String> {
+    let header = handle as *const RustFuture<T>;
+    unsafe { (*(*header).completion_state.get()).take_panic_message() }
 }

--- a/boltffi_core/src/safety.rs
+++ b/boltffi_core/src/safety.rs
@@ -1,6 +1,5 @@
-use std::panic::catch_unwind;
-
 use crate::status::FfiStatus;
+use std::panic::catch_unwind;
 
 pub const PANIC_STATUS: FfiStatus = FfiStatus { code: 10 };
 

--- a/boltffi_core/src/status.rs
+++ b/boltffi_core/src/status.rs
@@ -7,12 +7,12 @@ pub struct FfiStatus {
 }
 
 impl FfiStatus {
-    pub const OK: Self = Self { code: 0 };
-    pub const NULL_POINTER: Self = Self { code: 1 };
     pub const BUFFER_TOO_SMALL: Self = Self { code: 2 };
-    pub const INVALID_ARG: Self = Self { code: 3 };
     pub const CANCELLED: Self = Self { code: 4 };
     pub const INTERNAL_ERROR: Self = Self { code: 100 };
+    pub const INVALID_ARG: Self = Self { code: 3 };
+    pub const NULL_POINTER: Self = Self { code: 1 };
+    pub const OK: Self = Self { code: 0 };
 
     pub const fn new(code: i32) -> Self {
         Self { code }

--- a/boltffi_core/src/subscription.rs
+++ b/boltffi_core/src/subscription.rs
@@ -1,8 +1,11 @@
-use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU8, AtomicU64, Ordering};
-use std::sync::{Arc, Condvar, Mutex, Weak};
-use std::time::Duration;
-
 use crate::ringbuffer::SpscRingBuffer;
+use std::{
+    sync::{
+        Arc, Condvar, Mutex, Weak,
+        atomic::{AtomicBool, AtomicPtr, AtomicU8, AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
 #[repr(i8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -118,9 +121,7 @@ impl StreamContinuationScheduler {
     }
 
     fn try_transition(&self, from: ContinuationState, to: ContinuationState) -> bool {
-        self.state
-            .compare_exchange(from as u8, to as u8, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
+        self.state.compare_exchange(from as u8, to as u8, Ordering::AcqRel, Ordering::Acquire).is_ok()
     }
 
     fn store_continuation(&self, callback: StreamContinuationCallback, callback_data: u64) {
@@ -128,8 +129,7 @@ impl StreamContinuationScheduler {
             match self.current_state() {
                 ContinuationState::Empty => {
                     self.callback_data.store(callback_data, Ordering::Release);
-                    self.callback_ptr
-                        .store(callback as *mut (), Ordering::Release);
+                    self.callback_ptr.store(callback as *mut (), Ordering::Release);
                     if self.try_transition(ContinuationState::Empty, ContinuationState::Stored) {
                         return;
                     }
@@ -143,8 +143,7 @@ impl StreamContinuationScheduler {
                 ContinuationState::Stored => {
                     self.invoke_stored(StreamPollResult::Ready);
                     self.callback_data.store(callback_data, Ordering::Release);
-                    self.callback_ptr
-                        .store(callback as *mut (), Ordering::Release);
+                    self.callback_ptr.store(callback as *mut (), Ordering::Release);
                     return;
                 }
                 ContinuationState::Cancelled => {
@@ -178,8 +177,7 @@ impl StreamContinuationScheduler {
         loop {
             match self.current_state() {
                 ContinuationState::Stored => {
-                    if self.try_transition(ContinuationState::Stored, ContinuationState::Cancelled)
-                    {
+                    if self.try_transition(ContinuationState::Stored, ContinuationState::Cancelled) {
                         self.invoke_stored(StreamPollResult::Closed);
                         return;
                     }
@@ -270,11 +268,9 @@ impl<T: Send + 'static> EventSubscription<T> {
         let notification_guard = self.notification_mutex.lock().unwrap();
         let timeout_duration = Duration::from_millis(timeout_milliseconds as u64);
 
-        let wait_result = self.notification_condvar.wait_timeout_while(
-            notification_guard,
-            timeout_duration,
-            |_| self.is_active() && self.ring_buffer.is_empty(),
-        );
+        let wait_result = self
+            .notification_condvar
+            .wait_timeout_while(notification_guard, timeout_duration, |_| self.is_active() && self.ring_buffer.is_empty());
 
         if !self.is_active() {
             return WaitResult::Unsubscribed;
@@ -303,8 +299,7 @@ impl<T: Send + 'static> EventSubscription<T> {
             return;
         }
 
-        self.continuation_scheduler
-            .store_continuation(callback, callback_data);
+        self.continuation_scheduler.store_continuation(callback, callback_data);
     }
 
     pub fn unsubscribe(&self) {
@@ -339,27 +334,18 @@ pub unsafe fn subscription_push<T: Send + 'static>(handle: SubscriptionHandle, e
     subscription.push_event(event)
 }
 
-pub unsafe fn subscription_pop_batch<T: Send + Copy + 'static>(
-    handle: SubscriptionHandle,
-    output_ptr: *mut T,
-    output_capacity: usize,
-) -> usize {
+pub unsafe fn subscription_pop_batch<T: Send + Copy + 'static>(handle: SubscriptionHandle, output_ptr: *mut T, output_capacity: usize) -> usize {
     if handle.is_null() || output_ptr.is_null() || output_capacity == 0 {
         return 0;
     }
 
     let subscription = unsafe { &*(handle as *const EventSubscription<T>) };
-    let output_slice = unsafe {
-        std::slice::from_raw_parts_mut(output_ptr as *mut std::mem::MaybeUninit<T>, output_capacity)
-    };
+    let output_slice = unsafe { std::slice::from_raw_parts_mut(output_ptr as *mut std::mem::MaybeUninit<T>, output_capacity) };
 
     subscription.pop_batch_into(output_slice)
 }
 
-pub unsafe fn subscription_wait<T: Send + 'static>(
-    handle: SubscriptionHandle,
-    timeout_milliseconds: u32,
-) -> i32 {
+pub unsafe fn subscription_wait<T: Send + 'static>(handle: SubscriptionHandle, timeout_milliseconds: u32) -> i32 {
     if handle.is_null() {
         return WaitResult::Unsubscribed as i32;
     }
@@ -368,11 +354,7 @@ pub unsafe fn subscription_wait<T: Send + 'static>(
     subscription.wait_for_events(timeout_milliseconds) as i32
 }
 
-pub unsafe fn subscription_poll<T: Send + 'static>(
-    handle: SubscriptionHandle,
-    callback_data: u64,
-    callback: StreamContinuationCallback,
-) {
+pub unsafe fn subscription_poll<T: Send + 'static>(handle: SubscriptionHandle, callback_data: u64, callback: StreamContinuationCallback) {
     if handle.is_null() {
         callback(callback_data, StreamPollResult::Closed);
         return;
@@ -417,12 +399,7 @@ impl<T: Send + 'static> SubscriberSlot<T> {
         let weak = Arc::downgrade(subscription);
         let raw_ptr = Weak::into_raw(weak) as *mut ();
 
-        match self.weak_ptr.compare_exchange(
-            std::ptr::null_mut(),
-            raw_ptr,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ) {
+        match self.weak_ptr.compare_exchange(std::ptr::null_mut(), raw_ptr, Ordering::AcqRel, Ordering::Acquire) {
             Ok(_) => true,
             Err(_) => {
                 unsafe { Weak::from_raw(raw_ptr as *const EventSubscription<T>) };
@@ -453,16 +430,7 @@ impl<T: Send + 'static> SubscriberSlot<T> {
         let is_dead = weak.strong_count() == 0;
         std::mem::forget(weak);
 
-        let successfully_cleared = is_dead
-            && self
-                .weak_ptr
-                .compare_exchange(
-                    ptr,
-                    std::ptr::null_mut(),
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                )
-                .is_ok();
+        let successfully_cleared = is_dead && self.weak_ptr.compare_exchange(ptr, std::ptr::null_mut(), Ordering::AcqRel, Ordering::Acquire).is_ok();
 
         if successfully_cleared {
             unsafe { Weak::from_raw(ptr as *const EventSubscription<T>) };
@@ -503,20 +471,12 @@ impl<T: Send + Copy + 'static, const MAX_SUBSCRIBERS: usize> StreamProducer<T, M
     pub fn subscribe_with_capacity(&self, capacity: usize) -> Arc<EventSubscription<T>> {
         let subscription = Arc::new(EventSubscription::new(capacity));
 
-        self.subscriber_slots
-            .iter()
-            .for_each(|slot| slot.clear_if_dead());
+        self.subscriber_slots.iter().for_each(|slot| slot.clear_if_dead());
 
-        let slot_claimed = self
-            .subscriber_slots
-            .iter()
-            .any(|slot| slot.try_claim(&subscription));
+        let slot_claimed = self.subscriber_slots.iter().any(|slot| slot.try_claim(&subscription));
 
         if !slot_claimed {
-            eprintln!(
-                "StreamProducer: all {} subscriber slots full",
-                MAX_SUBSCRIBERS
-            );
+            eprintln!("StreamProducer: all {} subscriber slots full", MAX_SUBSCRIBERS);
         }
 
         subscription
@@ -531,29 +491,18 @@ impl<T: Send + Copy + 'static, const MAX_SUBSCRIBERS: usize> StreamProducer<T, M
     }
 
     pub fn subscriber_count(&self) -> usize {
-        self.subscriber_slots
-            .iter()
-            .filter(|slot| slot.is_alive())
-            .count()
+        self.subscriber_slots.iter().filter(|slot| slot.is_alive()).count()
     }
 }
 
-impl<T: Send + Copy + 'static, const MAX_SUBSCRIBERS: usize> Default
-    for StreamProducer<T, MAX_SUBSCRIBERS>
-{
+impl<T: Send + Copy + 'static, const MAX_SUBSCRIBERS: usize> Default for StreamProducer<T, MAX_SUBSCRIBERS> {
     fn default() -> Self {
         Self::new(256)
     }
 }
 
-unsafe impl<T: Send + Copy + 'static, const MAX_SUBSCRIBERS: usize> Send
-    for StreamProducer<T, MAX_SUBSCRIBERS>
-{
-}
-unsafe impl<T: Send + Copy + 'static, const MAX_SUBSCRIBERS: usize> Sync
-    for StreamProducer<T, MAX_SUBSCRIBERS>
-{
-}
+unsafe impl<T: Send + Copy + 'static, const MAX_SUBSCRIBERS: usize> Send for StreamProducer<T, MAX_SUBSCRIBERS> {}
+unsafe impl<T: Send + Copy + 'static, const MAX_SUBSCRIBERS: usize> Sync for StreamProducer<T, MAX_SUBSCRIBERS> {}
 
 #[cfg(test)]
 mod tests {
@@ -583,10 +532,7 @@ mod tests {
     fn test_subscription_wait_immediate_return() {
         let subscription = EventSubscription::<i32>::new(16);
         subscription.push_event(42);
-        assert_eq!(
-            subscription.wait_for_events(1000),
-            WaitResult::EventsAvailable
-        );
+        assert_eq!(subscription.wait_for_events(1000), WaitResult::EventsAvailable);
     }
 
     #[test]
@@ -623,11 +569,6 @@ mod tests {
 
         producer_thread.join().unwrap();
         assert_eq!(received_events.len(), 100);
-        assert!(
-            received_events
-                .iter()
-                .enumerate()
-                .all(|(index, &value)| value == index as i32)
-        );
+        assert!(received_events.iter().enumerate().all(|(index, &value)| value == index as i32));
     }
 }

--- a/boltffi_core/src/types/slice.rs
+++ b/boltffi_core/src/types/slice.rs
@@ -1,5 +1,4 @@
-use core::marker::PhantomData;
-use core::slice;
+use core::{marker::PhantomData, slice};
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]

--- a/boltffi_core/src/wasm.rs
+++ b/boltffi_core/src/wasm.rs
@@ -14,11 +14,7 @@ pub struct WasmCallbackOutBuf {
 #[cfg(target_arch = "wasm32")]
 impl WasmCallbackOutBuf {
     pub const fn empty() -> Self {
-        Self {
-            ptr: 0,
-            len: 0,
-            cap: 0,
-        }
+        Self { ptr: 0, len: 0, cap: 0 }
     }
 
     pub unsafe fn as_slice(&self) -> &[u8] {
@@ -34,33 +30,28 @@ impl WasmCallbackOutBuf {
 impl Drop for WasmCallbackOutBuf {
     fn drop(&mut self) {
         if self.ptr != 0 && self.cap > 0 {
-            boltffi_wasm_free_impl(self.ptr as usize, self.cap as usize);
+            boltffi_wasm_free_impl(self.ptr as *mut u8, self.cap as usize);
         }
     }
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
-fn boltffi_wasm_alloc_impl(size: usize) -> usize {
+fn boltffi_wasm_alloc_impl(size: usize) -> *mut u8 {
     if size == 0 {
-        return 0;
+        return std::ptr::null_mut();
     }
 
     let layout = match Layout::from_size_align(size, 8) {
         Ok(layout) => layout,
-        Err(_) => return 0,
+        Err(_) => return std::ptr::null_mut(),
     };
 
-    let pointer = unsafe { alloc(layout) };
-    if pointer.is_null() {
-        0
-    } else {
-        pointer as usize
-    }
+    unsafe { alloc(layout) }
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
-pub(crate) fn boltffi_wasm_free_impl(ptr: usize, size: usize) {
-    if ptr == 0 || size == 0 {
+pub(crate) fn boltffi_wasm_free_impl(ptr: *mut u8, size: usize) {
+    if ptr.is_null() || size == 0 {
         return;
     }
 
@@ -69,39 +60,34 @@ pub(crate) fn boltffi_wasm_free_impl(ptr: usize, size: usize) {
         Err(_) => return,
     };
 
-    unsafe { dealloc(ptr as *mut u8, layout) };
+    unsafe { dealloc(ptr, layout) };
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
-pub(crate) unsafe fn boltffi_wasm_free_string_return_impl(ptr: usize, len: usize) {
-    if ptr == 0 || len == 0 {
+pub(crate) unsafe fn boltffi_wasm_free_string_return_impl(ptr: *mut u8, len: usize) {
+    if ptr.is_null() || len == 0 {
         return;
     }
-    unsafe { drop(Vec::from_raw_parts(ptr as *mut u8, len, len)) };
+    unsafe { drop(Vec::from_raw_parts(ptr, len, len)) };
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
-fn boltffi_wasm_realloc_impl(ptr: usize, old_size: usize, new_size: usize) -> usize {
+fn boltffi_wasm_realloc_impl(ptr: *mut u8, old_size: usize, new_size: usize) -> *mut u8 {
     if new_size == 0 {
         boltffi_wasm_free_impl(ptr, old_size);
-        return 0;
+        return std::ptr::null_mut();
     }
 
-    if ptr == 0 {
+    if ptr.is_null() {
         return boltffi_wasm_alloc_impl(new_size);
     }
 
     let old_layout = match Layout::from_size_align(old_size, 8) {
         Ok(layout) => layout,
-        Err(_) => return 0,
+        Err(_) => return std::ptr::null_mut(),
     };
 
-    let new_pointer = unsafe { std::alloc::realloc(ptr as *mut u8, old_layout, new_size) };
-    if new_pointer.is_null() {
-        0
-    } else {
-        new_pointer as usize
-    }
+    unsafe { std::alloc::realloc(ptr, old_layout, new_size) }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -141,26 +127,23 @@ mod exports {
 
     #[unsafe(no_mangle)]
     pub extern "C" fn boltffi_wasm_free(ptr: u32, size: u32) {
-        super::boltffi_wasm_free_impl(ptr as usize, size as usize);
+        super::boltffi_wasm_free_impl(ptr as *mut u8, size as usize);
     }
 
     #[unsafe(no_mangle)]
     pub extern "C" fn boltffi_wasm_realloc(ptr: u32, old_size: u32, new_size: u32) -> u32 {
-        super::boltffi_wasm_realloc_impl(ptr as usize, old_size as usize, new_size as usize) as u32
+        super::boltffi_wasm_realloc_impl(ptr as *mut u8, old_size as usize, new_size as usize) as u32
     }
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn boltffi_wasm_free_string_return(ptr: u32, len: u32) {
-        unsafe { super::boltffi_wasm_free_string_return_impl(ptr as usize, len as usize) };
+        unsafe { super::boltffi_wasm_free_string_return_impl(ptr as *mut u8, len as usize) };
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        WASM_ABI_VERSION, boltffi_wasm_alloc_impl, boltffi_wasm_free_impl,
-        boltffi_wasm_free_string_return_impl, boltffi_wasm_realloc_impl,
-    };
+    use super::{WASM_ABI_VERSION, boltffi_wasm_alloc_impl, boltffi_wasm_free_impl, boltffi_wasm_free_string_return_impl, boltffi_wasm_realloc_impl};
 
     #[test]
     fn wasm_abi_version_is_stable() {
@@ -169,20 +152,20 @@ mod tests {
 
     #[test]
     fn alloc_zero_returns_zero_pointer() {
-        assert_eq!(boltffi_wasm_alloc_impl(0), 0);
+        assert!(boltffi_wasm_alloc_impl(0).is_null());
     }
 
     #[test]
     fn alloc_non_zero_returns_pointer_and_free_accepts_it() {
         let pointer = boltffi_wasm_alloc_impl(16);
-        assert_ne!(pointer, 0);
+        assert!(!pointer.is_null());
         boltffi_wasm_free_impl(pointer, 16);
     }
 
     #[test]
     fn realloc_from_null_matches_alloc_behavior() {
-        let pointer = boltffi_wasm_realloc_impl(0, 0, 24);
-        assert_ne!(pointer, 0);
+        let pointer = boltffi_wasm_realloc_impl(std::ptr::null_mut(), 0, 24);
+        assert!(!pointer.is_null());
         boltffi_wasm_free_impl(pointer, 24);
     }
 
@@ -191,22 +174,18 @@ mod tests {
         let old_size = 32usize;
         let new_size = 96usize;
         let old_pointer = boltffi_wasm_alloc_impl(old_size);
-        assert_ne!(old_pointer, 0);
+        assert!(!old_pointer.is_null());
 
-        let expected_prefix = (0..old_size)
-            .map(|index| ((index * 7 + 3) % 256) as u8)
-            .collect::<Vec<_>>();
+        let expected_prefix = (0..old_size).map(|index| ((index * 7 + 3) % 256) as u8).collect::<Vec<_>>();
 
         unsafe {
-            std::slice::from_raw_parts_mut(old_pointer as *mut u8, old_size)
-                .copy_from_slice(&expected_prefix);
+            std::slice::from_raw_parts_mut(old_pointer, old_size).copy_from_slice(&expected_prefix);
         }
 
         let new_pointer = boltffi_wasm_realloc_impl(old_pointer, old_size, new_size);
-        assert_ne!(new_pointer, 0);
+        assert!(!new_pointer.is_null());
 
-        let actual_prefix =
-            unsafe { std::slice::from_raw_parts(new_pointer as *const u8, old_size) }.to_vec();
+        let actual_prefix = unsafe { std::slice::from_raw_parts(new_pointer, old_size) }.to_vec();
         assert_eq!(actual_prefix, expected_prefix);
 
         boltffi_wasm_free_impl(new_pointer, new_size);
@@ -215,25 +194,24 @@ mod tests {
     #[test]
     fn realloc_to_zero_returns_null_pointer() {
         let pointer = boltffi_wasm_alloc_impl(64);
-        assert_ne!(pointer, 0);
+        assert!(!pointer.is_null());
 
         let reallocated = boltffi_wasm_realloc_impl(pointer, 64, 0);
-        assert_eq!(reallocated, 0);
+        assert!(reallocated.is_null());
     }
 
     #[test]
     fn free_ignores_zero_inputs() {
-        boltffi_wasm_free_impl(0, 32);
-        boltffi_wasm_free_impl(1024, 0);
+        boltffi_wasm_free_impl(std::ptr::null_mut(), 32);
+        boltffi_wasm_free_impl(std::ptr::NonNull::<u8>::dangling().as_ptr(), 0);
     }
 
     #[test]
     fn free_string_return_releases_owned_buffer() {
         let text = "boltffi";
-        let mut boxed = text.as_bytes().to_vec().into_boxed_slice();
-        let ptr = boxed.as_mut_ptr() as usize;
+        let boxed = text.as_bytes().to_vec().into_boxed_slice();
         let len = boxed.len();
-        std::mem::forget(boxed);
+        let ptr = Box::into_raw(boxed) as *mut u8;
         unsafe { boltffi_wasm_free_string_return_impl(ptr, len) };
     }
 }

--- a/boltffi_core/src/wire/blittable.rs
+++ b/boltffi_core/src/wire/blittable.rs
@@ -27,11 +27,7 @@ pub fn encode_blittable_slice<T: Blittable>(slice: &[T], buf: &mut [u8]) -> usiz
 
     let byte_count = std::mem::size_of_val(slice);
     unsafe {
-        std::ptr::copy_nonoverlapping(
-            slice.as_ptr() as *const u8,
-            buf.as_mut_ptr().add(VEC_COUNT_SIZE),
-            byte_count,
-        );
+        std::ptr::copy_nonoverlapping(slice.as_ptr() as *const u8, buf.as_mut_ptr().add(VEC_COUNT_SIZE), byte_count);
     }
     VEC_COUNT_SIZE + byte_count
 }
@@ -60,11 +56,7 @@ pub fn decode_blittable_slice<T: Blittable>(buf: &[u8]) -> Option<Vec<T>> {
 
     let mut result = Vec::<T>::with_capacity(count);
     unsafe {
-        std::ptr::copy_nonoverlapping(
-            buf.as_ptr().add(VEC_COUNT_SIZE),
-            result.as_mut_ptr() as *mut u8,
-            byte_count,
-        );
+        std::ptr::copy_nonoverlapping(buf.as_ptr().add(VEC_COUNT_SIZE), result.as_mut_ptr() as *mut u8, byte_count);
         result.set_len(count);
     }
     Some(result)

--- a/boltffi_core/src/wire/buffer.rs
+++ b/boltffi_core/src/wire/buffer.rs
@@ -1,5 +1,7 @@
-use crate::wire::decode::{DecodeError, WireDecode};
-use crate::wire::encode::WireEncode;
+use crate::wire::{
+    decode::{DecodeError, WireDecode},
+    encode::WireEncode,
+};
 
 pub struct WireBuffer {
     data: Vec<u8>,

--- a/boltffi_core/src/wire/decode.rs
+++ b/boltffi_core/src/wire/decode.rs
@@ -1,15 +1,11 @@
 use crate::wire::constants::*;
-
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, Utc};
-
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-#[cfg(feature = "uuid")]
-use uuid::Uuid;
-
 #[cfg(feature = "url")]
 use url::Url;
+#[cfg(feature = "uuid")]
+use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DecodeError {
@@ -74,11 +70,7 @@ impl WireDecode for bool {
 impl WireDecode for isize {
     #[inline]
     fn decode_from(buf: &[u8]) -> DecodeResult<Self> {
-        let bytes: [u8; 8] = buf
-            .get(..8)
-            .ok_or(DecodeError::BufferTooSmall)?
-            .try_into()
-            .map_err(|_| DecodeError::BufferTooSmall)?;
+        let bytes: [u8; 8] = buf.get(..8).ok_or(DecodeError::BufferTooSmall)?.try_into().map_err(|_| DecodeError::BufferTooSmall)?;
         let value = i64::from_le_bytes(bytes) as isize;
         Ok((value, 8))
     }
@@ -87,11 +79,7 @@ impl WireDecode for isize {
 impl WireDecode for usize {
     #[inline]
     fn decode_from(buf: &[u8]) -> DecodeResult<Self> {
-        let bytes: [u8; 8] = buf
-            .get(..8)
-            .ok_or(DecodeError::BufferTooSmall)?
-            .try_into()
-            .map_err(|_| DecodeError::BufferTooSmall)?;
+        let bytes: [u8; 8] = buf.get(..8).ok_or(DecodeError::BufferTooSmall)?.try_into().map_err(|_| DecodeError::BufferTooSmall)?;
         let value = u64::from_le_bytes(bytes) as usize;
         Ok((value, 8))
     }
@@ -100,12 +88,7 @@ impl WireDecode for usize {
 impl WireDecode for String {
     #[inline]
     fn decode_from(buf: &[u8]) -> DecodeResult<Self> {
-        let len = u32::from_le_bytes(
-            buf.get(..4)
-                .ok_or(DecodeError::BufferTooSmall)?
-                .try_into()
-                .unwrap(),
-        ) as usize;
+        let len = u32::from_le_bytes(buf.get(..4).ok_or(DecodeError::BufferTooSmall)?.try_into().unwrap()) as usize;
         let total_size = 4 + len;
         let string_bytes = buf.get(4..total_size).ok_or(DecodeError::BufferTooSmall)?;
         let string = unsafe { core::str::from_utf8_unchecked(string_bytes) }.to_owned();
@@ -117,8 +100,7 @@ impl WireDecode for Duration {
     #[inline]
     fn decode_from(buf: &[u8]) -> DecodeResult<Self> {
         let (seconds, seconds_used) = u64::decode_from(buf)?;
-        let (nanos, nanos_used) =
-            u32::decode_from(buf.get(seconds_used..).ok_or(DecodeError::BufferTooSmall)?)?;
+        let (nanos, nanos_used) = u32::decode_from(buf.get(seconds_used..).ok_or(DecodeError::BufferTooSmall)?)?;
         if nanos >= 1_000_000_000 {
             return Err(DecodeError::InvalidValue);
         }
@@ -130,8 +112,7 @@ impl WireDecode for SystemTime {
     #[inline]
     fn decode_from(buf: &[u8]) -> DecodeResult<Self> {
         let (seconds, seconds_used) = i64::decode_from(buf)?;
-        let (nanos, nanos_used) =
-            u32::decode_from(buf.get(seconds_used..).ok_or(DecodeError::BufferTooSmall)?)?;
+        let (nanos, nanos_used) = u32::decode_from(buf.get(seconds_used..).ok_or(DecodeError::BufferTooSmall)?)?;
         if nanos >= 1_000_000_000 {
             return Err(DecodeError::InvalidValue);
         }
@@ -140,10 +121,7 @@ impl WireDecode for SystemTime {
         let total_nanos = (seconds as i128) * nanos_per_second + (nanos as i128);
 
         let system_time = if total_nanos >= 0 {
-            let duration = Duration::new(
-                (total_nanos / nanos_per_second) as u64,
-                (total_nanos % nanos_per_second) as u32,
-            );
+            let duration = Duration::new((total_nanos / nanos_per_second) as u64, (total_nanos % nanos_per_second) as u32);
             UNIX_EPOCH + duration
         } else {
             let abs_total_nanos = (-total_nanos) as u128;
@@ -161,8 +139,7 @@ impl WireDecode for Uuid {
     #[inline]
     fn decode_from(buf: &[u8]) -> DecodeResult<Self> {
         let (hi, hi_used) = u64::decode_from(buf)?;
-        let (lo, lo_used) =
-            u64::decode_from(buf.get(hi_used..).ok_or(DecodeError::BufferTooSmall)?)?;
+        let (lo, lo_used) = u64::decode_from(buf.get(hi_used..).ok_or(DecodeError::BufferTooSmall)?)?;
         let mut bytes = [0u8; 16];
         bytes[..8].copy_from_slice(&hi.to_be_bytes());
         bytes[8..].copy_from_slice(&lo.to_be_bytes());
@@ -185,10 +162,8 @@ impl WireDecode for DateTime<Utc> {
     #[inline]
     fn decode_from(buf: &[u8]) -> DecodeResult<Self> {
         let (seconds, seconds_used) = i64::decode_from(buf)?;
-        let (nanos, nanos_used) =
-            u32::decode_from(buf.get(seconds_used..).ok_or(DecodeError::BufferTooSmall)?)?;
-        let date_time =
-            DateTime::from_timestamp(seconds, nanos).ok_or(DecodeError::InvalidValue)?;
+        let (nanos, nanos_used) = u32::decode_from(buf.get(seconds_used..).ok_or(DecodeError::BufferTooSmall)?)?;
+        let date_time = DateTime::from_timestamp(seconds, nanos).ok_or(DecodeError::InvalidValue)?;
         Ok((date_time, seconds_used + nanos_used))
     }
 }
@@ -277,11 +252,7 @@ impl FixedSizeWireDecode for isize {
 
     #[inline]
     fn decode_fixed(buf: &[u8]) -> Result<Self, DecodeError> {
-        let bytes: [u8; 8] = buf
-            .get(..8)
-            .ok_or(DecodeError::BufferTooSmall)?
-            .try_into()
-            .map_err(|_| DecodeError::BufferTooSmall)?;
+        let bytes: [u8; 8] = buf.get(..8).ok_or(DecodeError::BufferTooSmall)?.try_into().map_err(|_| DecodeError::BufferTooSmall)?;
         Ok(i64::from_le_bytes(bytes) as isize)
     }
 }
@@ -291,11 +262,7 @@ impl FixedSizeWireDecode for usize {
 
     #[inline]
     fn decode_fixed(buf: &[u8]) -> Result<Self, DecodeError> {
-        let bytes: [u8; 8] = buf
-            .get(..8)
-            .ok_or(DecodeError::BufferTooSmall)?
-            .try_into()
-            .map_err(|_| DecodeError::BufferTooSmall)?;
+        let bytes: [u8; 8] = buf.get(..8).ok_or(DecodeError::BufferTooSmall)?.try_into().map_err(|_| DecodeError::BufferTooSmall)?;
         Ok(u64::from_le_bytes(bytes) as usize)
     }
 }
@@ -421,8 +388,7 @@ mod tests {
     fn roundtrip_complex() {
         let mut buf = [0u8; 128];
 
-        let original: Vec<Option<String>> =
-            vec![Some("hello".to_string()), None, Some("world".to_string())];
+        let original: Vec<Option<String>> = vec![Some("hello".to_string()), None, Some("world".to_string())];
 
         let written = original.encode_to(&mut buf);
         let (decoded, size) = Vec::<Option<String>>::decode_from(&buf).unwrap();
@@ -606,12 +572,7 @@ mod tests {
 
         #[test]
         fn vec_of_unicode_strings_roundtrip() {
-            let original: Vec<String> = vec![
-                "Hello".to_string(),
-                "你好".to_string(),
-                "مرحبا".to_string(),
-                "👋🌍".to_string(),
-            ];
+            let original: Vec<String> = vec!["Hello".to_string(), "你好".to_string(), "مرحبا".to_string(), "👋🌍".to_string()];
 
             let mut buf = vec![0u8; original.wire_size()];
             original.encode_to(&mut buf);
@@ -660,18 +621,9 @@ mod tests {
         fn empty_buffer() {
             let buf: [u8; 0] = [];
 
-            assert!(matches!(
-                String::decode_from(&buf),
-                Err(DecodeError::BufferTooSmall)
-            ));
-            assert!(matches!(
-                Vec::<i32>::decode_from(&buf),
-                Err(DecodeError::BufferTooSmall)
-            ));
-            assert!(matches!(
-                i32::decode_from(&buf),
-                Err(DecodeError::BufferTooSmall)
-            ));
+            assert!(matches!(String::decode_from(&buf), Err(DecodeError::BufferTooSmall)));
+            assert!(matches!(Vec::<i32>::decode_from(&buf), Err(DecodeError::BufferTooSmall)));
+            assert!(matches!(i32::decode_from(&buf), Err(DecodeError::BufferTooSmall)));
         }
     }
 }

--- a/boltffi_core/src/wire/encode.rs
+++ b/boltffi_core/src/wire/encode.rs
@@ -1,15 +1,11 @@
 use crate::wire::constants::*;
-
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, Utc};
-
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-#[cfg(feature = "uuid")]
-use uuid::Uuid;
-
 #[cfg(feature = "url")]
 use url::Url;
+#[cfg(feature = "uuid")]
+use uuid::Uuid;
 
 pub trait WireSize {
     fn is_fixed_size() -> bool
@@ -232,13 +228,10 @@ impl WireEncode for SystemTime {
     fn encode_to(&self, buf: &mut [u8]) -> usize {
         let nanos_per_second = 1_000_000_000i128;
         let total_nanos: i128 = match self.duration_since(UNIX_EPOCH) {
-            Ok(duration) => {
-                (duration.as_secs() as i128) * nanos_per_second + (duration.subsec_nanos() as i128)
-            }
+            Ok(duration) => (duration.as_secs() as i128) * nanos_per_second + (duration.subsec_nanos() as i128),
             Err(error) => {
                 let duration = error.duration();
-                -((duration.as_secs() as i128) * nanos_per_second
-                    + (duration.subsec_nanos() as i128))
+                -((duration.as_secs() as i128) * nanos_per_second + (duration.subsec_nanos() as i128))
             }
         };
 
@@ -380,11 +373,7 @@ impl<T: WireEncode> WireSize for Vec<T> {
         if T::IS_BLITTABLE {
             VEC_COUNT_SIZE + self.len() * core::mem::size_of::<T>()
         } else {
-            VEC_COUNT_SIZE
-                + self
-                    .iter()
-                    .map(|element| element.wire_size())
-                    .sum::<usize>()
+            VEC_COUNT_SIZE + self.iter().map(|element| element.wire_size()).sum::<usize>()
         }
     }
 }
@@ -402,11 +391,7 @@ impl<T: WireEncode> WireEncode for Vec<T> {
         if T::IS_BLITTABLE {
             let byte_count = self.len() * core::mem::size_of::<T>();
             unsafe {
-                core::ptr::copy_nonoverlapping(
-                    self.as_ptr() as *const u8,
-                    buf.as_mut_ptr().add(VEC_COUNT_SIZE),
-                    byte_count,
-                );
+                core::ptr::copy_nonoverlapping(self.as_ptr() as *const u8, buf.as_mut_ptr().add(VEC_COUNT_SIZE), byte_count);
             }
             VEC_COUNT_SIZE + byte_count
         } else {
@@ -425,11 +410,7 @@ impl<T: WireEncode> WireSize for [T] {
         if T::IS_BLITTABLE {
             VEC_COUNT_SIZE + core::mem::size_of_val(self)
         } else {
-            VEC_COUNT_SIZE
-                + self
-                    .iter()
-                    .map(|element| element.wire_size())
-                    .sum::<usize>()
+            VEC_COUNT_SIZE + self.iter().map(|element| element.wire_size()).sum::<usize>()
         }
     }
 }
@@ -447,11 +428,7 @@ impl<T: WireEncode> WireEncode for [T] {
         if T::IS_BLITTABLE {
             let byte_count = core::mem::size_of_val(self);
             unsafe {
-                core::ptr::copy_nonoverlapping(
-                    self.as_ptr() as *const u8,
-                    buf.as_mut_ptr().add(VEC_COUNT_SIZE),
-                    byte_count,
-                );
+                core::ptr::copy_nonoverlapping(self.as_ptr() as *const u8, buf.as_mut_ptr().add(VEC_COUNT_SIZE), byte_count);
             }
             VEC_COUNT_SIZE + byte_count
         } else {
@@ -717,9 +694,7 @@ mod tests {
             let inner_count: usize = 1000;
             let outer_count: usize = 100;
 
-            let nested: Vec<Vec<i32>> = (0..outer_count)
-                .map(|_| (0..inner_count as i32).collect())
-                .collect();
+            let nested: Vec<Vec<i32>> = (0..outer_count).map(|_| (0..inner_count as i32).collect()).collect();
 
             let inner_size = 4 + inner_count * 4;
             let expected_size = 4 + outer_count * inner_size;

--- a/boltffi_core/src/wire/mod.rs
+++ b/boltffi_core/src/wire/mod.rs
@@ -4,10 +4,7 @@ mod constants;
 mod decode;
 mod encode;
 
-pub use blittable::{
-    Blittable, blittable_slice_wire_size, decode_blittable, decode_blittable_slice,
-    encode_blittable, encode_blittable_slice,
-};
+pub use blittable::{Blittable, blittable_slice_wire_size, decode_blittable, decode_blittable_slice, encode_blittable, encode_blittable_slice};
 pub use buffer::{WireBuffer, decode, encode};
 pub use constants::*;
 pub use decode::{DecodeError, DecodeResult, FixedSizeWireDecode, WireDecode};

--- a/boltffi_ffi_rules/src/lib.rs
+++ b/boltffi_ffi_rules/src/lib.rs
@@ -2,8 +2,7 @@ pub const FFI_PREFIX: &str = "boltffi";
 
 pub mod naming {
     use super::FFI_PREFIX;
-    use std::fmt;
-    use std::marker::PhantomData;
+    use std::{fmt, marker::PhantomData};
 
     #[derive(Clone, Debug, Eq, Hash, PartialEq)]
     pub struct Name<K>(String, PhantomData<K>);
@@ -56,18 +55,12 @@ pub mod naming {
     pub struct ClassPrefix;
 
     const C_KEYWORDS: &[&str] = &[
-        "auto", "break", "case", "char", "const", "continue", "default", "do", "double", "else",
-        "enum", "extern", "float", "for", "goto", "if", "int", "long", "register", "return",
-        "short", "signed", "sizeof", "static", "struct", "switch", "typedef", "union", "unsigned",
-        "void", "volatile", "while",
+        "auto", "break", "case", "char", "const", "continue", "default", "do", "double", "else", "enum", "extern", "float", "for", "goto", "if", "int", "long", "register",
+        "return", "short", "signed", "sizeof", "static", "struct", "switch", "typedef", "union", "unsigned", "void", "volatile", "while",
     ];
 
     pub fn escape_c_keyword(name: &str) -> String {
-        if C_KEYWORDS.contains(&name) {
-            format!("{}_", name)
-        } else {
-            name.to_string()
-        }
+        if C_KEYWORDS.contains(&name) { format!("{}_", name) } else { name.to_string() }
     }
 
     pub fn ffi_prefix() -> &'static str {
@@ -142,17 +135,11 @@ pub mod naming {
     }
 
     pub fn method_ffi_complete(class_name: &str, method_name: &str) -> Name<GlobalSymbol> {
-        Name::new(format!(
-            "{}_complete",
-            method_ffi_name(class_name, method_name)
-        ))
+        Name::new(format!("{}_complete", method_ffi_name(class_name, method_name)))
     }
 
     pub fn method_ffi_cancel(class_name: &str, method_name: &str) -> Name<GlobalSymbol> {
-        Name::new(format!(
-            "{}_cancel",
-            method_ffi_name(class_name, method_name)
-        ))
+        Name::new(format!("{}_cancel", method_ffi_name(class_name, method_name)))
     }
 
     pub fn method_ffi_free(class_name: &str, method_name: &str) -> Name<GlobalSymbol> {
@@ -180,19 +167,23 @@ pub mod naming {
     }
 
     pub fn function_ffi_vec_len(func_name: &str) -> Name<GlobalSymbol> {
-        Name::new(format!(
-            "{}{}",
-            function_ffi_name(func_name),
-            vec_len_suffix()
-        ))
+        Name::new(format!("{}{}", function_ffi_name(func_name), vec_len_suffix()))
     }
 
     pub fn function_ffi_vec_copy_into(func_name: &str) -> Name<GlobalSymbol> {
-        Name::new(format!(
-            "{}{}",
-            function_ffi_name(func_name),
-            vec_copy_into_suffix()
-        ))
+        Name::new(format!("{}{}", function_ffi_name(func_name), vec_copy_into_suffix()))
+    }
+
+    pub fn iterator_ffi_new(class_name: &str, method_name: &str) -> Name<GlobalSymbol> {
+        method_ffi_name(class_name, method_name)
+    }
+
+    pub fn iterator_ffi_next(class_name: &str, method_name: &str) -> Name<GlobalSymbol> {
+        Name::new(format!("{}_next", method_ffi_name(class_name, method_name)))
+    }
+
+    pub fn iterator_ffi_free(class_name: &str, method_name: &str) -> Name<GlobalSymbol> {
+        Name::new(format!("{}_free", method_ffi_name(class_name, method_name)))
     }
 
     pub fn stream_ffi_subscribe(class_name: &str, stream_name: &str) -> Name<GlobalSymbol> {
@@ -200,10 +191,7 @@ pub mod naming {
     }
 
     pub fn stream_ffi_pop_batch(class_name: &str, stream_name: &str) -> Name<GlobalSymbol> {
-        Name::new(format!(
-            "{}_pop_batch",
-            method_ffi_name(class_name, stream_name)
-        ))
+        Name::new(format!("{}_pop_batch", method_ffi_name(class_name, stream_name)))
     }
 
     pub fn stream_ffi_wait(class_name: &str, stream_name: &str) -> Name<GlobalSymbol> {
@@ -215,10 +203,7 @@ pub mod naming {
     }
 
     pub fn stream_ffi_unsubscribe(class_name: &str, stream_name: &str) -> Name<GlobalSymbol> {
-        Name::new(format!(
-            "{}_unsubscribe",
-            method_ffi_name(class_name, stream_name)
-        ))
+        Name::new(format!("{}_unsubscribe", method_ffi_name(class_name, stream_name)))
     }
 
     pub fn stream_ffi_free(class_name: &str, stream_name: &str) -> Name<GlobalSymbol> {
@@ -246,19 +231,11 @@ pub mod naming {
     }
 
     pub fn callback_register_fn(trait_name: &str) -> Name<RegisterFn> {
-        Name::new(format!(
-            "{}_register_{}_vtable",
-            FFI_PREFIX,
-            to_snake_case(trait_name)
-        ))
+        Name::new(format!("{}_register_{}_vtable", FFI_PREFIX, to_snake_case(trait_name)))
     }
 
     pub fn callback_create_fn(trait_name: &str) -> Name<CreateFn> {
-        Name::new(format!(
-            "{}_create_{}_handle",
-            FFI_PREFIX,
-            to_snake_case(trait_name)
-        ))
+        Name::new(format!("{}_create_{}_handle", FFI_PREFIX, to_snake_case(trait_name)))
     }
 
     pub fn vtable_field_name(method_name: &str) -> Name<VtableField> {
@@ -395,8 +372,7 @@ pub mod transforms {
 }
 
 pub mod signatures {
-    use super::c_types;
-    use super::naming;
+    use super::{c_types, naming};
 
     #[derive(Clone)]
     pub struct FfiParam {
@@ -425,11 +401,7 @@ pub mod signatures {
     }
 
     pub fn slice_param(param_name: &str, inner_c_type: &str, mutable: bool) -> Vec<FfiParam> {
-        let ptr_type = if mutable {
-            format!("{}*", inner_c_type)
-        } else {
-            format!("const {}*", inner_c_type)
-        };
+        let ptr_type = if mutable { format!("{}*", inner_c_type) } else { format!("const {}*", inner_c_type) };
         vec![
             FfiParam {
                 name: format!("{}{}", param_name, naming::param_ptr_suffix()),
@@ -446,11 +418,7 @@ pub mod signatures {
         slice_param(param_name, inner_c_type, false)
     }
 
-    pub fn vec_return_signatures(
-        base_name: &str,
-        inner_c_type: &str,
-        input_params: &[FfiParam],
-    ) -> Vec<FfiSignature> {
+    pub fn vec_return_signatures(base_name: &str, inner_c_type: &str, input_params: &[FfiParam]) -> Vec<FfiSignature> {
         let len_name = format!("{}{}", base_name, naming::vec_len_suffix());
         let copy_name = format!("{}{}", base_name, naming::vec_copy_into_suffix());
 
@@ -567,21 +535,13 @@ pub mod callback {
     }
 
     pub fn closure_signature_id(params: &[TypeId], returns: &TypeId) -> String {
-        let params_part = params
-            .iter()
-            .map(|p| p.as_signature_part())
-            .collect::<Vec<_>>()
-            .join("_");
+        let params_part = params.iter().map(|p| p.as_signature_part()).collect::<Vec<_>>().join("_");
 
         let is_void_return = matches!(returns, TypeId::Void);
         let ret_part = returns.as_signature_part();
 
         if is_void_return {
-            if params_part.is_empty() {
-                "Void".to_string()
-            } else {
-                params_part
-            }
+            if params_part.is_empty() { "Void".to_string() } else { params_part }
         } else if params_part.is_empty() {
             format!("To{}", ret_part)
         } else {
@@ -647,14 +607,8 @@ pub mod callback {
 
         #[test]
         fn type_id_from_rust_custom() {
-            assert_eq!(
-                TypeId::from_rust_type_str("Point"),
-                TypeId::Named("Point".into())
-            );
-            assert_eq!(
-                TypeId::from_rust_type_str("MyCustomType"),
-                TypeId::Named("MyCustomType".into())
-            );
+            assert_eq!(TypeId::from_rust_type_str("Point"), TypeId::Named("Point".into()));
+            assert_eq!(TypeId::from_rust_type_str("MyCustomType"), TypeId::Named("MyCustomType".into()));
         }
 
         #[test]
@@ -672,10 +626,7 @@ pub mod callback {
             let returns = TypeId::I32;
             assert_eq!(closure_signature_id(&params, &returns), "I32ToI32");
             assert_eq!(closure_callback_id(&params, &returns), "__Closure_I32ToI32");
-            assert_eq!(
-                closure_callback_id_snake(&params, &returns),
-                "___closure__i32_to_i32"
-            );
+            assert_eq!(closure_callback_id_snake(&params, &returns), "___closure__i32_to_i32");
         }
 
         #[test]
@@ -683,10 +634,7 @@ pub mod callback {
             let params = vec![TypeId::Named("Point".into())];
             let returns = TypeId::Named("Point".into());
             assert_eq!(closure_signature_id(&params, &returns), "PointToPoint");
-            assert_eq!(
-                closure_callback_id(&params, &returns),
-                "__Closure_PointToPoint"
-            );
+            assert_eq!(closure_callback_id(&params, &returns), "__Closure_PointToPoint");
         }
 
         #[test]
@@ -718,10 +666,7 @@ pub mod callback {
             let params = vec![TypeId::I32, TypeId::String];
             let returns = TypeId::Bool;
             assert_eq!(closure_signature_id(&params, &returns), "I32_StringToBool");
-            assert_eq!(
-                closure_callback_id(&params, &returns),
-                "__Closure_I32_StringToBool"
-            );
+            assert_eq!(closure_callback_id(&params, &returns), "__Closure_I32_StringToBool");
         }
 
         #[test]
@@ -747,18 +692,9 @@ pub mod callback {
         #[test]
         fn wasm_import_names() {
             let id_snake = "___closure__i32_to_i32";
-            assert_eq!(
-                callback_wasm_import_call(id_snake),
-                "__boltffi_callback____closure__i32_to_i32_call"
-            );
-            assert_eq!(
-                callback_wasm_import_free(id_snake),
-                "__boltffi_callback____closure__i32_to_i32_free"
-            );
-            assert_eq!(
-                callback_wasm_import_clone(id_snake),
-                "__boltffi_callback____closure__i32_to_i32_clone"
-            );
+            assert_eq!(callback_wasm_import_call(id_snake), "__boltffi_callback____closure__i32_to_i32_call");
+            assert_eq!(callback_wasm_import_free(id_snake), "__boltffi_callback____closure__i32_to_i32_free");
+            assert_eq!(callback_wasm_import_clone(id_snake), "__boltffi_callback____closure__i32_to_i32_clone");
         }
 
         #[test]
@@ -766,22 +702,13 @@ pub mod callback {
             let params = vec![];
             let returns = TypeId::Void;
             let id_snake = closure_callback_id_snake(&params, &returns);
-            assert_eq!(
-                callback_wasm_import_call(&id_snake),
-                "__boltffi_callback____closure__void_call"
-            );
-            assert_eq!(
-                callback_wasm_import_free(&id_snake),
-                "__boltffi_callback____closure__void_free"
-            );
+            assert_eq!(callback_wasm_import_call(&id_snake), "__boltffi_callback____closure__void_call");
+            assert_eq!(callback_wasm_import_free(&id_snake), "__boltffi_callback____closure__void_free");
         }
 
         #[test]
         fn global_create_handle_name() {
-            assert_eq!(
-                callback_create_handle_global(),
-                "boltffi_create_callback_handle"
-            );
+            assert_eq!(callback_create_handle_global(), "boltffi_create_callback_handle");
         }
 
         #[test]
@@ -854,34 +781,16 @@ pub mod transport {
 
         #[test]
         fn wasm_targets_use_packed() {
-            assert_eq!(
-                BufferTransport::for_target("wasm32"),
-                BufferTransport::Packed
-            );
-            assert_eq!(
-                BufferTransport::for_target("wasm32-unknown-unknown"),
-                BufferTransport::Packed
-            );
-            assert_eq!(
-                BufferTransport::for_target("wasm32-wasi"),
-                BufferTransport::Packed
-            );
+            assert_eq!(BufferTransport::for_target("wasm32"), BufferTransport::Packed);
+            assert_eq!(BufferTransport::for_target("wasm32-unknown-unknown"), BufferTransport::Packed);
+            assert_eq!(BufferTransport::for_target("wasm32-wasi"), BufferTransport::Packed);
         }
 
         #[test]
         fn native_targets_use_descriptor() {
-            assert_eq!(
-                BufferTransport::for_target("aarch64-apple-darwin"),
-                BufferTransport::Descriptor
-            );
-            assert_eq!(
-                BufferTransport::for_target("x86_64-unknown-linux-gnu"),
-                BufferTransport::Descriptor
-            );
-            assert_eq!(
-                BufferTransport::for_target("aarch64-linux-android"),
-                BufferTransport::Descriptor
-            );
+            assert_eq!(BufferTransport::for_target("aarch64-apple-darwin"), BufferTransport::Descriptor);
+            assert_eq!(BufferTransport::for_target("x86_64-unknown-linux-gnu"), BufferTransport::Descriptor);
+            assert_eq!(BufferTransport::for_target("aarch64-linux-android"), BufferTransport::Descriptor);
         }
     }
 }

--- a/boltffi_macros/src/callback_registry.rs
+++ b/boltffi_macros/src/callback_registry.rs
@@ -1,8 +1,9 @@
 use proc_macro2::Span;
-use std::cell::RefCell;
-use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::{
+    cell::RefCell,
+    env, fs,
+    path::{Path, PathBuf},
+};
 use syn::{Item, ItemMod, ItemTrait};
 
 #[derive(Clone)]
@@ -33,8 +34,7 @@ pub fn registry_for_current_crate() -> syn::Result<CallbackTraitRegistry> {
             return Ok(registry);
         }
 
-        let manifest_dir = env::var("CARGO_MANIFEST_DIR")
-            .map_err(|_| syn::Error::new(Span::call_site(), "CARGO_MANIFEST_DIR not set"))?;
+        let manifest_dir = env::var("CARGO_MANIFEST_DIR").map_err(|_| syn::Error::new(Span::call_site(), "CARGO_MANIFEST_DIR not set"))?;
         let registry = build_registry(Path::new(&manifest_dir))?;
         *cell.borrow_mut() = Some(registry.clone());
         Ok(registry)
@@ -69,21 +69,13 @@ fn build_registry(manifest_dir: &Path) -> syn::Result<CallbackTraitRegistry> {
 
     files.iter().try_for_each(|file_path| {
         let module_path = module_path_for_rs_file(&src_root, file_path)?;
-        let content = fs::read_to_string(file_path).map_err(|e| {
-            syn::Error::new(
-                Span::call_site(),
-                format!("read {}: {}", file_path.display(), e),
-            )
-        })?;
+        let content = fs::read_to_string(file_path).map_err(|e| syn::Error::new(Span::call_site(), format!("read {}: {}", file_path.display(), e)))?;
         let syntax = syn::parse_file(&content)?;
         let mut collector = CallbackTraitCollector {
             module_path,
             entries: &mut entries,
         };
-        syntax
-            .items
-            .iter()
-            .try_for_each(|item| collector.collect_item(item))
+        syntax.items.iter().try_for_each(|item| collector.collect_item(item))
     })?;
 
     Ok(CallbackTraitRegistry { entries })
@@ -132,12 +124,10 @@ impl<'a> CallbackTraitCollector<'a> {
 }
 
 fn is_callback_trait(item_trait: &ItemTrait) -> bool {
-    item_trait.attrs.iter().any(|attr| {
-        attr.path()
-            .segments
-            .last()
-            .is_some_and(|segment| segment.ident == "export" || segment.ident == "ffi_trait")
-    })
+    item_trait
+        .attrs
+        .iter()
+        .any(|attr| attr.path().segments.last().is_some_and(|segment| segment.ident == "export" || segment.ident == "ffi_trait"))
 }
 
 fn is_object_safe(item_trait: &ItemTrait) -> bool {
@@ -147,21 +137,15 @@ fn is_object_safe(item_trait: &ItemTrait) -> bool {
             syn::TraitItem::Fn(method) if method.sig.asyncness.is_some()
         )
     });
-    let has_async_trait_attr = item_trait.attrs.iter().any(|attr| {
-        attr.path()
-            .segments
-            .last()
-            .is_some_and(|segment| segment.ident == "async_trait")
-    });
+    let has_async_trait_attr = item_trait
+        .attrs
+        .iter()
+        .any(|attr| attr.path().segments.last().is_some_and(|segment| segment.ident == "async_trait"));
     !has_async_methods || has_async_trait_attr
 }
 
 fn normalize_segments(path: &syn::Path) -> Vec<String> {
-    let mut segments = path
-        .segments
-        .iter()
-        .map(|segment| segment.ident.to_string())
-        .collect::<Vec<_>>();
+    let mut segments = path.segments.iter().map(|segment| segment.ident.to_string()).collect::<Vec<_>>();
     if let Some(first) = segments.first()
         && matches!(first.as_str(), "crate" | "self" | "super")
     {
@@ -177,35 +161,22 @@ fn list_rs_files(src_root: &Path) -> syn::Result<Vec<PathBuf>> {
 }
 
 fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) -> syn::Result<()> {
-    let entries = fs::read_dir(dir).map_err(|e| {
-        syn::Error::new(
-            Span::call_site(),
-            format!("read_dir {}: {}", dir.display(), e),
-        )
-    })?;
+    let entries = fs::read_dir(dir).map_err(|e| syn::Error::new(Span::call_site(), format!("read_dir {}: {}", dir.display(), e)))?;
 
-    entries
-        .filter_map(|entry| entry.ok())
-        .map(|entry| entry.path())
-        .try_for_each(|path| {
-            if path.is_dir() {
-                return collect_rs_files(&path, out);
-            }
-            if path.extension().is_some_and(|ext| ext == "rs") {
-                out.push(path);
-            }
-            Ok(())
-        })
+    entries.filter_map(|entry| entry.ok()).map(|entry| entry.path()).try_for_each(|path| {
+        if path.is_dir() {
+            return collect_rs_files(&path, out);
+        }
+        if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+        Ok(())
+    })
 }
 
 fn module_path_for_rs_file(src_root: &Path, file_path: &Path) -> syn::Result<Vec<String>> {
-    let relative = file_path
-        .strip_prefix(src_root)
-        .map_err(|_| syn::Error::new(Span::call_site(), "path not under src"))?;
-    let mut parts = relative
-        .components()
-        .map(|c| c.as_os_str().to_string_lossy().to_string())
-        .collect::<Vec<_>>();
+    let relative = file_path.strip_prefix(src_root).map_err(|_| syn::Error::new(Span::call_site(), "path not under src"))?;
+    let mut parts = relative.components().map(|c| c.as_os_str().to_string_lossy().to_string()).collect::<Vec<_>>();
 
     let file_name = parts.pop().unwrap_or_default();
     let mut module_parts = parts;

--- a/boltffi_macros/src/callback_trait.rs
+++ b/boltffi_macros/src/callback_trait.rs
@@ -1,15 +1,12 @@
+use crate::custom_types;
 use boltffi_ffi_rules::naming;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{FnArg, Pat, ReturnType, Type};
 
-use crate::custom_types;
-
 pub fn ffi_trait_impl(item: TokenStream) -> TokenStream {
     let item_trait = syn::parse_macro_input!(item as syn::ItemTrait);
-    expand_ffi_trait(item_trait)
-        .unwrap_or_else(|error| error.to_compile_error())
-        .into()
+    expand_ffi_trait(item_trait).unwrap_or_else(|error| error.to_compile_error()).into()
 }
 
 fn expand_ffi_trait(item_trait: syn::ItemTrait) -> Result<proc_macro2::TokenStream, syn::Error> {
@@ -18,49 +15,19 @@ fn expand_ffi_trait(item_trait: syn::ItemTrait) -> Result<proc_macro2::TokenStre
     let trait_name_snake = to_snake_case_ident(&trait_name.to_string());
     let vtable_name = syn::Ident::new(&format!("{}VTable", trait_name), trait_name.span());
     let foreign_name = syn::Ident::new(&format!("Foreign{}", trait_name), trait_name.span());
-    let vtable_static = syn::Ident::new(
-        &format!("{}_VTABLE", trait_name_snake.to_string().to_uppercase()),
-        trait_name.span(),
-    );
-    let register_fn = syn::Ident::new(
-        &format!(
-            "{}_register_{}_vtable",
-            naming::ffi_prefix(),
-            trait_name_snake
-        ),
-        trait_name.span(),
-    );
-    let create_fn = syn::Ident::new(
-        &format!(
-            "{}_create_{}_handle",
-            naming::ffi_prefix(),
-            trait_name_snake
-        ),
-        trait_name.span(),
-    );
+    let vtable_static = syn::Ident::new(&format!("{}_VTABLE", trait_name_snake.to_string().to_uppercase()), trait_name.span());
+    let register_fn = syn::Ident::new(&format!("{}_register_{}_vtable", naming::ffi_prefix(), trait_name_snake), trait_name.span());
+    let create_fn = syn::Ident::new(&format!("{}_create_{}_handle", naming::ffi_prefix(), trait_name_snake), trait_name.span());
 
-    let has_async_trait_attr = item_trait.attrs.iter().any(|attr| {
-        attr.path()
-            .segments
-            .last()
-            .is_some_and(|s| s.ident == "async_trait")
-    });
+    let has_async_trait_attr = item_trait.attrs.iter().any(|attr| attr.path().segments.last().is_some_and(|s| s.ident == "async_trait"));
 
     let async_trait_attr = item_trait
         .attrs
         .iter()
-        .find(|attr| {
-            attr.path()
-                .segments
-                .last()
-                .is_some_and(|s| s.ident == "async_trait")
-        })
+        .find(|attr| attr.path().segments.last().is_some_and(|s| s.ident == "async_trait"))
         .cloned();
 
-    let mut vtable_fields = vec![
-        quote! { pub free: extern "C" fn(handle: u64) },
-        quote! { pub clone: extern "C" fn(handle: u64) -> u64 },
-    ];
+    let mut vtable_fields = vec![quote! { pub free: extern "C" fn(handle: u64) }, quote! { pub clone: extern "C" fn(handle: u64) -> u64 }];
 
     let has_async_methods = item_trait
         .items
@@ -91,18 +58,11 @@ fn expand_ffi_trait(item_trait: syn::ItemTrait) -> Result<proc_macro2::TokenStre
 
     let wasm_extern_imports: Vec<_> = wasm_expansions.iter().map(|e| &e.extern_import).collect();
     let wasm_impl_bodies: Vec<_> = wasm_expansions.iter().map(|e| &e.impl_body).collect();
-    let wasm_complete_exports: Vec<_> = wasm_expansions
-        .iter()
-        .filter_map(|e| e.complete_export.as_ref())
-        .collect();
+    let wasm_complete_exports: Vec<_> = wasm_expansions.iter().filter_map(|e| e.complete_export.as_ref()).collect();
 
     let wasm_free_import = format_ident!("__boltffi_callback_{}_free", trait_name_snake);
     let wasm_clone_import = format_ident!("__boltffi_callback_{}_clone", trait_name_snake);
-    let wasm_create_fn = format_ident!(
-        "{}_create_{}_handle",
-        naming::ffi_prefix(),
-        trait_name_snake
-    );
+    let wasm_create_fn = format_ident!("{}_create_{}_handle", naming::ffi_prefix(), trait_name_snake);
 
     let expanded = quote! {
         #item_trait
@@ -333,22 +293,14 @@ fn expand_method(
             },
             FnArg::Receiver(_) => None,
         })
-        .map(|(param_name, param_type)| {
-            lower_callback_param(&param_name, &param_type, custom_types)
-        })
-        .fold(
-            (Vec::new(), Vec::new(), Vec::new(), Vec::new()),
-            |(mut ffi, mut rust, mut call, mut preludes), lowering| {
-                ffi.push(lowering.ffi_param);
-                rust.push(lowering.rust_param);
-                call.push(lowering.call_arg);
-                lowering
-                    .prelude
-                    .into_iter()
-                    .for_each(|stmt| preludes.push(stmt));
-                (ffi, rust, call, preludes)
-            },
-        );
+        .map(|(param_name, param_type)| lower_callback_param(&param_name, &param_type, custom_types))
+        .fold((Vec::new(), Vec::new(), Vec::new(), Vec::new()), |(mut ffi, mut rust, mut call, mut preludes), lowering| {
+            ffi.push(lowering.ffi_param);
+            rust.push(lowering.rust_param);
+            call.push(lowering.call_arg);
+            lowering.prelude.into_iter().for_each(|stmt| preludes.push(stmt));
+            (ffi, rust, call, preludes)
+        });
 
     let return_type = match &method.sig.output {
         ReturnType::Default => None,
@@ -356,10 +308,7 @@ fn expand_method(
     };
 
     if is_async {
-        let async_wire_return = return_type
-            .as_deref()
-            .map(needs_wire_return)
-            .unwrap_or(false);
+        let async_wire_return = return_type.as_deref().map(needs_wire_return).unwrap_or(false);
 
         let callback_type = if let Some(ref ret_ty) = return_type {
             if async_wire_return {
@@ -381,21 +330,17 @@ fn expand_method(
             )
         });
 
-        let output_type = return_type
-            .as_ref()
-            .map(|t| quote! { -> #t })
-            .unwrap_or_default();
+        let output_type = return_type.as_ref().map(|t| quote! { -> #t }).unwrap_or_default();
 
         let impl_body = match return_type.as_deref() {
             Some(ret_ty) => {
-                let error_expr = parse_result_type(ret_ty)
-                    .map(|(_, err_ty)| {
-                        quote! {
-                            Err(<#err_ty as ::core::convert::From<::boltffi::UnexpectedFfiCallbackError>>::from(
-                                ::boltffi::UnexpectedFfiCallbackError::new(error_msg)
-                            ))
-                        }
-                    });
+                let error_expr = parse_result_type(ret_ty).map(|(_, err_ty)| {
+                    quote! {
+                        Err(<#err_ty as ::core::convert::From<::boltffi::UnexpectedFfiCallbackError>>::from(
+                            ::boltffi::UnexpectedFfiCallbackError::new(error_msg)
+                        ))
+                    }
+                });
 
                 let (callback_body, poll_body) = if async_wire_return {
                     let poll_error_branch = error_expr
@@ -627,10 +572,7 @@ fn expand_method(
             }
         })
     } else {
-        let wire_return = return_type
-            .as_deref()
-            .map(needs_wire_return)
-            .unwrap_or(false);
+        let wire_return = return_type.as_deref().map(needs_wire_return).unwrap_or(false);
 
         let out_params = if let Some(ref ret_ty) = return_type {
             if wire_return {
@@ -652,10 +594,7 @@ fn expand_method(
             )
         });
 
-        let output_type = return_type
-            .as_ref()
-            .map(|t| quote! { -> #t })
-            .unwrap_or_default();
+        let output_type = return_type.as_ref().map(|t| quote! { -> #t }).unwrap_or_default();
 
         let impl_body = match return_type.as_deref() {
             Some(ret_ty) => {
@@ -737,8 +676,7 @@ fn to_snake_case_ident(name: &str) -> syn::Ident {
 fn rust_type_to_ffi_param_type(ty: &syn::Type) -> proc_macro2::TokenStream {
     let type_str = quote!(#ty).to_string().replace(' ', "");
     match type_str.as_str() {
-        "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "f32" | "f64" | "bool"
-        | "usize" | "isize" => quote!(#ty),
+        "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "f32" | "f64" | "bool" | "usize" | "isize" => quote!(#ty),
         "&str" => quote!(*const std::os::raw::c_char),
         "String" => quote!(*const std::os::raw::c_char),
         _ => quote!(#ty),
@@ -752,11 +690,7 @@ struct CallbackParamLowering {
     prelude: Option<proc_macro2::TokenStream>,
 }
 
-fn lower_callback_param(
-    param_name: &syn::Ident,
-    param_type: &syn::Type,
-    custom_types: &custom_types::CustomTypeRegistry,
-) -> CallbackParamLowering {
+fn lower_callback_param(param_name: &syn::Ident, param_type: &syn::Type, custom_types: &custom_types::CustomTypeRegistry) -> CallbackParamLowering {
     let rust_param = quote! { #param_name: #param_type };
 
     let type_str = quote!(#param_type).to_string().replace(' ', "");
@@ -796,18 +730,7 @@ fn lower_callback_param(
 fn is_ffi_primitive(type_str: &str) -> bool {
     matches!(
         type_str,
-        "i8" | "i16"
-            | "i32"
-            | "i64"
-            | "u8"
-            | "u16"
-            | "u32"
-            | "u64"
-            | "f32"
-            | "f64"
-            | "bool"
-            | "usize"
-            | "isize"
+        "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "f32" | "f64" | "bool" | "usize" | "isize"
     )
 }
 
@@ -842,11 +765,7 @@ struct WasmMethodExpansion {
     complete_export: Option<proc_macro2::TokenStream>,
 }
 
-fn expand_method_wasm(
-    method: &syn::TraitItemFn,
-    trait_name_snake: &syn::Ident,
-    custom_types: &custom_types::CustomTypeRegistry,
-) -> Result<WasmMethodExpansion, syn::Error> {
+fn expand_method_wasm(method: &syn::TraitItemFn, trait_name_snake: &syn::Ident, custom_types: &custom_types::CustomTypeRegistry) -> Result<WasmMethodExpansion, syn::Error> {
     let method_name = &method.sig.ident;
     let method_name_snake = to_snake_case_ident(&method_name.to_string());
 
@@ -855,53 +774,40 @@ fn expand_method_wasm(
         return expand_method_wasm_async(method, trait_name_snake, custom_types);
     }
 
-    let import_name = format_ident!(
-        "__boltffi_callback_{}_{}",
-        trait_name_snake,
-        method_name_snake
-    );
+    let import_name = format_ident!("__boltffi_callback_{}_{}", trait_name_snake, method_name_snake);
 
-    let (ffi_param_types, param_names, call_args, prelude_stmts): (Vec<_>, Vec<_>, Vec<_>, Vec<_>) =
-        method
-            .sig
-            .inputs
-            .iter()
-            .filter_map(|input| match input {
-                FnArg::Typed(pat_type) => match pat_type.pat.as_ref() {
-                    Pat::Ident(pat_ident) => Some((pat_ident.ident.clone(), pat_type.ty.clone())),
-                    _ => None,
-                },
-                FnArg::Receiver(_) => None,
-            })
-            .map(|(param_name, param_type)| {
-                lower_callback_param_wasm(&param_name, &param_type, custom_types)
-            })
-            .fold(
-                (Vec::new(), Vec::new(), Vec::new(), Vec::new()),
-                |(mut ffi, mut rust, mut call, mut preludes), lowering| {
-                    for p in lowering.ffi_params {
-                        ffi.push(p);
-                    }
-                    rust.push(lowering.rust_param);
-                    for a in lowering.call_args {
-                        call.push(a);
-                    }
-                    if let Some(stmt) = lowering.prelude {
-                        preludes.push(stmt);
-                    }
-                    (ffi, rust, call, preludes)
-                },
-            );
+    let (ffi_param_types, param_names, call_args, prelude_stmts): (Vec<_>, Vec<_>, Vec<_>, Vec<_>) = method
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|input| match input {
+            FnArg::Typed(pat_type) => match pat_type.pat.as_ref() {
+                Pat::Ident(pat_ident) => Some((pat_ident.ident.clone(), pat_type.ty.clone())),
+                _ => None,
+            },
+            FnArg::Receiver(_) => None,
+        })
+        .map(|(param_name, param_type)| lower_callback_param_wasm(&param_name, &param_type, custom_types))
+        .fold((Vec::new(), Vec::new(), Vec::new(), Vec::new()), |(mut ffi, mut rust, mut call, mut preludes), lowering| {
+            for p in lowering.ffi_params {
+                ffi.push(p);
+            }
+            rust.push(lowering.rust_param);
+            for a in lowering.call_args {
+                call.push(a);
+            }
+            if let Some(stmt) = lowering.prelude {
+                preludes.push(stmt);
+            }
+            (ffi, rust, call, preludes)
+        });
 
     let return_type = match &method.sig.output {
         ReturnType::Default => None,
         ReturnType::Type(_, ty) => Some(ty.clone()),
     };
 
-    let wire_return = return_type
-        .as_deref()
-        .map(needs_wire_return)
-        .unwrap_or(false);
+    let wire_return = return_type.as_deref().map(needs_wire_return).unwrap_or(false);
 
     let (extern_import, impl_body) = if let Some(ref ret_ty) = return_type {
         if wire_return {
@@ -952,10 +858,7 @@ fn expand_method_wasm(
         )
     };
 
-    let output_type = return_type
-        .as_ref()
-        .map(|t| quote! { -> #t })
-        .unwrap_or_default();
+    let output_type = return_type.as_ref().map(|t| quote! { -> #t }).unwrap_or_default();
 
     Ok(WasmMethodExpansion {
         extern_import,
@@ -968,56 +871,38 @@ fn expand_method_wasm(
     })
 }
 
-fn expand_method_wasm_async(
-    method: &syn::TraitItemFn,
-    trait_name_snake: &syn::Ident,
-    custom_types: &custom_types::CustomTypeRegistry,
-) -> Result<WasmMethodExpansion, syn::Error> {
+fn expand_method_wasm_async(method: &syn::TraitItemFn, trait_name_snake: &syn::Ident, custom_types: &custom_types::CustomTypeRegistry) -> Result<WasmMethodExpansion, syn::Error> {
     let method_name = &method.sig.ident;
     let method_name_snake = to_snake_case_ident(&method_name.to_string());
 
-    let start_import_name = format_ident!(
-        "__boltffi_callback_{}_{}_start",
-        trait_name_snake,
-        method_name_snake
-    );
-    let complete_export_name = format_ident!(
-        "boltffi_callback_{}_{}_complete",
-        trait_name_snake,
-        method_name_snake
-    );
+    let start_import_name = format_ident!("__boltffi_callback_{}_{}_start", trait_name_snake, method_name_snake);
+    let complete_export_name = format_ident!("boltffi_callback_{}_{}_complete", trait_name_snake, method_name_snake);
 
-    let (ffi_param_types, param_names, call_args, prelude_stmts): (Vec<_>, Vec<_>, Vec<_>, Vec<_>) =
-        method
-            .sig
-            .inputs
-            .iter()
-            .filter_map(|input| match input {
-                FnArg::Typed(pat_type) => match pat_type.pat.as_ref() {
-                    Pat::Ident(pat_ident) => Some((pat_ident.ident.clone(), pat_type.ty.clone())),
-                    _ => None,
-                },
-                FnArg::Receiver(_) => None,
-            })
-            .map(|(param_name, param_type)| {
-                lower_callback_param_wasm(&param_name, &param_type, custom_types)
-            })
-            .fold(
-                (Vec::new(), Vec::new(), Vec::new(), Vec::new()),
-                |(mut ffi, mut rust, mut call, mut preludes), lowering| {
-                    for p in lowering.ffi_params {
-                        ffi.push(p);
-                    }
-                    rust.push(lowering.rust_param);
-                    for a in lowering.call_args {
-                        call.push(a);
-                    }
-                    if let Some(stmt) = lowering.prelude {
-                        preludes.push(stmt);
-                    }
-                    (ffi, rust, call, preludes)
-                },
-            );
+    let (ffi_param_types, param_names, call_args, prelude_stmts): (Vec<_>, Vec<_>, Vec<_>, Vec<_>) = method
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|input| match input {
+            FnArg::Typed(pat_type) => match pat_type.pat.as_ref() {
+                Pat::Ident(pat_ident) => Some((pat_ident.ident.clone(), pat_type.ty.clone())),
+                _ => None,
+            },
+            FnArg::Receiver(_) => None,
+        })
+        .map(|(param_name, param_type)| lower_callback_param_wasm(&param_name, &param_type, custom_types))
+        .fold((Vec::new(), Vec::new(), Vec::new(), Vec::new()), |(mut ffi, mut rust, mut call, mut preludes), lowering| {
+            for p in lowering.ffi_params {
+                ffi.push(p);
+            }
+            rust.push(lowering.rust_param);
+            for a in lowering.call_args {
+                call.push(a);
+            }
+            if let Some(stmt) = lowering.prelude {
+                preludes.push(stmt);
+            }
+            (ffi, rust, call, preludes)
+        });
 
     let return_type = match &method.sig.output {
         ReturnType::Default => None,
@@ -1048,10 +933,7 @@ fn expand_method_wasm_async(
         }
     };
 
-    let output_type = return_type
-        .as_ref()
-        .map(|t| quote! { -> #t })
-        .unwrap_or_default();
+    let output_type = return_type.as_ref().map(|t| quote! { -> #t }).unwrap_or_default();
 
     let poll_body = match return_type.as_deref() {
         Some(ret_ty) => {
@@ -1165,11 +1047,7 @@ struct WasmCallbackParamLowering {
     prelude: Option<proc_macro2::TokenStream>,
 }
 
-fn lower_callback_param_wasm(
-    param_name: &syn::Ident,
-    param_type: &syn::Type,
-    custom_types: &custom_types::CustomTypeRegistry,
-) -> WasmCallbackParamLowering {
+fn lower_callback_param_wasm(param_name: &syn::Ident, param_type: &syn::Type, custom_types: &custom_types::CustomTypeRegistry) -> WasmCallbackParamLowering {
     let rust_param = quote! { #param_name: #param_type };
     let type_str = quote!(#param_type).to_string().replace(' ', "");
 
@@ -1201,10 +1079,7 @@ fn lower_callback_param_wasm(
     WasmCallbackParamLowering {
         ffi_params: vec![quote! { #ptr_name: *const u8 }, quote! { #len_name: u32 }],
         rust_param,
-        call_args: vec![
-            quote! { #wire_name.as_ptr() },
-            quote! { #wire_name.len() as u32 },
-        ],
+        call_args: vec![quote! { #wire_name.as_ptr() }, quote! { #wire_name.len() as u32 }],
         prelude: Some(prelude),
     }
 }

--- a/boltffi_macros/src/class.rs
+++ b/boltffi_macros/src/class.rs
@@ -1,13 +1,12 @@
-use boltffi_ffi_rules::naming;
+use crate::{
+    callback_registry, custom_types,
+    params::{FfiParams, transform_method_params, transform_method_params_async},
+    returns::{ReturnAbi, classify_return, encoded_return_body, lower_return_abi},
+};
+use boltffi_ffi_rules::{naming, transport::EncodedReturnStrategy};
 use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::{FnArg, ReturnType, Type};
-
-use crate::callback_registry;
-use crate::custom_types;
-use crate::params::{FfiParams, transform_method_params, transform_method_params_async};
-use crate::returns::{ReturnAbi, classify_return, encoded_return_body, lower_return_abi};
-use boltffi_ffi_rules::transport::EncodedReturnStrategy;
 
 fn has_mut_self_methods(input: &syn::ItemImpl) -> bool {
     input.items.iter().any(|item| {
@@ -27,10 +26,7 @@ fn parse_single_threaded_attr(attr: &TokenStream) -> bool {
     let parser = syn::punctuated::Punctuated::<syn::Ident, syn::Token![,]>::parse_terminated;
     parser
         .parse(attr.clone())
-        .map(|args| {
-            args.iter()
-                .any(|id| id == "single_threaded" || id == "thread_unsafe")
-        })
+        .map(|args| args.iter().any(|id| id == "single_threaded" || id == "thread_unsafe"))
         .unwrap_or(false)
 }
 
@@ -69,17 +65,12 @@ pub fn ffi_class_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
     let type_name = match self_ty {
         Some(name) => name,
         None => {
-            return syn::Error::new_spanned(&input, "ffi_class requires a named type")
-                .to_compile_error()
-                .into();
+            return syn::Error::new_spanned(&input, "ffi_class requires a named type").to_compile_error().into();
         }
     };
 
     let type_name_str = type_name.to_string();
-    let free_ident = syn::Ident::new(
-        naming::class_ffi_free(&type_name_str).as_str(),
-        type_name.span(),
-    );
+    let free_ident = syn::Ident::new(naming::class_ffi_free(&type_name_str).as_str(), type_name.span());
 
     let method_exports: Vec<_> = input
         .items
@@ -90,30 +81,16 @@ pub fn ffi_class_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                     return None;
                 }
                 if matches!(method.vis, syn::Visibility::Public(_)) {
+                    if let Some(item_type) = extract_ffi_iterator_item(&method.attrs) {
+                        return Some(generate_iterator_exports(&type_name, &type_name_str, method, &item_type));
+                    }
                     if let Some(item_type) = extract_ffi_stream_item(&method.attrs) {
-                        return Some(generate_stream_exports(
-                            &type_name,
-                            &type_name_str,
-                            method,
-                            &item_type,
-                        ));
+                        return Some(generate_stream_exports(&type_name, &type_name_str, method, &item_type));
                     }
                     if method.sig.asyncness.is_some() {
-                        return generate_async_method_export(
-                            &type_name,
-                            &type_name_str,
-                            method,
-                            &custom_types,
-                            &callback_registry,
-                        );
+                        return generate_async_method_export(&type_name, &type_name_str, method, &custom_types, &callback_registry);
                     }
-                    return generate_method_export(
-                        &type_name,
-                        &type_name_str,
-                        method,
-                        &custom_types,
-                        &callback_registry,
-                    );
+                    return generate_method_export(&type_name, &type_name_str, method, &custom_types, &callback_registry);
                 }
             }
             None
@@ -206,11 +183,7 @@ fn build_instance_encoded_return_exports(
     }
 }
 
-fn build_static_encoded_return_exports(
-    export_name: &syn::Ident,
-    ffi_params: &[proc_macro2::TokenStream],
-    encode_body: proc_macro2::TokenStream,
-) -> proc_macro2::TokenStream {
+fn build_static_encoded_return_exports(export_name: &syn::Ident, ffi_params: &[proc_macro2::TokenStream], encode_body: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     match ffi_params.is_empty() {
         true => quote! {
             #[cfg(target_arch = "wasm32")]
@@ -335,12 +308,7 @@ fn build_static_f64_wasm_exports(
 }
 
 fn is_factory_constructor(method: &syn::ImplItemFn, type_name: &syn::Ident) -> bool {
-    let has_self = method
-        .sig
-        .inputs
-        .first()
-        .map(|arg| matches!(arg, FnArg::Receiver(_)))
-        .unwrap_or(false);
+    let has_self = method.sig.inputs.first().map(|arg| matches!(arg, FnArg::Receiver(_))).unwrap_or(false);
 
     if has_self {
         return false;
@@ -353,19 +321,14 @@ fn is_factory_return(output: &ReturnType, type_name: &syn::Ident) -> bool {
     match output {
         ReturnType::Default => false,
         ReturnType::Type(_, ty) => match ty.as_ref() {
-            Type::Path(type_path) => {
-                is_self_type_path(&type_path.path, type_name)
-                    || is_result_of_self_type_path(&type_path.path, type_name)
-            }
+            Type::Path(type_path) => is_self_type_path(&type_path.path, type_name) || is_result_of_self_type_path(&type_path.path, type_name),
             _ => false,
         },
     }
 }
 
 fn is_self_type_path(path: &syn::Path, type_name: &syn::Ident) -> bool {
-    path.segments
-        .last()
-        .is_some_and(|segment| segment.ident == "Self" || segment.ident == *type_name)
+    path.segments.last().is_some_and(|segment| segment.ident == "Self" || segment.ident == *type_name)
 }
 
 fn is_result_of_self_type_path(path: &syn::Path, type_name: &syn::Ident) -> bool {
@@ -474,35 +437,15 @@ fn generate_method_export(
     callback_registry: &callback_registry::CallbackTraitRegistry,
 ) -> Option<proc_macro2::TokenStream> {
     let method_name = &method.sig.ident;
-    let export_name = syn::Ident::new(
-        naming::method_ffi_name(class_name, &method_name.to_string()).as_str(),
-        method_name.span(),
-    );
+    let export_name = syn::Ident::new(naming::method_ffi_name(class_name, &method_name.to_string()).as_str(), method_name.span());
 
-    let has_self = method
-        .sig
-        .inputs
-        .first()
-        .map(|arg| matches!(arg, FnArg::Receiver(_)))
-        .unwrap_or(false);
+    let has_self = method.sig.inputs.first().map(|arg| matches!(arg, FnArg::Receiver(_))).unwrap_or(false);
 
     if !has_self {
         if is_factory_constructor(method, type_name) {
-            return generate_factory_constructor_export(
-                type_name,
-                class_name,
-                method,
-                custom_types,
-                callback_registry,
-            );
+            return generate_factory_constructor_export(type_name, class_name, method, custom_types, callback_registry);
         }
-        return generate_static_method_export(
-            type_name,
-            class_name,
-            method,
-            custom_types,
-            callback_registry,
-        );
+        return generate_static_method_export(type_name, class_name, method, custom_types, callback_registry);
     }
 
     let other_inputs = method.sig.inputs.iter().skip(1).cloned();
@@ -546,10 +489,7 @@ fn generate_method_export(
             };
             (body, quote! { #fn_output }, false)
         }
-        ReturnAbi::Encoded {
-            rust_type: inner_ty,
-            strategy,
-        } => {
+        ReturnAbi::Encoded { rust_type: inner_ty, strategy } => {
             let result_ident = syn::Ident::new("result", method_name.span());
 
             if matches!(strategy, EncodedReturnStrategy::OptionScalar) {
@@ -577,34 +517,16 @@ fn generate_method_export(
                     ::boltffi::__private::FfiBuf::wire_encode(&#result_ident)
                 };
 
-                return Some(build_instance_f64_wasm_exports(
-                    &export_name,
-                    type_name,
-                    &ffi_params,
-                    wasm_body,
-                    native_body,
-                ));
+                return Some(build_instance_f64_wasm_exports(&export_name, type_name, &ffi_params, wasm_body, native_body));
             }
 
-            let body = encoded_return_body(
-                &inner_ty,
-                strategy,
-                &result_ident,
-                quote! { #call_expr },
-                &conversions,
-                custom_types,
-            );
+            let body = encoded_return_body(&inner_ty, strategy, &result_ident, quote! { #call_expr }, &conversions, custom_types);
             (body, quote! { -> ::boltffi::__private::FfiBuf<u8> }, true)
         }
     };
 
     if is_wire_encoded {
-        return Some(build_instance_encoded_return_exports(
-            &export_name,
-            type_name,
-            &ffi_params,
-            body,
-        ));
+        return Some(build_instance_encoded_return_exports(&export_name, type_name, &ffi_params, body));
     }
 
     if ffi_params.is_empty() {
@@ -637,10 +559,7 @@ fn generate_static_method_export(
     callback_registry: &callback_registry::CallbackTraitRegistry,
 ) -> Option<proc_macro2::TokenStream> {
     let method_name = &method.sig.ident;
-    let export_name = syn::Ident::new(
-        naming::method_ffi_name(class_name, &method_name.to_string()).as_str(),
-        method_name.span(),
-    );
+    let export_name = syn::Ident::new(naming::method_ffi_name(class_name, &method_name.to_string()).as_str(), method_name.span());
 
     let all_inputs = method.sig.inputs.iter().cloned();
     let FfiParams {
@@ -682,10 +601,7 @@ fn generate_static_method_export(
             };
             (body, quote! { #fn_output }, false)
         }
-        ReturnAbi::Encoded {
-            rust_type: inner_ty,
-            strategy,
-        } => {
+        ReturnAbi::Encoded { rust_type: inner_ty, strategy } => {
             let result_ident = syn::Ident::new("result", method_name.span());
 
             if matches!(strategy, EncodedReturnStrategy::OptionScalar) {
@@ -713,32 +629,16 @@ fn generate_static_method_export(
                     ::boltffi::__private::FfiBuf::wire_encode(&#result_ident)
                 };
 
-                return Some(build_static_f64_wasm_exports(
-                    &export_name,
-                    &ffi_params,
-                    wasm_body,
-                    native_body,
-                ));
+                return Some(build_static_f64_wasm_exports(&export_name, &ffi_params, wasm_body, native_body));
             }
 
-            let body = encoded_return_body(
-                &inner_ty,
-                strategy,
-                &result_ident,
-                quote! { #call_expr },
-                &conversions,
-                custom_types,
-            );
+            let body = encoded_return_body(&inner_ty, strategy, &result_ident, quote! { #call_expr }, &conversions, custom_types);
             (body, quote! { -> ::boltffi::__private::FfiBuf<u8> }, true)
         }
     };
 
     if is_wire_encoded {
-        return Some(build_static_encoded_return_exports(
-            &export_name,
-            &ffi_params,
-            body,
-        ));
+        return Some(build_static_encoded_return_exports(&export_name, &ffi_params, body));
     }
 
     if ffi_params.is_empty() {
@@ -780,14 +680,12 @@ fn generate_async_method_export(
     let poll_ident = syn::Ident::new(&format!("{}_poll", base_name), method_name.span());
     let poll_sync_ident = syn::Ident::new(&format!("{}_poll_sync", base_name), method_name.span());
     let complete_ident = syn::Ident::new(&format!("{}_complete", base_name), method_name.span());
-    let panic_message_ident =
-        syn::Ident::new(&format!("{}_panic_message", base_name), method_name.span());
+    let panic_message_ident = syn::Ident::new(&format!("{}_panic_message", base_name), method_name.span());
     let cancel_ident = syn::Ident::new(&format!("{}_cancel", base_name), method_name.span());
     let free_ident = syn::Ident::new(&format!("{}_free", base_name), method_name.span());
 
     let other_inputs = method.sig.inputs.iter().skip(1).cloned();
-    let params = match transform_method_params_async(other_inputs, custom_types, callback_registry)
-    {
+    let params = match transform_method_params_async(other_inputs, custom_types, callback_registry) {
         Ok(params) => params,
         Err(error) => return Some(error.to_compile_error()),
     };
@@ -958,39 +856,16 @@ fn extract_ffi_stream_item(attrs: &[syn::Attribute]) -> Option<syn::Type> {
     })
 }
 
-fn generate_stream_exports(
-    type_name: &syn::Ident,
-    class_name: &str,
-    method: &syn::ImplItemFn,
-    item_type: &syn::Type,
-) -> proc_macro2::TokenStream {
+fn generate_stream_exports(type_name: &syn::Ident, class_name: &str, method: &syn::ImplItemFn, item_type: &syn::Type) -> proc_macro2::TokenStream {
     let method_name = &method.sig.ident;
     let stream_name = method_name.to_string();
 
-    let subscribe_ident = syn::Ident::new(
-        naming::stream_ffi_subscribe(class_name, &stream_name).as_str(),
-        method_name.span(),
-    );
-    let pop_batch_ident = syn::Ident::new(
-        naming::stream_ffi_pop_batch(class_name, &stream_name).as_str(),
-        method_name.span(),
-    );
-    let wait_ident = syn::Ident::new(
-        naming::stream_ffi_wait(class_name, &stream_name).as_str(),
-        method_name.span(),
-    );
-    let poll_ident = syn::Ident::new(
-        naming::stream_ffi_poll(class_name, &stream_name).as_str(),
-        method_name.span(),
-    );
-    let unsubscribe_ident = syn::Ident::new(
-        naming::stream_ffi_unsubscribe(class_name, &stream_name).as_str(),
-        method_name.span(),
-    );
-    let free_ident = syn::Ident::new(
-        naming::stream_ffi_free(class_name, &stream_name).as_str(),
-        method_name.span(),
-    );
+    let subscribe_ident = syn::Ident::new(naming::stream_ffi_subscribe(class_name, &stream_name).as_str(), method_name.span());
+    let pop_batch_ident = syn::Ident::new(naming::stream_ffi_pop_batch(class_name, &stream_name).as_str(), method_name.span());
+    let wait_ident = syn::Ident::new(naming::stream_ffi_wait(class_name, &stream_name).as_str(), method_name.span());
+    let poll_ident = syn::Ident::new(naming::stream_ffi_poll(class_name, &stream_name).as_str(), method_name.span());
+    let unsubscribe_ident = syn::Ident::new(naming::stream_ffi_unsubscribe(class_name, &stream_name).as_str(), method_name.span());
+    let free_ident = syn::Ident::new(naming::stream_ffi_free(class_name, &stream_name).as_str(), method_name.span());
 
     quote! {
         #[unsafe(no_mangle)]
@@ -1081,6 +956,118 @@ fn generate_stream_exports(
                     subscription_handle as *const ::boltffi::__private::EventSubscription<#item_type>
                 )
             });
+        }
+    }
+}
+
+fn extract_ffi_iterator_item(attrs: &[syn::Attribute]) -> Option<syn::Type> {
+    attrs.iter().find_map(|attr| {
+        if !attr.path().is_ident("ffi_async_iter") {
+            return None;
+        }
+
+        let mut item_type: Option<syn::Type> = None;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("item") {
+                let value: syn::Type = meta.value()?.parse()?;
+                item_type = Some(value);
+            }
+            Ok(())
+        });
+
+        item_type
+    })
+}
+
+fn generate_iterator_exports(type_name: &syn::Ident, class_name: &str, method: &syn::ImplItemFn, item_type: &syn::Type) -> proc_macro2::TokenStream {
+    let method_name = &method.sig.ident;
+    let method_name_str = method_name.to_string();
+
+    let new_ident = syn::Ident::new(naming::iterator_ffi_new(class_name, &method_name_str).as_str(), method_name.span());
+    let next_ident = syn::Ident::new(naming::iterator_ffi_next(class_name, &method_name_str).as_str(), method_name.span());
+    let next_poll_ident = syn::Ident::new(&format!("{}_poll", next_ident), method_name.span());
+    let next_complete_ident = syn::Ident::new(&format!("{}_complete", next_ident), method_name.span());
+    let next_cancel_ident = syn::Ident::new(&format!("{}_cancel", next_ident), method_name.span());
+    let next_free_ident = syn::Ident::new(&format!("{}_free", next_ident), method_name.span());
+    let free_ident = syn::Ident::new(naming::iterator_ffi_free(class_name, &method_name_str).as_str(), method_name.span());
+
+    quote! {
+        // Creates the iterator and returns an opaque IteratorHandle.
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #new_ident(
+            handle: *const #type_name,
+        ) -> ::boltffi::__private::IteratorHandle {
+            if handle.is_null() {
+                return std::ptr::null_mut();
+            }
+            let instance = unsafe { &*handle };
+            let iterator = instance.#method_name();
+            ::boltffi::__private::iterator_new::<#item_type, _>(iterator)
+        }
+
+        // Drives one `next()` call and returns a RustFutureHandle for `Option<item_type>`.
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #next_ident(
+            iterator_handle: ::boltffi::__private::IteratorHandle,
+        ) -> ::boltffi::__private::RustFutureHandle {
+            ::boltffi::__private::rustfuture::rust_future_new(
+                unsafe { ::boltffi::__private::iterator_next::<#item_type>(iterator_handle) }
+            )
+        }
+
+        // Standard async future suite for the next() future.
+        #[cfg(not(target_arch = "wasm32"))]
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #next_poll_ident(
+            handle: ::boltffi::__private::RustFutureHandle,
+            callback_data: u64,
+            callback: ::boltffi::__private::RustFutureContinuationCallback,
+        ) {
+            ::boltffi::__private::rustfuture::rust_future_poll::<Option<#item_type>>(handle, callback, callback_data)
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #next_complete_ident(
+            handle: ::boltffi::__private::RustFutureHandle,
+            out_status: *mut ::boltffi::__private::FfiStatus,
+        ) -> ::boltffi::__private::FfiBuf<u8> {
+            match ::boltffi::__private::rustfuture::rust_future_complete::<Option<#item_type>>(handle) {
+                Some(result) => {
+                    if !out_status.is_null() {
+                        unsafe { *out_status = ::boltffi::__private::FfiStatus::OK; }
+                    }
+                    ::boltffi::__private::FfiBuf::wire_encode(&result)
+                }
+                None => {
+                    if !out_status.is_null() {
+                        unsafe { *out_status = ::boltffi::__private::FfiStatus::CANCELLED; }
+                    }
+                    ::boltffi::__private::FfiBuf::default()
+                }
+            }
+        }
+
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #next_cancel_ident(
+            handle: ::boltffi::__private::RustFutureHandle,
+        ) {
+            ::boltffi::__private::rustfuture::rust_future_cancel::<Option<#item_type>>(handle)
+        }
+
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #next_free_ident(
+            handle: ::boltffi::__private::RustFutureHandle,
+        ) {
+            ::boltffi::__private::rustfuture::rust_future_free::<Option<#item_type>>(handle)
+        }
+
+        // Drops the iterator, freeing all resources.
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn #free_ident(
+            iterator_handle: ::boltffi::__private::IteratorHandle,
+        ) {
+            unsafe { ::boltffi::__private::iterator_free::<#item_type>(iterator_handle) }
         }
     }
 }

--- a/boltffi_macros/src/custom_ffi.rs
+++ b/boltffi_macros/src/custom_ffi.rs
@@ -6,12 +6,9 @@ pub fn custom_ffi_impl(item: TokenStream) -> TokenStream {
     let item_impl = parse_macro_input!(item as ItemImpl);
 
     if !item_impl.generics.params.is_empty() {
-        return syn::Error::new_spanned(
-            &item_impl.generics,
-            "custom_ffi does not support generics",
-        )
-        .to_compile_error()
-        .into();
+        return syn::Error::new_spanned(&item_impl.generics, "custom_ffi does not support generics")
+            .to_compile_error()
+            .into();
     }
 
     let trait_ident_ok = item_impl
@@ -21,12 +18,9 @@ pub fn custom_ffi_impl(item: TokenStream) -> TokenStream {
         .is_some_and(|seg| seg.ident == "CustomFfiConvertible");
 
     if !trait_ident_ok {
-        return syn::Error::new_spanned(
-            &item_impl,
-            "custom_ffi must annotate an impl of CustomFfiConvertible",
-        )
-        .to_compile_error()
-        .into();
+        return syn::Error::new_spanned(&item_impl, "custom_ffi must annotate an impl of CustomFfiConvertible")
+            .to_compile_error()
+            .into();
     }
 
     let self_ty = item_impl.self_ty.as_ref();
@@ -41,12 +35,9 @@ pub fn custom_ffi_impl(item: TokenStream) -> TokenStream {
         .next();
 
     let Some(ffi_repr) = ffi_repr else {
-        return syn::Error::new_spanned(
-            &item_impl,
-            "custom_ffi requires `type FfiRepr = ...;` in the impl block",
-        )
-        .to_compile_error()
-        .into();
+        return syn::Error::new_spanned(&item_impl, "custom_ffi requires `type FfiRepr = ...;` in the impl block")
+            .to_compile_error()
+            .into();
     };
 
     let self_ty_no_group = match self_ty {

--- a/boltffi_macros/src/custom_type.rs
+++ b/boltffi_macros/src/custom_type.rs
@@ -56,12 +56,9 @@ impl Parse for CustomTypeSpec {
 
         let remote = remote.ok_or_else(|| input.error("custom_type!: missing `remote = ...`"))?;
         let repr = repr.ok_or_else(|| input.error("custom_type!: missing `repr = ...`"))?;
-        let error =
-            error.unwrap_or_else(|| syn::parse_quote!(::boltffi::CustomTypeConversionError));
-        let into_ffi =
-            into_ffi.ok_or_else(|| input.error("custom_type!: missing `into_ffi = ...`"))?;
-        let try_from_ffi = try_from_ffi
-            .ok_or_else(|| input.error("custom_type!: missing `try_from_ffi = ...`"))?;
+        let error = error.unwrap_or_else(|| syn::parse_quote!(::boltffi::CustomTypeConversionError));
+        let into_ffi = into_ffi.ok_or_else(|| input.error("custom_type!: missing `into_ffi = ...`"))?;
+        let try_from_ffi = try_from_ffi.ok_or_else(|| input.error("custom_type!: missing `try_from_ffi = ...`"))?;
 
         Ok(Self {
             visibility,

--- a/boltffi_macros/src/custom_types.rs
+++ b/boltffi_macros/src/custom_types.rs
@@ -1,13 +1,13 @@
-use std::collections::HashMap;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
-
 use boltffi_ffi_rules::naming;
 use proc_macro2::Span;
 use quote::{format_ident, quote};
-use syn::parse::Parse;
-use syn::{GenericArgument, PathArguments, Type};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
+};
+use syn::{GenericArgument, PathArguments, Type, parse::Parse};
 
 #[derive(Clone)]
 pub struct CustomTypeEntry {
@@ -27,22 +27,14 @@ impl CustomTypeEntry {
     pub fn to_fn_path(&self) -> proc_macro2::TokenStream {
         let snake = naming::to_snake_case(&self.name);
         let fn_name = format_ident!("__boltffi_custom_type_{}_into_ffi", snake);
-        let module_path = self
-            .module_path
-            .iter()
-            .map(|segment| syn::Ident::new(segment, Span::call_site()))
-            .collect::<Vec<_>>();
+        let module_path = self.module_path.iter().map(|segment| syn::Ident::new(segment, Span::call_site())).collect::<Vec<_>>();
         quote! { crate::#(#module_path::)*#fn_name }
     }
 
     pub fn try_from_fn_path(&self) -> proc_macro2::TokenStream {
         let snake = naming::to_snake_case(&self.name);
         let fn_name = format_ident!("__boltffi_custom_type_{}_try_from_ffi", snake);
-        let module_path = self
-            .module_path
-            .iter()
-            .map(|segment| syn::Ident::new(segment, Span::call_site()))
-            .collect::<Vec<_>>();
+        let module_path = self.module_path.iter().map(|segment| syn::Ident::new(segment, Span::call_site())).collect::<Vec<_>>();
         quote! { crate::#(#module_path::)*#fn_name }
     }
 }
@@ -74,11 +66,7 @@ fn qualify_type_for_module(ty: Type, module_path: &[String]) -> Type {
             ..slice
         }),
         Type::Tuple(tuple) => Type::Tuple(syn::TypeTuple {
-            elems: tuple
-                .elems
-                .into_iter()
-                .map(|elem| qualify_type_for_module(elem, module_path))
-                .collect(),
+            elems: tuple.elems.into_iter().map(|elem| qualify_type_for_module(elem, module_path)).collect(),
             ..tuple
         }),
         Type::Path(type_path) => Type::Path(qualify_type_path_for_module(type_path, module_path)),
@@ -108,8 +96,7 @@ fn qualify_type_path_for_module(type_path: syn::TypePath, module_path: &[String]
     };
 
     let ident = segment.ident.to_string();
-    let should_qualify =
-        ident.chars().next().is_some_and(|ch| ch.is_uppercase()) && !is_std_global_ident(&ident);
+    let should_qualify = ident.chars().next().is_some_and(|ch| ch.is_uppercase()) && !is_std_global_ident(&ident);
 
     if should_qualify {
         {
@@ -119,23 +106,14 @@ fn qualify_type_path_for_module(type_path: syn::TypePath, module_path: &[String]
                 .map(syn::PathSegment::from)
                 .collect::<syn::punctuated::Punctuated<_, syn::Token![::]>>();
 
-            let mut segments =
-                syn::punctuated::Punctuated::<syn::PathSegment, syn::Token![::]>::new();
-            segments.push(syn::PathSegment::from(syn::Ident::new(
-                "crate",
-                Span::call_site(),
-            )));
-            module_segments
-                .into_iter()
-                .for_each(|segment| segments.push(segment));
+            let mut segments = syn::punctuated::Punctuated::<syn::PathSegment, syn::Token![::]>::new();
+            segments.push(syn::PathSegment::from(syn::Ident::new("crate", Span::call_site())));
+            module_segments.into_iter().for_each(|segment| segments.push(segment));
             segments.push(segment.clone());
 
             syn::TypePath {
                 qself: None,
-                path: syn::Path {
-                    leading_colon: None,
-                    segments,
-                },
+                path: syn::Path { leading_colon: None, segments },
             }
         }
     } else {
@@ -155,26 +133,19 @@ fn qualify_path_segments_for_module(path: syn::Path, module_path: &[String]) -> 
     }
 }
 
-fn qualify_path_segment_for_module(
-    mut segment: syn::PathSegment,
-    module_path: &[String],
-) -> syn::PathSegment {
+fn qualify_path_segment_for_module(mut segment: syn::PathSegment, module_path: &[String]) -> syn::PathSegment {
     segment.arguments = match segment.arguments {
-        PathArguments::AngleBracketed(args) => {
-            PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
-                args: args
-                    .args
-                    .into_iter()
-                    .map(|arg| match arg {
-                        GenericArgument::Type(inner_ty) => {
-                            GenericArgument::Type(qualify_type_for_module(inner_ty, module_path))
-                        }
-                        other => other,
-                    })
-                    .collect(),
-                ..args
-            })
-        }
+        PathArguments::AngleBracketed(args) => PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
+            args: args
+                .args
+                .into_iter()
+                .map(|arg| match arg {
+                    GenericArgument::Type(inner_ty) => GenericArgument::Type(qualify_type_for_module(inner_ty, module_path)),
+                    other => other,
+                })
+                .collect(),
+            ..args
+        }),
         other => other,
     };
     segment
@@ -185,10 +156,7 @@ fn is_single_segment_path(path: &syn::Path) -> bool {
 }
 
 fn is_std_global_ident(ident: &str) -> bool {
-    matches!(
-        ident,
-        "String" | "Vec" | "Option" | "Result" | "Box" | "Arc" | "Rc" | "Cow"
-    )
+    matches!(ident, "String" | "Vec" | "Option" | "Result" | "Box" | "Arc" | "Rc" | "Cow")
 }
 
 #[derive(Default, Clone)]
@@ -206,9 +174,7 @@ impl CustomTypeRegistry {
             .and_then(|name| self.by_name.get(name))
             .or_else(|| {
                 let shape = type_shape_key(ty);
-                self.by_remote_shape
-                    .get(&shape)
-                    .and_then(|name| self.by_name.get(name))
+                self.by_remote_shape.get(&shape).and_then(|name| self.by_name.get(name))
             })
             .or_else(|| type_last_segment(ty).and_then(|name| self.by_name.get(&name)))
     }
@@ -217,10 +183,7 @@ impl CustomTypeRegistry {
         match self.by_name.get(&entry.name) {
             None => {}
             Some(_) => {
-                return Err(syn::Error::new(
-                    Span::call_site(),
-                    format!("custom_type!: duplicate definition for `{}`", entry.name),
-                ));
+                return Err(syn::Error::new(Span::call_site(), format!("custom_type!: duplicate definition for `{}`", entry.name)));
             }
         }
 
@@ -229,10 +192,7 @@ impl CustomTypeRegistry {
             Some(existing) => {
                 return Err(syn::Error::new(
                     Span::call_site(),
-                    format!(
-                        "custom_type!: remote type already registered by `{}`",
-                        existing
-                    ),
+                    format!("custom_type!: remote type already registered by `{}`", existing),
                 ));
             }
         }
@@ -248,8 +208,7 @@ impl CustomTypeRegistry {
         let remote_shape = entry.remote_shape.clone();
 
         self.by_name.insert(name.clone(), entry);
-        self.by_remote_normalized
-            .insert(remote_normalized, name.clone());
+        self.by_remote_normalized.insert(remote_normalized, name.clone());
         self.by_remote_shape.entry(remote_shape).or_insert(name);
         Ok(())
     }
@@ -303,7 +262,6 @@ impl Parse for CustomTypeMacroSpec {
         })
     }
 }
-
 struct CustomTypeCollector<'a> {
     module_path: Vec<syn::Ident>,
     custom_types: &'a mut CustomTypeRegistry,
@@ -334,12 +292,7 @@ impl<'a> CustomTypeCollector<'a> {
     }
 
     fn collect_item_macro(&mut self, item_macro: &syn::ItemMacro) -> syn::Result<()> {
-        let is_custom_type = item_macro
-            .mac
-            .path
-            .segments
-            .last()
-            .is_some_and(|segment| segment.ident == "custom_type");
+        let is_custom_type = item_macro.mac.path.segments.last().is_some_and(|segment| segment.ident == "custom_type");
 
         if !is_custom_type {
             return Ok(());
@@ -367,8 +320,7 @@ impl<'a> CustomTypeCollector<'a> {
 static REGISTRY_CACHE: OnceLock<Mutex<HashMap<PathBuf, CustomTypeRegistry>>> = OnceLock::new();
 
 pub fn registry_for_current_crate() -> syn::Result<CustomTypeRegistry> {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
-        .map_err(|_| syn::Error::new(Span::call_site(), "CARGO_MANIFEST_DIR not set"))?;
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").map_err(|_| syn::Error::new(Span::call_site(), "CARGO_MANIFEST_DIR not set"))?;
     let manifest_dir = PathBuf::from(manifest_dir);
 
     let cache = REGISTRY_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
@@ -382,9 +334,7 @@ pub fn registry_for_current_crate() -> syn::Result<CustomTypeRegistry> {
     }
 
     let registry = build_registry(&manifest_dir)?;
-    let mut guard = cache
-        .lock()
-        .map_err(|_| syn::Error::new(Span::call_site(), "custom type registry lock poisoned"))?;
+    let mut guard = cache.lock().map_err(|_| syn::Error::new(Span::call_site(), "custom type registry lock poisoned"))?;
     guard.insert(manifest_dir, registry.clone());
     Ok(registry)
 }
@@ -396,12 +346,7 @@ fn build_registry(manifest_dir: &Path) -> syn::Result<CustomTypeRegistry> {
     let mut registry = CustomTypeRegistry::default();
     files.iter().try_for_each(|file_path| {
         let module_path = module_path_for_rs_file(&src_root, file_path)?;
-        let content = fs::read_to_string(file_path).map_err(|e| {
-            syn::Error::new(
-                Span::call_site(),
-                format!("read {}: {}", file_path.display(), e),
-            )
-        })?;
+        let content = fs::read_to_string(file_path).map_err(|e| syn::Error::new(Span::call_site(), format!("read {}: {}", file_path.display(), e)))?;
         let syntax = syn::parse_file(&content)?;
 
         let mut collector = CustomTypeCollector {
@@ -409,10 +354,7 @@ fn build_registry(manifest_dir: &Path) -> syn::Result<CustomTypeRegistry> {
             custom_types: &mut registry,
         };
 
-        syntax
-            .items
-            .iter()
-            .try_for_each(|item| collector.collect_item(item))
+        syntax.items.iter().try_for_each(|item| collector.collect_item(item))
     })?;
 
     Ok(registry)
@@ -425,35 +367,22 @@ fn list_rs_files(src_root: &Path) -> syn::Result<Vec<PathBuf>> {
 }
 
 fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) -> syn::Result<()> {
-    let entries = fs::read_dir(dir).map_err(|e| {
-        syn::Error::new(
-            Span::call_site(),
-            format!("read_dir {}: {}", dir.display(), e),
-        )
-    })?;
+    let entries = fs::read_dir(dir).map_err(|e| syn::Error::new(Span::call_site(), format!("read_dir {}: {}", dir.display(), e)))?;
 
-    entries
-        .filter_map(|entry| entry.ok())
-        .map(|entry| entry.path())
-        .try_for_each(|path| {
-            if path.is_dir() {
-                return collect_rs_files(&path, out);
-            }
-            if path.extension().is_some_and(|ext| ext == "rs") {
-                out.push(path);
-            }
-            Ok(())
-        })
+    entries.filter_map(|entry| entry.ok()).map(|entry| entry.path()).try_for_each(|path| {
+        if path.is_dir() {
+            return collect_rs_files(&path, out);
+        }
+        if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+        Ok(())
+    })
 }
 
 fn module_path_for_rs_file(src_root: &Path, file_path: &Path) -> syn::Result<Vec<syn::Ident>> {
-    let relative = file_path
-        .strip_prefix(src_root)
-        .map_err(|_| syn::Error::new(Span::call_site(), "path not under src"))?;
-    let mut parts = relative
-        .components()
-        .map(|c| c.as_os_str().to_string_lossy().to_string())
-        .collect::<Vec<_>>();
+    let relative = file_path.strip_prefix(src_root).map_err(|_| syn::Error::new(Span::call_site(), "path not under src"))?;
+    let mut parts = relative.components().map(|c| c.as_os_str().to_string_lossy().to_string()).collect::<Vec<_>>();
 
     let file_name = parts.pop().unwrap_or_default();
     let mut module_parts = parts;
@@ -468,11 +397,7 @@ fn module_path_for_rs_file(src_root: &Path, file_path: &Path) -> syn::Result<Vec
         _ => {}
     }
 
-    Ok(module_parts
-        .into_iter()
-        .filter(|p| !p.is_empty())
-        .map(|p| syn::Ident::new(&p, Span::call_site()))
-        .collect())
+    Ok(module_parts.into_iter().filter(|p| !p.is_empty()).map(|p| syn::Ident::new(&p, Span::call_site())).collect())
 }
 
 pub fn contains_custom_types(ty: &syn::Type, registry: &CustomTypeRegistry) -> bool {
@@ -494,11 +419,7 @@ pub fn contains_custom_types(ty: &syn::Type, registry: &CustomTypeRegistry) -> b
                     .is_some_and(|inner| contains_custom_types(inner, registry)),
                 "Result" => {
                     let mut args = angle_arg_types(&segment.arguments).into_iter();
-                    args.next()
-                        .is_some_and(|ok| contains_custom_types(ok, registry))
-                        || args
-                            .next()
-                            .is_some_and(|err| contains_custom_types(err, registry))
+                    args.next().is_some_and(|ok| contains_custom_types(ok, registry)) || args.next().is_some_and(|err| contains_custom_types(err, registry))
                 }
                 _ => false,
             }
@@ -564,11 +485,7 @@ fn type_arg(arg: &syn::GenericArgument) -> Option<&syn::Type> {
     }
 }
 
-pub fn to_wire_expr_owned(
-    ty: &syn::Type,
-    registry: &CustomTypeRegistry,
-    value_ident: &syn::Ident,
-) -> proc_macro2::TokenStream {
+pub fn to_wire_expr_owned(ty: &syn::Type, registry: &CustomTypeRegistry, value_ident: &syn::Ident) -> proc_macro2::TokenStream {
     if let Some(entry) = registry.lookup(ty) {
         let into_fn = entry.to_fn_path();
         return quote! { #into_fn(&#value_ident) };
@@ -629,11 +546,7 @@ pub fn to_wire_expr_owned(
     }
 }
 
-pub fn from_wire_expr_owned(
-    ty: &syn::Type,
-    registry: &CustomTypeRegistry,
-    value_ident: &syn::Ident,
-) -> proc_macro2::TokenStream {
+pub fn from_wire_expr_owned(ty: &syn::Type, registry: &CustomTypeRegistry, value_ident: &syn::Ident) -> proc_macro2::TokenStream {
     if let Some(entry) = registry.lookup(ty) {
         let try_from_fn = entry.try_from_fn_path();
         let error_message = format!("{}: custom type conversion failed", entry.name);
@@ -703,22 +616,13 @@ fn type_last_segment(ty: &syn::Type) -> Option<String> {
     let syn::Type::Path(type_path) = ty else {
         return None;
     };
-    type_path
-        .path
-        .segments
-        .last()
-        .map(|segment| segment.ident.to_string())
+    type_path.path.segments.last().map(|segment| segment.ident.to_string())
 }
 
 fn type_shape_key(ty: &syn::Type) -> String {
     match ty {
         syn::Type::Reference(reference) => type_shape_key(reference.elem.as_ref()),
-        syn::Type::Path(type_path) => type_path
-            .path
-            .segments
-            .last()
-            .map(shape_key_for_segment)
-            .unwrap_or_else(|| normalize_type(ty)),
+        syn::Type::Path(type_path) => type_path.path.segments.last().map(shape_key_for_segment).unwrap_or_else(|| normalize_type(ty)),
         _ => normalize_type(ty),
     }
 }
@@ -737,9 +641,5 @@ fn shape_key_for_segment(segment: &syn::PathSegment) -> String {
         _ => Vec::new(),
     };
 
-    if args.is_empty() {
-        ident.clone()
-    } else {
-        format!("{}<{}>", ident, args.join(","))
-    }
+    if args.is_empty() { ident.clone() } else { format!("{}<{}>", ident, args.join(",")) }
 }

--- a/boltffi_macros/src/data.rs
+++ b/boltffi_macros/src/data.rs
@@ -1,8 +1,6 @@
+use crate::{custom_types, wire_gen};
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-
-use crate::custom_types;
-use crate::wire_gen;
 
 pub fn data_impl(item: TokenStream) -> TokenStream {
     let item_clone = item.clone();
@@ -41,9 +39,7 @@ pub fn data_impl(item: TokenStream) -> TokenStream {
         if !has_repr {
             let has_data = item_enum.variants.iter().any(|v| !v.fields.is_empty());
             if has_data {
-                item_enum
-                    .attrs
-                    .insert(0, syn::parse_quote!(#[repr(C, i32)]));
+                item_enum.attrs.insert(0, syn::parse_quote!(#[repr(C, i32)]));
             } else {
                 item_enum.attrs.insert(0, syn::parse_quote!(#[repr(i32)]));
             }
@@ -61,19 +57,14 @@ pub fn data_impl(item: TokenStream) -> TokenStream {
         });
     }
 
-    syn::Error::new_spanned(
-        proc_macro2::TokenStream::from(item),
-        "data can only be applied to struct or enum",
-    )
-    .to_compile_error()
-    .into()
+    syn::Error::new_spanned(proc_macro2::TokenStream::from(item), "data can only be applied to struct or enum")
+        .to_compile_error()
+        .into()
 }
 
 fn is_boltffi_field_attr(attr: &syn::Attribute) -> bool {
     let path = attr.path();
-    path.segments.len() == 2
-        && path.segments[0].ident == "boltffi"
-        && path.segments[1].ident == "default"
+    path.segments.len() == 2 && path.segments[0].ident == "boltffi" && path.segments[1].ident == "default"
 }
 
 fn strip_boltffi_field_attrs(fields: &mut syn::Fields) {

--- a/boltffi_macros/src/export.rs
+++ b/boltffi_macros/src/export.rs
@@ -1,14 +1,13 @@
-use boltffi_ffi_rules::naming;
-use boltffi_ffi_rules::transport::EncodedReturnStrategy;
+use crate::{
+    callback_registry, custom_types,
+    params::{FfiParams, transform_params, transform_params_async},
+    returns::{ReturnAbi, classify_return, encoded_return_body, lower_return_abi},
+    safety,
+};
+use boltffi_ffi_rules::{naming, transport::EncodedReturnStrategy};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::ItemFn;
-
-use crate::callback_registry;
-use crate::custom_types;
-use crate::params::{FfiParams, transform_params, transform_params_async};
-use crate::returns::{ReturnAbi, classify_return, encoded_return_body, lower_return_abi};
-use crate::safety;
 
 fn build_encoded_return_exports(
     input: &ItemFn,
@@ -288,10 +287,7 @@ pub fn ffi_export_impl(item: TokenStream) -> TokenStream {
                     }
             }
         }
-        ReturnAbi::Encoded {
-            rust_type: inner_ty,
-            strategy,
-        } => {
+        ReturnAbi::Encoded { rust_type: inner_ty, strategy } => {
             let result_ident = syn::Ident::new("result", fn_name.span());
 
             if matches!(strategy, EncodedReturnStrategy::OptionScalar) {
@@ -319,14 +315,7 @@ pub fn ffi_export_impl(item: TokenStream) -> TokenStream {
                     ::boltffi::__private::FfiBuf::wire_encode(&#result_ident)
                 };
 
-                return build_f64_wasm_return_exports(
-                    &input,
-                    fn_vis,
-                    &export_ident,
-                    &ffi_params,
-                    wasm_body,
-                    native_body,
-                );
+                return build_f64_wasm_return_exports(&input, fn_vis, &export_ident, &ffi_params, wasm_body, native_body);
             }
 
             if matches!(strategy, EncodedReturnStrategy::PrimitiveVec) {
@@ -354,43 +343,19 @@ pub fn ffi_export_impl(item: TokenStream) -> TokenStream {
                     ::boltffi::__private::FfiBuf::wire_encode(&#result_ident)
                 };
 
-                return build_void_wasm_return_exports(
-                    &input,
-                    fn_vis,
-                    &export_ident,
-                    &ffi_params,
-                    wasm_body,
-                    native_body,
-                );
+                return build_void_wasm_return_exports(&input, fn_vis, &export_ident, &ffi_params, wasm_body, native_body);
             }
 
-            let encode_body = encoded_return_body(
-                &inner_ty,
-                strategy,
-                &result_ident,
-                quote! { #fn_name(#(#call_args),*) },
-                &conversions,
-                &custom_types,
-            );
+            let encode_body = encoded_return_body(&inner_ty, strategy, &result_ident, quote! { #fn_name(#(#call_args),*) }, &conversions, &custom_types);
 
-            return build_encoded_return_exports(
-                &input,
-                fn_vis,
-                &export_ident,
-                &ffi_params,
-                encode_body,
-            );
+            return build_encoded_return_exports(&input, fn_vis, &export_ident, &ffi_params, encode_body);
         }
     };
 
     TokenStream::from(expanded)
 }
 
-fn generate_async_export(
-    input: &ItemFn,
-    custom_types: &custom_types::CustomTypeRegistry,
-    callback_registry: &callback_registry::CallbackTraitRegistry,
-) -> TokenStream {
+fn generate_async_export(input: &ItemFn, custom_types: &custom_types::CustomTypeRegistry, callback_registry: &callback_registry::CallbackTraitRegistry) -> TokenStream {
     let fn_name = &input.sig.ident;
     let fn_inputs = &input.sig.inputs;
     let fn_output = &input.sig.output;
@@ -402,8 +367,7 @@ fn generate_async_export(
     let poll_ident = syn::Ident::new(&format!("{}_poll", base_name), fn_name.span());
     let poll_sync_ident = syn::Ident::new(&format!("{}_poll_sync", base_name), fn_name.span());
     let complete_ident = syn::Ident::new(&format!("{}_complete", base_name), fn_name.span());
-    let panic_message_ident =
-        syn::Ident::new(&format!("{}_panic_message", base_name), fn_name.span());
+    let panic_message_ident = syn::Ident::new(&format!("{}_panic_message", base_name), fn_name.span());
     let cancel_ident = syn::Ident::new(&format!("{}_cancel", base_name), fn_name.span());
     let free_ident = syn::Ident::new(&format!("{}_free", base_name), fn_name.span());
 

--- a/boltffi_macros/src/lib.rs
+++ b/boltffi_macros/src/lib.rs
@@ -20,18 +20,13 @@ mod wire_gen;
 pub fn derive_ffi_type(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    let has_repr_c = input.attrs.iter().any(|attr| {
-        attr.path().is_ident("repr")
-            && attr
-                .parse_args::<syn::Ident>()
-                .map(|id| id == "C")
-                .unwrap_or(false)
-    });
+    let has_repr_c = input
+        .attrs
+        .iter()
+        .any(|attr| attr.path().is_ident("repr") && attr.parse_args::<syn::Ident>().map(|id| id == "C").unwrap_or(false));
 
     if !has_repr_c {
-        return syn::Error::new_spanned(&input, "FfiType requires #[repr(C)]")
-            .to_compile_error()
-            .into();
+        return syn::Error::new_spanned(&input, "FfiType requires #[repr(C)]").to_compile_error().into();
     }
 
     TokenStream::from(quote! {})
@@ -40,6 +35,11 @@ pub fn derive_ffi_type(input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn ffi_export(_attr: TokenStream, item: TokenStream) -> TokenStream {
     export::ffi_export_impl(item)
+}
+
+#[proc_macro_attribute]
+pub fn ffi_async_iter(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
 }
 
 #[proc_macro_attribute]
@@ -98,12 +98,9 @@ pub fn export(attr: TokenStream, item: TokenStream) -> TokenStream {
         return ffi_trait(attr, TokenStream::from(quote!(#item_trait)));
     }
 
-    syn::Error::new_spanned(
-        proc_macro2::TokenStream::from(item),
-        "export can only be applied to fn, impl, or trait",
-    )
-    .to_compile_error()
-    .into()
+    syn::Error::new_spanned(proc_macro2::TokenStream::from(item), "export can only be applied to fn, impl, or trait")
+        .to_compile_error()
+        .into()
 }
 
 #[proc_macro_attribute]

--- a/boltffi_macros/src/params.rs
+++ b/boltffi_macros/src/params.rs
@@ -1,17 +1,12 @@
+use crate::{
+    callback_registry::CallbackTraitRegistry,
+    custom_types::{CustomTypeRegistry, contains_custom_types, from_wire_expr_owned, to_wire_expr_owned, wire_type_for},
+    util::{ParamTransform, WireEncodedParam, WireEncodedParamKind, classify_param_transform, foreign_trait_path, is_primitive_vec_inner, len_ident, ptr_ident},
+};
+use boltffi_ffi_rules::callback as cb_naming;
 use proc_macro2::Span;
 use quote::quote;
 use syn::{FnArg, Pat};
-
-use crate::callback_registry::CallbackTraitRegistry;
-use crate::custom_types::{
-    CustomTypeRegistry, contains_custom_types, from_wire_expr_owned, to_wire_expr_owned,
-    wire_type_for,
-};
-use crate::util::{
-    ParamTransform, WireEncodedParam, WireEncodedParamKind, classify_param_transform,
-    foreign_trait_path, is_primitive_vec_inner, len_ident, ptr_ident,
-};
-use boltffi_ffi_rules::callback as cb_naming;
 
 fn generate_wasm_closure_codegen(
     name: &syn::Ident,
@@ -56,8 +51,7 @@ fn generate_wasm_closure_codegen(
                 let wire_name = syn::Ident::new(&format!("__wire{}", index), name.span());
                 let wire_var = if contains_custom_types(arg_ty, custom_types) {
                     let wire_ty = wire_type_for(arg_ty, custom_types);
-                    let wire_value_ident =
-                        syn::Ident::new(&format!("__wire_value{}", index), name.span());
+                    let wire_value_ident = syn::Ident::new(&format!("__wire_value{}", index), name.span());
                     let to_wire = to_wire_expr_owned(arg_ty, custom_types, &arg_name);
                     quote! {
                         let #wire_value_ident: #wire_ty = { #to_wire };
@@ -68,28 +62,17 @@ fn generate_wasm_closure_codegen(
                         let #wire_name = ::boltffi::__private::wire::encode(&#arg_name);
                     }
                 };
-                (
-                    arg_name,
-                    wire_var,
-                    quote! { #wire_name.as_ptr(), #wire_name.len() },
-                )
+                (arg_name, wire_var, quote! { #wire_name.as_ptr(), #wire_name.len() })
             }
         })
-        .fold(
-            (vec![], vec![], vec![]),
-            |(mut names, mut vars, mut args), (n, v, a)| {
-                names.push(n);
-                vars.push(v);
-                args.push(a);
-                (names, vars, args)
-            },
-        );
+        .fold((vec![], vec![], vec![]), |(mut names, mut vars, mut args), (n, v, a)| {
+            names.push(n);
+            vars.push(v);
+            args.push(a);
+            (names, vars, args)
+        });
 
-    let closure_params: Vec<proc_macro2::TokenStream> = arg_names
-        .iter()
-        .zip(arg_types.iter())
-        .map(|(n, t)| quote! { #n: #t })
-        .collect();
+    let closure_params: Vec<proc_macro2::TokenStream> = arg_names.iter().zip(arg_types.iter()).map(|(n, t)| quote! { #n: #t }).collect();
 
     let closure_params_tokens = if closure_params.is_empty() {
         quote! {}
@@ -148,8 +131,7 @@ fn generate_wasm_closure_codegen(
         let from_wire = if contains_custom_types(return_ty, custom_types) {
             let wire_ty = wire_type_for(return_ty, custom_types);
             let wire_result_ident = syn::Ident::new("__wire_result", name.span());
-            let from_wire_conversion =
-                from_wire_expr_owned(return_ty, custom_types, &wire_result_ident);
+            let from_wire_conversion = from_wire_expr_owned(return_ty, custom_types, &wire_result_ident);
             quote! {
                 let #wire_result_ident: #wire_ty = ::boltffi::__private::wire::decode(__result_bytes)
                     .expect("closure return: wire decode failed");
@@ -196,10 +178,7 @@ struct ImplTraitResolution {
     error: Option<proc_macro2::TokenStream>,
 }
 
-fn impl_trait_resolution(
-    trait_path: &syn::Path,
-    callback_registry: &CallbackTraitRegistry,
-) -> ImplTraitResolution {
+fn impl_trait_resolution(trait_path: &syn::Path, callback_registry: &CallbackTraitRegistry) -> ImplTraitResolution {
     if let Some(resolution) = callback_registry.resolve(trait_path) {
         let foreign_path = resolution.foreign_path;
         if resolution.is_object_safe {
@@ -229,11 +208,7 @@ fn impl_trait_resolution(
     }
 }
 
-fn wire_bytes_expression(
-    ptr_name: &syn::Ident,
-    len_name: &syn::Ident,
-    requires_unsafe: bool,
-) -> proc_macro2::TokenStream {
+fn wire_bytes_expression(ptr_name: &syn::Ident, len_name: &syn::Ident, requires_unsafe: bool) -> proc_macro2::TokenStream {
     if requires_unsafe {
         quote! { unsafe { ::core::slice::from_raw_parts(#ptr_name, #len_name) } }
     } else {
@@ -241,12 +216,7 @@ fn wire_bytes_expression(
     }
 }
 
-fn utf8_str_expression(
-    name: &syn::Ident,
-    ptr_name: &syn::Ident,
-    len_name: &syn::Ident,
-    requires_unsafe: bool,
-) -> proc_macro2::TokenStream {
+fn utf8_str_expression(name: &syn::Ident, ptr_name: &syn::Ident, len_name: &syn::Ident, requires_unsafe: bool) -> proc_macro2::TokenStream {
     let bytes_expr = wire_bytes_expression(ptr_name, len_name, requires_unsafe);
     quote! {
         match ::core::str::from_utf8(#bytes_expr) {
@@ -264,12 +234,7 @@ fn utf8_str_expression(
     }
 }
 
-fn utf8_string_expression(
-    name: &syn::Ident,
-    ptr_name: &syn::Ident,
-    len_name: &syn::Ident,
-    requires_unsafe: bool,
-) -> proc_macro2::TokenStream {
+fn utf8_string_expression(name: &syn::Ident, ptr_name: &syn::Ident, len_name: &syn::Ident, requires_unsafe: bool) -> proc_macro2::TokenStream {
     let bytes_expr = wire_bytes_expression(ptr_name, len_name, requires_unsafe);
     quote! {
         match ::core::str::from_utf8(#bytes_expr) {
@@ -417,14 +382,7 @@ fn push_wire_encoded_param(
     let len_name = len_ident(name);
     ffi_params.push(quote! { #ptr_name: *const u8 });
     ffi_params.push(quote! { #len_name: usize });
-    conversions.push(wire_decode_conversion(
-        name,
-        wire_param,
-        &ptr_name,
-        &len_name,
-        custom_types,
-        requires_unsafe,
-    ));
+    conversions.push(wire_decode_conversion(name, wire_param, &ptr_name, &len_name, custom_types, requires_unsafe));
 }
 
 pub struct AsyncFfiParams {
@@ -445,15 +403,9 @@ enum UnsupportedAsyncParam {
 impl UnsupportedAsyncParam {
     fn error_message(self) -> &'static str {
         match self {
-            Self::Callback => {
-                "boltffi: async exports do not support closure callback parameters yet"
-            }
-            Self::MutableSlice => {
-                "boltffi: async exports do not support mutable slice parameters (`&mut [T]`)"
-            }
-            Self::TraitObject => {
-                "boltffi: async exports do not support trait object callback parameters (`Box<dyn Trait>`, `Arc<dyn Trait>`, `Option<Arc<dyn Trait>>`) yet"
-            }
+            Self::Callback => "boltffi: async exports do not support closure callback parameters yet",
+            Self::MutableSlice => "boltffi: async exports do not support mutable slice parameters (`&mut [T]`)",
+            Self::TraitObject => "boltffi: async exports do not support trait object callback parameters (`Box<dyn Trait>`, `Arc<dyn Trait>`, `Option<Arc<dyn Trait>>`) yet",
         }
     }
 }
@@ -462,9 +414,7 @@ fn unsupported_async_param(transform: &ParamTransform) -> Option<UnsupportedAsyn
     match transform {
         ParamTransform::Callback { .. } => Some(UnsupportedAsyncParam::Callback),
         ParamTransform::SliceMut(_) => Some(UnsupportedAsyncParam::MutableSlice),
-        ParamTransform::BoxedDynTrait(_)
-        | ParamTransform::ArcDynTrait(_)
-        | ParamTransform::OptionArcDynTrait(_) => Some(UnsupportedAsyncParam::TraitObject),
+        ParamTransform::BoxedDynTrait(_) | ParamTransform::ArcDynTrait(_) | ParamTransform::OptionArcDynTrait(_) => Some(UnsupportedAsyncParam::TraitObject),
         ParamTransform::StrRef
         | ParamTransform::OwnedString
         | ParamTransform::SliceRef(_)
@@ -475,9 +425,7 @@ fn unsupported_async_param(transform: &ParamTransform) -> Option<UnsupportedAsyn
     }
 }
 
-fn validate_async_params(
-    inputs: &syn::punctuated::Punctuated<FnArg, syn::Token![,]>,
-) -> syn::Result<()> {
+fn validate_async_params(inputs: &syn::punctuated::Punctuated<FnArg, syn::Token![,]>) -> syn::Result<()> {
     inputs
         .iter()
         .filter_map(|arg| match arg {
@@ -486,9 +434,7 @@ fn validate_async_params(
         })
         .filter_map(|pat_type| {
             let param_transform = classify_param_transform(&pat_type.ty);
-            unsupported_async_param(&param_transform).map(|unsupported| {
-                syn::Error::new_spanned(&pat_type.ty, unsupported.error_message())
-            })
+            unsupported_async_param(&param_transform).map(|unsupported| syn::Error::new_spanned(&pat_type.ty, unsupported.error_message()))
         })
         .reduce(|mut left, right| {
             left.combine(right);
@@ -568,8 +514,7 @@ fn lower_callback_param_transform(
                         ffi_cb_args.push(quote! { usize });
                         let wire_vars_expr = if contains_custom_types(arg_ty, custom_types) {
                             let wire_ty = wire_type_for(arg_ty, custom_types);
-                            let wire_value_ident =
-                                syn::Ident::new(&format!("__wire_value{}", index), name.span());
+                            let wire_value_ident = syn::Ident::new(&format!("__wire_value{}", index), name.span());
                             let to_wire = to_wire_expr_owned(arg_ty, custom_types, &arg_name);
                             quote! {
                                 let #wire_value_ident: #wire_ty = { #to_wire };
@@ -590,20 +535,10 @@ fn lower_callback_param_transform(
                 },
             );
 
-            let ffi_return_type = returns
-                .as_ref()
-                .map(|ty| quote! { -> #ty })
-                .unwrap_or_default();
-            let closure_return_type = returns
-                .as_ref()
-                .map(|ty| quote! { -> #ty })
-                .unwrap_or_default();
+            let ffi_return_type = returns.as_ref().map(|ty| quote! { -> #ty }).unwrap_or_default();
+            let closure_return_type = returns.as_ref().map(|ty| quote! { -> #ty }).unwrap_or_default();
 
-            let closure_params: Vec<proc_macro2::TokenStream> = arg_names
-                .iter()
-                .zip(arg_types.iter())
-                .map(|(n, t)| quote! { #n: #t })
-                .collect();
+            let closure_params: Vec<proc_macro2::TokenStream> = arg_names.iter().zip(arg_types.iter()).map(|(n, t)| quote! { #n: #t }).collect();
 
             acc.ffi_params.push(quote! {
                 #[cfg(not(target_arch = "wasm32"))]
@@ -614,13 +549,7 @@ fn lower_callback_param_transform(
                 #name: u32
             });
 
-            let wasm_codegen = generate_wasm_closure_codegen(
-                name,
-                arg_types,
-                returns.as_ref(),
-                &ffi_cb_args,
-                custom_types,
-            );
+            let wasm_codegen = generate_wasm_closure_codegen(name, arg_types, returns.as_ref(), &ffi_cb_args, custom_types);
 
             acc.setup.push(quote! {
                 #[cfg(not(target_arch = "wasm32"))]
@@ -636,13 +565,7 @@ fn lower_callback_param_transform(
     }
 }
 
-fn lower_impl_trait_param_transform(
-    acc: &mut ParamLoweringState,
-    name: &syn::Ident,
-    trait_path: &syn::Path,
-    mode: ParamExecutionMode,
-    callback_registry: &CallbackTraitRegistry,
-) {
+fn lower_impl_trait_param_transform(acc: &mut ParamLoweringState, name: &syn::Ident, trait_path: &syn::Path, mode: ParamExecutionMode, callback_registry: &CallbackTraitRegistry) {
     let resolution = impl_trait_resolution(trait_path, callback_registry);
     let foreign_type = resolution.foreign_type;
 
@@ -689,11 +612,7 @@ fn lower_impl_trait_param_transform(
     }
 }
 
-fn lower_str_ref_param_transform(
-    acc: &mut ParamLoweringState,
-    name: &syn::Ident,
-    mode: ParamExecutionMode,
-) {
+fn lower_str_ref_param_transform(acc: &mut ParamLoweringState, name: &syn::Ident, mode: ParamExecutionMode) {
     let ptr_name = ptr_ident(name);
     let len_name = len_ident(name);
     let sync_str_expr = utf8_str_expression(name, &ptr_name, &len_name, false);
@@ -730,11 +649,7 @@ fn lower_str_ref_param_transform(
     acc.call_args.push(quote! { #name });
 }
 
-fn lower_owned_string_param_transform(
-    acc: &mut ParamLoweringState,
-    name: &syn::Ident,
-    mode: ParamExecutionMode,
-) {
+fn lower_owned_string_param_transform(acc: &mut ParamLoweringState, name: &syn::Ident, mode: ParamExecutionMode) {
     let ptr_name = ptr_ident(name);
     let len_name = len_ident(name);
     let sync_string_expr = utf8_string_expression(name, &ptr_name, &len_name, false);
@@ -767,12 +682,7 @@ fn lower_owned_string_param_transform(
     acc.call_args.push(quote! { #name });
 }
 
-fn lower_slice_ref_param_transform(
-    acc: &mut ParamLoweringState,
-    name: &syn::Ident,
-    inner_ty: &syn::Type,
-    mode: ParamExecutionMode,
-) {
+fn lower_slice_ref_param_transform(acc: &mut ParamLoweringState, name: &syn::Ident, inner_ty: &syn::Type, mode: ParamExecutionMode) {
     let ptr_name = ptr_ident(name);
     let len_name = len_ident(name);
     acc.ffi_params.push(quote! { #ptr_name: *const #inner_ty });
@@ -807,12 +717,7 @@ fn lower_slice_ref_param_transform(
     acc.call_args.push(quote! { #name });
 }
 
-fn lower_slice_mut_param_transform(
-    acc: &mut ParamLoweringState,
-    name: &syn::Ident,
-    inner_ty: &syn::Type,
-    mode: ParamExecutionMode,
-) {
+fn lower_slice_mut_param_transform(acc: &mut ParamLoweringState, name: &syn::Ident, inner_ty: &syn::Type, mode: ParamExecutionMode) {
     match mode {
         ParamExecutionMode::Sync => {
             let ptr_name = ptr_ident(name);
@@ -834,12 +739,7 @@ fn lower_slice_mut_param_transform(
     }
 }
 
-fn lower_vec_primitive_param_transform(
-    acc: &mut ParamLoweringState,
-    name: &syn::Ident,
-    inner_ty: &syn::Type,
-    mode: ParamExecutionMode,
-) {
+fn lower_vec_primitive_param_transform(acc: &mut ParamLoweringState, name: &syn::Ident, inner_ty: &syn::Type, mode: ParamExecutionMode) {
     let ptr_name = ptr_ident(name);
     let len_name = len_ident(name);
     acc.ffi_params.push(quote! { #ptr_name: *const #inner_ty });
@@ -870,21 +770,8 @@ fn lower_vec_primitive_param_transform(
     acc.call_args.push(quote! { #name });
 }
 
-fn lower_wire_encoded_param_transform(
-    acc: &mut ParamLoweringState,
-    name: &syn::Ident,
-    wire_param: &WireEncodedParam,
-    custom_types: &CustomTypeRegistry,
-    mode: ParamExecutionMode,
-) {
-    push_wire_encoded_param(
-        &mut acc.ffi_params,
-        &mut acc.setup,
-        name,
-        wire_param,
-        custom_types,
-        mode.requires_unsafe_wire_decode(),
-    );
+fn lower_wire_encoded_param_transform(acc: &mut ParamLoweringState, name: &syn::Ident, wire_param: &WireEncodedParam, custom_types: &CustomTypeRegistry, mode: ParamExecutionMode) {
+    push_wire_encoded_param(&mut acc.ffi_params, &mut acc.setup, name, wire_param, custom_types, mode.requires_unsafe_wire_decode());
     if matches!(mode, ParamExecutionMode::Async) {
         acc.move_vars.push(name.clone());
     }
@@ -898,13 +785,7 @@ enum TraitObjectParamKind {
     OptionArc,
 }
 
-fn lower_trait_object_param_transform(
-    acc: &mut ParamLoweringState,
-    name: &syn::Ident,
-    trait_path: &syn::Path,
-    mode: ParamExecutionMode,
-    kind: TraitObjectParamKind,
-) {
+fn lower_trait_object_param_transform(acc: &mut ParamLoweringState, name: &syn::Ident, trait_path: &syn::Path, mode: ParamExecutionMode, kind: TraitObjectParamKind) {
     match mode {
         ParamExecutionMode::Async => {
             unreachable!("async trait object params are rejected during macro validation");
@@ -953,12 +834,7 @@ fn lower_trait_object_param_transform(
     }
 }
 
-fn lower_pass_through_param_transform(
-    acc: &mut ParamLoweringState,
-    name: &syn::Ident,
-    ty: &syn::Type,
-    mode: ParamExecutionMode,
-) {
+fn lower_pass_through_param_transform(acc: &mut ParamLoweringState, name: &syn::Ident, ty: &syn::Type, mode: ParamExecutionMode) {
     acc.ffi_params.push(quote! { #name: #ty });
     if matches!(mode, ParamExecutionMode::Async) {
         acc.move_vars.push(name.clone());
@@ -996,73 +872,19 @@ fn transform_params_with_mode(
 
                 match classify_param_transform(&pat_type.ty) {
                     ParamTransform::StrRef => lower_str_ref_param_transform(&mut acc, &name, mode),
-                    ParamTransform::OwnedString => {
-                        lower_owned_string_param_transform(&mut acc, &name, mode)
-                    }
-                    ParamTransform::Callback {
-                        params: arg_types,
-                        returns,
-                    } => lower_callback_param_transform(
-                        &mut acc,
-                        &name,
-                        &arg_types,
-                        &returns,
-                        mode,
-                        custom_types,
-                    ),
-                    ParamTransform::SliceRef(inner_ty) => {
-                        lower_slice_ref_param_transform(&mut acc, &name, &inner_ty, mode)
-                    }
-                    ParamTransform::SliceMut(inner_ty) => {
-                        lower_slice_mut_param_transform(&mut acc, &name, &inner_ty, mode)
-                    }
-                    ParamTransform::BoxedDynTrait(trait_path) => {
-                        lower_trait_object_param_transform(
-                            &mut acc,
-                            &name,
-                            &trait_path,
-                            mode,
-                            TraitObjectParamKind::Boxed,
-                        )
-                    }
-                    ParamTransform::ArcDynTrait(trait_path) => lower_trait_object_param_transform(
-                        &mut acc,
-                        &name,
-                        &trait_path,
-                        mode,
-                        TraitObjectParamKind::Arc,
-                    ),
-                    ParamTransform::OptionArcDynTrait(trait_path) => {
-                        lower_trait_object_param_transform(
-                            &mut acc,
-                            &name,
-                            &trait_path,
-                            mode,
-                            TraitObjectParamKind::OptionArc,
-                        )
-                    }
-                    ParamTransform::VecPrimitive(inner_ty) => {
-                        lower_vec_primitive_param_transform(&mut acc, &name, &inner_ty, mode)
-                    }
-                    ParamTransform::WireEncoded(wire_param) => lower_wire_encoded_param_transform(
-                        &mut acc,
-                        &name,
-                        &wire_param,
-                        custom_types,
-                        mode,
-                    ),
+                    ParamTransform::OwnedString => lower_owned_string_param_transform(&mut acc, &name, mode),
+                    ParamTransform::Callback { params: arg_types, returns } => lower_callback_param_transform(&mut acc, &name, &arg_types, &returns, mode, custom_types),
+                    ParamTransform::SliceRef(inner_ty) => lower_slice_ref_param_transform(&mut acc, &name, &inner_ty, mode),
+                    ParamTransform::SliceMut(inner_ty) => lower_slice_mut_param_transform(&mut acc, &name, &inner_ty, mode),
+                    ParamTransform::BoxedDynTrait(trait_path) => lower_trait_object_param_transform(&mut acc, &name, &trait_path, mode, TraitObjectParamKind::Boxed),
+                    ParamTransform::ArcDynTrait(trait_path) => lower_trait_object_param_transform(&mut acc, &name, &trait_path, mode, TraitObjectParamKind::Arc),
+                    ParamTransform::OptionArcDynTrait(trait_path) => lower_trait_object_param_transform(&mut acc, &name, &trait_path, mode, TraitObjectParamKind::OptionArc),
+                    ParamTransform::VecPrimitive(inner_ty) => lower_vec_primitive_param_transform(&mut acc, &name, &inner_ty, mode),
+                    ParamTransform::WireEncoded(wire_param) => lower_wire_encoded_param_transform(&mut acc, &name, &wire_param, custom_types, mode),
                     ParamTransform::ImplTrait(trait_path) => {
-                        lower_impl_trait_param_transform(
-                            &mut acc,
-                            &name,
-                            &trait_path,
-                            mode,
-                            callback_registry,
-                        );
+                        lower_impl_trait_param_transform(&mut acc, &name, &trait_path, mode, callback_registry);
                     }
-                    ParamTransform::PassThrough => {
-                        lower_pass_through_param_transform(&mut acc, &name, &pat_type.ty, mode)
-                    }
+                    ParamTransform::PassThrough => lower_pass_through_param_transform(&mut acc, &name, &pat_type.ty, mode),
                 }
 
                 acc
@@ -1070,18 +892,8 @@ fn transform_params_with_mode(
         )
 }
 
-pub fn transform_params(
-    inputs: &syn::punctuated::Punctuated<FnArg, syn::Token![,]>,
-    custom_types: &CustomTypeRegistry,
-    callback_registry: &CallbackTraitRegistry,
-) -> FfiParams {
-    transform_params_with_mode(
-        inputs,
-        custom_types,
-        callback_registry,
-        ParamExecutionMode::Sync,
-    )
-    .into_sync()
+pub fn transform_params(inputs: &syn::punctuated::Punctuated<FnArg, syn::Token![,]>, custom_types: &CustomTypeRegistry, callback_registry: &CallbackTraitRegistry) -> FfiParams {
+    transform_params_with_mode(inputs, custom_types, callback_registry, ParamExecutionMode::Sync).into_sync()
 }
 
 pub fn transform_params_async(
@@ -1090,20 +902,10 @@ pub fn transform_params_async(
     callback_registry: &CallbackTraitRegistry,
 ) -> syn::Result<AsyncFfiParams> {
     validate_async_params(inputs)?;
-    Ok(transform_params_with_mode(
-        inputs,
-        custom_types,
-        callback_registry,
-        ParamExecutionMode::Async,
-    )
-    .into_async())
+    Ok(transform_params_with_mode(inputs, custom_types, callback_registry, ParamExecutionMode::Async).into_async())
 }
 
-pub fn transform_method_params(
-    inputs: impl Iterator<Item = syn::FnArg>,
-    custom_types: &CustomTypeRegistry,
-    callback_registry: &CallbackTraitRegistry,
-) -> FfiParams {
+pub fn transform_method_params(inputs: impl Iterator<Item = syn::FnArg>, custom_types: &CustomTypeRegistry, callback_registry: &CallbackTraitRegistry) -> FfiParams {
     let function_like_inputs: syn::punctuated::Punctuated<FnArg, syn::Token![,]> = inputs.collect();
     transform_params(&function_like_inputs, custom_types, callback_registry)
 }
@@ -1129,11 +931,7 @@ mod tests {
         };
 
         let error = validate_async_params(&function.sig.inputs).expect_err("expected rejection");
-        assert!(
-            error
-                .to_string()
-                .contains("do not support closure callback parameters yet")
-        );
+        assert!(error.to_string().contains("do not support closure callback parameters yet"));
     }
 
     #[test]
@@ -1143,11 +941,7 @@ mod tests {
         };
 
         let error = validate_async_params(&function.sig.inputs).expect_err("expected rejection");
-        assert!(
-            error
-                .to_string()
-                .contains("do not support mutable slice parameters")
-        );
+        assert!(error.to_string().contains("do not support mutable slice parameters"));
     }
 
     #[test]
@@ -1161,11 +955,7 @@ mod tests {
         };
 
         let error = validate_async_params(&function.sig.inputs).expect_err("expected rejection");
-        assert!(
-            error
-                .to_string()
-                .contains("do not support trait object callback parameters")
-        );
+        assert!(error.to_string().contains("do not support trait object callback parameters"));
     }
 
     #[test]

--- a/boltffi_macros/src/returns.rs
+++ b/boltffi_macros/src/returns.rs
@@ -1,9 +1,8 @@
+use crate::custom_types;
 pub use boltffi_ffi_rules::transport::EncodedReturnStrategy;
 use proc_macro2::Span;
 use quote::quote;
 use syn::{ReturnType, Type};
-
-use crate::custom_types;
 
 pub enum OptionReturnAbi {
     OutValue { inner: syn::Type },
@@ -26,13 +25,8 @@ pub enum ReturnKind {
 
 pub enum ReturnAbi {
     Unit,
-    Scalar {
-        rust_type: syn::Type,
-    },
-    Encoded {
-        rust_type: syn::Type,
-        strategy: EncodedReturnStrategy,
-    },
+    Scalar { rust_type: syn::Type },
+    Encoded { rust_type: syn::Type, strategy: EncodedReturnStrategy },
 }
 
 pub fn extract_vec_inner(ty: &Type) -> Option<syn::Type> {
@@ -49,11 +43,7 @@ pub fn extract_vec_inner(ty: &Type) -> Option<syn::Type> {
 
 fn is_string_like_type(ty: &Type) -> bool {
     match ty {
-        Type::Path(path) => path
-            .path
-            .segments
-            .last()
-            .is_some_and(|s| s.ident == "String"),
+        Type::Path(path) => path.path.segments.last().is_some_and(|s| s.ident == "String"),
         Type::Reference(reference) => match reference.elem.as_ref() {
             Type::Path(path) => path.path.segments.last().is_some_and(|s| s.ident == "str"),
             _ => false,
@@ -65,19 +55,7 @@ fn is_string_like_type(ty: &Type) -> bool {
 pub fn is_primitive_type(s: &str) -> bool {
     matches!(
         s,
-        "i8" | "i16"
-            | "i32"
-            | "i64"
-            | "u8"
-            | "u16"
-            | "u32"
-            | "u64"
-            | "f32"
-            | "f64"
-            | "bool"
-            | "usize"
-            | "isize"
-            | "()"
+        "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "f32" | "f64" | "bool" | "usize" | "isize" | "()"
     )
 }
 
@@ -106,13 +84,9 @@ pub fn classify_return(output: &ReturnType) -> ReturnKind {
                 {
                     let ok_str = quote!(#ok_ty).to_string().replace(' ', "");
                     if ok_str == "String" || ok_str == "std::string::String" {
-                        return ReturnKind::ResultString {
-                            err: err_ty.clone(),
-                        };
+                        return ReturnKind::ResultString { err: err_ty.clone() };
                     } else if ok_str == "()" {
-                        return ReturnKind::ResultUnit {
-                            err: err_ty.clone(),
-                        };
+                        return ReturnKind::ResultUnit { err: err_ty.clone() };
                     } else {
                         return ReturnKind::ResultPrimitive {
                             ok: ok_ty.clone(),
@@ -132,9 +106,7 @@ pub fn classify_return(output: &ReturnType) -> ReturnKind {
                         return ReturnKind::Option(OptionReturnAbi::OutFfiString);
                     }
 
-                    return ReturnKind::Option(OptionReturnAbi::OutValue {
-                        inner: inner_ty.clone(),
-                    });
+                    return ReturnKind::Option(OptionReturnAbi::OutValue { inner: inner_ty.clone() });
                 }
             }
 
@@ -181,12 +153,10 @@ pub fn lower_return_abi(kind: ReturnKind) -> ReturnAbi {
             },
         },
         ReturnKind::Option(abi) => match abi {
-            OptionReturnAbi::OutValue { inner } if type_is_primitive(&inner) => {
-                ReturnAbi::Encoded {
-                    rust_type: syn::parse_quote!(Option<#inner>),
-                    strategy: EncodedReturnStrategy::OptionScalar,
-                }
-            }
+            OptionReturnAbi::OutValue { inner } if type_is_primitive(&inner) => ReturnAbi::Encoded {
+                rust_type: syn::parse_quote!(Option<#inner>),
+                strategy: EncodedReturnStrategy::OptionScalar,
+            },
             other => ReturnAbi::Encoded {
                 rust_type: option_rust_type(other),
                 strategy: EncodedReturnStrategy::WireEncoded,
@@ -252,18 +222,10 @@ impl ReturnAbi {
                 if !out_status.is_null() { *out_status = ::boltffi::__private::FfiStatus::OK; }
                 result
             },
-            Self::Encoded {
-                rust_type,
-                strategy,
-            } => {
+            Self::Encoded { rust_type, strategy } => {
                 let registry = custom_types::registry_for_current_crate().ok();
                 let result_ident = syn::Ident::new("result", Span::call_site());
-                let encode_expression = encoded_return_buffer_expression(
-                    rust_type,
-                    *strategy,
-                    &result_ident,
-                    registry.as_ref(),
-                );
+                let encode_expression = encoded_return_buffer_expression(rust_type, *strategy, &result_ident, registry.as_ref());
                 quote! {
                     if !out_status.is_null() { *out_status = ::boltffi::__private::FfiStatus::OK; }
                     #encode_expression
@@ -289,12 +251,7 @@ pub fn encoded_return_body(
     conversions: &[proc_macro2::TokenStream],
     custom_type_registry: &custom_types::CustomTypeRegistry,
 ) -> proc_macro2::TokenStream {
-    let encode_expression = encoded_return_buffer_expression(
-        rust_type,
-        strategy,
-        result_ident,
-        Some(custom_type_registry),
-    );
+    let encode_expression = encoded_return_buffer_expression(rust_type, strategy, result_ident, Some(custom_type_registry));
 
     quote! {
         #(#conversions)*
@@ -326,17 +283,11 @@ fn encoded_return_buffer_expression(
         EncodedReturnStrategy::OptionScalar | EncodedReturnStrategy::ResultScalar => quote! {
             ::boltffi::__private::FfiBuf::wire_encode(&#result_ident)
         },
-        EncodedReturnStrategy::WireEncoded => {
-            wire_encode_expression(rust_type, result_ident, custom_type_registry)
-        }
+        EncodedReturnStrategy::WireEncoded => wire_encode_expression(rust_type, result_ident, custom_type_registry),
     }
 }
 
-fn wire_encode_expression(
-    rust_type: &syn::Type,
-    result_ident: &syn::Ident,
-    custom_type_registry: Option<&custom_types::CustomTypeRegistry>,
-) -> proc_macro2::TokenStream {
+fn wire_encode_expression(rust_type: &syn::Type, result_ident: &syn::Ident, custom_type_registry: Option<&custom_types::CustomTypeRegistry>) -> proc_macro2::TokenStream {
     match custom_type_registry {
         Some(registry) if custom_types::contains_custom_types(rust_type, registry) => {
             let wire_ty = custom_types::wire_type_for(rust_type, registry);

--- a/boltffi_macros/src/safety.rs
+++ b/boltffi_macros/src/safety.rs
@@ -1,7 +1,5 @@
 use proc_macro2::Span;
-use syn::spanned::Spanned;
-use syn::visit::Visit;
-use syn::{Expr, ExprPath, ExprUnsafe, ItemFn, Path, Type};
+use syn::{Expr, ExprPath, ExprUnsafe, ItemFn, Path, Type, spanned::Spanned, visit::Visit};
 
 #[derive(Debug)]
 pub struct SafetyViolation {
@@ -28,9 +26,7 @@ impl ViolationKind {
             Self::UnsafeBlock => "unsafe blocks are not allowed in #[boltffi::export] functions",
             Self::MemForget => "mem::forget is not allowed - it can violate ownership semantics",
             Self::MemTransmute => "mem::transmute is not allowed - it can violate type safety",
-            Self::RawPointerType => {
-                "raw pointer types (*const/*mut) are not allowed - use safe references"
-            }
+            Self::RawPointerType => "raw pointer types (*const/*mut) are not allowed - use safe references",
             Self::BoxIntoRaw => "Box::into_raw is not allowed - ownership must flow through return",
             Self::BoxLeak => "Box::leak is not allowed - it creates untracked references",
             Self::VecIntoRawParts => "Vec::into_raw_parts is not allowed - use normal Vec returns",
@@ -51,9 +47,7 @@ struct SafetyScanner {
 
 impl SafetyScanner {
     fn new() -> Self {
-        Self {
-            violations: Vec::new(),
-        }
+        Self { violations: Vec::new() }
     }
 
     fn add_violation(&mut self, span: Span, kind: ViolationKind) {
@@ -118,12 +112,7 @@ impl SafetyScanner {
                 self.add_violation(ptr.span(), ViolationKind::RawPointerType);
             }
             Type::Path(type_path) => {
-                let segments: Vec<_> = type_path
-                    .path
-                    .segments
-                    .iter()
-                    .map(|s| s.ident.to_string())
-                    .collect();
+                let segments: Vec<_> = type_path.path.segments.iter().map(|s| s.ident.to_string()).collect();
 
                 if segments.iter().any(|s| s == "ManuallyDrop") {
                     self.add_violation(type_path.span(), ViolationKind::ManuallyDrop);
@@ -183,10 +172,7 @@ pub fn scan_function(func: &ItemFn) -> Vec<SafetyViolation> {
 }
 
 pub fn violations_to_compile_errors(violations: &[SafetyViolation]) -> proc_macro2::TokenStream {
-    violations
-        .iter()
-        .map(|v| v.kind.to_compile_error(v.span))
-        .collect()
+    violations.iter().map(|v| v.kind.to_compile_error(v.span)).collect()
 }
 
 #[cfg(test)]
@@ -233,11 +219,7 @@ mod tests {
             }
         "#,
         );
-        assert!(
-            violations
-                .iter()
-                .any(|v| matches!(v.kind, ViolationKind::MemForget))
-        );
+        assert!(violations.iter().any(|v| matches!(v.kind, ViolationKind::MemForget)));
     }
 
     #[test]
@@ -249,11 +231,7 @@ mod tests {
             }
         "#,
         );
-        assert!(
-            violations
-                .iter()
-                .any(|v| matches!(v.kind, ViolationKind::RawPointerType))
-        );
+        assert!(violations.iter().any(|v| matches!(v.kind, ViolationKind::RawPointerType)));
     }
 
     #[test]
@@ -266,11 +244,7 @@ mod tests {
             }
         "#,
         );
-        assert!(
-            violations
-                .iter()
-                .any(|v| matches!(v.kind, ViolationKind::BoxIntoRaw))
-        );
+        assert!(violations.iter().any(|v| matches!(v.kind, ViolationKind::BoxIntoRaw)));
     }
 
     #[test]
@@ -295,10 +269,6 @@ mod tests {
             }
         "#,
         );
-        assert!(
-            violations
-                .iter()
-                .any(|v| matches!(v.kind, ViolationKind::ManuallyDrop))
-        );
+        assert!(violations.iter().any(|v| matches!(v.kind, ViolationKind::ManuallyDrop)));
     }
 }

--- a/boltffi_macros/src/util.rs
+++ b/boltffi_macros/src/util.rs
@@ -1,35 +1,26 @@
 use boltffi_ffi_rules::naming;
 use proc_macro2::Span;
 use quote::quote;
-use std::collections::HashMap;
-use std::env;
-use std::fs;
-use std::path::{Path as FsPath, PathBuf};
-use syn::punctuated::Punctuated;
-use syn::{Item, Path, PathArguments, PathSegment, Type, UseTree};
+use std::{
+    collections::HashMap,
+    env, fs,
+    path::{Path as FsPath, PathBuf},
+};
+use syn::{Item, Path, PathArguments, PathSegment, Type, UseTree, punctuated::Punctuated};
 
 pub fn ptr_ident(base: &syn::Ident) -> syn::Ident {
-    syn::Ident::new(
-        &format!("{}{}", base, naming::param_ptr_suffix()),
-        base.span(),
-    )
+    syn::Ident::new(&format!("{}{}", base, naming::param_ptr_suffix()), base.span())
 }
 
 pub fn len_ident(base: &syn::Ident) -> syn::Ident {
-    syn::Ident::new(
-        &format!("{}{}", base, naming::param_len_suffix()),
-        base.span(),
-    )
+    syn::Ident::new(&format!("{}{}", base, naming::param_len_suffix()), base.span())
 }
 
 pub enum ParamTransform {
     PassThrough,
     StrRef,
     OwnedString,
-    Callback {
-        params: Vec<syn::Type>,
-        returns: Option<syn::Type>,
-    },
+    Callback { params: Vec<syn::Type>, returns: Option<syn::Type> },
     SliceRef(syn::Type),
     SliceMut(syn::Type),
     BoxedDynTrait(syn::Path),
@@ -74,8 +65,7 @@ pub fn extract_closure_signature(ty: &Type) -> Option<(Vec<syn::Type>, Option<sy
             .filter_map(|path| path.segments.last())
             .filter_map(|segment| {
                 let ident = segment.ident.to_string();
-                (ident == "Fn" || ident == "FnMut" || ident == "FnOnce")
-                    .then_some(&segment.arguments)
+                (ident == "Fn" || ident == "FnMut" || ident == "FnOnce").then_some(&segment.arguments)
             })
             .filter_map(|arguments| match arguments {
                 syn::PathArguments::Parenthesized(args) => Some(args),
@@ -111,17 +101,11 @@ pub fn extract_impl_callback_trait(ty: &Type) -> Option<syn::Path> {
             .bounds
             .iter()
             .filter_map(|bound| match bound {
-                syn::TypeParamBound::Trait(trait_bound) => {
-                    Some((trait_bound.modifier, &trait_bound.path))
-                }
+                syn::TypeParamBound::Trait(trait_bound) => Some((trait_bound.modifier, &trait_bound.path)),
                 _ => None,
             })
             .filter(|(modifier, path)| {
-                let trait_name = path
-                    .segments
-                    .last()
-                    .map(|s| s.ident.to_string())
-                    .unwrap_or_default();
+                let trait_name = path.segments.last().map(|s| s.ident.to_string()).unwrap_or_default();
                 !is_non_callback_bound(*modifier, &trait_name)
             })
             .map(|(_, path)| path.clone())
@@ -276,11 +260,7 @@ impl AliasResolver {
                 let rest = segments.iter().skip(1).cloned();
                 prefix.iter().cloned().chain(rest).collect::<Vec<_>>()
             })
-            .or_else(|| {
-                is_single
-                    .then(|| self.type_aliases.get(&first_name).cloned())
-                    .flatten()
-            })?;
+            .or_else(|| is_single.then(|| self.type_aliases.get(&first_name).cloned()).flatten())?;
 
         let original_args = first.arguments.clone();
         let mut adjusted = resolved;
@@ -308,10 +288,7 @@ impl AliasResolver {
                 target.push(path_segment(&rename.ident));
                 self.use_aliases.insert(rename.rename.to_string(), target);
             }
-            UseTree::Group(group) => group
-                .items
-                .iter()
-                .for_each(|item| self.collect_use_tree(prefix.clone(), item)),
+            UseTree::Group(group) => group.items.iter().for_each(|item| self.collect_use_tree(prefix.clone(), item)),
             UseTree::Glob(_) => {}
         }
     }
@@ -374,10 +351,7 @@ pub fn extract_option_param_inner(ty: &Type) -> Option<syn::Type> {
 }
 
 pub fn is_primitive_vec_inner(s: &str) -> bool {
-    matches!(
-        s,
-        "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "f32" | "f64" | "bool"
-    )
+    matches!(s, "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "f32" | "f64" | "bool")
 }
 
 pub fn classify_param_transform(ty: &Type) -> ParamTransform {
@@ -467,18 +441,6 @@ fn is_record_type(type_str: &str) -> bool {
 fn is_primitive_type(s: &str) -> bool {
     matches!(
         s,
-        "i8" | "i16"
-            | "i32"
-            | "i64"
-            | "u8"
-            | "u16"
-            | "u32"
-            | "u64"
-            | "f32"
-            | "f64"
-            | "bool"
-            | "isize"
-            | "usize"
-            | "()"
+        "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "f32" | "f64" | "bool" | "isize" | "usize" | "()"
     )
 }

--- a/boltffi_macros/src/wire_gen.rs
+++ b/boltffi_macros/src/wire_gen.rs
@@ -1,8 +1,7 @@
+use crate::custom_types::{CustomTypeRegistry, contains_custom_types};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Fields, ItemEnum, ItemStruct, Type};
-
-use crate::custom_types::{CustomTypeRegistry, contains_custom_types};
 
 pub fn is_primitive_type(ty: &Type) -> bool {
     match ty {
@@ -11,19 +10,7 @@ pub fn is_primitive_type(ty: &Type) -> bool {
                 let name = ident.to_string();
                 matches!(
                     name.as_str(),
-                    "bool"
-                        | "i8"
-                        | "u8"
-                        | "i16"
-                        | "u16"
-                        | "i32"
-                        | "u32"
-                        | "i64"
-                        | "u64"
-                        | "f32"
-                        | "f64"
-                        | "isize"
-                        | "usize"
+                    "bool" | "i8" | "u8" | "i16" | "u16" | "i32" | "u32" | "i64" | "u64" | "f32" | "f64" | "isize" | "usize"
                 )
             } else {
                 false
@@ -37,10 +24,7 @@ pub fn is_struct_blittable(field_types: &[&Type]) -> bool {
     field_types.iter().all(|ty| is_primitive_type(ty))
 }
 
-pub fn generate_wire_impls(
-    item_struct: &ItemStruct,
-    custom_types: &CustomTypeRegistry,
-) -> TokenStream {
+pub fn generate_wire_impls(item_struct: &ItemStruct, custom_types: &CustomTypeRegistry) -> TokenStream {
     let struct_name = &item_struct.ident;
     let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
 
@@ -229,22 +213,14 @@ fn generate_wire_encode_impl(
         };
     }
 
-    let encode_fields = field_names
-        .iter()
-        .zip(field_types.iter())
-        .map(|(name, ty)| {
-            let field_buf = syn::Ident::new(&format!("__boltffi_buf_{}", name), name.span());
-            let encode_expr = encode_to_expr(
-                ty,
-                custom_types,
-                quote! { &self.#name },
-                quote! { #field_buf },
-            );
-            quote! {
-                let #field_buf = &mut buf[written..];
-                written += #encode_expr;
-            }
-        });
+    let encode_fields = field_names.iter().zip(field_types.iter()).map(|(name, ty)| {
+        let field_buf = syn::Ident::new(&format!("__boltffi_buf_{}", name), name.span());
+        let encode_expr = encode_to_expr(ty, custom_types, quote! { &self.#name }, quote! { #field_buf });
+        quote! {
+            let #field_buf = &mut buf[written..];
+            written += #encode_expr;
+        }
+    });
 
     quote! {
         impl #impl_generics ::boltffi::__private::wire::WireEncode for #struct_name #ty_generics #where_clause {
@@ -288,22 +264,19 @@ fn generate_wire_decode_impl(
     }
 
     let struct_name_str = struct_name.to_string();
-    let decode_fields = field_names
-        .iter()
-        .zip(field_types.iter())
-        .map(|(name, ty)| {
-            let decode_expr = decode_from_expr(ty, custom_types, quote! { &buf[position..] });
-            let field_name_str = name.to_string();
-            let struct_name_lit = &struct_name_str;
-            quote! {
-                let (#name, size) = #decode_expr.map_err(|e| {
-                    eprintln!("[boltffi] wire decode error in {}.{} at position {} (buf_len={}): {:?}",
-                        #struct_name_lit, #field_name_str, position, buf.len(), e);
-                    e
-                })?;
-                position += size;
-            }
-        });
+    let decode_fields = field_names.iter().zip(field_types.iter()).map(|(name, ty)| {
+        let decode_expr = decode_from_expr(ty, custom_types, quote! { &buf[position..] });
+        let field_name_str = name.to_string();
+        let struct_name_lit = &struct_name_str;
+        quote! {
+            let (#name, size) = #decode_expr.map_err(|e| {
+                eprintln!("[boltffi] wire decode error in {}.{} at position {} (buf_len={}): {:?}",
+                    #struct_name_lit, #field_name_str, position, buf.len(), e);
+                e
+            })?;
+            position += size;
+        }
+    });
 
     quote! {
         impl #impl_generics ::boltffi::__private::wire::WireDecode for #struct_name #ty_generics #where_clause {
@@ -377,11 +350,7 @@ fn type_arg(arg: &syn::GenericArgument) -> Option<&Type> {
     }
 }
 
-fn wire_size_expr(
-    ty: &Type,
-    custom_types: &CustomTypeRegistry,
-    value_expr: TokenStream,
-) -> TokenStream {
+fn wire_size_expr(ty: &Type, custom_types: &CustomTypeRegistry, value_expr: TokenStream) -> TokenStream {
     if let Some(entry) = custom_types.lookup(ty) {
         let into_fn = entry.to_fn_path();
         return quote! { ::boltffi::__private::wire::WireSize::wire_size(&#into_fn(#value_expr)) };
@@ -415,9 +384,7 @@ fn wire_size_expr(
                             .sum::<usize>()
                 }
             })
-            .unwrap_or_else(
-                || quote! { ::boltffi::__private::wire::WireSize::wire_size(#value_expr) },
-            ),
+            .unwrap_or_else(|| quote! { ::boltffi::__private::wire::WireSize::wire_size(#value_expr) }),
         "Option" => args
             .args
             .first()
@@ -432,18 +399,13 @@ fn wire_size_expr(
                     }
                 }
             })
-            .unwrap_or_else(
-                || quote! { ::boltffi::__private::wire::WireSize::wire_size(#value_expr) },
-            ),
+            .unwrap_or_else(|| quote! { ::boltffi::__private::wire::WireSize::wire_size(#value_expr) }),
         "Result" => {
             let ok = args.args.first().and_then(type_arg);
             let err = args.args.iter().nth(1).and_then(type_arg);
 
             match (ok, err) {
-                (Some(ok), Some(err))
-                    if contains_custom_types(ok, custom_types)
-                        || contains_custom_types(err, custom_types) =>
-                {
+                (Some(ok), Some(err)) if contains_custom_types(ok, custom_types) || contains_custom_types(err, custom_types) => {
                     let ok_size = wire_size_expr(ok, custom_types, quote! { ok_value });
                     let err_size = wire_size_expr(err, custom_types, quote! { err_value });
                     quote! {
@@ -460,12 +422,7 @@ fn wire_size_expr(
     }
 }
 
-fn encode_to_expr(
-    ty: &Type,
-    custom_types: &CustomTypeRegistry,
-    value_expr: TokenStream,
-    buf_expr: TokenStream,
-) -> TokenStream {
+fn encode_to_expr(ty: &Type, custom_types: &CustomTypeRegistry, value_expr: TokenStream, buf_expr: TokenStream) -> TokenStream {
     if let Some(entry) = custom_types.lookup(ty) {
         let into_fn = entry.to_fn_path();
         return quote! {
@@ -495,7 +452,12 @@ fn encode_to_expr(
             .and_then(type_arg)
             .filter(|inner| contains_custom_types(inner, custom_types))
             .map(|inner| {
-                let inner_encode = encode_to_expr(inner, custom_types, quote! { element }, quote! { &mut #buf_expr[::boltffi::__private::wire::VEC_COUNT_SIZE + offset..] });
+                let inner_encode = encode_to_expr(
+                    inner,
+                    custom_types,
+                    quote! { element },
+                    quote! { &mut #buf_expr[::boltffi::__private::wire::VEC_COUNT_SIZE + offset..] },
+                );
                 quote! {
                     {
                         let count = (#value_expr).len() as u32;
@@ -514,7 +476,12 @@ fn encode_to_expr(
             .and_then(type_arg)
             .filter(|inner| contains_custom_types(inner, custom_types))
             .map(|inner| {
-                let inner_encode = encode_to_expr(inner, custom_types, quote! { value }, quote! { &mut #buf_expr[::boltffi::__private::wire::OPTION_FLAG_SIZE..] });
+                let inner_encode = encode_to_expr(
+                    inner,
+                    custom_types,
+                    quote! { value },
+                    quote! { &mut #buf_expr[::boltffi::__private::wire::OPTION_FLAG_SIZE..] },
+                );
                 quote! {
                     match #value_expr {
                         Some(value) => {
@@ -534,11 +501,19 @@ fn encode_to_expr(
             let err = args.args.iter().nth(1).and_then(type_arg);
 
             match (ok, err) {
-                (Some(ok), Some(err))
-                    if contains_custom_types(ok, custom_types) || contains_custom_types(err, custom_types) =>
-                {
-                    let ok_encode = encode_to_expr(ok, custom_types, quote! { ok_value }, quote! { &mut #buf_expr[::boltffi::__private::wire::RESULT_TAG_SIZE..] });
-                    let err_encode = encode_to_expr(err, custom_types, quote! { err_value }, quote! { &mut #buf_expr[::boltffi::__private::wire::RESULT_TAG_SIZE..] });
+                (Some(ok), Some(err)) if contains_custom_types(ok, custom_types) || contains_custom_types(err, custom_types) => {
+                    let ok_encode = encode_to_expr(
+                        ok,
+                        custom_types,
+                        quote! { ok_value },
+                        quote! { &mut #buf_expr[::boltffi::__private::wire::RESULT_TAG_SIZE..] },
+                    );
+                    let err_encode = encode_to_expr(
+                        err,
+                        custom_types,
+                        quote! { err_value },
+                        quote! { &mut #buf_expr[::boltffi::__private::wire::RESULT_TAG_SIZE..] },
+                    );
                     quote! {
                         match #value_expr {
                             Ok(ok_value) => {
@@ -559,11 +534,7 @@ fn encode_to_expr(
     }
 }
 
-fn decode_from_expr(
-    ty: &Type,
-    custom_types: &CustomTypeRegistry,
-    buf_expr: TokenStream,
-) -> TokenStream {
+fn decode_from_expr(ty: &Type, custom_types: &CustomTypeRegistry, buf_expr: TokenStream) -> TokenStream {
     if let Some(entry) = custom_types.lookup(ty) {
         let repr_ty = entry.repr_type().unwrap_or_else(|_| syn::parse_quote!(()));
         let try_from_fn = entry.try_from_fn_path();
@@ -649,9 +620,7 @@ fn decode_from_expr(
             let err = args.args.iter().nth(1).and_then(type_arg);
 
             match (ok, err) {
-                (Some(ok), Some(err))
-                    if contains_custom_types(ok, custom_types) || contains_custom_types(err, custom_types) =>
-                {
+                (Some(ok), Some(err)) if contains_custom_types(ok, custom_types) || contains_custom_types(err, custom_types) => {
                     let ok_decode = decode_from_expr(ok, custom_types, quote! { inner_buf });
                     let err_decode = decode_from_expr(err, custom_types, quote! { inner_buf });
                     quote! {
@@ -684,10 +653,7 @@ fn decode_from_expr(
     }
 }
 
-pub fn generate_enum_wire_impls(
-    item_enum: &ItemEnum,
-    custom_types: &CustomTypeRegistry,
-) -> TokenStream {
+pub fn generate_enum_wire_impls(item_enum: &ItemEnum, custom_types: &CustomTypeRegistry) -> TokenStream {
     let enum_name = &item_enum.ident;
     let (impl_generics, ty_generics, where_clause) = item_enum.generics.split_for_impl();
 
@@ -697,32 +663,11 @@ pub fn generate_enum_wire_impls(
         return quote! {};
     }
 
-    let wire_size_impl = generate_enum_wire_size_impl(
-        enum_name,
-        &impl_generics,
-        &ty_generics,
-        where_clause,
-        &variants,
-        custom_types,
-    );
+    let wire_size_impl = generate_enum_wire_size_impl(enum_name, &impl_generics, &ty_generics, where_clause, &variants, custom_types);
 
-    let wire_encode_impl = generate_enum_wire_encode_impl(
-        enum_name,
-        &impl_generics,
-        &ty_generics,
-        where_clause,
-        &variants,
-        custom_types,
-    );
+    let wire_encode_impl = generate_enum_wire_encode_impl(enum_name, &impl_generics, &ty_generics, where_clause, &variants, custom_types);
 
-    let wire_decode_impl = generate_enum_wire_decode_impl(
-        enum_name,
-        &impl_generics,
-        &ty_generics,
-        where_clause,
-        &variants,
-        custom_types,
-    );
+    let wire_decode_impl = generate_enum_wire_decode_impl(enum_name, &impl_generics, &ty_generics, where_clause, &variants, custom_types);
 
     quote! {
         #wire_size_impl
@@ -749,9 +694,7 @@ fn generate_enum_wire_size_impl(
             }
             Fields::Unnamed(fields) => {
                 let field_types: Vec<_> = fields.unnamed.iter().map(|f| &f.ty).collect();
-                let field_bindings: Vec<_> = (0..fields.unnamed.len())
-                    .map(|i| quote::format_ident!("f{}", i))
-                    .collect();
+                let field_bindings: Vec<_> = (0..fields.unnamed.len()).map(|i| quote::format_ident!("f{}", i)).collect();
                 let field_wire_sizes = field_bindings
                     .iter()
                     .zip(field_types.iter())
@@ -763,11 +706,7 @@ fn generate_enum_wire_size_impl(
                 }
             }
             Fields::Named(fields) => {
-                let field_names: Vec<_> = fields
-                    .named
-                    .iter()
-                    .filter_map(|f| f.ident.as_ref())
-                    .collect();
+                let field_names: Vec<_> = fields.named.iter().filter_map(|f| f.ident.as_ref()).collect();
                 let field_types: Vec<_> = fields.named.iter().map(|f| &f.ty).collect();
                 let field_wire_sizes = field_names
                     .iter()
@@ -828,26 +767,15 @@ fn generate_enum_wire_encode_impl(
             }
             Fields::Unnamed(fields) => {
                 let field_types: Vec<_> = fields.unnamed.iter().map(|f| &f.ty).collect();
-                let field_bindings: Vec<_> = (0..fields.unnamed.len())
-                    .map(|i| quote::format_ident!("f{}", i))
-                    .collect();
-                let encode_fields =
-                    field_bindings
-                        .iter()
-                        .zip(field_types.iter())
-                        .map(|(binding, ty)| {
-                            let field_buf = quote::format_ident!("__boltffi_buf_{}", binding);
-                            let encode_expr = encode_to_expr(
-                                ty,
-                                custom_types,
-                                quote! { #binding },
-                                quote! { #field_buf },
-                            );
-                            quote! {
-                                let #field_buf = &mut buf[written..];
-                                written += #encode_expr;
-                            }
-                        });
+                let field_bindings: Vec<_> = (0..fields.unnamed.len()).map(|i| quote::format_ident!("f{}", i)).collect();
+                let encode_fields = field_bindings.iter().zip(field_types.iter()).map(|(binding, ty)| {
+                    let field_buf = quote::format_ident!("__boltffi_buf_{}", binding);
+                    let encode_expr = encode_to_expr(ty, custom_types, quote! { #binding }, quote! { #field_buf });
+                    quote! {
+                        let #field_buf = &mut buf[written..];
+                        written += #encode_expr;
+                    }
+                });
                 quote! {
                     Self::#variant_name(#(#field_bindings),*) => {
                         buf[0..4].copy_from_slice(&(#discriminant_i32 as i32).to_le_bytes());
@@ -858,29 +786,16 @@ fn generate_enum_wire_encode_impl(
                 }
             }
             Fields::Named(fields) => {
-                let field_names: Vec<_> = fields
-                    .named
-                    .iter()
-                    .filter_map(|f| f.ident.as_ref())
-                    .collect();
+                let field_names: Vec<_> = fields.named.iter().filter_map(|f| f.ident.as_ref()).collect();
                 let field_types: Vec<_> = fields.named.iter().map(|f| &f.ty).collect();
-                let encode_fields =
-                    field_names
-                        .iter()
-                        .zip(field_types.iter())
-                        .map(|(binding, ty)| {
-                            let field_buf = quote::format_ident!("__boltffi_buf_{}", binding);
-                            let encode_expr = encode_to_expr(
-                                ty,
-                                custom_types,
-                                quote! { #binding },
-                                quote! { #field_buf },
-                            );
-                            quote! {
-                                let #field_buf = &mut buf[written..];
-                                written += #encode_expr;
-                            }
-                        });
+                let encode_fields = field_names.iter().zip(field_types.iter()).map(|(binding, ty)| {
+                    let field_buf = quote::format_ident!("__boltffi_buf_{}", binding);
+                    let encode_expr = encode_to_expr(ty, custom_types, quote! { #binding }, quote! { #field_buf });
+                    quote! {
+                        let #field_buf = &mut buf[written..];
+                        written += #encode_expr;
+                    }
+                });
                 quote! {
                     Self::#variant_name { #(#field_names),* } => {
                         buf[0..4].copy_from_slice(&(#discriminant_i32 as i32).to_le_bytes());
@@ -924,21 +839,14 @@ fn generate_enum_wire_decode_impl(
             }
             Fields::Unnamed(fields) => {
                 let field_types: Vec<_> = fields.unnamed.iter().map(|f| &f.ty).collect();
-                let field_bindings: Vec<_> = (0..fields.unnamed.len())
-                    .map(|i| quote::format_ident!("f{}", i))
-                    .collect();
-                let decode_fields =
-                    field_bindings
-                        .iter()
-                        .zip(field_types.iter())
-                        .map(|(binding, ty)| {
-                            let decode_expr =
-                                decode_from_expr(ty, custom_types, quote! { &buf[position..] });
-                            quote! {
-                                let (#binding, size) = #decode_expr?;
-                                position += size;
-                            }
-                        });
+                let field_bindings: Vec<_> = (0..fields.unnamed.len()).map(|i| quote::format_ident!("f{}", i)).collect();
+                let decode_fields = field_bindings.iter().zip(field_types.iter()).map(|(binding, ty)| {
+                    let decode_expr = decode_from_expr(ty, custom_types, quote! { &buf[position..] });
+                    quote! {
+                        let (#binding, size) = #decode_expr?;
+                        position += size;
+                    }
+                });
                 quote! {
                     #discriminant_i32 => {
                         let mut position = 4usize;
@@ -948,23 +856,15 @@ fn generate_enum_wire_decode_impl(
                 }
             }
             Fields::Named(fields) => {
-                let field_names: Vec<_> = fields
-                    .named
-                    .iter()
-                    .filter_map(|f| f.ident.as_ref())
-                    .collect();
+                let field_names: Vec<_> = fields.named.iter().filter_map(|f| f.ident.as_ref()).collect();
                 let field_types: Vec<_> = fields.named.iter().map(|f| &f.ty).collect();
-                let decode_fields = field_names
-                    .iter()
-                    .zip(field_types.iter())
-                    .map(|(name, ty)| {
-                        let decode_expr =
-                            decode_from_expr(ty, custom_types, quote! { &buf[position..] });
-                        quote! {
-                            let (#name, size) = #decode_expr?;
-                            position += size;
-                        }
-                    });
+                let decode_fields = field_names.iter().zip(field_types.iter()).map(|(name, ty)| {
+                    let decode_expr = decode_from_expr(ty, custom_types, quote! { &buf[position..] });
+                    quote! {
+                        let (#name, size) = #decode_expr?;
+                        position += size;
+                    }
+                });
                 quote! {
                     #discriminant_i32 => {
                         let mut position = 4usize;

--- a/boltffi_tests/Cargo.toml
+++ b/boltffi_tests/Cargo.toml
@@ -6,10 +6,8 @@ publish = false
 
 [dependencies]
 boltffi = { path = "../boltffi" }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros"] }
-
-[dev-dependencies]
 boltffi_core = { path = "../boltffi_core" }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros"] }
 
 [lints]
 workspace = true

--- a/boltffi_tests/src/lib.rs
+++ b/boltffi_tests/src/lib.rs
@@ -2,9 +2,8 @@
 #![allow(clippy::unused_unit)]
 #![allow(clippy::too_many_arguments)]
 
-use std::sync::Mutex;
-
 use boltffi::*;
+use std::sync::Mutex;
 
 #[data]
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
@@ -120,10 +119,7 @@ pub fn invoke_vec_impl(callback: impl SyncVecCallback, values: Vec<i32>) -> Vec<
 }
 
 #[export]
-pub fn invoke_struct_boxed(
-    callback: Box<dyn SyncStructCallback>,
-    point: FixturePoint,
-) -> FixturePoint {
+pub fn invoke_struct_boxed(callback: Box<dyn SyncStructCallback>, point: FixturePoint) -> FixturePoint {
     callback.on_struct(point)
 }
 
@@ -153,11 +149,7 @@ pub fn invoke_enum_impl(callback: impl SyncEnumCallback, id: i32) -> FixtureStat
 }
 
 #[export]
-pub fn invoke_multi_method_boxed(
-    callback: Box<dyn SyncMultiMethodCallback>,
-    x: i32,
-    y: i32,
-) -> i32 {
+pub fn invoke_multi_method_boxed(callback: Box<dyn SyncMultiMethodCallback>, x: i32, y: i32) -> i32 {
     callback.method_a(x) + callback.method_b(x, y) + callback.method_c()
 }
 
@@ -167,30 +159,17 @@ pub fn invoke_multi_method_impl(callback: impl SyncMultiMethodCallback, x: i32, 
 }
 
 #[export]
-pub fn invoke_two_sync_impl(
-    first: impl SyncValueCallback,
-    second: impl SyncValueCallback,
-    value: i32,
-) -> i32 {
+pub fn invoke_two_sync_impl(first: impl SyncValueCallback, second: impl SyncValueCallback, value: i32) -> i32 {
     first.on_value(value) + second.on_value(value)
 }
 
 #[export]
-pub fn invoke_three_sync_impl(
-    first: impl SyncValueCallback,
-    second: impl SyncValueCallback,
-    third: impl SyncValueCallback,
-    value: i32,
-) -> i32 {
+pub fn invoke_three_sync_impl(first: impl SyncValueCallback, second: impl SyncValueCallback, third: impl SyncValueCallback, value: i32) -> i32 {
     first.on_value(value) + second.on_value(value) + third.on_value(value)
 }
 
 #[export]
-pub fn invoke_mixed_sync(
-    boxed: Box<dyn SyncValueCallback>,
-    impl_cb: impl SyncValueCallback,
-    value: i32,
-) -> i32 {
+pub fn invoke_mixed_sync(boxed: Box<dyn SyncValueCallback>, impl_cb: impl SyncValueCallback, value: i32) -> i32 {
     boxed.on_value(value) * impl_cb.on_value(value)
 }
 
@@ -205,12 +184,7 @@ pub fn simple_try_divide(a: i32, b: i32) -> Result<i32, i32> {
 }
 
 #[export]
-pub fn invoke_mixed_three(
-    boxed: Box<dyn SyncValueCallback>,
-    impl1: impl SyncValueCallback,
-    impl2: impl SyncValueCallback,
-    value: i32,
-) -> i32 {
+pub fn invoke_mixed_three(boxed: Box<dyn SyncValueCallback>, impl1: impl SyncValueCallback, impl2: impl SyncValueCallback, value: i32) -> i32 {
     boxed.on_value(value) + impl1.on_value(value) + impl2.on_value(value)
 }
 
@@ -220,21 +194,12 @@ pub async fn invoke_async_impl(fetcher: impl AsyncFetcher, key: u32) -> u64 {
 }
 
 #[export]
-pub async fn invoke_two_async_impl(
-    first: impl AsyncFetcher,
-    second: impl AsyncFetcher,
-    key: u32,
-) -> u64 {
+pub async fn invoke_two_async_impl(first: impl AsyncFetcher, second: impl AsyncFetcher, key: u32) -> u64 {
     first.fetch(key).await.wrapping_mul(second.fetch(key).await)
 }
 
 #[export]
-pub async fn invoke_three_async_impl(
-    first: impl AsyncFetcher,
-    second: impl AsyncFetcher,
-    third: impl AsyncFetcher,
-    key: u32,
-) -> u64 {
+pub async fn invoke_three_async_impl(first: impl AsyncFetcher, second: impl AsyncFetcher, third: impl AsyncFetcher, key: u32) -> u64 {
     first.fetch(key).await + second.fetch(key).await + third.fetch(key).await
 }
 
@@ -244,12 +209,7 @@ pub async fn invoke_async_option_impl(fetcher: impl AsyncOptionFetcher, key: i32
 }
 
 #[export]
-pub async fn invoke_async_multi_impl(
-    callback: impl AsyncMultiMethod,
-    id: i64,
-    a: i32,
-    b: i32,
-) -> i64 {
+pub async fn invoke_async_multi_impl(callback: impl AsyncMultiMethod, id: i64, a: i32, b: i32) -> i64 {
     callback.load(id).await + callback.compute(a, b).await
 }
 
@@ -271,11 +231,7 @@ impl SyncProcessor {
         callback.on_value(value * self.multiplier)
     }
 
-    pub fn apply_struct_impl(
-        &self,
-        callback: impl SyncStructCallback,
-        point: FixturePoint,
-    ) -> FixturePoint {
+    pub fn apply_struct_impl(&self, callback: impl SyncStructCallback, point: FixturePoint) -> FixturePoint {
         let scaled = FixturePoint {
             x: point.x * self.multiplier as f64,
             y: point.y * self.multiplier as f64,
@@ -302,21 +258,21 @@ impl AsyncProcessor {
         fetcher.fetch(key).await.wrapping_add(self.offset)
     }
 
-    pub async fn find_with_offset(
-        &self,
-        fetcher: impl AsyncOptionFetcher,
-        key: i32,
-    ) -> Option<i64> {
+    pub async fn find_with_offset(&self, fetcher: impl AsyncOptionFetcher, key: i32) -> Option<i64> {
         fetcher.find(key).await.map(|v| v + self.offset as i64)
     }
 }
 
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use std::task::{Context, Poll};
-use std::time::Duration;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU32, Ordering},
+    },
+    task::{Context, Poll},
+    time::Duration,
+};
 
 struct YieldOnce(bool);
 
@@ -363,11 +319,7 @@ impl std::error::Error for FixtureError {}
 
 #[export]
 pub fn fallible_divide(a: i32, b: i32) -> Result<i32, FixtureError> {
-    if b == 0 {
-        Err(FixtureError::InvalidInput)
-    } else {
-        Ok(a / b)
-    }
+    if b == 0 { Err(FixtureError::InvalidInput) } else { Ok(a / b) }
 }
 
 #[export]
@@ -560,6 +512,51 @@ impl PointStream {
     }
 }
 
+// --- async iterator fixtures ---
+
+use boltffi_core::async_iterator::Stream as FfiIterStream;
+use std::collections::VecDeque;
+
+/// A simple stream that yields items from a Vec, one per poll.
+pub struct VecStream<T> {
+    items: VecDeque<T>,
+}
+
+impl<T> VecStream<T> {
+    pub fn new(items: impl IntoIterator<Item = T>) -> Self {
+        Self {
+            items: items.into_iter().collect(),
+        }
+    }
+}
+
+impl<T: Send + Unpin + 'static> FfiIterStream for VecStream<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<T>> {
+        Poll::Ready(self.items.pop_front())
+    }
+}
+
+pub struct NumberIterator;
+
+#[export]
+impl NumberIterator {
+    pub fn new() -> Self {
+        Self
+    }
+
+    #[ffi_async_iter(item = i32)]
+    pub fn count_to_three(&self) -> VecStream<i32> {
+        VecStream::new([1, 2, 3])
+    }
+
+    #[ffi_async_iter(item = i32)]
+    pub fn empty(&self) -> VecStream<i32> {
+        VecStream::new([])
+    }
+}
+
 pub struct TestCounter {
     value: i32,
 }
@@ -600,9 +597,7 @@ pub struct ThreadSafeCounter {
 #[export]
 impl ThreadSafeCounter {
     pub fn new(initial: i32) -> Self {
-        Self {
-            value: Mutex::new(initial),
-        }
+        Self { value: Mutex::new(initial) }
     }
 
     pub fn get(&self) -> i32 {
@@ -782,10 +777,7 @@ impl ClassTestFixture {
     }
 
     pub fn find_value(&self, target: i32) -> Option<i32> {
-        self.values
-            .iter()
-            .position(|&v| v == target)
-            .map(|i| i as i32)
+        self.values.iter().position(|&v| v == target).map(|i| i as i32)
     }
 
     pub fn static_add(a: i32, b: i32) -> i32 {
@@ -846,33 +838,11 @@ impl ClassTestFixture {
     }
 
     pub async fn async_find(&self, target: i32) -> Option<i32> {
-        self.values
-            .iter()
-            .position(|&v| v == target)
-            .map(|i| i as i32)
+        self.values.iter().position(|&v| v == target).map(|i| i as i32)
     }
 
-    pub fn with_primitives(
-        &self,
-        a: i8,
-        b: u8,
-        c: i16,
-        d: u16,
-        e: i64,
-        f: u64,
-        g: f32,
-        h: f64,
-        i: bool,
-    ) -> i64 {
-        (a as i64)
-            + (b as i64)
-            + (c as i64)
-            + (d as i64)
-            + e
-            + (f as i64)
-            + (g as i64)
-            + (h as i64)
-            + (if i { 1 } else { 0 })
+    pub fn with_primitives(&self, a: i8, b: u8, c: i16, d: u16, e: i64, f: u64, g: f32, h: f64, i: bool) -> i64 {
+        (a as i64) + (b as i64) + (c as i64) + (d as i64) + e + (f as i64) + (g as i64) + (h as i64) + (if i { 1 } else { 0 })
     }
 
     pub fn echo_bytes(&self, data: Vec<u8>) -> Vec<u8> {

--- a/boltffi_tests/tests/async_iterator.rs
+++ b/boltffi_tests/tests/async_iterator.rs
@@ -1,0 +1,165 @@
+use boltffi::__private::{
+    FfiBuf,
+    rustfuture::{self, RustFuturePoll},
+};
+use boltffi_core::wire::WireDecode;
+use boltffi_tests::*;
+
+fn decode_option_i32(buf: &FfiBuf<u8>) -> Option<i32> {
+    let (result, _) = <Option<i32>>::decode_from(unsafe { buf.as_slice() }).unwrap();
+    result
+}
+
+/// Poll a future to completion synchronously (works for immediately-ready futures).
+fn complete_option_i32(future: boltffi::__private::RustFutureHandle) -> Option<Option<i32>> {
+    extern "C" fn noop(_: u64, _: RustFuturePoll) {}
+    unsafe { rustfuture::rust_future_poll::<Option<i32>>(future, noop, 0) };
+    unsafe { rustfuture::rust_future_complete::<Option<i32>>(future) }
+}
+
+mod number_iterator_new {
+    use super::*;
+
+    #[test]
+    fn returns_non_null_handle() {
+        let obj = boltffi_number_iterator_new();
+        let iter = unsafe { boltffi_number_iterator_count_to_three(obj) };
+        assert!(!iter.is_null());
+        unsafe { boltffi_number_iterator_count_to_three_free(iter) };
+        unsafe { boltffi_number_iterator_free(obj) };
+    }
+
+    #[test]
+    fn empty_returns_non_null_handle() {
+        let obj = boltffi_number_iterator_new();
+        let iter = unsafe { boltffi_number_iterator_empty(obj) };
+        assert!(!iter.is_null());
+        unsafe { boltffi_number_iterator_empty_free(iter) };
+        unsafe { boltffi_number_iterator_free(obj) };
+    }
+}
+
+mod number_iterator_count_to_three {
+    use super::*;
+
+    #[test]
+    fn next_returns_future_handle() {
+        let obj = boltffi_number_iterator_new();
+        let iter = unsafe { boltffi_number_iterator_count_to_three(obj) };
+
+        let future = unsafe { boltffi_number_iterator_count_to_three_next(iter) };
+        assert!(!future.is_null());
+
+        unsafe { boltffi_number_iterator_count_to_three_next_free(future) };
+        unsafe { boltffi_number_iterator_count_to_three_free(iter) };
+        unsafe { boltffi_number_iterator_free(obj) };
+    }
+
+    #[test]
+    fn yields_items_in_order() {
+        let obj = boltffi_number_iterator_new();
+        let iter = unsafe { boltffi_number_iterator_count_to_three(obj) };
+
+        let f1 = unsafe { boltffi_number_iterator_count_to_three_next(iter) };
+        let r1 = complete_option_i32(f1);
+        assert_eq!(r1, Some(Some(1)));
+        unsafe { boltffi_number_iterator_count_to_three_next_free(f1) };
+
+        let f2 = unsafe { boltffi_number_iterator_count_to_three_next(iter) };
+        let r2 = complete_option_i32(f2);
+        assert_eq!(r2, Some(Some(2)));
+        unsafe { boltffi_number_iterator_count_to_three_next_free(f2) };
+
+        let f3 = unsafe { boltffi_number_iterator_count_to_three_next(iter) };
+        let r3 = complete_option_i32(f3);
+        assert_eq!(r3, Some(Some(3)));
+        unsafe { boltffi_number_iterator_count_to_three_next_free(f3) };
+
+        unsafe { boltffi_number_iterator_count_to_three_free(iter) };
+        unsafe { boltffi_number_iterator_free(obj) };
+    }
+
+    #[test]
+    fn returns_none_after_exhausted() {
+        let obj = boltffi_number_iterator_new();
+        let iter = unsafe { boltffi_number_iterator_count_to_three(obj) };
+
+        for _ in 0..3 {
+            let f = unsafe { boltffi_number_iterator_count_to_three_next(iter) };
+            complete_option_i32(f);
+            unsafe { boltffi_number_iterator_count_to_three_next_free(f) };
+        }
+
+        // Fourth call must return None (end of stream)
+        let f = unsafe { boltffi_number_iterator_count_to_three_next(iter) };
+        let result = complete_option_i32(f);
+        assert_eq!(result, Some(None));
+        unsafe { boltffi_number_iterator_count_to_three_next_free(f) };
+
+        unsafe { boltffi_number_iterator_count_to_three_free(iter) };
+        unsafe { boltffi_number_iterator_free(obj) };
+    }
+
+    #[test]
+    fn next_complete_returns_wire_encoded_option() {
+        let obj = boltffi_number_iterator_new();
+        let iter = unsafe { boltffi_number_iterator_count_to_three(obj) };
+
+        extern "C" fn noop(_: u64, _: RustFuturePoll) {}
+        let future = unsafe { boltffi_number_iterator_count_to_three_next(iter) };
+        unsafe { rustfuture::rust_future_poll::<Option<i32>>(future, noop, 0) };
+
+        let mut status = boltffi::__private::FfiStatus::OK;
+        let buf: FfiBuf<u8> = unsafe { boltffi_number_iterator_count_to_three_next_complete(future, &mut status) };
+        assert_eq!(status, boltffi::__private::FfiStatus::OK);
+
+        let value = decode_option_i32(&buf);
+        assert_eq!(value, Some(1));
+
+        unsafe { boltffi_number_iterator_count_to_three_next_free(future) };
+        unsafe { boltffi_number_iterator_count_to_three_free(iter) };
+        unsafe { boltffi_number_iterator_free(obj) };
+    }
+
+    #[test]
+    fn multiple_independent_iterators_are_independent() {
+        let obj = boltffi_number_iterator_new();
+
+        let iter1 = unsafe { boltffi_number_iterator_count_to_three(obj) };
+        let iter2 = unsafe { boltffi_number_iterator_count_to_three(obj) };
+
+        // Advance iter1 by one
+        let f1 = unsafe { boltffi_number_iterator_count_to_three_next(iter1) };
+        let r1 = complete_option_i32(f1);
+        assert_eq!(r1, Some(Some(1)));
+        unsafe { boltffi_number_iterator_count_to_three_next_free(f1) };
+
+        // iter2 should still start at 1
+        let f2 = unsafe { boltffi_number_iterator_count_to_three_next(iter2) };
+        let r2 = complete_option_i32(f2);
+        assert_eq!(r2, Some(Some(1)));
+        unsafe { boltffi_number_iterator_count_to_three_next_free(f2) };
+
+        unsafe { boltffi_number_iterator_count_to_three_free(iter1) };
+        unsafe { boltffi_number_iterator_count_to_three_free(iter2) };
+        unsafe { boltffi_number_iterator_free(obj) };
+    }
+}
+
+mod number_iterator_empty {
+    use super::*;
+
+    #[test]
+    fn first_next_returns_none() {
+        let obj = boltffi_number_iterator_new();
+        let iter = unsafe { boltffi_number_iterator_empty(obj) };
+
+        let f = unsafe { boltffi_number_iterator_empty_next(iter) };
+        let result = complete_option_i32(f);
+        assert_eq!(result, Some(None));
+        unsafe { boltffi_number_iterator_empty_next_free(f) };
+
+        unsafe { boltffi_number_iterator_empty_free(iter) };
+        unsafe { boltffi_number_iterator_free(obj) };
+    }
+}

--- a/boltffi_verify/src/parse/swift.rs
+++ b/boltffi_verify/src/parse/swift.rs
@@ -767,7 +767,7 @@ impl ExtractionContext {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod tests {
     use super::*;
 

--- a/boltffi_verify/src/verifier.rs
+++ b/boltffi_verify/src/verifier.rs
@@ -162,7 +162,7 @@ impl Default for Verifier {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod tests {
     use super::*;
 

--- a/boltffi_verify/tests/integration.rs
+++ b/boltffi_verify/tests/integration.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use boltffi_verify::{Reporter, VerificationResult, Verifier, ViolationKind};
 use std::path::Path;
 

--- a/examples/demo/src/classes.rs
+++ b/examples/demo/src/classes.rs
@@ -1,7 +1,32 @@
-use boltffi::export;
+use boltffi::{FfiStream, export, ffi_async_iter};
+use std::{
+    collections::VecDeque,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 pub struct Counter {
     count: i32,
+}
+
+struct VecStream<T> {
+    items: VecDeque<T>,
+}
+
+impl<T> VecStream<T> {
+    fn new(items: impl IntoIterator<Item = T>) -> Self {
+        Self {
+            items: items.into_iter().collect(),
+        }
+    }
+}
+
+impl<T: Send + Unpin + 'static> FfiStream for VecStream<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<T>> {
+        Poll::Ready(self.items.pop_front())
+    }
 }
 
 #[export(single_threaded)]
@@ -42,5 +67,11 @@ impl Counter {
 
     pub fn apply_binary(&self, f: impl Fn(i32, i32) -> i32, other: i32) -> i32 {
         f(self.count, other)
+    }
+
+    #[ffi_async_iter(item = i32)]
+    pub fn count_up(&self) -> VecStream<i32> {
+        let items: Vec<i32> = (1..=self.count).collect();
+        VecStream::new(items)
     }
 }


### PR DESCRIPTION
Here’s a small example of how a lazy async iterator could be exposed by BoltFFI and bridged as an AsyncSequence in Swift.
This PR is mainly intended as a proof of concept, so feel free to take it over if you think it would be valuable for the codebase. I believe ffi_stream could simply be implemented as an ffi_async_iter under the hood.
I’m not sure whether this kind of implementation is compatible with all the target languages, but I hope it is.

cc #60

*EDIT*: Sorry for the noise caused by the file formatting. For some reason, some files weren’t formatted properly, which generated a lot of unnecessary changes.

