### PR TITLE
Scaffold record methods and constructors support

### DIFF
--- a/boltffi_bindgen/src/ir/build.rs
+++ b/boltffi_bindgen/src/ir/build.rs
@@ -86,6 +86,22 @@ impl<'m> ContractBuilder<'m> {
     }
 
     fn convert_record(&self, record: &model::Record) -> RecordDef {
+        let has_default_init = record.constructors.iter().any(|c| c.name == "new");
+        let constructors = record
+            .constructors
+            .iter()
+            .fold(
+                (Vec::new(), has_default_init),
+                |(mut converted, default_slot_taken), ctor| {
+                    let result = self.convert_constructor(ctor, default_slot_taken);
+                    let promoted =
+                        default_slot_taken || (ctor.name != "new" && ctor.inputs.is_empty());
+                    converted.push(result);
+                    (converted, promoted)
+                },
+            )
+            .0;
+
         RecordDef {
             id: RecordId::new(&record.name),
             is_repr_c: record.is_repr_c,
@@ -109,6 +125,12 @@ impl<'m> ContractBuilder<'m> {
                         default,
                     }
                 })
+                .collect(),
+            constructors,
+            methods: record
+                .methods
+                .iter()
+                .map(|m| self.convert_method(m))
                 .collect(),
             doc: record.doc.clone(),
             deprecated: record.deprecated.as_ref().map(convert_deprecation),

--- a/boltffi_bindgen/src/ir/definitions.rs
+++ b/boltffi_bindgen/src/ir/definitions.rs
@@ -17,11 +17,17 @@ pub struct RecordDef {
     pub id: RecordId,
     pub is_repr_c: bool,
     pub fields: Vec<FieldDef>,
+    pub constructors: Vec<ConstructorDef>,
+    pub methods: Vec<MethodDef>,
     pub doc: Option<String>,
     pub deprecated: Option<DeprecationInfo>,
 }
 
 impl RecordDef {
+    pub fn has_methods(&self) -> bool {
+        !self.constructors.is_empty() || !self.methods.is_empty()
+    }
+
     pub fn is_blittable(&self) -> bool {
         let field_primitives: Vec<FieldPrimitive> = self
             .fields

--- a/boltffi_bindgen/src/ir/lower.rs
+++ b/boltffi_bindgen/src/ir/lower.rs
@@ -2561,6 +2561,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2592,6 +2594,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2754,6 +2758,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2800,6 +2806,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -3024,6 +3032,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -3107,6 +3117,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -3269,6 +3281,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });

--- a/boltffi_bindgen/src/lib.rs
+++ b/boltffi_bindgen/src/lib.rs
@@ -14,7 +14,9 @@ pub use boltffi_ffi_rules::naming::ffi_prefix;
 pub use render::c::CHeaderLowerer;
 pub use render::kotlin::{FactoryStyle, KotlinApiStyle, KotlinOptions};
 pub use render::{Renderer, TypeConversion, TypeMapping, TypeMappings, swift::SwiftLowerer};
