### PR TITLE
Add primitive function support to C# backend

### DIFF
--- a/boltffi_bindgen/Cargo.toml
+++ b/boltffi_bindgen/Cargo.toml
@@ -24,6 +24,7 @@ indexmap = "2.7"
 
 [dev-dependencies]
 insta = "1.46"
+rstest = "0.25"
 
 [lints]
 workspace = true

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -106,14 +106,26 @@ mod tests {
 
         let output = emit_contract(&contract);
 
-        assert!(output.source.contains("public static int EchoI32(int value)"));
-        assert!(output.source.contains("return NativeMethods.EchoI32(value);"));
-        assert!(output
-            .source
-            .contains(r#"[DllImport(LibName, EntryPoint = "boltffi_echo_i32")]"#));
-        assert!(output
-            .source
-            .contains("internal static extern int EchoI32(int value);"));
+        assert!(
+            output
+                .source
+                .contains("public static int EchoI32(int value)")
+        );
+        assert!(
+            output
+                .source
+                .contains("return NativeMethods.EchoI32(value);")
+        );
+        assert!(
+            output
+                .source
+                .contains(r#"[DllImport(LibName, EntryPoint = "boltffi_echo_i32")]"#)
+        );
+        assert!(
+            output
+                .source
+                .contains("internal static extern int EchoI32(int value);")
+        );
     }
 
     #[test]
@@ -146,9 +158,11 @@ mod tests {
 
         let output = emit_contract(&contract);
 
-        assert!(output
-            .source
-            .contains("uint UnsignedEcho(byte a, ushort b, uint c, ulong d)"));
+        assert!(
+            output
+                .source
+                .contains("uint UnsignedEcho(byte a, ushort b, uint c, ulong d)")
+        );
     }
 
     #[test]
@@ -189,12 +203,18 @@ mod tests {
 
         let output = emit_contract(&contract);
 
-        assert!(output.source.contains("public static bool Flip(bool value)"));
-        assert!(output
-            .source
-            .contains("[return: MarshalAs(UnmanagedType.I1)]"));
-        assert!(output
-            .source
-            .contains("internal static extern bool Flip([MarshalAs(UnmanagedType.I1)] bool value);"));
+        assert!(
+            output
+                .source
+                .contains("public static bool Flip(bool value)")
+        );
+        assert!(
+            output
+                .source
+                .contains("[return: MarshalAs(UnmanagedType.I1)]")
+        );
+        assert!(output.source.contains(
+            "internal static extern bool Flip([MarshalAs(UnmanagedType.I1)] bool value);"
+        ));
     }
 }

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -7,7 +7,7 @@ use crate::ir::{AbiContract, FfiContract};
 use super::{
     CSharpOptions,
     lower::CSharpLowerer,
-    templates::{NativeTemplate, PreambleTemplate},
+    templates::{FunctionsTemplate, NativeTemplate, PreambleTemplate},
 };
 
 /// The rendered C# output: source code plus metadata for file naming.
@@ -34,6 +34,7 @@ impl CSharpEmitter {
 
         source.push_str(&PreambleTemplate { module: &module }.render().unwrap());
         source.push('\n');
+        source.push_str(&FunctionsTemplate { module: &module }.render().unwrap());
         source.push_str(&NativeTemplate { module: &module }.render().unwrap());
         source.push('\n');
 
@@ -42,5 +43,135 @@ impl CSharpEmitter {
             namespace: module.namespace,
             source,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::Lowerer as IrLowerer;
+    use crate::ir::contract::{FfiContract, PackageInfo};
+    use crate::ir::definitions::{FunctionDef, ParamDef, ParamPassing, ReturnDef};
+    use crate::ir::ids::{FunctionId, ParamName};
+    use crate::ir::types::{PrimitiveType, TypeExpr};
+    use boltffi_ffi_rules::callable::ExecutionKind;
+
+    fn empty_contract() -> FfiContract {
+        FfiContract {
+            package: PackageInfo {
+                name: "demo_lib".to_string(),
+                version: None,
+            },
+            functions: vec![],
+            catalog: Default::default(),
+        }
+    }
+
+    fn primitive_function(
+        name: &str,
+        params: Vec<(&str, PrimitiveType)>,
+        returns: ReturnDef,
+    ) -> FunctionDef {
+        FunctionDef {
+            id: FunctionId::new(name),
+            params: params
+                .into_iter()
+                .map(|(param_name, prim)| ParamDef {
+                    name: ParamName::new(param_name),
+                    type_expr: TypeExpr::Primitive(prim),
+                    passing: ParamPassing::Value,
+                    doc: None,
+                })
+                .collect(),
+            returns,
+            execution_kind: ExecutionKind::Sync,
+            doc: None,
+            deprecated: None,
+        }
+    }
+
+    fn emit_contract(contract: &FfiContract) -> CSharpOutput {
+        let abi = IrLowerer::new(contract).to_abi_contract();
+        CSharpEmitter::emit(contract, &abi, &CSharpOptions::default())
+    }
+
+    #[test]
+    fn emit_primitive_function_generates_wrapper_and_native() {
+        let mut contract = empty_contract();
+        contract.functions.push(primitive_function(
+            "echo_i32",
+            vec![("value", PrimitiveType::I32)],
+            ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::I32)),
+        ));
+
+        let output = emit_contract(&contract);
+
+        assert!(output.source.contains("public static int EchoI32(int value)"));
+        assert!(output.source.contains("return NativeMethods.EchoI32(value);"));
+        assert!(output
+            .source
+            .contains(r#"[DllImport(LibName, EntryPoint = "boltffi_echo_i32")]"#));
+        assert!(output
+            .source
+            .contains("internal static extern int EchoI32(int value);"));
+    }
+
+    #[test]
+    fn emit_void_function_omits_return_keyword() {
+        let mut contract = empty_contract();
+        contract
+            .functions
+            .push(primitive_function("noop", vec![], ReturnDef::Void));
+
+        let output = emit_contract(&contract);
+
+        assert!(output.source.contains("public static void Noop()"));
+        assert!(output.source.contains("NativeMethods.Noop();"));
+        assert!(!output.source.contains("return NativeMethods.Noop()"));
+    }
+
+    #[test]
+    fn emit_unsigned_types_use_csharp_unsigned_keywords() {
+        let mut contract = empty_contract();
+        contract.functions.push(primitive_function(
+            "unsigned_echo",
+            vec![
+                ("a", PrimitiveType::U8),
+                ("b", PrimitiveType::U16),
+                ("c", PrimitiveType::U32),
+                ("d", PrimitiveType::U64),
+            ],
+            ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::U32)),
+        ));
+
+        let output = emit_contract(&contract);
+
+        assert!(output
+            .source
+            .contains("uint UnsignedEcho(byte a, ushort b, uint c, ulong d)"));
+    }
+
+    #[test]
+    fn emit_namespace_and_class_use_pascal_case() {
+        let contract = empty_contract();
+        let output = emit_contract(&contract);
+
+        assert_eq!(output.namespace, "DemoLib");
+        assert_eq!(output.class_name, "DemoLib");
+        assert!(output.source.contains("namespace DemoLib"));
+    }
+
+    #[test]
+    fn emit_escapes_csharp_keywords_in_param_names() {
+        let mut contract = empty_contract();
+        contract.functions.push(primitive_function(
+            "test_keywords",
+            vec![("int", PrimitiveType::I32), ("value", PrimitiveType::I32)],
+            ReturnDef::Void,
+        ));
+
+        let output = emit_contract(&contract);
+
+        assert!(output.source.contains("@int"));
     }
 }

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -174,4 +174,27 @@ mod tests {
 
         assert!(output.source.contains("@int"));
     }
+
+    /// C# P/Invoke marshals `bool` as a 4-byte Win32 BOOL by default, but
+    /// BoltFFI's C ABI uses a 1-byte native bool, so the generated native
+    /// signature must force `UnmanagedType.I1` for both param and return.
+    #[test]
+    fn emit_bool_function_uses_i1_marshalling_for_native_signature() {
+        let mut contract = empty_contract();
+        contract.functions.push(primitive_function(
+            "flip",
+            vec![("value", PrimitiveType::Bool)],
+            ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::Bool)),
+        ));
+
+        let output = emit_contract(&contract);
+
+        assert!(output.source.contains("public static bool Flip(bool value)"));
+        assert!(output
+            .source
+            .contains("[return: MarshalAs(UnmanagedType.I1)]"));
+        assert!(output
+            .source
+            .contains("internal static extern bool Flip([MarshalAs(UnmanagedType.I1)] bool value);"));
+    }
 }

