### PR TITLE
feat: add WireEncode/WireDecode impls for Box<T> and ()

### DIFF
--- a/boltffi_core/src/wire/decode.rs
+++ b/boltffi_core/src/wire/decode.rs
@@ -474,6 +474,141 @@ mod tests {
         assert_eq!(size, written);
     }
 
+    mod unit_type {
+        use super::*;
+
+        #[test]
+        fn unit_decode_from_empty_buffer() {
+            let buf: [u8; 0] = [];
+            let (value, consumed) = <()>::decode_from(&buf).unwrap();
+            assert_eq!(value, ());
+            assert_eq!(consumed, 0);
+        }
+
+        #[test]
+        fn unit_decode_from_nonempty_buffer() {
+            let buf = [0xFF; 8];
+            let (value, consumed) = <()>::decode_from(&buf).unwrap();
+            assert_eq!(value, ());
+            assert_eq!(consumed, 0);
+        }
+
+        #[test]
+        fn unit_roundtrip() {
+            let original = ();
+            let mut buf = [0u8; 4];
+            let written = original.encode_to(&mut buf);
+            assert_eq!(written, 0);
+
+            let (_decoded, consumed) = <()>::decode_from(&buf).unwrap();
+            assert_eq!(consumed, 0);
+        }
+
+        #[test]
+        fn result_ok_unit_roundtrip() {
+            let original: Result<(), i32> = Ok(());
+            let mut buf = [0u8; 16];
+            let written = original.encode_to(&mut buf);
+
+            let (decoded, consumed) = Result::<(), i32>::decode_from(&buf).unwrap();
+            assert_eq!(decoded, Ok(()));
+            assert_eq!(consumed, written);
+        }
+
+        #[test]
+        fn result_err_with_unit_ok_roundtrip() {
+            let original: Result<(), i32> = Err(99);
+            let mut buf = [0u8; 16];
+            let written = original.encode_to(&mut buf);
+
+            let (decoded, consumed) = Result::<(), i32>::decode_from(&buf).unwrap();
+            assert_eq!(decoded, Err(99));
+            assert_eq!(consumed, written);
+        }
+
+        #[test]
+        fn option_some_unit_roundtrip() {
+            let original: Option<()> = Some(());
+            let mut buf = [0u8; 4];
+            let written = original.encode_to(&mut buf);
+
+            let (decoded, consumed) = Option::<()>::decode_from(&buf).unwrap();
+            assert_eq!(decoded, Some(()));
+            assert_eq!(consumed, written);
+        }
+    }
+
+    mod box_type {
+        use super::*;
+
+        #[test]
+        fn box_i32_roundtrip() {
+            let original = Box::new(42i32);
+            let mut buf = [0u8; 4];
+            original.encode_to(&mut buf);
+
+            let (decoded, consumed) = Box::<i32>::decode_from(&buf).unwrap();
+            assert_eq!(decoded, original);
+            assert_eq!(consumed, 4);
+        }
+
+        #[test]
+        fn box_string_roundtrip() {
+            let original = Box::new("hello".to_string());
+            let mut buf = vec![0u8; original.wire_size()];
+            original.encode_to(&mut buf);
+
+            let (decoded, consumed) = Box::<String>::decode_from(&buf).unwrap();
+            assert_eq!(decoded, original);
+            assert_eq!(consumed, 9);
+        }
+
+        #[test]
+        fn box_decode_matches_bare_decode() {
+            let mut buf = [0u8; 4];
+            42i32.encode_to(&mut buf);
+
+            let (bare, bare_consumed) = i32::decode_from(&buf).unwrap();
+            let (boxed, box_consumed) = Box::<i32>::decode_from(&buf).unwrap();
+
+            assert_eq!(*boxed, bare);
+            assert_eq!(box_consumed, bare_consumed);
+        }
+
+        #[test]
+        fn box_vec_roundtrip() {
+            let original = Box::new(vec![1i32, 2, 3]);
+            let mut buf = vec![0u8; original.wire_size()];
+            original.encode_to(&mut buf);
+
+            let (decoded, consumed) = Box::<Vec<i32>>::decode_from(&buf).unwrap();
+            assert_eq!(decoded, original);
+            assert_eq!(consumed, 16);
+        }
+
+        #[test]
+        fn nested_box_roundtrip() {
+            let original = Box::new(Box::new(42i32));
+            let mut buf = [0u8; 4];
+            original.encode_to(&mut buf);
+
+            let (decoded, consumed) = Box::<Box<i32>>::decode_from(&buf).unwrap();
+            assert_eq!(decoded, original);
+            assert_eq!(consumed, 4);
+        }
+
+        #[test]
+        fn option_box_roundtrip() {
+            let original: Option<Box<i32>> = Some(Box::new(99));
+            let mut buf = [0u8; 16];
+            let written = original.encode_to(&mut buf);
+
+            let (decoded, consumed) = Option::<Box<i32>>::decode_from(&buf).unwrap();
+            assert_eq!(decoded, Some(Box::new(99)));
+            assert_eq!(consumed, written);
+        }
+    }
+
     mod large_payload_roundtrip {
         use super::*;
 

--- a/boltffi_core/src/wire/decode.rs
+++ b/boltffi_core/src/wire/decode.rs
@@ -305,6 +305,13 @@ impl WireDecode for DateTime<Utc> {
     }
 }
 
