### PR TITLE
Promote JAVA to GA

### DIFF
--- a/BOLTFFI_TOML_SPEC.md
+++ b/BOLTFFI_TOML_SPEC.md
@@ -29,23 +29,24 @@ Placeholder references like `{package.crate}` follow these fallback rules:
 List of experimental targets or features that are explicitly enabled.
 
 ```toml
-experimental = ["java"]
+experimental = ["typescript.async_streams", "records.methods"]
 ```
 
 ```toml
-experimental = ["kotlin.kmp", "swift.actors"]
+experimental = ["typescript.async_streams"]
 ```
 
 - Type: array of strings
 - Default: `[]`
 - Format: `"target"` or `"target.feature"`
-- CLI requires `--experimental` flag when using experimental targets/features
+- CLI `--experimental` flag includes experimental targets for that command
 
 Experimental targets:
-- `java`
+- none currently
 
 Experimental features:
-- `kotlin.kmp`
+- `typescript.async_streams`
+- `records.methods`
 
 ### `[package]` (required)
 

--- a/benchmarks/rust-boltffi/boltffi.toml
+++ b/benchmarks/rust-boltffi/boltffi.toml
@@ -1,5 +1,3 @@
-experimental = ["java"]
-
 [package]
 name = "bench_boltffi"
 

--- a/boltffi_cli/src/commands/generate.rs
+++ b/boltffi_cli/src/commands/generate.rs
@@ -31,14 +31,28 @@ pub struct GenerateOptions {
     pub experimental: bool,
 }
 
-fn require_experimental(target: Target, experimental_flag: bool) -> Result<()> {
-    if Experimental::is_target_experimental(target) && !experimental_flag {
-        return Err(CliError::CommandFailed {
-            command: format!("{} is experimental, use --experimental flag", target.name()),
-            status: None,
-        });
+fn require_experimental_target(
+    config: &Config,
+    target: Target,
+    experimental_flag: bool,
+) -> Result<()> {
+    if !Experimental::is_target_experimental(target) {
+        return Ok(());
     }
-    Ok(())
+
+    let enabled_in_config = config.experimental.contains(&target.name().to_string());
+    if experimental_flag || enabled_in_config {
+        return Ok(());
+    }
+
+    Err(CliError::CommandFailed {
+        command: format!(
+            "{} is experimental, use --experimental flag or add \"{}\" to [experimental]",
+            target.name(),
+            target.name()
+        ),
+        status: None,
+    })
 }
 
 pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Result<()> {
@@ -46,7 +60,7 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
         GenerateTarget::Swift => generate_swift(config, options.output),
         GenerateTarget::Kotlin => generate_kotlin(config, options.output),
         GenerateTarget::Java => {
-            require_experimental(Target::Java, options.experimental)?;
+            require_experimental_target(config, Target::Java, options.experimental)?;
             generate_java(config, options.output)
         }
         GenerateTarget::Header => generate_header(config, options.output),

--- a/boltffi_cli/src/commands/pack.rs
+++ b/boltffi_cli/src/commands/pack.rs
@@ -63,6 +63,7 @@ pub struct PackJavaOptions {
     pub release: bool,
     pub regenerate: bool,
     pub no_build: bool,
+    pub experimental: bool,
     pub cargo_args: Vec<String>,
 }
 
@@ -132,6 +133,7 @@ fn pack_all(config: &Config, options: PackAllOptions, reporter: &Reporter) -> Re
                 release: options.release,
                 regenerate: options.regenerate,
                 no_build: options.no_build,
+                experimental: options.experimental,
                 cargo_args: options.cargo_args.clone(),
             },
             reporter,
@@ -497,7 +499,7 @@ fn pack_java(config: &Config, options: PackJavaOptions, reporter: &Reporter) -> 
             GenerateOptions {
                 target: GenerateTarget::Java,
                 output: Some(config.java_jvm_output()),
-                experimental: true,
+                experimental: options.experimental,
             },
         )?;
         step.finish_success();

--- a/boltffi_cli/src/config.rs
+++ b/boltffi_cli/src/config.rs
@@ -30,20 +30,17 @@ pub enum Experimental {
 }
 
 impl Experimental {
-    pub const ALL: &'static [Experimental] = &[
-        Experimental::WholeTarget(Target::Java),
-        Experimental::Feature {
-            target: Target::TypeScript,
-            name: "async_streams",
-        },
-    ];
+    pub const ALL: &'static [Experimental] = &[Experimental::Feature {
+        target: Target::TypeScript,
+        name: "async_streams",
+    }];
 
     pub const RECORDS_METHODS: &'static str = "records.methods";
 
     pub fn is_target_experimental(target: Target) -> bool {
-        Self::ALL
-            .iter()
-            .any(|e| matches!(e, Experimental::WholeTarget(t) if *t == target))
+        Self::ALL.iter().any(
+            |experimental| matches!(experimental, Experimental::WholeTarget(t) if *t == target),
+        )
     }
 }
 