--- a/boltffi_bindgen/src/render/csharp/lower.rs
+++ b/boltffi_bindgen/src/render/csharp/lower.rs
@@ -1,8 +1,12 @@
 use boltffi_ffi_rules::naming;
 
+use crate::ir::definitions::{FunctionDef, ParamDef, ParamPassing, ReturnDef};
+use crate::ir::types::TypeExpr;
 use crate::ir::{AbiContract, FfiContract};
 
-use super::{CSharpModule, CSharpOptions, NamingConvention};
+use super::mappings;
+use super::plan::{CSharpFunction, CSharpModule, CSharpParam};
+use super::{CSharpOptions, NamingConvention};
 
 /// Transforms the language-agnostic [`FfiContract`] and [`AbiContract`] into
 /// a [`CSharpModule`] containing everything the C# templates need to render.
@@ -30,11 +34,76 @@ impl<'a> CSharpLowerer<'a> {
         let namespace = NamingConvention::namespace(&self.ffi.package.name);
         let prefix = naming::ffi_prefix().to_string();
 
+        let functions: Vec<CSharpFunction> = self
+            .ffi
+            .functions
+            .iter()
+            .filter_map(Self::lower_function)
+            .collect();
+
         CSharpModule {
             namespace,
             class_name,
             lib_name,
             prefix,
+            functions,
+        }
+    }
+
+    /// Converts a Rust FFI function definition into its C# representation,
+    /// mapping Rust types to C# types and snake_case names to PascalCase.
+    ///
+    /// Returns `None` for functions whose signatures include types not yet
+    /// supported by the C# backend. Once the backend is fully implemented
+    /// and the experimental flag is removed, this will succeed for all
+    /// functions and the `Option` return will be replaced with a direct
+    /// return.
+    fn lower_function(function: &FunctionDef) -> Option<CSharpFunction> {
+        if function.is_async() {
+            return None;
+        }
+
+        let params: Vec<CSharpParam> = function
+            .params
+            .iter()
+            .map(Self::lower_param)
+            .collect::<Option<Vec<_>>>()?;
+
+        let return_type = Self::lower_return(&function.returns)?;
+
+        Some(CSharpFunction {
+            name: NamingConvention::method_name(function.id.as_str()),
+            ffi_name: naming::function_ffi_name(function.id.as_str()).into_string(),
+            params,
+            return_type,
+        })
+    }
+
+    fn lower_param(param: &ParamDef) -> Option<CSharpParam> {
+        if param.passing != ParamPassing::Value {
+            return None;
+        }
+
+        let csharp_type = Self::lower_type(&param.type_expr)?;
+
+        Some(CSharpParam {
+            name: NamingConvention::field_name(param.name.as_str()),
+            csharp_type,
+        })
+    }
+
+    fn lower_return(return_def: &ReturnDef) -> Option<String> {
+        match return_def {
+            ReturnDef::Void => Some("void".to_string()),
+            ReturnDef::Value(type_expr) => Self::lower_type(type_expr),
+            ReturnDef::Result { .. } => None,
+        }
+    }
+
+    fn lower_type(type_expr: &TypeExpr) -> Option<String> {
+        match type_expr {
+            TypeExpr::Primitive(primitive) => Some(mappings::csharp_type(*primitive).to_string()),
+            _ => None,
         }
     }
 }

