### PR TITLE
Add scalar inc_u64_value benchmark

### DIFF
--- a/benchmarks/kotlin-jvm-bench/build.gradle.kts
+++ b/benchmarks/kotlin-jvm-bench/build.gradle.kts
@@ -25,7 +25,13 @@ application {
     mainClass.set("com.example.bench_compare.CompareMainKt")
 }
 
+val buildBoltffi by tasks.registering(Exec::class) {
+    workingDir = projectDir
+    commandLine("../rust-boltffi/build-kotlin.sh")
+}
+
 val buildJni by tasks.registering(Exec::class) {
+    dependsOn(buildBoltffi)
     workingDir = projectDir
     commandLine("./build-jni.sh")
 }

--- a/benchmarks/kotlin-jvm-bench/src/jmh/kotlin/com/example/bench_compare/JmhBenchmarks.kt
+++ b/benchmarks/kotlin-jvm-bench/src/jmh/kotlin/com/example/bench_compare/JmhBenchmarks.kt
@@ -120,6 +120,16 @@ open class BoltFFIVsUniffiBench {
     }
 
     @Benchmark
+    open fun boltffi_inc_u64_value(blackhole: Blackhole) {
+        blackhole.consume(incU64Value(0uL))
+    }
+
+    @Benchmark
+    open fun uniffi_inc_u64_value(blackhole: Blackhole) {
+        blackhole.consume(uniffi.bench_uniffi.incU64(0uL))
+    }
+
+    @Benchmark
     open fun boltffi_echo_string_small(blackhole: Blackhole) {
         blackhole.consume(echoString("hello"))
     }

--- a/benchmarks/kotlin-jvm-bench/src/main/kotlin/com/example/bench_compare/CompareMain.kt
+++ b/benchmarks/kotlin-jvm-bench/src/main/kotlin/com/example/bench_compare/CompareMain.kt
@@ -52,6 +52,16 @@ fun main() = runBlocking {
                 check(uniffi.bench_uniffi.incU64(value) == 1uL)
             },
         ),
+        pairedBenchmark(
+            "inc_u64_value",
+            boltffi = {
+                check(incU64Value(0uL) == 1uL)
+            },
+            uniffi = {
+                val value = 0uL
+                check(uniffi.bench_uniffi.incU64(value) == 1uL)
+            },
+        ),
         pairedBenchmark("echo_string_small", boltffi = { echoString("hello") }, uniffi = { uniffi.bench_uniffi.echoString("hello") }),
         pairedBenchmark(
             "echo_string_1k",

--- a/benchmarks/rust-boltffi/build-kotlin.sh
+++ b/benchmarks/rust-boltffi/build-kotlin.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/../.."
+
+cd "$SCRIPT_DIR"
+
+cargo build --lib --release
+
+rm -rf dist/android/kotlin dist/android/include dist/apple/include
+
+cargo run --manifest-path "$ROOT_DIR/Cargo.toml" -p boltffi_cli -- generate header
+cargo run --manifest-path "$ROOT_DIR/Cargo.toml" -p boltffi_cli -- generate kotlin
+
+# Keep the Android include layout used by pack android and benchmark scripts.
+mkdir -p dist/android/include
+cp dist/apple/include/bench_boltffi.h dist/android/include/bench_boltffi.h

--- a/benchmarks/rust-boltffi/src/lib.rs
+++ b/benchmarks/rust-boltffi/src/lib.rs
@@ -462,6 +462,12 @@ pub fn inc_u64(value: &mut [u64]) {
     }
 }
 
+/// Increments a u64 value by one and returns the result.
+#[export]
+pub fn inc_u64_value(value: u64) -> u64 {
+    value + 1
+}
+
 /// Thread-safe 64-bit counter using Mutex (comparable to UniFFI).
 #[derive(Default)]
 pub struct Counter {


### PR DESCRIPTION
Today, the inc_u64 benchmark takes a mutable long[] slice, while FFM
takes a scalar u64. This patch adds an inc_u64_value benchmark to make
these comparisons more fair.
