### PR TITLE
fix: DirectVec method early return generates valid FfiBuf

### DIFF
--- a/boltffi_bindgen/src/scan/compiler_type_resolution.rs
+++ b/boltffi_bindgen/src/scan/compiler_type_resolution.rs
@@ -188,7 +188,7 @@ pub fn resolve(
     fs::create_dir_all(&src_dir).map_err(|e| format!("mkdir {}: {}", src_dir.display(), e))?;
 
     let cargo_toml = format!(
-        "[package]\nname = \"boltffi_bindgen_type_resolution_runner\"\nversion = \"0.1.0\"\nedition = \"{}\"\n\n[dependencies]\ntarget_crate = {{ path = '{}', package = \"{}\" }}\n",
+        "[workspace]\n\n[package]\nname = \"boltffi_bindgen_type_resolution_runner\"\nversion = \"0.1.0\"\nedition = \"{}\"\n\n[dependencies]\ntarget_crate = {{ path = '{}', package = \"{}\" }}\n",
         target_package.edition,
         target_manifest_dir.display(),
         target_package.name,

--- a/boltffi_bindgen/src/scan/compiler_type_resolution.rs
+++ b/boltffi_bindgen/src/scan/compiler_type_resolution.rs
@@ -188,7 +188,7 @@ pub fn resolve(
     fs::create_dir_all(&src_dir).map_err(|e| format!("mkdir {}: {}", src_dir.display(), e))?;
 
     let cargo_toml = format!(
-        "[workspace]\n\n[package]\nname = \"boltffi_bindgen_type_resolution_runner\"\nversion = \"0.1.0\"\nedition = \"{}\"\n\n[dependencies]\ntarget_crate = {{ path = '{}', package = \"{}\" }}\n",
+        "[package]\nname = \"boltffi_bindgen_type_resolution_runner\"\nversion = \"0.1.0\"\nedition = \"{}\"\n\n[dependencies]\ntarget_crate = {{ path = '{}', package = \"{}\" }}\n",
         target_package.edition,
         target_manifest_dir.display(),
         target_package.name,

--- a/boltffi_macros/src/exports/function.rs
+++ b/boltffi_macros/src/exports/function.rs
@@ -426,18 +426,38 @@ fn ffi_export_item_impl(input: ItemFn) -> proc_macro2::TokenStream {
         }
 
         if matches!(strategy, EncodedReturnStrategy::DirectVec) {
-            let call_and_bind = quote! {
-                #(#conversions)*
-                let #result_ident: #inner_ty = #fn_name(#(#call_args),*);
-            };
+            let native_on_error = return_abi.native_invalid_arg_early_return_statement();
+            let wasm_on_error = return_abi.wasm_invalid_arg_early_return_statement();
+            let FfiParams {
+                conversions: native_conversions,
+                call_args: native_call_args,
+                ..
+            } = transform_params(
+                fn_inputs,
+                &return_lowering,
+                &callback_registry,
+                &native_on_error,
+            );
+            let FfiParams {
+                conversions: wasm_conversions,
+                call_args: wasm_call_args,
+                ..
+            } = transform_params(
+                fn_inputs,
+                &return_lowering,
+                &callback_registry,
+                &wasm_on_error,
+            );
 
             let native_body = quote! {
-                #call_and_bind
+                #(#native_conversions)*
+                let #result_ident: #inner_ty = #fn_name(#(#native_call_args),*);
                 <_ as ::boltffi::__private::VecTransport>::pack_vec(#result_ident)
             };
 
             let wasm_body = quote! {
-                #call_and_bind
+                #(#wasm_conversions)*
+                let #result_ident: #inner_ty = #fn_name(#(#wasm_call_args),*);
                 let __buf = ::boltffi::__private::FfiBuf::from_vec(#result_ident);
                 ::boltffi::__private::write_return_slot(__buf.as_ptr() as u32, __buf.len() as u32, __buf.cap() as u32, __buf.align() as u32);
                 core::mem::forget(__buf);

--- a/boltffi_macros/src/exports/methods.rs
+++ b/boltffi_macros/src/exports/methods.rs
@@ -810,24 +810,43 @@ fn generate_sync_method_export(
         }
 
         if matches!(strategy, EncodedReturnStrategy::DirectVec) {
-            let call_and_bind = if has_conversions {
-                quote! {
-                    #(#conversions)*
-                    let #result_ident: #inner_ty = #call_expr;
-                }
-            } else {
-                quote! {
-                    let #result_ident: #inner_ty = #call_expr;
-                }
-            };
+            let native_on_error = return_abi.native_invalid_arg_early_return_statement();
+            let wasm_on_error = return_abi.wasm_invalid_arg_early_return_statement();
+            let other_inputs_native = method.sig.inputs.iter().skip(1).cloned();
+            let FfiParams {
+                conversions: native_conversions,
+                call_args: native_call_args,
+                ..
+            } = transform_method_params(
+                other_inputs_native,
+                return_lowering,
+                callback_registry,
+                &native_on_error,
+            );
+            let other_inputs_wasm = method.sig.inputs.iter().skip(1).cloned();
+            let FfiParams {
+                conversions: wasm_conversions,
+                call_args: wasm_call_args,
+                ..
+            } = transform_method_params(
+                other_inputs_wasm,
+                return_lowering,
+                callback_registry,
+                &wasm_on_error,
+            );
+
+            let native_call = quote! { (*handle).#method_name(#(#native_call_args),*) };
+            let wasm_call = quote! { (*handle).#method_name(#(#wasm_call_args),*) };
 
             let native_body = quote! {
-                #call_and_bind
+                #(#native_conversions)*
+                let #result_ident: #inner_ty = #native_call;
                 <_ as ::boltffi::__private::VecTransport>::pack_vec(#result_ident)
             };
 
             let wasm_body = quote! {
-                #call_and_bind
+                #(#wasm_conversions)*
+                let #result_ident: #inner_ty = #wasm_call;
                 let __buf = ::boltffi::__private::FfiBuf::from_vec(#result_ident);
                 ::boltffi::__private::write_return_slot(__buf.as_ptr() as u32, __buf.len() as u32, __buf.cap() as u32, __buf.align() as u32);
                 core::mem::forget(__buf);
@@ -1077,24 +1096,43 @@ fn generate_static_method_export(
         }
 
         if matches!(strategy, EncodedReturnStrategy::DirectVec) {
-            let call_and_bind = if has_conversions {
-                quote! {
-                    #(#conversions)*
-                    let #result_ident: #inner_ty = #call_expr;
-                }
-            } else {
-                quote! {
-                    let #result_ident: #inner_ty = #call_expr;
-                }
-            };
+            let native_on_error = return_abi.native_invalid_arg_early_return_statement();
+            let wasm_on_error = return_abi.wasm_invalid_arg_early_return_statement();
+            let all_inputs_native = method.sig.inputs.iter().cloned();
+            let FfiParams {
+                conversions: native_conversions,
+                call_args: native_call_args,
+                ..
+            } = transform_method_params(
+                all_inputs_native,
+                return_lowering,
+                callback_registry,
+                &native_on_error,
+            );
+            let all_inputs_wasm = method.sig.inputs.iter().cloned();
+            let FfiParams {
+                conversions: wasm_conversions,
+                call_args: wasm_call_args,
+                ..
+            } = transform_method_params(
+                all_inputs_wasm,
+                return_lowering,
+                callback_registry,
+                &wasm_on_error,
+            );
+
+            let native_call = quote! { #type_name::#method_name(#(#native_call_args),*) };
+            let wasm_call = quote! { #type_name::#method_name(#(#wasm_call_args),*) };
 
             let native_body = quote! {
-                #call_and_bind
+                #(#native_conversions)*
+                let #result_ident: #inner_ty = #native_call;
                 <_ as ::boltffi::__private::VecTransport>::pack_vec(#result_ident)
             };
 
             let wasm_body = quote! {
-                #call_and_bind
+                #(#wasm_conversions)*
+                let #result_ident: #inner_ty = #wasm_call;
                 let __buf = ::boltffi::__private::FfiBuf::from_vec(#result_ident);
                 ::boltffi::__private::write_return_slot(__buf.as_ptr() as u32, __buf.len() as u32, __buf.cap() as u32, __buf.align() as u32);
                 core::mem::forget(__buf);

--- a/boltffi_macros/src/lowering/returns/lower.rs
+++ b/boltffi_macros/src/lowering/returns/lower.rs
@@ -29,7 +29,7 @@ impl ResolvedReturn {
             }
             ValueReturnStrategy::Buffer(EncodedReturnStrategy::DirectVec) => {
                 quote! {
-                    return;
+                    return ::boltffi::__private::FfiBuf::default();
                 }
             }
             ValueReturnStrategy::Buffer(_) => match (

--- a/boltffi_macros/src/lowering/returns/lower.rs
+++ b/boltffi_macros/src/lowering/returns/lower.rs
@@ -29,7 +29,14 @@ impl ResolvedReturn {
             }
             ValueReturnStrategy::Buffer(EncodedReturnStrategy::DirectVec) => {
                 quote! {
-                    return ::boltffi::__private::FfiBuf::default();
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        return;
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        return ::boltffi::__private::FfiBuf::default();
+                    }
                 }
             }
             ValueReturnStrategy::Buffer(_) => match (

--- a/boltffi_macros/src/lowering/returns/lower.rs
+++ b/boltffi_macros/src/lowering/returns/lower.rs
@@ -81,6 +81,49 @@ impl ResolvedReturn {
         }
     }
 
+    pub fn wasm_invalid_arg_early_return_statement(&self) -> proc_macro2::TokenStream {
+        match self.value_return_strategy() {
+            ValueReturnStrategy::Buffer(EncodedReturnStrategy::DirectVec) => quote! {
+                return;
+            },
+            ValueReturnStrategy::Buffer(EncodedReturnStrategy::OptionScalar) => {
+                let _ = WasmOptionScalarEncoding::from_option_rust_type(self.rust_type())
+                    .expect("OptionScalar return must have a primitive Option inner type");
+                quote! {
+                    return f64::NAN;
+                }
+            }
+            ValueReturnStrategy::Buffer(_) => match self.direct_buffer_return_method(
+                ReturnInvocationContext::SyncExport,
+                ReturnPlatform::Wasm,
+            ) {
+                Some(DirectBufferReturnMethod::Packed) => quote! {
+                    return ::boltffi::__private::FfiBuf::default().into_packed();
+                },
+                method => panic!(
+                    "unexpected wasm direct buffer return method for invalid-arg return: {:?}",
+                    method
+                ),
+            },
+            _ => self.invalid_arg_early_return_statement(),
+        }
+    }
+
+    pub fn native_invalid_arg_early_return_statement(&self) -> proc_macro2::TokenStream {
+        match self.value_return_strategy() {
+            ValueReturnStrategy::Buffer(EncodedReturnStrategy::DirectVec)
+            | ValueReturnStrategy::Buffer(EncodedReturnStrategy::WireEncoded)
+            | ValueReturnStrategy::Buffer(EncodedReturnStrategy::Utf8String)
+            | ValueReturnStrategy::Buffer(EncodedReturnStrategy::ResultScalar) => quote! {
+                return ::boltffi::__private::FfiBuf::default();
+            },
+            ValueReturnStrategy::Buffer(EncodedReturnStrategy::OptionScalar) => quote! {
+                return ::boltffi::__private::FfiBuf::default();
+            },
+            _ => self.invalid_arg_early_return_statement(),
+        }
+    }
+
     pub fn async_ffi_return_type(&self) -> proc_macro2::TokenStream {
         let rust_type = self.rust_type();
         match self.value_return_strategy() {

--- a/boltffi_macros/src/lowering/returns/mod.rs
+++ b/boltffi_macros/src/lowering/returns/mod.rs
@@ -50,7 +50,7 @@ mod tests {
     }
 
     #[test]
-    fn direct_vec_return_uses_void_wasm_failure() {
+    fn direct_vec_return_uses_platform_aware_early_return() {
         let resolved_return = ResolvedReturn::new(
             parse_quote!(Vec<i32>),
             ReturnContract::infallible(ValueReturnStrategy::Buffer(
@@ -63,11 +63,17 @@ mod tests {
                 .value_return_method(ReturnInvocationContext::SyncExport, ReturnPlatform::Wasm,),
             ValueReturnMethod::WriteToReturnSlot
         ));
-        assert_eq!(
-            resolved_return
-                .invalid_arg_early_return_statement()
-                .to_string(),
-            "return ;"
+
+        let statement = resolved_return
+            .invalid_arg_early_return_statement()
+            .to_string();
+        assert!(
+            statement.contains("return ;"),
+            "wasm branch should use void return"
+        );
+        assert!(
+            statement.contains("return :: boltffi :: __private :: FfiBuf :: default ()"),
+            "native branch should return FfiBuf::default()"
         );
     }
 }

--- a/boltffi_macros/src/lowering/returns/mod.rs
+++ b/boltffi_macros/src/lowering/returns/mod.rs
@@ -64,16 +64,29 @@ mod tests {
             ValueReturnMethod::WriteToReturnSlot
         ));
 
-        let statement = resolved_return
+        let combined = resolved_return
             .invalid_arg_early_return_statement()
             .to_string();
         assert!(
-            statement.contains("return ;"),
-            "wasm branch should use void return"
+            combined.contains("return ;"),
+            "combined: wasm branch should use void return"
         );
         assert!(
-            statement.contains("return :: boltffi :: __private :: FfiBuf :: default ()"),
-            "native branch should return FfiBuf::default()"
+            combined.contains("return :: boltffi :: __private :: FfiBuf :: default ()"),
+            "combined: native branch should return FfiBuf::default()"
+        );
+
+        assert_eq!(
+            resolved_return
+                .wasm_invalid_arg_early_return_statement()
+                .to_string(),
+            "return ;",
+        );
+        assert_eq!(
+            resolved_return
+                .native_invalid_arg_early_return_statement()
+                .to_string(),
+            "return :: boltffi :: __private :: FfiBuf :: default () ;",
         );
     }
 }

--- a/boltffi_tests/src/lib.rs
+++ b/boltffi_tests/src/lib.rs
@@ -878,6 +878,15 @@ impl ClassTestFixture {
     pub fn echo_bytes(&self, data: Vec<u8>) -> Vec<u8> {
         data
     }
+
+    pub fn values_near_point(&self, target: FixturePoint) -> Vec<i32> {
+        let threshold = (target.x.abs() + target.y.abs()) as i32;
+        self.values
+            .iter()
+            .copied()
+            .filter(|&v| v.abs() <= threshold)
+            .collect()
+    }
 }
 
 #[data(impl)]

--- a/boltffi_tests/tests/class_ffi.rs
+++ b/boltffi_tests/tests/class_ffi.rs
@@ -776,8 +776,7 @@ mod fixture_wire_encoded_getters {
         unsafe { boltffi_class_test_fixture_add_value(handle, -3) };
 
         let point = FixturePoint { x: 3.0, y: 2.0 };
-        let buf =
-            unsafe { boltffi_class_test_fixture_values_near_point(handle, point) };
+        let buf = unsafe { boltffi_class_test_fixture_values_near_point(handle, point) };
         let result: Vec<i32> = decode_i32_vec(buf);
         assert_eq!(result, vec![1, 5, -3]);
 
@@ -789,8 +788,7 @@ mod fixture_wire_encoded_getters {
         let handle = boltffi_class_test_fixture_new_default();
 
         let point = FixturePoint { x: 10.0, y: 10.0 };
-        let buf =
-            unsafe { boltffi_class_test_fixture_values_near_point(handle, point) };
+        let buf = unsafe { boltffi_class_test_fixture_values_near_point(handle, point) };
         let result: Vec<i32> = decode_i32_vec(buf);
         assert!(result.is_empty());
 

--- a/boltffi_tests/tests/class_ffi.rs
+++ b/boltffi_tests/tests/class_ffi.rs
@@ -766,6 +766,36 @@ mod fixture_wire_encoded_getters {
 
         unsafe { boltffi_class_test_fixture_free(handle) };
     }
+
+    #[test]
+    fn values_near_point_filters_by_threshold() {
+        let handle = boltffi_class_test_fixture_new_default();
+        unsafe { boltffi_class_test_fixture_add_value(handle, 1) };
+        unsafe { boltffi_class_test_fixture_add_value(handle, 5) };
+        unsafe { boltffi_class_test_fixture_add_value(handle, 10) };
+        unsafe { boltffi_class_test_fixture_add_value(handle, -3) };
+
+        let point = FixturePoint { x: 3.0, y: 2.0 };
+        let buf =
+            unsafe { boltffi_class_test_fixture_values_near_point(handle, point) };
+        let result: Vec<i32> = decode_i32_vec(buf);
+        assert_eq!(result, vec![1, 5, -3]);
+
+        unsafe { boltffi_class_test_fixture_free(handle) };
+    }
+
+    #[test]
+    fn values_near_point_empty_values() {
+        let handle = boltffi_class_test_fixture_new_default();
+
+        let point = FixturePoint { x: 10.0, y: 10.0 };
+        let buf =
+            unsafe { boltffi_class_test_fixture_values_near_point(handle, point) };
+        let result: Vec<i32> = decode_i32_vec(buf);
+        assert!(result.is_empty());
+
+        unsafe { boltffi_class_test_fixture_free(handle) };
+    }
 }
 
 mod fixture_wire_encoded_setters {


### PR DESCRIPTION
When an exported method takes a wire-decoded #[data] parameter and returns Vec<T> (DirectVec strategy), the error path for null pointer and decode failure generated bare `return;` instead of returning a valid FfiBuf. This caused a compile error:

    error[E0069]: `return;` in a function whose return type is not `()`

Fix: return `FfiBuf::default()` on error, matching the pattern used by other return strategies in the same match arm.

Same bug class as the constructor fix in PR #122, but for regular method exports.

Addressses #155.