--- a/boltffi_bindgen/src/render/csharp/lower.rs
+++ b/boltffi_bindgen/src/render/csharp/lower.rs
@@ -5,7 +5,7 @@ use crate::ir::types::TypeExpr;
 use crate::ir::{AbiContract, FfiContract};
 
 use super::mappings;
-use super::plan::{CSharpFunction, CSharpModule, CSharpParam};
+use super::plan::{CSharpFunction, CSharpModule, CSharpParam, CSharpType};
 use super::{CSharpOptions, NamingConvention};
 
 /// Transforms the language-agnostic [`FfiContract`] and [`AbiContract`] into
@@ -92,17 +92,17 @@ impl<'a> CSharpLowerer<'a> {
         })
     }
 
-    fn lower_return(return_def: &ReturnDef) -> Option<String> {
+    fn lower_return(return_def: &ReturnDef) -> Option<CSharpType> {
         match return_def {
-            ReturnDef::Void => Some("void".to_string()),
+            ReturnDef::Void => Some(CSharpType::Void),
             ReturnDef::Value(type_expr) => Self::lower_type(type_expr),
             ReturnDef::Result { .. } => None,
         }
     }
 
-    fn lower_type(type_expr: &TypeExpr) -> Option<String> {
+    fn lower_type(type_expr: &TypeExpr) -> Option<CSharpType> {
         match type_expr {
-            TypeExpr::Primitive(primitive) => Some(mappings::csharp_type(*primitive).to_string()),
+            TypeExpr::Primitive(primitive) => Some(mappings::csharp_type(*primitive)),
             _ => None,
         }
     }

--- a/boltffi_bindgen/src/render/csharp/mappings.rs
+++ b/boltffi_bindgen/src/render/csharp/mappings.rs
@@ -1,0 +1,24 @@
+use crate::ir::types::PrimitiveType;
+
+/// Maps a BoltFFI primitive to the corresponding C# type keyword.
+///
+/// C# has native unsigned types (`byte`, `ushort`, `uint`, `ulong`) and
+/// platform-sized integers (`nint`, `nuint`), so every primitive maps
+/// to a distinct C# type with no information loss.
+pub fn csharp_type(primitive: PrimitiveType) -> &'static str {
+    match primitive {
+        PrimitiveType::Bool => "bool",
+        PrimitiveType::I8 => "sbyte",
+        PrimitiveType::U8 => "byte",
+        PrimitiveType::I16 => "short",
+        PrimitiveType::U16 => "ushort",
+        PrimitiveType::I32 => "int",
+        PrimitiveType::U32 => "uint",
+        PrimitiveType::I64 => "long",
+        PrimitiveType::U64 => "ulong",
+        PrimitiveType::ISize => "nint",
+        PrimitiveType::USize => "nuint",
+        PrimitiveType::F32 => "float",
+        PrimitiveType::F64 => "double",
+    }
+}

--- a/boltffi_bindgen/src/render/csharp/mappings.rs
+++ b/boltffi_bindgen/src/render/csharp/mappings.rs
@@ -1,24 +1,26 @@
 use crate::ir::types::PrimitiveType;
 
-/// Maps a BoltFFI primitive to the corresponding C# type keyword.
+use super::plan::CSharpType;
+
+/// Maps a BoltFFI primitive to the corresponding [`CSharpType`].
 ///
 /// C# has native unsigned types (`byte`, `ushort`, `uint`, `ulong`) and
 /// platform-sized integers (`nint`, `nuint`), so every primitive maps
 /// to a distinct C# type with no information loss.
-pub fn csharp_type(primitive: PrimitiveType) -> &'static str {
+pub fn csharp_type(primitive: PrimitiveType) -> CSharpType {
     match primitive {
-        PrimitiveType::Bool => "bool",
-        PrimitiveType::I8 => "sbyte",
-        PrimitiveType::U8 => "byte",
-        PrimitiveType::I16 => "short",
-        PrimitiveType::U16 => "ushort",
-        PrimitiveType::I32 => "int",
-        PrimitiveType::U32 => "uint",
-        PrimitiveType::I64 => "long",
-        PrimitiveType::U64 => "ulong",
-        PrimitiveType::ISize => "nint",
-        PrimitiveType::USize => "nuint",
-        PrimitiveType::F32 => "float",
-        PrimitiveType::F64 => "double",
+        PrimitiveType::Bool => CSharpType::Bool,
+        PrimitiveType::I8 => CSharpType::SByte,
+        PrimitiveType::U8 => CSharpType::Byte,
+        PrimitiveType::I16 => CSharpType::Short,
+        PrimitiveType::U16 => CSharpType::UShort,
+        PrimitiveType::I32 => CSharpType::Int,
+        PrimitiveType::U32 => CSharpType::UInt,
+        PrimitiveType::I64 => CSharpType::Long,
+        PrimitiveType::U64 => CSharpType::ULong,
+        PrimitiveType::ISize => CSharpType::NInt,
+        PrimitiveType::USize => CSharpType::NUInt,
+        PrimitiveType::F32 => CSharpType::Float,
+        PrimitiveType::F64 => CSharpType::Double,
     }
 }

--- a/boltffi_bindgen/src/render/csharp/mod.rs
+++ b/boltffi_bindgen/src/render/csharp/mod.rs
@@ -3,6 +3,7 @@
 
 mod emit;
 mod lower;
+mod mappings;
 mod names;
 mod plan;
 mod templates;

--- a/boltffi_bindgen/src/render/csharp/plan.rs
+++ b/boltffi_bindgen/src/render/csharp/plan.rs
@@ -12,4 +12,68 @@ pub struct CSharpModule {
     pub lib_name: Name<LibraryName>,
     /// FFI symbol prefix (e.g., `"boltffi"`).
     pub prefix: String,
+    /// Top-level primitive functions. Used by both the public wrapper class
+    /// and the `[DllImport]` native declarations — C# P/Invoke passes
+    /// primitives directly, so one struct serves both layers.
+    pub functions: Vec<CSharpFunction>,
+}
+
+impl CSharpModule {
+    pub fn has_functions(&self) -> bool {
+        !self.functions.is_empty()
+    }
+}
+
+/// A primitive function binding. Serves double duty: the template uses `name`
+/// and C# types for the public static method, and `ffi_name` for the
+/// `[DllImport]` entry point.
+#[derive(Debug, Clone)]
+pub struct CSharpFunction {
+    /// PascalCase method name (e.g., `"EchoI32"`).
+    pub name: String,
+    /// Parameters with C# types.
+    pub params: Vec<CSharpParam>,
+    /// C# return type (e.g., `"int"`, `"void"`).
+    pub return_type: String,
+    /// The C symbol name (e.g., `"boltffi_echo_i32"`).
+    pub ffi_name: String,
+}
+
+impl CSharpFunction {
+    pub fn is_void(&self) -> bool {
+        self.return_type == "void"
+    }
+}
+
+/// A parameter in a C# function.
+#[derive(Debug, Clone)]
+pub struct CSharpParam {
+    /// camelCase parameter name, keyword-escaped with `@` if needed.
+    pub name: String,
+    /// C# type (e.g., `"int"`, `"double"`, `"bool"`).
+    pub csharp_type: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    fn function_with_return(return_type: &str) -> CSharpFunction {
+        CSharpFunction {
+            name: "Test".to_string(),
+            params: vec![],
+            return_type: return_type.to_string(),
+            ffi_name: "boltffi_test".to_string(),
+        }
+    }
+
+    #[rstest]
+    #[case::void("void", true)]
+    #[case::int("int", false)]
+    #[case::bool("bool", false)]
+    #[case::double("double", false)]
+    fn is_void(#[case] return_type: &str, #[case] expected: bool) {
+        assert_eq!(function_with_return(return_type).is_void(), expected);
+    }
 }

--- a/boltffi_bindgen/src/render/csharp/plan.rs
+++ b/boltffi_bindgen/src/render/csharp/plan.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use boltffi_ffi_rules::naming::{LibraryName, Name};
 
 /// Represents a lowered C# module, containing everything the templates need
@@ -24,6 +26,62 @@ impl CSharpModule {
     }
 }
 
