### PR TITLE
fix: emit useWireBytes helper unconditionally in Kotlin codegen

### DIFF
--- a/boltffi_bindgen/src/render/kotlin/templates/render_kotlin/preamble.txt
+++ b/boltffi_bindgen/src/render/kotlin/templates/render_kotlin/preamble.txt
@@ -70,6 +70,10 @@ class FfiException(val code: Int, message: String) : Exception(message)
 private fun takeLastErrorMessage(): String =
     Native.{{ prefix }}_last_error_message().toString(Charsets.UTF_8)
 
+private inline fun <T> useWireBytes(bytes: ByteArray, block: (java.nio.ByteBuffer) -> T): T {
+    return block(java.nio.ByteBuffer.wrap(bytes).order(java.nio.ByteOrder.LITTLE_ENDIAN))
+}
+
 {%- if has_async_runtime %}
 object BoltFFIScope : CoroutineScope {
     override val coroutineContext = Dispatchers.Default + SupervisorJob()
@@ -83,12 +87,6 @@ class BoltFFIException(val errorBuffer: ByteBuffer) : Exception("Structured erro
         errorBuffer.order(ByteOrder.nativeOrder())
     }
 }
-
-private inline fun <T> useWireBytes(bytes: ByteArray, block: (java.nio.ByteBuffer) -> T): T {
-    return block(java.nio.ByteBuffer.wrap(bytes).order(java.nio.ByteOrder.LITTLE_ENDIAN))
-}
-
-
 
 private const val BOLTFFI_FUTURE_POLL_READY: Byte = 0
 private const val BOLTFFI_FUTURE_POLL_WAKE: Byte = 1


### PR DESCRIPTION
useWireBytes is a general-purpose helper that wraps a ByteArray into a little-endian ByteBuffer. It was incorrectly placed inside the `{%- if has_async_runtime %}` conditional block in the Kotlin preamble template, so it was only emitted when the module contained async functions.

Methods on exported classes that return Vec<u8> call useWireBytes regardless of whether async is used, causing "Unresolved reference 'useWireBytes'" compilation errors when the module has no async functions.

Move useWireBytes above the async_runtime conditional so it is always emitted.