### PR TITLE
Support overlays for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ When `architectures` is omitted, BoltFFI keeps the existing default Android matr
 configured ABI already has a built Rust static library and ignores stale artifacts for
 unconfigured ABIs.
 
+You can also apply per-invocation overlays without mutating the tracked base config.
+BoltFFI still requires a base `boltffi.toml`, then merges the overlay on top for that one command:
+
+```bash
+boltffi --overlay boltffi.ci.toml pack android
+boltffi --overlay boltffi.release.toml pack all --release
+```
+
+This is useful for CI, release builds, or machine-local overrides. `boltffi init` does not accept
+`--overlay`.
+
 Use it from Swift, Kotlin, or TypeScript:
 
 ```swift

--- a/boltffi_bindgen/src/scan/compiler_type_resolution.rs
+++ b/boltffi_bindgen/src/scan/compiler_type_resolution.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use proc_macro2::Span;
 use quote::quote;
@@ -126,6 +127,23 @@ fn cargo_manifest_dir(manifest_path: &str) -> Result<PathBuf, String> {
         .ok_or_else(|| format!("invalid manifest path: {}", manifest_path))
 }
 
+fn runner_lock(crate_path: &Path) -> Result<Arc<Mutex<()>>, String> {
+    static RUNNER_LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
+
+    let key = crate_path
+        .canonicalize()
+        .map_err(|e| format!("canonicalize {}: {}", crate_path.display(), e))?;
+    let locks = RUNNER_LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut locks = locks
+        .lock()
+        .map_err(|_| "runner lock registry poisoned".to_string())?;
+
+    Ok(locks
+        .entry(key)
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone())
+}
+
 pub fn resolve(
     crate_path: &Path,
     package_hint: &str,
@@ -160,6 +178,10 @@ pub fn resolve(
     let metadata = load_cargo_metadata(crate_path)?;
     let target_package = select_target_package(crate_path, package_hint, &metadata)?;
     let target_manifest_dir = cargo_manifest_dir(&target_package.manifest_path)?;
+    let lock = runner_lock(crate_path)?;
+    let _guard = lock
+        .lock()
+        .map_err(|_| "type resolution runner lock poisoned".to_string())?;
 
     let dir = runner_dir(crate_path);
     let src_dir = dir.join("src");

--- a/boltffi_cli/src/commands/doctor.rs
+++ b/boltffi_cli/src/commands/doctor.rs
@@ -1,10 +1,16 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::check::EnvironmentCheck;
 use crate::commands::check::apple_targets_require_lipo;
 use crate::config::Config;
 use crate::error::Result;
 use crate::target::RustTarget;
+
+pub enum ConfigSummary {
+    Loaded(Box<Config>),
+    Missing,
+    Invalid(String),
+}
 
 pub struct DoctorOptions {
     pub apple: bool,
@@ -13,6 +19,9 @@ pub struct DoctorOptions {
     pub android_targets: Vec<RustTarget>,
     pub wasm: bool,
     pub wasm_target_triple: Option<String>,
+    pub config_summary: ConfigSummary,
+    pub config_path: PathBuf,
+    pub overlay_path: Option<PathBuf>,
     pub config_warning: Option<String>,
 }
 
@@ -28,7 +37,11 @@ pub fn run_doctor(options: DoctorOptions) -> Result<()> {
     }
     print_environment(&check, &options);
     println!();
-    print_config_summary();
+    print_config_summary(
+        &options.config_summary,
+        &options.config_path,
+        options.overlay_path.as_deref(),
+    );
 
     Ok(())
 }
@@ -140,17 +153,13 @@ fn print_environment(check: &EnvironmentCheck, options: &DoctorOptions) {
     }
 }
 
-fn print_config_summary() {
-    let config_path = PathBuf::from("boltffi.toml");
-
-    if !config_path.exists() {
-        println!("Config: missing (expected ./boltffi.toml)");
-        return;
-    }
-
-    match Config::load(&config_path) {
-        Ok(config) => {
+fn print_config_summary(summary: &ConfigSummary, config_path: &Path, overlay_path: Option<&Path>) {
+    match summary {
+        ConfigSummary::Loaded(config) => {
             println!("Config: {}", config_path.display());
+            if let Some(overlay_path) = overlay_path {
+                println!("Overlay: {}", overlay_path.display());
+            }
             println!("  crate: {}", config.library_name());
             println!(
                 "  targets.apple.output: {}",
@@ -243,8 +252,23 @@ fn print_config_summary() {
                 config.wasm_npm_output().display()
             );
         }
-        Err(error) => {
-            println!("Config: {} (invalid: {})", config_path.display(), error);
+        ConfigSummary::Missing => {
+            if let Some(overlay_path) = overlay_path {
+                println!(
+                    "Config: missing (expected {} before applying overlay {})",
+                    config_path.display(),
+                    overlay_path.display()
+                );
+            } else {
+                println!("Config: missing (expected {})", config_path.display());
+            }
+        }
+        ConfigSummary::Invalid(error) => {
+            println!("Config: {}", config_path.display());
+            if let Some(overlay_path) = overlay_path {
+                println!("Overlay: {}", overlay_path.display());
+            }
+            println!("  invalid: {}", error);
         }
     }
 }
@@ -255,8 +279,9 @@ fn readiness(is_ready: bool) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{DoctorOptions, required_target_triples};
+    use super::{ConfigSummary, DoctorOptions, required_target_triples};
     use crate::target::RustTarget;
+    use std::path::PathBuf;
 
     #[test]
     fn uses_configured_wasm_target_triple() {
@@ -267,6 +292,9 @@ mod tests {
             android_targets: Vec::new(),
             wasm: true,
             wasm_target_triple: Some("wasm32-wasip1".to_string()),
+            config_summary: ConfigSummary::Missing,
+            config_path: PathBuf::from("boltffi.toml"),
+            overlay_path: None,
             config_warning: None,
         };
 
@@ -285,6 +313,9 @@ mod tests {
             android_targets: Vec::new(),
             wasm: true,
             wasm_target_triple: None,
+            config_summary: ConfigSummary::Missing,
+            config_path: PathBuf::from("boltffi.toml"),
+            overlay_path: None,
             config_warning: None,
         };
 

--- a/boltffi_cli/src/commands/init.rs
+++ b/boltffi_cli/src/commands/init.rs
@@ -48,15 +48,13 @@ fn detect_package_name(path: &Path) -> Option<String> {
 
     std::fs::read_to_string(&cargo_toml)
         .ok()
-        .and_then(|content| {
-            content
-                .lines()
-                .find(|line| line.starts_with("name = "))
-                .and_then(|line| {
-                    line.split('=')
-                        .nth(1)
-                        .map(|s| s.trim().trim_matches('"').to_string())
-                })
+        .and_then(|content| toml::from_str::<toml::Value>(&content).ok())
+        .and_then(|value| {
+            value
+                .get("package")
+                .and_then(|package| package.get("name"))
+                .and_then(toml::Value::as_str)
+                .map(str::to_string)
         })
 }
 
@@ -144,4 +142,64 @@ fn to_pascal_case(input: &str) -> String {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InitOptions, run_init};
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn run_init_writes_requested_config_path() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("boltffi-init-test-{unique}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        fs::write(
+            temp_root.join("Cargo.toml"),
+            "[package]\nname = \"demo_lib\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("write cargo toml");
+
+        let config_path = temp_root.join("boltffi.toml");
+        let written_path = run_init(InitOptions {
+            name: None,
+            path: temp_root.clone(),
+        })
+        .expect("init should succeed");
+
+        assert_eq!(written_path, config_path);
+        assert!(config_path.exists());
+        let content = fs::read_to_string(&config_path).expect("read config");
+        assert!(content.contains("name = \"demo_lib\""));
+
+        fs::remove_dir_all(temp_root).expect("cleanup temp root");
+    }
+
+    #[test]
+    fn run_init_falls_back_when_cargo_manifest_has_no_package_table() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("boltffi-init-workspace-test-{unique}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        fs::write(temp_root.join("Cargo.toml"), "[workspace]\nmembers = []\n")
+            .expect("write workspace cargo toml");
+
+        let config_path = temp_root.join("boltffi.toml");
+        run_init(InitOptions {
+            name: None,
+            path: temp_root.clone(),
+        })
+        .expect("init should succeed");
+
+        let content = fs::read_to_string(&config_path).expect("read config");
+        assert!(content.contains("name = \"mylib\""));
+
+        fs::remove_dir_all(temp_root).expect("cleanup temp root");
+    }
 }

--- a/boltffi_cli/src/commands/pack.rs
+++ b/boltffi_cli/src/commands/pack.rs
@@ -260,7 +260,7 @@ fn pack_all(config: &Config, options: PackAllOptions, reporter: &Reporter) -> Re
     }
 
     if !packed_any {
-        reporter.warning("no targets enabled in boltffi.toml");
+        reporter.warning("no targets enabled in config");
     }
 
     reporter.finish();

--- a/boltffi_cli/src/config.rs
+++ b/boltffi_cli/src/config.rs
@@ -522,16 +522,60 @@ fn default_dart_output() -> PathBuf {
     PathBuf::from("dist/dart")
 }
 
+fn read_toml_value(path: &Path) -> Result<toml::Value, ConfigError> {
+    let content = std::fs::read_to_string(path).map_err(|err| ConfigError::Read {
+        path: path.to_path_buf(),
+        source: err,
+    })?;
+
+    toml::from_str(&content).map_err(|source| ConfigError::Parse {
+        path: path.to_path_buf(),
+        source: Box::new(source),
+    })
+}
+
+fn merge_toml_value(base: &mut toml::Value, overlay: toml::Value) {
+    match (base, overlay) {
+        (toml::Value::Table(base_table), toml::Value::Table(overlay_table)) => {
+            for (key, overlay_value) in overlay_table {
+                match base_table.get_mut(&key) {
+                    Some(base_value) => merge_toml_value(base_value, overlay_value),
+                    None => {
+                        base_table.insert(key, overlay_value);
+                    }
+                }
+            }
+        }
+        (base_value, overlay_value) => *base_value = overlay_value,
+    }
+}
+
 impl Config {
     pub fn load(path: &Path) -> Result<Self, ConfigError> {
-        let content = std::fs::read_to_string(path).map_err(|err| ConfigError::Read {
-            path: path.to_path_buf(),
-            source: err,
-        })?;
+        Self::load_with_overlay(path, None)
+    }
 
-        let config: Config = toml::from_str(&content).map_err(|err| ConfigError::Parse {
-            path: path.to_path_buf(),
-            source: err,
+    pub fn load_with_overlay(
+        path: &Path,
+        overlay_path: Option<&Path>,
+    ) -> Result<Self, ConfigError> {
+        let mut merged = read_toml_value(path)?;
+
+        if let Some(overlay_path) = overlay_path {
+            let overlay = read_toml_value(overlay_path)?;
+            merge_toml_value(&mut merged, overlay);
+        }
+
+        let config: Config = merged.try_into().map_err(|source| match overlay_path {
+            Some(overlay_path) => ConfigError::ParseMerged {
+                base_path: path.to_path_buf(),
+                overlay_path: overlay_path.to_path_buf(),
+                source: Box::new(source),
+            },
+            None => ConfigError::Parse {
+                path: path.to_path_buf(),
+                source: Box::new(source),
+            },
         })?;
 
         config.validate()?;
@@ -1266,7 +1310,14 @@ pub enum ConfigError {
     #[error("failed to parse config from {path}: {source}")]
     Parse {
         path: PathBuf,
-        source: toml::de::Error,
+        source: Box<toml::de::Error>,
+    },
+
+    #[error("failed to parse merged config from {base_path} with overlay {overlay_path}: {source}")]
+    ParseMerged {
+        base_path: PathBuf,
+        overlay_path: PathBuf,
+        source: Box<toml::de::Error>,
     },
 
     #[error("invalid config: {0}")]
@@ -1289,6 +1340,16 @@ mod tests {
     fn parse_config(input: &str) -> Config {
         let parsed: Config = toml::from_str(input).expect("toml parse failed");
         parsed.validate().expect("config validation failed");
+        parsed
+    }
+
+    fn parse_config_with_overlay(base: &str, overlay: &str) -> Config {
+        let mut merged: toml::Value = toml::from_str(base).expect("base toml parse failed");
+        let overlay: toml::Value = toml::from_str(overlay).expect("overlay toml parse failed");
+        merge_toml_value(&mut merged, overlay);
+
+        let parsed: Config = merged.try_into().expect("merged config parse failed");
+        parsed.validate().expect("merged config validation failed");
         parsed
     }
 
@@ -1805,5 +1866,99 @@ global_args = ["--frozen"]
             config.cargo_args_for_command("test"),
             vec!["--frozen".to_string()]
         );
+    }
+
+    #[test]
+    fn overlay_can_override_android_architectures_while_inheriting_other_fields() {
+        let config = parse_config_with_overlay(
+            r#"
+[package]
+name = "mylib"
+
+[targets.android]
+min_sdk = 26
+output = "dist/android-release"
+architectures = ["arm64", "armv7"]
+"#,
+            r#"
+[targets.android]
+architectures = ["arm64"]
+"#,
+        );
+
+        assert_eq!(config.android_min_sdk(), 26);
+        assert_eq!(
+            config.android_output(),
+            PathBuf::from("dist/android-release")
+        );
+        assert_eq!(
+            config
+                .android_architectures()
+                .iter()
+                .map(|architecture| architecture.canonical_name())
+                .collect::<Vec<_>>(),
+            vec!["arm64"]
+        );
+    }
+
+    #[test]
+    fn overlay_can_override_java_host_targets_while_inheriting_other_fields() {
+        let config = parse_config_with_overlay(
+            r#"
+[package]
+name = "mylib"
+
+[targets.android]
+min_sdk = 29
+
+[targets.java]
+package = "com.example.base"
+
+[targets.java.jvm]
+enabled = true
+host_targets = ["current", "linux-x86_64"]
+"#,
+            r#"
+[targets.java.jvm]
+host_targets = ["linux-x86_64"]
+"#,
+        );
+
+        assert_eq!(config.android_min_sdk(), 29);
+        assert_eq!(config.java_package(), "com.example.base");
+        assert_eq!(
+            config
+                .java_jvm_requested_host_targets()
+                .iter()
+                .map(|target| target.canonical_name())
+                .collect::<Vec<_>>(),
+            vec!["linux-x86_64"]
+        );
+    }
+
+    #[test]
+    fn overlay_deep_merges_nested_tables() {
+        let config = parse_config_with_overlay(
+            r#"
+[package]
+name = "mylib"
+
+[targets.apple.spm]
+distribution = "remote"
+repo_url = "https://example.com/base.git"
+package_name = "BaseKit"
+"#,
+            r#"
+[targets.apple.spm]
+package_name = "OverlayKit"
+"#,
+        );
+
+        assert_eq!(config.apple_spm_distribution(), SpmDistribution::Remote);
+        assert_eq!(
+            config.apple_spm_repo_url(),
+            Some("https://example.com/base.git")
+        );
+        assert_eq!(config.apple_spm_package_name(), Some("OverlayKit"));
     }
 }

--- a/boltffi_cli/src/error.rs
+++ b/boltffi_cli/src/error.rs
@@ -4,10 +4,10 @@ use std::path::PathBuf;
 #[derive(Debug, thiserror::Error)]
 pub enum CliError {
     #[error("config error: {0}")]
-    Config(#[from] ConfigError),
+    Config(Box<ConfigError>),
 
-    #[error("boltffi.toml not found in current directory")]
-    ConfigNotFound,
+    #[error("config file not found: {0}")]
+    ConfigNotFound(PathBuf),
 
     #[error("no built libraries found for {platform}")]
     NoLibrariesFound { platform: String },
@@ -78,6 +78,12 @@ pub enum CliError {
 
     #[error("build failed for targets: {targets:?}")]
     BuildFailed { targets: Vec<String> },
+}
+
+impl From<ConfigError> for CliError {
+    fn from(error: ConfigError) -> Self {
+        Self::Config(Box::new(error))
+    }
 }
 
 pub type Result<T> = std::result::Result<T, CliError>;

--- a/boltffi_cli/src/main.rs
+++ b/boltffi_cli/src/main.rs
@@ -10,11 +10,11 @@ mod reporter;
 mod target;
 
 use clap::{Parser, Subcommand};
-use std::path::PathBuf;
+use std::{fmt, path::PathBuf};
 
 use commands::build::{BuildCommandOptions, BuildPlatform};
 use commands::check::CheckOptions;
-use commands::doctor::DoctorOptions;
+use commands::doctor::{ConfigSummary, DoctorOptions};
 use commands::generate::{GenerateOptions, GenerateTarget, run_generate_with_output};
 use commands::init::InitOptions;
 use commands::pack::{
@@ -30,7 +30,7 @@ use error::{CliError, Result};
 #[command(name = "boltffi")]
 #[command(about = "BoltFFI - Rust FFI toolchain (Apple + Android + WASM)")]
 #[command(
-    after_help = "Examples:\n  boltffi init\n  boltffi check --apple\n  boltffi generate swift\n  boltffi build apple --release\n  boltffi build wasm --release\n  boltffi pack apple --layout bundled\n  boltffi pack wasm --release\n\nConfig:\n  boltffi reads ./boltffi.toml\n  Settings live under [targets.apple.*], [targets.android.*], [targets.wasm.*]\n"
+    after_help = "Examples:\n  boltffi init\n  boltffi check --apple\n  boltffi generate swift\n  boltffi build apple --release\n  boltffi build wasm --release\n  boltffi pack apple --layout bundled\n  boltffi pack wasm --release\n  boltffi --overlay boltffi.ci.toml pack android\n\nConfig:\n  boltffi reads ./boltffi.toml\n  Use --overlay PATH to load a merged overlay config on top of it\n  Settings live under [targets.apple.*], [targets.android.*], [targets.wasm.*]\n"
 )]
 #[command(version)]
 struct Cli {
@@ -49,6 +49,14 @@ struct Cli {
         help = "Pass an argument to cargo invocations (repeatable)"
     )]
     cargo_args: Vec<String>,
+
+    #[arg(
+        long,
+        global = true,
+        value_name = "PATH",
+        help = "Optional overlay config file merged on top of the base config"
+    )]
+    overlay: Option<PathBuf>,
 
     #[command(subcommand)]
     command: Commands,
@@ -282,6 +290,7 @@ enum PackLayoutArg {
 
 fn main() {
     let cli = Cli::parse();
+    let config_paths = ConfigPaths::from(&cli);
 
     let verbosity = if cli.quiet {
         reporter::Verbosity::Quiet
@@ -292,7 +301,7 @@ fn main() {
     };
 
     let reporter = reporter::Reporter::new(verbosity);
-    let result = execute_command(cli.command, &reporter, cli.cargo_args);
+    let result = execute_command(cli.command, &reporter, cli.cargo_args, &config_paths);
 
     if let Err(err) = result {
         eprintln!("\n{} {}", console::style("error:").red().bold(), err);
@@ -304,13 +313,11 @@ fn execute_command(
     command: Commands,
     reporter: &reporter::Reporter,
     cargo_args: Vec<String>,
+    config_paths: &ConfigPaths,
 ) -> Result<()> {
     match command {
         Commands::Init { name } => {
-            let options = InitOptions {
-                name,
-                path: std::env::current_dir().unwrap_or_default(),
-            };
+            let options = resolve_init_options(name, config_paths)?;
             run_init(options).map(|_| ())
         }
 
@@ -321,7 +328,7 @@ fn execute_command(
             wasm,
         } => {
             let explicit_target_selected = apple || android || wasm;
-            let config = load_config_if_present()?;
+            let config = load_config_if_present(config_paths)?;
             let check_wasm = if explicit_target_selected { wasm } else { true };
             let wasm_target_triple = if check_wasm {
                 configured_wasm_target_triple_for_diagnostics(config.as_ref())
@@ -354,28 +361,34 @@ fn execute_command(
             wasm,
         } => {
             let explicit_target_selected = apple || android || wasm;
-            let doctor_config = resolve_doctor_config(load_config_if_present());
+            let doctor_config =
+                resolve_doctor_config(load_config_if_present(config_paths), config_paths);
+            let diagnostic_config = match &doctor_config.summary {
+                ConfigSummary::Loaded(config) => Some(config.as_ref()),
+                ConfigSummary::Missing | ConfigSummary::Invalid(_) => None,
+            };
+            let apple_targets = configured_apple_targets_for_diagnostics(diagnostic_config);
+            let android_targets = configured_android_targets_for_diagnostics(diagnostic_config);
+            let wasm_target_triple =
+                configured_wasm_target_triple_for_diagnostics(diagnostic_config);
             let options = DoctorOptions {
                 apple: if explicit_target_selected {
                     apple
                 } else {
                     true
                 },
-                apple_targets: configured_apple_targets_for_diagnostics(
-                    doctor_config.config.as_ref(),
-                ),
+                apple_targets,
                 android: if explicit_target_selected {
                     android
                 } else {
                     true
                 },
-                android_targets: configured_android_targets_for_diagnostics(
-                    doctor_config.config.as_ref(),
-                ),
+                android_targets,
                 wasm: if explicit_target_selected { wasm } else { true },
-                wasm_target_triple: configured_wasm_target_triple_for_diagnostics(
-                    doctor_config.config.as_ref(),
-                ),
+                wasm_target_triple,
+                config_summary: doctor_config.summary,
+                config_path: PathBuf::from("boltffi.toml"),
+                overlay_path: config_paths.overlay.clone(),
                 config_warning: doctor_config.warning,
             };
             run_doctor(options)
@@ -386,7 +399,7 @@ fn execute_command(
             output,
             experimental,
         } => {
-            let config = load_config()?;
+            let config = load_config(config_paths)?;
             let options = GenerateOptions {
                 target: target
                     .map(|t| match t {
@@ -406,7 +419,7 @@ fn execute_command(
         }
 
         Commands::Build { platform, release } => {
-            let config = load_config()?;
+            let config = load_config(config_paths)?;
             let options = BuildCommandOptions {
                 platform: platform
                     .map(|p| match p {
@@ -423,7 +436,7 @@ fn execute_command(
         }
 
         Commands::Pack { target } => {
-            let config = load_config()?;
+            let config = load_config(config_paths)?;
             let command = match target {
                 PackTargetArg::All {
                     release,
@@ -495,7 +508,7 @@ fn execute_command(
         }
 
         Commands::Release { platform } => {
-            let config = load_config()?;
+            let config = load_config(config_paths)?;
             run_release(&config, platform, reporter, cargo_args)
         }
 
@@ -510,24 +523,58 @@ fn execute_command(
     }
 }
 
-fn load_config() -> Result<Config> {
-    let config_path = PathBuf::from("boltffi.toml");
-
-    if !config_path.exists() {
-        return Err(CliError::ConfigNotFound);
-    }
-
-    Config::load(&config_path).map_err(Into::into)
+#[derive(Debug, Clone)]
+struct ConfigPaths {
+    overlay: Option<PathBuf>,
 }
 
-fn load_config_if_present() -> Result<Option<Config>> {
+impl From<&Cli> for ConfigPaths {
+    fn from(cli: &Cli) -> Self {
+        Self {
+            overlay: cli.overlay.clone(),
+        }
+    }
+}
+
+impl fmt::Display for ConfigPaths {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.overlay {
+            Some(overlay) => write!(f, "boltffi.toml with overlay {}", overlay.display()),
+            None => f.write_str("boltffi.toml"),
+        }
+    }
+}
+
+fn load_config(config_paths: &ConfigPaths) -> Result<Config> {
     let config_path = PathBuf::from("boltffi.toml");
 
     if !config_path.exists() {
+        return Err(CliError::ConfigNotFound(config_path));
+    }
+
+    match config_paths.overlay.as_deref() {
+        Some(overlay_path) => Config::load_with_overlay(&config_path, Some(overlay_path)),
+        None => Config::load(&config_path),
+    }
+    .map_err(Into::into)
+}
+
+fn load_config_if_present(config_paths: &ConfigPaths) -> Result<Option<Config>> {
+    let config_path = PathBuf::from("boltffi.toml");
+
+    if !config_path.exists() {
+        if config_paths.overlay.is_some() {
+            return Err(CliError::ConfigNotFound(config_path));
+        }
         return Ok(None);
     }
 
-    Config::load(&config_path).map(Some).map_err(Into::into)
+    match config_paths.overlay.as_deref() {
+        Some(overlay_path) => Config::load_with_overlay(&config_path, Some(overlay_path)),
+        None => Config::load(&config_path),
+    }
+    .map(Some)
+    .map_err(Into::into)
 }
 
 fn configured_apple_targets_for_diagnostics(
@@ -553,21 +600,50 @@ fn configured_wasm_target_triple_for_diagnostics(config: Option<&Config>) -> Opt
 }
 
 struct DoctorConfig {
-    config: Option<Config>,
+    summary: ConfigSummary,
     warning: Option<String>,
 }
 
-fn resolve_doctor_config(config_result: Result<Option<Config>>) -> DoctorConfig {
+fn resolve_init_options(name: Option<String>, config_paths: &ConfigPaths) -> Result<InitOptions> {
+    if config_paths.overlay.is_some() {
+        return Err(CliError::CommandFailed {
+            command: "--overlay is not supported with init".to_string(),
+            status: None,
+        });
+    }
+
+    Ok(InitOptions {
+        name,
+        path: std::env::current_dir().unwrap_or_default(),
+    })
+}
+
+fn resolve_doctor_config(
+    config_result: Result<Option<Config>>,
+    config_paths: &ConfigPaths,
+) -> DoctorConfig {
     match config_result {
-        Ok(config) => DoctorConfig {
-            config,
+        Ok(Some(config)) => DoctorConfig {
+            summary: ConfigSummary::Loaded(Box::new(config)),
             warning: None,
         },
-        Err(error) => DoctorConfig {
-            config: None,
+        Ok(None) => DoctorConfig {
+            summary: ConfigSummary::Missing,
+            warning: None,
+        },
+        Err(CliError::ConfigNotFound(_)) => DoctorConfig {
+            summary: ConfigSummary::Missing,
             warning: Some(format!(
-                "failed to load boltffi.toml ({}); using default Apple/Android/WASM target checks",
-                error
+                "failed to load config {} ({}); using default Apple/Android/WASM target checks",
+                config_paths,
+                CliError::ConfigNotFound(PathBuf::from("boltffi.toml"))
+            )),
+        },
+        Err(error) => DoctorConfig {
+            summary: ConfigSummary::Invalid(error.to_string()),
+            warning: Some(format!(
+                "failed to load config {} ({}); using default Apple/Android/WASM target checks",
+                config_paths, error
             )),
         },
     }
@@ -743,13 +819,16 @@ fn release_requires_java_environment_validation(
 #[cfg(test)]
 mod tests {
     use super::{
-        BuildPlatformArg, configured_android_targets_for_diagnostics,
+        BuildPlatformArg, ConfigPaths, configured_android_targets_for_diagnostics,
         configured_apple_targets_for_diagnostics, configured_wasm_target_triple_for_diagnostics,
-        release_pack_commands, release_requires_java_environment_validation, resolve_doctor_config,
+        load_config_if_present, release_pack_commands,
+        release_requires_java_environment_validation, resolve_doctor_config, resolve_init_options,
     };
+    use crate::commands::doctor::ConfigSummary;
     use crate::commands::pack::PackCommand;
     use crate::target::RustTarget;
     use crate::{config::Config, error::CliError};
+    use std::path::PathBuf;
 
     fn parse_config(input: &str) -> Config {
         let parsed: Config = toml::from_str(input).expect("toml parse failed");
@@ -819,14 +898,76 @@ triple = "wasm32-wasip1"
 
     #[test]
     fn doctor_falls_back_to_defaults_when_config_load_fails() {
-        let resolved = resolve_doctor_config(Err(CliError::Config(
-            crate::config::ConfigError::Validation("bad config".to_string()),
-        )));
+        let config_paths = ConfigPaths {
+            overlay: Some(PathBuf::from("boltffi.ci.toml")),
+        };
+        let resolved = resolve_doctor_config(
+            Err(crate::config::ConfigError::Validation("bad config".to_string()).into()),
+            &config_paths,
+        );
 
-        assert!(resolved.config.is_none());
+        assert!(matches!(resolved.summary, ConfigSummary::Invalid(_)));
         assert!(resolved.warning.as_deref().is_some_and(|warning| {
             warning.contains("using default Apple/Android/WASM target checks")
         }));
+    }
+
+    #[test]
+    fn missing_base_config_fails_when_overlay_is_requested() {
+        let config_paths = ConfigPaths {
+            overlay: Some(PathBuf::from("boltffi.ci.toml")),
+        };
+
+        let error =
+            load_config_if_present(&config_paths).expect_err("overlay without base should fail");
+
+        assert!(
+            matches!(error, CliError::ConfigNotFound(path) if path == std::path::Path::new("boltffi.toml"))
+        );
+    }
+
+    #[test]
+    fn doctor_warns_when_overlay_is_requested_without_base_config() {
+        let config_paths = ConfigPaths {
+            overlay: Some(PathBuf::from("boltffi.ci.toml")),
+        };
+        let resolved = resolve_doctor_config(
+            Err(CliError::ConfigNotFound(PathBuf::from("boltffi.toml"))),
+            &config_paths,
+        );
+
+        assert!(matches!(resolved.summary, ConfigSummary::Missing));
+        assert!(resolved.warning.as_deref().is_some_and(|warning| {
+            warning.contains("boltffi.toml with overlay boltffi.ci.toml")
+                && warning.contains("config file not found")
+        }));
+    }
+
+    #[test]
+    fn init_uses_current_directory() {
+        let config_paths = ConfigPaths { overlay: None };
+
+        let options = resolve_init_options(Some("mylib".to_string()), &config_paths)
+            .expect("init options should resolve");
+
+        assert_eq!(options.path, std::env::current_dir().unwrap_or_default());
+    }
+
+    #[test]
+    fn init_rejects_overlay_config() {
+        let config_paths = ConfigPaths {
+            overlay: Some(PathBuf::from("boltffi.ci.toml")),
+        };
+
+        let error = match resolve_init_options(None, &config_paths) {
+            Ok(_) => panic!("overlay should fail"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            CliError::CommandFailed { command, status: None }
+                if command == "--overlay is not supported with init"
+        ));
     }
 
     #[test]

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -7,6 +7,21 @@ description: "Configure boltffi.toml package names, target outputs, and platform
 
 BoltFFI reads its configuration from a file called `boltffi.toml` in your project's root directory. This file tells BoltFFI how to name your modules, where to put generated files, and how to structure the output packages. Run `boltffi init` to create one with sensible defaults, then customize it for your needs.
 
+## Overlay Configs
+
+BoltFFI always starts from `./boltffi.toml`. For one-off builds, you can merge an additional TOML
+file on top with the global `--overlay` flag:
+
+```bash
+boltffi --overlay boltffi.ci.toml pack android
+boltffi --overlay boltffi.release.toml pack all --release
+```
+
+This is useful when you want CI or release-specific settings without changing the tracked base
+config. The base `boltffi.toml` must still exist; the overlay only augments or overrides values in
+that file for the current command. `boltffi init` is the one command that intentionally rejects
+`--overlay`.
+
 ## Package Identity
 
 Every `boltffi.toml` starts with a `[package]` section that identifies your library:


### PR DESCRIPTION
It's useful to have different configurations for different use cases,
such as CI, builds, development, and so on. This patch allows passing in
a file via --overlay which overrides some of the base options set within
the boltffi.toml file.