-pub use scan::{SourceScanner, scan_crate, scan_crate_with_pointer_width};
+pub use scan::{
+    ScanFeatures, SourceScanner, scan_crate, scan_crate_with_options, scan_crate_with_pointer_width,
+};
 
 #[cfg(test)]
 mod tests {

--- a/boltffi_bindgen/src/model/module.rs
+++ b/boltffi_bindgen/src/model/module.rs
@@ -112,6 +112,10 @@ impl Module {
                 .classes
                 .iter()
                 .any(|c| c.methods.iter().any(|m| m.is_async))
+            || self
+                .records
+                .iter()
+                .any(|r| r.methods.iter().any(|m| m.is_async))
     }
 
     pub fn has_streams(&self) -> bool {
@@ -147,6 +151,22 @@ impl Module {
             .iter()
             .flat_map(|r| r.fields.iter().map(|f| &f.field_type))
             .for_each(|ty| collector.visit(ty));
+
+        self.records.iter().for_each(|r| {
+            r.constructors.iter().for_each(|ctor| {
+                ctor.inputs
+                    .iter()
+                    .map(|p| &p.param_type)
+                    .for_each(|ty| collector.visit(ty));
+            });
+            r.methods.iter().for_each(|m| {
+                m.inputs
+                    .iter()
+                    .map(|p| &p.param_type)
+                    .for_each(|ty| collector.visit(ty));
+                collector.visit_return_type(&m.returns);
+            });
+        });
 
         self.enums
             .iter()

--- a/boltffi_bindgen/src/model/record.rs
+++ b/boltffi_bindgen/src/model/record.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+use super::class::Constructor;
 use super::layout::{CLayout, Size, StructLayout};
+use super::method::Method;
 use super::types::{Deprecation, Type};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -9,6 +11,10 @@ pub struct Record {
     #[serde(default = "default_true")]
     pub is_repr_c: bool,
     pub fields: Vec<RecordField>,
+    #[serde(default)]
+    pub constructors: Vec<Constructor>,
+    #[serde(default)]
+    pub methods: Vec<Method>,
     pub doc: Option<String>,
     pub deprecated: Option<Deprecation>,
 }
@@ -23,6 +29,8 @@ impl Record {
             name: name.into(),
             is_repr_c: true,
             fields: Vec::new(),
+            constructors: Vec::new(),
+            methods: Vec::new(),
             doc: None,
             deprecated: None,
         }
@@ -36,6 +44,20 @@ impl Record {
     pub fn with_field(mut self, field: RecordField) -> Self {
         self.fields.push(field);
         self
+    }
+
+    pub fn with_constructor(mut self, constructor: Constructor) -> Self {
+        self.constructors.push(constructor);
+        self
+    }
+
+    pub fn with_method(mut self, method: Method) -> Self {
+        self.methods.push(method);
+        self
+    }
+
+    pub fn has_methods(&self) -> bool {
+        !self.constructors.is_empty() || !self.methods.is_empty()
     }
 
     pub fn with_doc(mut self, doc: impl Into<String>) -> Self {

--- a/boltffi_bindgen/src/render/java/lower.rs
+++ b/boltffi_bindgen/src/render/java/lower.rs
@@ -1196,6 +1196,8 @@ mod tests {
             is_repr_c: true,
             id: RecordId::new(id),
             fields,
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         }

--- a/boltffi_bindgen/src/render/jni/lower.rs
+++ b/boltffi_bindgen/src/render/jni/lower.rs
@@ -2631,6 +2631,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });

--- a/boltffi_bindgen/src/render/swift/lower.rs
+++ b/boltffi_bindgen/src/render/swift/lower.rs
@@ -1790,6 +1790,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -1825,6 +1827,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -1852,6 +1856,8 @@ mod tests {
                 doc: None,
                 default: None,
             }],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -1886,6 +1892,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -1971,6 +1979,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2097,6 +2107,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2122,6 +2134,8 @@ mod tests {
                 doc: None,
                 default: None,
             }],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2144,6 +2158,8 @@ mod tests {
                 doc: None,
                 default: None,
             }],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2166,6 +2182,8 @@ mod tests {
                 doc: None,
                 default: None,
             }],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2178,6 +2196,8 @@ mod tests {
                 doc: None,
                 default: None,
             }],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2289,6 +2309,8 @@ mod tests {
                     default: Some(DefaultValue::Null),
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });
@@ -2320,6 +2342,8 @@ mod tests {
                     default: None,
                 },
             ],
+            constructors: vec![],
+            methods: vec![],
             doc: None,
             deprecated: None,
         });

--- a/boltffi_bindgen/src/render/typescript/lower.rs
+++ b/boltffi_bindgen/src/render/typescript/lower.rs
@@ -2646,6 +2646,8 @@ mod tests {
                         default: None,
                     },
                 ],
+                constructors: vec![],
+                methods: vec![],
                 doc: None,
                 deprecated: None,
             });