+impl WireDecode for () {
+    #[inline]
+    fn decode_from(_buf: &[u8]) -> DecodeResult<Self> {
+        Ok(((), 0))
+    }
+}
+
 impl<T: WireDecode> WireDecode for Option<T> {
     fn decode_from(buf: &[u8]) -> DecodeResult<Self> {
         let mut reader = WireReader::new(buf);
@@ -331,6 +338,13 @@ impl<T: WireDecode, E: WireDecode> WireDecode for Result<T, E> {
                 reader.finish(Err(value))
             }
         }
+    }
+}
+
+impl<T: WireDecode> WireDecode for Box<T> {
+    fn decode_from(buf: &[u8]) -> DecodeResult<Self> {
+        let (value, consumed) = T::decode_from(buf)?;
+        Ok((Box::new(value), consumed))
     }
 }
 

--- a/boltffi_core/src/wire/encode.rs
+++ b/boltffi_core/src/wire/encode.rs
@@ -837,6 +837,112 @@ mod tests {
         }
     }
 
+    mod unit_type {
+        use super::*;
+
+        #[test]
+        fn unit_wire_size_is_zero() {
+            assert_eq!(().wire_size(), 0);
+        }
+
+        #[test]
+        fn unit_is_fixed_size() {
+            assert!(<()>::is_fixed_size());
+            assert_eq!(<()>::fixed_size(), Some(0));
+        }
+
+        #[test]
+        fn unit_encode_writes_nothing() {
+            let mut buf = [0xFFu8; 4];
+            let written = ().encode_to(&mut buf);
+            assert_eq!(written, 0);
+            assert_eq!(buf, [0xFF; 4]); // buffer untouched
+        }
+
+        #[test]
+        fn result_ok_unit_wire_size() {
+            let val: Result<(), String> = Ok(());
+            assert_eq!(val.wire_size(), 1); // tag only, no payload
+        }
+
+        #[test]
+        fn result_ok_unit_encode() {
+            let mut buf = [0u8; 16];
+            let val: Result<(), i32> = Ok(());
+            let written = val.encode_to(&mut buf);
+            assert_eq!(written, 1);
+            assert_eq!(buf[0], 0); // Ok tag
+        }
+    }
+
+    #[allow(unused_allocation)]
+    mod box_type {
+        use super::*;
+
+        #[test]
+        fn box_i32_wire_size() {
+            let val = Box::new(42i32);
+            assert_eq!(val.wire_size(), 4);
+        }
+
+        #[test]
+        fn box_i32_is_fixed_size() {
+            assert!(<Box<i32>>::is_fixed_size());
+            assert_eq!(<Box<i32>>::fixed_size(), Some(4));
+        }
+
+        #[test]
+        fn box_i32_encoding_kind_is_blittable() {
+            assert_eq!(<Box<i32>>::ENCODING_KIND, WireEncodingKind::Blittable);
+        }
+
+        #[test]
+        fn box_string_encoding_kind_is_general() {
+            assert_eq!(<Box<String>>::ENCODING_KIND, WireEncodingKind::General);
+        }
+
+        #[test]
+        fn box_string_not_fixed_size() {
+            assert!(!<Box<String>>::is_fixed_size());
+            assert_eq!(<Box<String>>::fixed_size(), None);
+        }
+
+        #[test]
+        fn box_i32_encode_matches_bare() {
+            let mut buf_boxed = [0u8; 4];
+            let mut buf_bare = [0u8; 4];
+
+            Box::new(42i32).encode_to(&mut buf_boxed);
+            42i32.encode_to(&mut buf_bare);
+
+            assert_eq!(buf_boxed, buf_bare);
+        }
+
+        #[test]
+        fn box_string_encode_matches_bare() {
+            let s = "hello".to_string();
+            let mut buf_boxed = vec![0u8; s.wire_size()];
+            let mut buf_bare = vec![0u8; s.wire_size()];
+
+            Box::new(s.clone()).encode_to(&mut buf_boxed);
+            s.encode_to(&mut buf_bare);
+
+            assert_eq!(buf_boxed, buf_bare);
+        }
+
+        #[test]
+        fn box_vec_encode_matches_bare() {
+            let v: Vec<i32> = vec![1, 2, 3];
+            let mut buf_boxed = vec![0u8; v.wire_size()];
+            let mut buf_bare = vec![0u8; v.wire_size()];
+
+            Box::new(v.clone()).encode_to(&mut buf_boxed);
+            v.encode_to(&mut buf_bare);
+
+            assert_eq!(buf_boxed, buf_bare);
+        }
+    }
+
     #[allow(clippy::assertions_on_constants)]
     mod blittable {
         use super::*;

--- a/boltffi_core/src/wire/encode.rs
+++ b/boltffi_core/src/wire/encode.rs
@@ -338,6 +338,30 @@ impl<T: WireEncode> WireEncode for Option<T> {
     }
 }
 
