### PR TITLE
Fix Windows test failures caused by backslashes in generated TOML path

### DIFF
--- a/boltffi_bindgen/src/scan/compiler_type_resolution.rs
+++ b/boltffi_bindgen/src/scan/compiler_type_resolution.rs
@@ -188,7 +188,7 @@ pub fn resolve(
     fs::create_dir_all(&src_dir).map_err(|e| format!("mkdir {}: {}", src_dir.display(), e))?;
 
     let cargo_toml = format!(
-        "[package]\nname = \"boltffi_bindgen_type_resolution_runner\"\nversion = \"0.1.0\"\nedition = \"{}\"\n\n[dependencies]\ntarget_crate = {{ path = \"{}\", package = \"{}\" }}\n",
+        "[package]\nname = \"boltffi_bindgen_type_resolution_runner\"\nversion = \"0.1.0\"\nedition = \"{}\"\n\n[dependencies]\ntarget_crate = {{ path = '{}', package = \"{}\" }}\n",
         target_package.edition,
         target_manifest_dir.display(),
         target_package.name,


### PR DESCRIPTION
This PR addresses #151 - `cargo test` now works on a windows machine by not using the double quoted string `"` which would interpret `C:\Users\...` as escaped strings.

closes #151