+/// A C# type keyword. Includes `Void` so return types and value types share
+/// one enum; params never carry `Void` because the lowerer rejects it before
+/// constructing a [`CSharpParam`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CSharpType {
+    Void,
+    Bool,
+    SByte,
+    Byte,
+    Short,
+    UShort,
+    Int,
+    UInt,
+    Long,
+    ULong,
+    NInt,
+    NUInt,
+    Float,
+    Double,
+}
+
+impl CSharpType {
+    pub fn keyword(self) -> &'static str {
+        match self {
+            Self::Void => "void",
+            Self::Bool => "bool",
+            Self::SByte => "sbyte",
+            Self::Byte => "byte",
+            Self::Short => "short",
+            Self::UShort => "ushort",
+            Self::Int => "int",
+            Self::UInt => "uint",
+            Self::Long => "long",
+            Self::ULong => "ulong",
+            Self::NInt => "nint",
+            Self::NUInt => "nuint",
+            Self::Float => "float",
+            Self::Double => "double",
+        }
+    }
+
+    pub fn is_void(self) -> bool {
+        matches!(self, Self::Void)
+    }
+
+    pub fn is_bool(self) -> bool {
+        matches!(self, Self::Bool)
+    }
+}
+
+impl fmt::Display for CSharpType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.keyword())
+    }
+}
+
 /// A primitive function binding. Serves double duty: the template uses `name`
 /// and C# types for the public static method, and `ffi_name` for the
 /// `[DllImport]` entry point.