@@ -756,7 +753,9 @@ impl Config {
 
     pub fn should_process(&self, target: Target, experimental_flag: bool) -> bool {
         self.is_enabled(target)
-            && (!Experimental::is_target_experimental(target) || experimental_flag)
+            && (!Experimental::is_target_experimental(target)
+                || experimental_flag
+                || self.is_experimental_enabled(&Experimental::WholeTarget(target)))
     }
 
     pub fn cargo_args_for_command(&self, command_name: &str) -> Vec<String> {
@@ -776,7 +775,7 @@ impl Config {
 
     fn is_experimental_enabled(&self, exp: &Experimental) -> bool {
         let key = match exp {
-            Experimental::WholeTarget(t) => t.name().to_string(),
+            Experimental::WholeTarget(target) => target.name().to_string(),
             Experimental::Feature { target, name } => format!("{}.{}", target.name(), name),
         };
         self.experimental.contains(&key)

--- a/boltffi_cli/src/main.rs
+++ b/boltffi_cli/src/main.rs
@@ -190,7 +190,7 @@ enum PackTargetArg {
         #[arg(long)]
         no_build: bool,
 
-        #[arg(long, help = "Include experimental targets")]
+        #[arg(long, help = "Include experimental targets/features")]
         experimental: bool,
     },
 
@@ -252,7 +252,7 @@ enum PackTargetArg {
     },
 
     #[command(
-        about = "Build + package Java artifacts (experimental)",
+        about = "Build + package Java artifacts",
         long_about = "Build + package Java artifacts.\n\nOutputs:\n  - Java bindings: {targets.java.jvm.output}\n"
     )]
     Java {
@@ -475,6 +475,7 @@ fn execute_command(
                     release,
                     regenerate,
                     no_build,
+                    experimental: false,
                     cargo_args: cargo_args.clone(),
                 }),
             };

--- a/docs/src/content/docs/experimental.mdx
+++ b/docs/src/content/docs/experimental.mdx
@@ -1,15 +1,16 @@
 ---
 title: "Experimental Features"
-description: "Enable and manage experimental BoltFFI features including Java bindings, TypeScript async streams, and record methods."
+description: "Enable and manage experimental BoltFFI features such as TypeScript async streams and record methods."
 ---
 
 # Experimental Features
 
 Some BoltFFI features are behind an experimental flag. The API for these features may change between releases, so they require an explicit opt-in.
 
+Java bindings are now generally available and no longer require experimental opt-in.
+
 | Feature | Key | Status |
 |---------|-----|--------|
-| Java bindings | `java` | Functional |
 | TS async streams | `typescript.async_streams` | Functional |
 | Record methods | `records.methods` | Functional |
 
@@ -17,32 +18,24 @@ Some BoltFFI features are behind an experimental flag. The API for these feature
 
 ### CLI flag
 
+Pass `--experimental` to include experimental targets during that command run:
+
 ```bash
-boltffi generate java --experimental
-boltffi pack java --experimental
+boltffi generate all --experimental
+boltffi pack all --experimental
 ```
 
 ### Config file
 
+Add the feature key to `experimental` in `boltffi.toml`:
+
 ```toml
-experimental = ["java", "typescript.async_streams", "records.methods"]
+experimental = ["typescript.async_streams", "records.methods"]
 ```
 
 The CLI flag applies to a single command. The config array applies to every build.
 
 ## Feature Details
-
-### Java Bindings
-
-**Key:** `java`
-
-The entire Java target (JVM and Android codegen, JNI bridge, all generated sources) requires this flag.
-
-Known gaps:
-
-- Custom types (`Duration`, `SystemTime`, `Uuid`, `Url`) are not yet supported. Functions using them are silently skipped.
-- Record field defaults (`#[boltffi::default(...)]`) don't generate overloaded constructors.
-- Error enum variant payloads are not carried across (error enums are flat in Java).
 
 ### TypeScript Async Streams
 

--- a/examples/platforms/java/test-demo.sh
+++ b/examples/platforms/java/test-demo.sh
@@ -104,7 +104,7 @@ run_case() {
 
   set_min_version "$config_version"
 
-  (cd "$demo_dir" && cargo run -q --manifest-path "$manifest_path" -p boltffi_cli -- generate --experimental java --output "$output_dir")
+  (cd "$demo_dir" && cargo run -q --manifest-path "$manifest_path" -p boltffi_cli -- generate java --output "$output_dir")
 
   local point_file="$output_dir/com/boltffi/demo/Point.java"
   if ! grep -q "$expected_point_declaration" "$point_file"; then


### PR DESCRIPTION
Closes #54 Java bindings are GA now.