--- a/boltffi_bindgen/src/scan/mod.rs
+++ b/boltffi_bindgen/src/scan/mod.rs
@@ -29,6 +29,8 @@ pub enum TypeShape {
     Record {
         fields: Vec<RecordField>,
         is_repr_c: bool,
+        constructors: Vec<Constructor>,
+        methods: Vec<Method>,
     },
     Enum {
         variants: Vec<Variant>,
@@ -83,9 +85,72 @@ impl TypeRegistry {
         }
     }
 
+    pub fn fill_record_fields(&mut self, name: &str, fields: Vec<RecordField>, is_repr_c: bool) {
+        let Some(meta) = self.types.get_mut(name) else {
+            return;
+        };
+        match &mut meta.shape {
+            TypeShape::Record {
+                fields: existing_fields,
+                is_repr_c: existing_repr_c,
+                ..
+            } => {
+                *existing_fields = fields;
+                *existing_repr_c = is_repr_c;
+            }
+            _ => {
+                meta.shape = TypeShape::Record {
+                    fields,
+                    is_repr_c,
+                    constructors: Vec::new(),
+                    methods: Vec::new(),
+                };
+            }
+        }
+    }
+
     pub fn set_doc(&mut self, name: &str, doc: String) {
         if let Some(meta) = self.types.get_mut(name) {
             meta.doc = Some(doc);
+        }
+    }
+
+    pub fn is_record(&self, name: &str) -> bool {
+        self.types.get(name).is_some_and(|meta| {
+            matches!(
+                meta.shape,
+                TypeShape::Pending(PendingKind::Record) | TypeShape::Record { .. }
+            )
+        })
+    }
+
+    pub fn merge_record_impl(
+        &mut self,
+        name: &str,
+        constructors: Vec<Constructor>,
+        methods: Vec<Method>,
+    ) {
+        let Some(meta) = self.types.get_mut(name) else {
+            return;
+        };
+        match &mut meta.shape {
+            TypeShape::Record {
+                constructors: existing_ctors,
+                methods: existing_methods,
+                ..
+            } => {
+                existing_ctors.extend(constructors);
+                existing_methods.extend(methods);
+            }
+            TypeShape::Pending(PendingKind::Record) => {
+                meta.shape = TypeShape::Record {
+                    fields: Vec::new(),
+                    is_repr_c: true,
+                    constructors,
+                    methods,
+                };
+            }
+            _ => {}
         }
     }
 
@@ -260,6 +325,11 @@ impl AliasResolver {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct ScanFeatures {
+    pub record_methods: bool,
+}
+
 pub struct SourceScanner {
     module_name: String,
     type_registry: TypeRegistry,
@@ -271,6 +341,7 @@ pub struct SourceScanner {
     integer_constants: HashMap<String, i128>,
     source_root: Option<PathBuf>,
     target_pointer_width_bits: Option<u8>,
+    features: ScanFeatures,
 }
 
 impl SourceScanner {
@@ -293,7 +364,13 @@ impl SourceScanner {
             integer_constants: HashMap::new(),
             source_root: None,
             target_pointer_width_bits,
+            features: ScanFeatures::default(),
         }
+    }
+
+    pub fn with_features(mut self, features: ScanFeatures) -> Self {
+        self.features = features;
+        self
     }
 
     pub fn scan_directory(&mut self, crate_path: &Path, dir: &Path) -> Result<(), String> {
@@ -384,7 +461,8 @@ impl SourceScanner {
             }
             Item::Impl(item_impl) => {
                 let is_exported = has_attribute(&item_impl.attrs, "ffi_class")
-                    || has_attribute(&item_impl.attrs, "export");
+                    || has_attribute(&item_impl.attrs, "export")
+                    || has_data_impl_attribute(&item_impl.attrs);
                 if is_exported {
                     item_impl
                         .items
@@ -812,6 +890,7 @@ impl SourceScanner {
                 Item::Impl(item_impl) => {
                     if (has_attribute(&item_impl.attrs, "ffi_class")
                         || has_attribute(&item_impl.attrs, "export"))
+                        && !has_data_impl_attribute(&item_impl.attrs)
                         && let Type::Path(type_path) = item_impl.self_ty.as_ref()
                         && let Some(seg) = type_path.path.segments.last()
                     {
@@ -871,7 +950,9 @@ impl SourceScanner {
                 }
             }
             Item::Impl(item_impl) => {
-                if has_attribute(&item_impl.attrs, "ffi_class")
+                if self.features.record_methods && has_data_impl_attribute(&item_impl.attrs) {
+                    self.process_record_impl(item_impl);
+                } else if has_attribute(&item_impl.attrs, "ffi_class")
                     || has_attribute(&item_impl.attrs, "export")
                 {
                     self.process_class(item_impl);
@@ -1002,7 +1083,7 @@ impl SourceScanner {
             has_repr_c(&item_struct.attrs)
         };
         self.type_registry
-            .fill(&name, TypeShape::Record { fields, is_repr_c });
+            .fill_record_fields(&name, fields, is_repr_c);
     }
 
     fn process_enum(
@@ -1204,6 +1285,44 @@ impl SourceScanner {
         );
     }
 
+    fn process_record_impl(&mut self, item_impl: &ItemImpl) {
+        let Some(record_name) = impl_self_type_ident(item_impl) else {
+            return;
+        };
+
+        if !self.type_registry.is_record(&record_name) {
+            return;
+        }
+
+        let mut constructors = Vec::new();
+        let mut methods = Vec::new();
+
+        item_impl
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                ImplItem::Fn(method) => Some(method),
+                _ => None,
+            })
+            .filter(|method| matches!(method.vis, syn::Visibility::Public(_)))
+            .filter(|method| !has_attribute(&method.attrs, "skip"))
+            .for_each(|method| {
+                if self.is_constructor(method, &record_name) {
+                    if let Some(ctor) = self.build_constructor(method, &record_name) {
+                        constructors.push(ctor);
+                    }
+                    return;
+                }
+
+                if let Some(built_method) = self.build_method(method, &record_name) {
+                    methods.push(built_method);
+                }
+            });
+
+        self.type_registry
+            .merge_record_impl(&record_name, constructors, methods);
+    }
+
     fn build_method(&self, method: &syn::ImplItemFn, self_type_name: &str) -> Option<Method> {
         let sig = &method.sig;
         let receiver = Self::extract_receiver(sig);
@@ -1289,12 +1408,21 @@ impl SourceScanner {
 
         for (name, entry) in self.type_registry.drain() {
             match entry.shape {
-                TypeShape::Record { fields, is_repr_c } => {
+                TypeShape::Record {
+                    fields,
+                    is_repr_c,
+                    constructors,
+                    methods,
+                } => {
                     let record = fields
                         .into_iter()
                         .fold(Record::new(&name), |r, f| r.with_field(f))
                         .with_repr_c(is_repr_c)
                         .maybe_doc(entry.doc);
+                    let record = constructors
+                        .into_iter()
+                        .fold(record, |r, ctor| r.with_constructor(ctor));
+                    let record = methods.into_iter().fold(record, |r, m| r.with_method(m));
                     module = module.with_record(record);
                 }
                 TypeShape::Enum {
@@ -1398,6 +1526,21 @@ fn has_attribute(attrs: &[Attribute], name: &str) -> bool {
                 .segments
                 .last()
                 .is_some_and(|segment| segment.ident == name)
+    })
+}
+
+fn has_data_impl_attribute(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        let is_data = attr.path().is_ident("data")
+            || attr
+                .path()
+                .segments
+                .last()
+                .is_some_and(|segment| segment.ident == "data");
+        if !is_data {
+            return false;
+        }
+        matches!(&attr.meta, syn::Meta::List(list) if list.tokens.to_string().trim() == "impl")
     })
 }
 
@@ -2302,11 +2445,26 @@ pub fn scan_crate_with_pointer_width(
     module_name: &str,
     target_pointer_width_bits: Option<u8>,
 ) -> Result<Module, String> {
+    scan_crate_with_options(
+        crate_path,
+        module_name,
+        target_pointer_width_bits,
+        ScanFeatures::default(),
+    )
+}
+
+pub fn scan_crate_with_options(
+    crate_path: &Path,
+    module_name: &str,
+    target_pointer_width_bits: Option<u8>,
+    features: ScanFeatures,
+) -> Result<Module, String> {
     let src_path = crate_path.join("src");
     let mut scanner = SourceScanner::new_with_pointer_width(
         module_name,
         target_pointer_width_bits.or_else(parse_target_pointer_width),
-    );
+    )
+    .with_features(features);
     scanner.scan_directory(crate_path, &src_path)?;
     Ok(scanner.into_module())
 }
@@ -2503,6 +2661,8 @@ mod tests {
             TypeShape::Record {
                 fields: vec![RecordField::new("x", MType::Primitive(Primitive::F64))],
                 is_repr_c: true,
+                constructors: Vec::new(),
+                methods: Vec::new(),
             },
         );
 
@@ -2530,6 +2690,91 @@ mod tests {
         );
 
         assert!(reg.is_enum("Color"));
+    }
+
+    #[test]
+    fn merge_record_impl_upgrades_pending_to_filled_shape() {
+        let mut reg = TypeRegistry::default();
+        reg.register("Point".into(), pending(PendingKind::Record));
+
+        let ctor = Constructor::new().with_name("origin");
+        let method = Method::new("magnitude", Receiver::Ref);
+        reg.merge_record_impl("Point", vec![ctor], vec![method]);
+
+        match &reg.types.get("Point").unwrap().shape {
+            TypeShape::Record {
+                fields,
+                constructors,
+                methods,
+                ..
+            } => {
+                assert!(fields.is_empty());
+                assert_eq!(constructors.len(), 1);
+                assert_eq!(constructors[0].name, "origin");
+                assert_eq!(methods.len(), 1);
+                assert_eq!(methods[0].name, "magnitude");
+            }
+            other => panic!("expected Record, got {:?}", std::mem::discriminant(other)),
+        }
+    }
+
+    #[test]
+    fn fill_record_fields_preserves_existing_methods() {
+        let mut reg = TypeRegistry::default();
+        reg.register("Point".into(), pending(PendingKind::Record));
+
+        let ctor = Constructor::new().with_name("origin");
+        let method = Method::new("magnitude", Receiver::Ref);
+        reg.merge_record_impl("Point", vec![ctor], vec![method]);
+
+        reg.fill_record_fields(
+            "Point",
+            vec![RecordField::new("x", MType::Primitive(Primitive::F64))],
+            true,
+        );
+
+        match &reg.types.get("Point").unwrap().shape {
+            TypeShape::Record {
+                fields,
+                is_repr_c,
+                constructors,
+                methods,
+            } => {
+                assert_eq!(fields.len(), 1);
+                assert_eq!(fields[0].name, "x");
+                assert!(*is_repr_c);
+                assert_eq!(constructors.len(), 1);
+                assert_eq!(methods.len(), 1);
+            }
+            other => panic!("expected Record, got {:?}", std::mem::discriminant(other)),
+        }
+    }
+
+    #[test]
+    fn fill_record_fields_creates_fresh_shape_from_pending() {
+        let mut reg = TypeRegistry::default();
+        reg.register("Point".into(), pending(PendingKind::Record));
+
+        reg.fill_record_fields(
+            "Point",
+            vec![RecordField::new("x", MType::Primitive(Primitive::F64))],
+            false,
+        );
+
+        match &reg.types.get("Point").unwrap().shape {
+            TypeShape::Record {
+                fields,
+                is_repr_c,
+                constructors,
+                methods,
+            } => {
+                assert_eq!(fields.len(), 1);
+                assert!(!*is_repr_c);
+                assert!(constructors.is_empty());
+                assert!(methods.is_empty());
+            }
+            other => panic!("expected Record, got {:?}", std::mem::discriminant(other)),
+        }
     }
 
     #[test]
@@ -2799,5 +3044,159 @@ mod tests {
         );
 
         fs::remove_dir_all(temp_root).expect("cleanup temp root");
+    }
+
+    fn scan_temp_crate(source: &str, features: ScanFeatures) -> Module {
+        let unique_suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!(
+            "boltffi_scan_record_methods_{}_{}",
+            std::process::id(),
+            unique_suffix
+        ));
+        let src_dir = temp_root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(src_dir.join("lib.rs"), source).expect("write lib.rs");
+
+        let module =
+            scan_crate_with_options(&temp_root, "testlib", None, features).expect("scan failed");
+        fs::remove_dir_all(&temp_root).expect("cleanup");
+        module
+    }
+
+    fn scan_temp_crate_multi(files: &[(&str, &str)], features: ScanFeatures) -> Module {
+        let unique_suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!(
+            "boltffi_scan_record_methods_{}_{}",
+            std::process::id(),
+            unique_suffix
+        ));
+        let src_dir = temp_root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+
+        files.iter().for_each(|(name, content)| {
+            fs::write(src_dir.join(name), content).expect("write file");
+        });
+
+        let module =
+            scan_crate_with_options(&temp_root, "testlib", None, features).expect("scan failed");
+        fs::remove_dir_all(&temp_root).expect("cleanup");
+        module
+    }
+
+    #[test]
+    fn record_impl_scanned_with_feature_enabled() {
+        let source = r#"
+            #[boltffi::data]
+            pub struct Point {
+                pub x: f64,
+                pub y: f64,
+            }
+
+            #[boltffi::data(impl)]
+            impl Point {
+                pub fn origin() -> Self {
+                    Self { x: 0.0, y: 0.0 }
+                }
+
+                pub fn magnitude(&self) -> f64 {
+                    (self.x * self.x + self.y * self.y).sqrt()
+                }
+            }
+        "#;
+
+        let module = scan_temp_crate(
+            source,
+            ScanFeatures {
+                record_methods: true,
+            },
+        );
+
+        let record = module.find_record("Point").expect("Point not found");
+        assert_eq!(record.fields.len(), 2);
+        assert_eq!(record.constructors.len(), 1);
+        assert_eq!(record.constructors[0].name, "origin");
+        assert_eq!(record.methods.len(), 1);
+        assert_eq!(record.methods[0].name, "magnitude");
+    }
+
+    #[test]
+    fn record_impl_ignored_with_feature_disabled() {
+        let source = r#"
+            #[boltffi::data]
+            pub struct Point {
+                pub x: f64,
+                pub y: f64,
+            }
+
+            #[boltffi::data(impl)]
+            impl Point {
+                pub fn origin() -> Self {
+                    Self { x: 0.0, y: 0.0 }
+                }
+
+                pub fn magnitude(&self) -> f64 {
+                    (self.x * self.x + self.y * self.y).sqrt()
+                }
+            }
+        "#;
+
+        let module = scan_temp_crate(source, ScanFeatures::default());
+
+        let record = module.find_record("Point").expect("Point not found");
+        assert_eq!(record.fields.len(), 2);
+        assert!(record.constructors.is_empty());
+        assert!(record.methods.is_empty());
+    }
+
+    #[test]
+    fn record_impl_cross_file_impl_before_struct() {
+        let module = scan_temp_crate_multi(
+            &[
+                ("lib.rs", "pub mod record_impl;\npub mod record_struct;\n"),
+                (
+                    "record_impl.rs",
+                    r#"
+                        use super::record_struct::Point;
+
+                        #[boltffi::data(impl)]
+                        impl Point {
+                            pub fn origin() -> Self {
+                                Self { x: 0.0, y: 0.0 }
+                            }
+
+                            pub fn magnitude(&self) -> f64 {
+                                (self.x * self.x + self.y * self.y).sqrt()
+                            }
+                        }
+                    "#,
+                ),
+                (
+                    "record_struct.rs",
+                    r#"
+                        #[boltffi::data]
+                        pub struct Point {
+                            pub x: f64,
+                            pub y: f64,
+                        }
+                    "#,
+                ),
+            ],
+            ScanFeatures {
+                record_methods: true,
+            },
+        );
+
+        let record = module.find_record("Point").expect("Point not found");
+        assert_eq!(record.fields.len(), 2);
+        assert_eq!(record.constructors.len(), 1);
+        assert_eq!(record.constructors[0].name, "origin");
+        assert_eq!(record.methods.len(), 1);
+        assert_eq!(record.methods[0].name, "magnitude");
     }
 }

--- a/boltffi_cli/src/commands/generate.rs
+++ b/boltffi_cli/src/commands/generate.rs
@@ -3,8 +3,9 @@ use std::path::{Component, Path};
 
 use boltffi_bindgen::render::typescript::{TypeScriptEmitter, TypeScriptLowerer};
 use boltffi_bindgen::{
-    CHeaderLowerer, FactoryStyle, KotlinOptions, TypeConversion as BindgenTypeConversion,
-    TypeMapping as BindgenTypeMapping, TypeMappings, ir, render, scan_crate_with_pointer_width,
+    CHeaderLowerer, FactoryStyle, KotlinOptions, ScanFeatures,
+    TypeConversion as BindgenTypeConversion, TypeMapping as BindgenTypeMapping, TypeMappings, ir,
+    render, scan_crate_with_options,
 };
 
 use crate::config::{
@@ -90,16 +91,24 @@ fn convert_type_mappings(
         .collect()
 }
 
-fn scan_with_pointer_width(
-    crate_dir: &Path,
-    crate_name: &str,
-    pointer_width_bits: Option<u8>,
+fn scan_crate(
+    source_directory: &Path,
+    library_name: &str,
+    target_pointer_width: Option<u8>,
+    config: &Config,
 ) -> Result<boltffi_bindgen::Module> {
-    scan_crate_with_pointer_width(crate_dir, crate_name, pointer_width_bits).map_err(|error| {
-        CliError::CommandFailed {
-            command: format!("scan_crate: {}", error),
-            status: None,
-        }
+    let features = ScanFeatures {
+        record_methods: config.record_methods_enabled(),
+    };
+    scan_crate_with_options(
+        source_directory,
+        library_name,
+        target_pointer_width,
+        features,
+    )
+    .map_err(|error| CliError::CommandFailed {
+        command: format!("scan_crate: {}", error),
+        status: None,
     })
 }
 
@@ -192,7 +201,7 @@ fn generate_swift(config: &Config, output: Option<PathBuf>) -> Result<()> {
         .unwrap_or_else(|_| PathBuf::from("."));
     let crate_name = config.library_name();
 
-    let mut module = scan_with_pointer_width(&crate_dir, crate_name, Some(64))?;
+    let mut module = scan_crate(&crate_dir, crate_name, Some(64), config)?;
 
     let ffi_module_name = config
         .apple_swift_ffi_module_name()
@@ -247,7 +256,7 @@ fn generate_kotlin(config: &Config, output: Option<PathBuf>) -> Result<()> {
         .unwrap_or_else(|_| PathBuf::from("."));
     let crate_name = config.library_name();
 
-    let mut module = scan_with_pointer_width(&crate_dir, crate_name, None)?;
+    let mut module = scan_crate(&crate_dir, crate_name, None, config)?;
 
     let factory_style = match config.android_kotlin_factory_style() {
         ConfigFactoryStyle::Constructors => FactoryStyle::Constructors,
@@ -351,7 +360,7 @@ fn generate_java(config: &Config, output: Option<PathBuf>) -> Result<()> {
         JavaGenerationMode::Jvm => host_pointer_width_bits(),
         JavaGenerationMode::Android => None,
     };
-    let mut module = scan_with_pointer_width(&crate_dir, crate_name, java_pointer_width_bits)?;
+    let mut module = scan_crate(&crate_dir, crate_name, java_pointer_width_bits, config)?;
 
     let contract = ir::build_contract(&mut module);
     let abi_contract = ir::Lowerer::new(&contract).to_abi_contract();
@@ -421,7 +430,7 @@ fn generate_header(config: &Config, output: Option<PathBuf>) -> Result<()> {
     } else {
         None
     };
-    let mut module = scan_with_pointer_width(&crate_dir, crate_name, header_pointer_width_bits)?;
+    let mut module = scan_crate(&crate_dir, crate_name, header_pointer_width_bits, config)?;
 
     let contract = ir::build_contract(&mut module);
     let abi = ir::Lowerer::new(&contract).to_abi_contract();
@@ -460,7 +469,7 @@ fn generate_typescript(config: &Config, output: Option<PathBuf>) -> Result<()> {
         .unwrap_or_else(|_| PathBuf::from("."));
     let crate_name = config.library_name();
 
-    let mut module = scan_with_pointer_width(&crate_dir, crate_name, Some(32))?;
+    let mut module = scan_crate(&crate_dir, crate_name, Some(32), config)?;
 
     let contract = ir::build_contract(&mut module);
     let abi_contract = ir::Lowerer::new(&contract).to_abi_contract();

--- a/boltffi_cli/src/config.rs
+++ b/boltffi_cli/src/config.rs
@@ -38,6 +38,8 @@ impl Experimental {
         },
     ];
 
+    pub const RECORDS_METHODS: &'static str = "records.methods";
+
     pub fn is_target_experimental(target: Target) -> bool {
         Self::ALL
             .iter()
@@ -766,6 +768,11 @@ impl Config {
         }
     }
 
+    pub fn record_methods_enabled(&self) -> bool {
+        self.experimental
+            .contains(&Experimental::RECORDS_METHODS.to_string())
+    }
+
     pub fn java_package(&self) -> String {
         self.targets
             .java
@@ -1159,5 +1166,32 @@ deployment_target = "16.0"
         );
 
         assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn record_methods_experimental_flag() {
+        let config = parse_config(
+            r#"
+experimental = ["records.methods"]
+
+[package]
+name = "mylib"
+"#,
+        );
+
+        assert!(config.record_methods_enabled());
+        assert_eq!(Experimental::RECORDS_METHODS, "records.methods");
+    }
+
+    #[test]
+    fn record_methods_disabled_by_default() {
+        let config = parse_config(
+            r#"
+[package]
+name = "mylib"
+"#,
+        );
+
+        assert!(!config.record_methods_enabled());
     }
 }


### PR DESCRIPTION
this is the plumbing PR, it adds `#[data(impl)]` attribute recognition so records can have constructors and methods the work is gated behind `experimental = ["records.methods"] in boltffi.toml` so it extends the models, IR layer, and scanner layers with the required fields  and there is no codegen yet.
kikstart the work for #57 