@@ -33,15 +91,15 @@ pub struct CSharpFunction {
     pub name: String,
     /// Parameters with C# types.
     pub params: Vec<CSharpParam>,
-    /// C# return type (e.g., `"int"`, `"void"`).
-    pub return_type: String,
+    /// C# return type.
+    pub return_type: CSharpType,
     /// The C symbol name (e.g., `"boltffi_echo_i32"`).
     pub ffi_name: String,
 }
 
 impl CSharpFunction {
     pub fn is_void(&self) -> bool {
-        self.return_type == "void"
+        self.return_type.is_void()
     }
 }
 
@@ -50,8 +108,8 @@ impl CSharpFunction {
 pub struct CSharpParam {
     /// camelCase parameter name, keyword-escaped with `@` if needed.
     pub name: String,
-    /// C# type (e.g., `"int"`, `"double"`, `"bool"`).
-    pub csharp_type: String,
+    /// C# type.
+    pub csharp_type: CSharpType,
 }
 
 #[cfg(test)]
@@ -59,21 +117,21 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    fn function_with_return(return_type: &str) -> CSharpFunction {
+    fn function_with_return(return_type: CSharpType) -> CSharpFunction {
         CSharpFunction {
             name: "Test".to_string(),
             params: vec![],
-            return_type: return_type.to_string(),
+            return_type,
             ffi_name: "boltffi_test".to_string(),
         }
     }
 
     #[rstest]
-    #[case::void("void", true)]
-    #[case::int("int", false)]
-    #[case::bool("bool", false)]
-    #[case::double("double", false)]
-    fn is_void(#[case] return_type: &str, #[case] expected: bool) {
+    #[case::void(CSharpType::Void, true)]
+    #[case::int(CSharpType::Int, false)]
+    #[case::bool(CSharpType::Bool, false)]
+    #[case::double(CSharpType::Double, false)]
+    fn is_void(#[case] return_type: CSharpType, #[case] expected: bool) {
         assert_eq!(function_with_return(return_type).is_void(), expected);
     }
 }

--- a/boltffi_bindgen/src/render/csharp/templates.rs
+++ b/boltffi_bindgen/src/render/csharp/templates.rs
@@ -12,6 +12,14 @@ pub struct PreambleTemplate<'a> {
     pub module: &'a CSharpModule,
 }
 
+/// Renders the public static wrapper class with methods that delegate
+/// to the native P/Invoke declarations.
+#[derive(Template)]
+#[template(path = "render_csharp/functions.txt", escape = "none")]
+pub struct FunctionsTemplate<'a> {
+    pub module: &'a CSharpModule,
+}
+
 /// Renders the `NativeMethods` static class containing `[DllImport]`
 /// declarations for the C FFI functions.
 #[derive(Template)]

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/functions.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/functions.txt
@@ -1,0 +1,16 @@
+{%- if module.has_functions() %}
+    public static class {{ module.class_name }}
+    {
+{%- for func in module.functions %}
+        public static {{ func.return_type }} {{ func.name }}({% for param in func.params %}{{ param.csharp_type }} {{ param.name }}{% if !loop.last %}, {% endif %}{% endfor %})
+        {
+{%- if func.is_void() %}
+            NativeMethods.{{ func.name }}({% for param in func.params %}{{ param.name }}{% if !loop.last %}, {% endif %}{% endfor %});
+{%- else %}
+            return NativeMethods.{{ func.name }}({% for param in func.params %}{{ param.name }}{% if !loop.last %}, {% endif %}{% endfor %});
+{%- endif %}
+        }
+{% endfor %}
+    }
+
+{% endif -%}

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
@@ -10,10 +10,10 @@
 {%- for func in module.functions %}
 
         [DllImport(LibName, EntryPoint = "{{ func.ffi_name }}")]
