### PR TITLE
fix: add [workspace] to type resolution runner Cargo.toml

### DIFF
--- a/boltffi_bindgen/src/scan/compiler_type_resolution.rs
+++ b/boltffi_bindgen/src/scan/compiler_type_resolution.rs
@@ -188,7 +188,7 @@ pub fn resolve(
     fs::create_dir_all(&src_dir).map_err(|e| format!("mkdir {}: {}", src_dir.display(), e))?;
 
     let cargo_toml = format!(
-        "[package]\nname = \"boltffi_bindgen_type_resolution_runner\"\nversion = \"0.1.0\"\nedition = \"{}\"\n\n[dependencies]\ntarget_crate = {{ path = '{}', package = \"{}\" }}\n",
+        "[workspace]\n\n[package]\nname = \"boltffi_bindgen_type_resolution_runner\"\nversion = \"0.1.0\"\nedition = \"{}\"\n\n[dependencies]\ntarget_crate = {{ path = '{}', package = \"{}\" }}\n",
         target_package.edition,
         target_manifest_dir.display(),
         target_package.name,


### PR DESCRIPTION
The type resolution runner creates a temporary crate at target/boltffi_bindgen_type_resolution/ to resolve Rust type names. When the target crate is a member of a Cargo workspace, Cargo walks up from the temp crate and finds the parent workspace, then errors because the temp crate isn't listed as a member.

Adding an empty [workspace] table to the generated Cargo.toml makes it a standalone workspace root, preventing Cargo from searching for a parent workspace.

Without this fix, `boltffi generate` and `boltffi pack` fail on any crate that lives inside a workspace:

```
    error: current package believes it's in a workspace when it's not
```