### PR TITLE
fix: new clippy warning which wants match to include if

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
-      - run: cargo miri setup
-      - run: cargo miri test -p boltffi -p boltffi_tests
+      - run: cargo +nightly miri setup
+      - run: cargo +nightly miri test -p boltffi -p boltffi_tests
 
   cross-build:
     name: Cross Build (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          components: rustfmt
+          # caching handled by Swatinem/rust-cache in other jobs
+          cache: false
       - run: cargo fmt --all --check
 
   clippy:
@@ -25,9 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          components: clippy
+          # caching handled by Swatinem/rust-cache below
+          cache: false
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -42,7 +44,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # caching handled by Swatinem/rust-cache below
+          cache: false
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -63,9 +68,11 @@ jobs:
             target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          targets: ${{ matrix.target }}
+          # caching handled by Swatinem/rust-cache below
+          cache: false
+          target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -78,7 +85,10 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # caching handled by Swatinem/rust-cache below
+          cache: false
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -90,7 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # caching handled by Swatinem/rust-cache below
+          cache: false
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -121,7 +134,10 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # caching handled by Swatinem/rust-cache below
+          cache: false
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -162,7 +178,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # caching handled by Swatinem/rust-cache below
+          cache: false
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,10 @@ jobs:
             exit 1
           fi
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # caching handled by Swatinem/rust-cache below
+          cache: false
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -112,9 +115,11 @@ jobs:
         with:
           ref: v${{ needs.release.outputs.version }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          targets: ${{ matrix.target }}
+          # caching handled by Swatinem/rust-cache below
+          cache: false
+          target: ${{ matrix.target }}
 
       - name: Install musl-tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
@@ -177,7 +182,10 @@ jobs:
         with:
           ref: v${{ needs.release.outputs.version }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # caching handled by Swatinem/rust-cache below
+          cache: false
       - uses: Swatinem/rust-cache@v2
 
       - name: Publish crates

--- a/boltffi_bindgen/src/scan/mod.rs
+++ b/boltffi_bindgen/src/scan/mod.rs
@@ -960,36 +960,34 @@ impl SourceScanner {
 
         for item in &syntax.items {
             match item {
-                Item::Struct(item_struct) => {
+                Item::Struct(item_struct)
                     if has_attribute(&item_struct.attrs, "ffi_record")
                         || has_attribute(&item_struct.attrs, "data")
                         || has_attribute(&item_struct.attrs, "error")
                         || has_repr_c(&item_struct.attrs)
                         || (has_attribute(&item_struct.attrs, "derive")
-                            && has_ffi_type_derive(&item_struct.attrs))
-                    {
-                        self.type_registry.register(
-                            item_struct.ident.to_string(),
-                            TypeMeta {
-                                doc: extract_doc_string(&item_struct.attrs),
-                                shape: TypeShape::Pending(PendingKind::Record),
-                            },
-                        );
-                    }
+                            && has_ffi_type_derive(&item_struct.attrs)) =>
+                {
+                    self.type_registry.register(
+                        item_struct.ident.to_string(),
+                        TypeMeta {
+                            doc: extract_doc_string(&item_struct.attrs),
+                            shape: TypeShape::Pending(PendingKind::Record),
+                        },
+                    );
                 }
-                Item::Enum(item_enum) => {
+                Item::Enum(item_enum)
                     if has_repr_int(&item_enum.attrs)
                         || has_attribute(&item_enum.attrs, "data")
-                        || has_attribute(&item_enum.attrs, "error")
-                    {
-                        self.type_registry.register(
-                            item_enum.ident.to_string(),
-                            TypeMeta {
-                                doc: extract_doc_string(&item_enum.attrs),
-                                shape: TypeShape::Pending(PendingKind::Enum),
-                            },
-                        );
-                    }
+                        || has_attribute(&item_enum.attrs, "error") =>
+                {
+                    self.type_registry.register(
+                        item_enum.ident.to_string(),
+                        TypeMeta {
+                            doc: extract_doc_string(&item_enum.attrs),
+                            shape: TypeShape::Pending(PendingKind::Enum),
+                        },
+                    );
                 }
                 Item::Impl(item_impl) => {
                     if (has_attribute(&item_impl.attrs, "ffi_class")
@@ -1063,19 +1061,17 @@ impl SourceScanner {
                     self.process_class(item_impl);
                 }
             }
-            Item::Trait(item_trait) => {
+            Item::Trait(item_trait)
                 if has_attribute(&item_trait.attrs, "ffi_trait")
-                    || has_attribute(&item_trait.attrs, "export")
-                {
-                    self.process_callback_trait(item_trait);
-                }
+                    || has_attribute(&item_trait.attrs, "export") =>
+            {
+                self.process_callback_trait(item_trait);
             }
-            Item::Fn(item_fn) => {
+            Item::Fn(item_fn)
                 if has_attribute(&item_fn.attrs, "ffi_export")
-                    || has_attribute(&item_fn.attrs, "export")
-                {
-                    self.process_function(item_fn);
-                }
+                    || has_attribute(&item_fn.attrs, "export") =>
+            {
+                self.process_function(item_fn);
             }
             Item::Enum(item_enum) => {
                 let is_error = has_attribute(&item_enum.attrs, "error");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.94.1"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This fixes a clippy warning introduced in the new stable version [today](https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/), 1.95.0.

The clippy warning wants the code to include an if clause to a match if that's possible, and that was possible in the scan.rs.