-{%- if func.return_type == "bool" %}
+{%- if func.return_type.is_bool() %}
         [return: MarshalAs(UnmanagedType.I1)]
 {%- endif %}
-        internal static extern {{ func.return_type }} {{ func.name }}({% for param in func.params %}{% if param.csharp_type == "bool" %}[MarshalAs(UnmanagedType.I1)] {% endif %}{{ param.csharp_type }} {{ param.name }}{% if !loop.last %}, {% endif %}{% endfor %});
+        internal static extern {{ func.return_type }} {{ func.name }}({% for param in func.params %}{% if param.csharp_type.is_bool() %}[MarshalAs(UnmanagedType.I1)] {% endif %}{{ param.csharp_type }} {{ param.name }}{% if !loop.last %}, {% endif %}{% endfor %});
 {%- endfor %}
     }
 }

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
@@ -7,5 +7,10 @@
 
         [DllImport(LibName, EntryPoint = "{{ module.prefix }}_last_error_message")]
         internal static extern int LastErrorMessage(out IntPtr message);
+{%- for func in module.functions %}
+
+        [DllImport(LibName, EntryPoint = "{{ func.ffi_name }}")]
+        internal static extern {{ func.return_type }} {{ func.name }}({% for param in func.params %}{{ param.csharp_type }} {{ param.name }}{% if !loop.last %}, {% endif %}{% endfor %});
+{%- endfor %}
     }
 }

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
@@ -10,7 +10,10 @@
 {%- for func in module.functions %}
 
         [DllImport(LibName, EntryPoint = "{{ func.ffi_name }}")]