+impl<T: WireEncode> WireEncode for Box<T> {
+    const ENCODING_KIND: WireEncodingKind = T::ENCODING_KIND;
+
+    #[inline]
+    fn is_fixed_size() -> bool {
+        T::is_fixed_size()
+    }
+
+    #[inline]
+    fn fixed_size() -> Option<usize> {
+        T::fixed_size()
+    }
+
+    #[inline]
+    fn wire_size(&self) -> usize {
+        (**self).wire_size()
+    }
+
+    #[inline]
+    fn encode_to(&self, buffer: &mut [u8]) -> usize {
+        (**self).encode_to(buffer)
+    }
+}
+
 impl<T: WireEncode> WireEncode for Vec<T> {
     #[inline]
     fn wire_size(&self) -> usize {


### PR DESCRIPTION
Adds `WireEncode`/`WireDecode` implementations for two previously-unsupported types: `Box<T>` and `()`.

### `Box<T>`

`Box<T>` currently has no wire impls. Any type containing a `Box<SomeWireType>` field fails to satisfy the derive bounds. This PR adds a wire-transparent implementation that delegates all trait methods to the inner `T`:

- `encode_to` writes the same bytes as bare `T`
- `decode_from` decodes as `T`, then boxes
- `ENCODING_KIND`, `wire_size`, `is_fixed_size`, `fixed_size` all inherit from `T`

This unlocks common patterns like `Option<Box<T>>`, `Vec<Box<T>>`, and `Result<Box<T>, E>` where boxing is used for indirection, sizing, or ownership reasons unrelated to the FFI boundary itself.

### `()` decode

`WireEncode for ()` already existed (zero-size encoding), but `WireDecode` was missing. This prevents `Result<(), Error>` and `Option<()>` from crossing the FFI boundary. The new decode impl reads zero bytes and returns `((), 0)`.

### Scope

This PR intentionally covers only the core wire impls. It does **not** attempt to deliver full support for recursive enum types like:

```rust
enum Tree {
    Leaf(i32),
    Node(Box<Tree>, Box<Tree>),
}
```

Recursive types depend on the full scan -> IR -> render pipeline producing correct `indirect enum` (Swift), `sealed class` (Kotlin), and equivalent shapes across all targets. They also raise concerns around stack-depth safety in the recursive wire encode/decode path and lack cycle detection. 

With the changes in this PR, `Box<T>` is useful for non-recursive patterns (`Option<Box<Large>>`, `Box<String>` fields, etc.) where the box is an ownership/sizing tool rather than a recursion enabler.

### Codegen compatibility

No changes needed in downstream codegen. The type scanner in `boltffi_bindgen/src/scan/mod.rs` already unwraps `Box<T>` (and `Arc<T>`) to the inner type during the scan phase, before any language-specific codegen runs. All 7 targets (Swift, Kotlin, Dart, TypeScript, Java, JNI, C) receive the unwrapped type and emit their native equivalent.

### Tests

25 unit tests covering both types:

- `Box<T>` wire-transparency (byte-identical to bare `T` for `i32`, `String`, `Vec<i32>`)
- `Box<T>` trait delegation (`ENCODING_KIND`, `is_fixed_size`, `fixed_size`)
- `Box<T>` roundtrips including `Box<Box<i32>>` (nesting, not recursive type definition) and `Option<Box<i32>>`
- `()` decode from empty and non-empty buffers
- Composite patterns: `Result<(), E>` (Ok/Err), `Option<()>`