-        internal static extern {{ func.return_type }} {{ func.name }}({% for param in func.params %}{{ param.csharp_type }} {{ param.name }}{% if !loop.last %}, {% endif %}{% endfor %});
+{%- if func.return_type == "bool" %}
+        [return: MarshalAs(UnmanagedType.I1)]
+{%- endif %}
+        internal static extern {{ func.return_type }} {{ func.name }}({% for param in func.params %}{% if param.csharp_type == "bool" %}[MarshalAs(UnmanagedType.I1)] {% endif %}{{ param.csharp_type }} {{ param.name }}{% if !loop.last %}, {% endif %}{% endfor %});
 {%- endfor %}
     }
 }

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -14,3 +14,5 @@ platforms/apple/Sources/
 
 platforms/android/src/main/jniLibs/
 platforms/android/src/main/kotlin/
+
+platforms/csharp/dist/


### PR DESCRIPTION
This addresses the next task in #146 - Primitive function support

I was careful to follow the patterns for Java (#70)/Python where appropriate.

One difference here: C# marshals bools as a 4 byte structure, so I have to decorate the bool type and method params to force it to marshal as a single byte.

C# also has native unsigned types and platform-sized integers (i.e. `usize` equivalent) with `nint`/`nuint` so every Rust primitive maps 1:1 without wrapper classes or boxing.

I added unit tests for this but the acceptance tests are saved for a later phase, but as I run these I am running the cli against the `csharp` backend for `examples/demo` and looking over the output to make sure it looks right.