### PR TITLE
Support C# Vec<T>

### DIFF
--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -2080,6 +2080,68 @@ mod tests {
         );
     }
 
+    /// Regression: when a data-enum variant field is `Vec<Vec<String>>`,
+    /// the `_v` prefix rewrite must apply only to the outer field access
+    /// (`_v.Groups`) and must leave the nested loop / lambda bindings
+    /// alone. Rewriting the inner references to `_v.item1` or `_v.item0`
+    /// would break both the size expression and the encode loop.
+    #[test]
+    fn emit_data_enum_variant_nested_vec_string_prefixes_only_outer_field_access() {
+        let mut contract = empty_contract();
+        contract.catalog.insert_enum(data_enum_single_variant(
+            "filter",
+            "ByGroups",
+            (
+                "groups",
+                TypeExpr::Vec(Box::new(TypeExpr::Vec(Box::new(TypeExpr::String)))),
+            ),
+        ));
+        contract.functions.push(function_with_types(
+            "echo_filter",
+            vec![("f", TypeExpr::Enum(EnumId::new("filter")))],
+            ReturnDef::Value(TypeExpr::Enum(EnumId::new("filter"))),
+        ));
+
+        let files = emit_files_for(&contract);
+        let enum_src = files
+            .iter()
+            .find(|(name, _)| name == "Filter.cs")
+            .expect("Filter.cs")
+            .1
+            .as_str();
+
+        assert_source_contains(
+            enum_src,
+            "ByGroups _v => WireWriter.EncodedArraySize(_v.Groups, sizeItem1 => WireWriter.EncodedArraySize(sizeItem1, sizeItem0 => (4 + Encoding.UTF8.GetByteCount(sizeItem0))))",
+            "the size expression to prefix only the outer field access and keep distinct nested lambda variables",
+        );
+        assert_source_contains(
+            enum_src,
+            "wire.WriteI32(_v.Groups.Length); foreach (string[] item1 in _v.Groups) { wire.WriteI32(item1.Length); foreach (string item0 in item1) { wire.WriteString(item0); }; }",
+            "the encode body to prefix only the outer field access and keep the nested foreach bindings untouched",
+        );
+        assert_source_lacks(
+            enum_src,
+            "_v.item1",
+            "the outer `_v` prefix must not leak into the nested foreach binding",
+        );
+        assert_source_lacks(
+            enum_src,
+            "_v.item0",
+            "the outer `_v` prefix must not leak into the innermost foreach binding",
+        );
+        assert_source_lacks(
+            enum_src,
+            "_v.sizeItem1",
+            "the outer `_v` prefix must not leak into the nested size lambda binding",
+        );
+        assert_source_lacks(
+            enum_src,
+            "_v.sizeItem0",
+            "the outer `_v` prefix must not leak into the innermost size lambda binding",
+        );
+    }
+
     /// A function that returns `Vec<i32>` by flattening a `Vec<Vec<i32>>`
     /// param keeps the top-level return on the no-prefix blittable fast
     /// path: the outer count comes from `FfiBuf.len`. This guards against

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -12,9 +12,9 @@ use std::collections::HashSet;
 
 use askama::Template as _;
 
-use crate::ir::codec::EnumLayout;
+use crate::ir::codec::{EnumLayout, VecLayout};
 use crate::ir::ops::{ReadOp, ReadSeq, SizeExpr, ValueExpr, WriteOp, WriteSeq};
-use crate::ir::types::PrimitiveType;
+use crate::ir::types::{PrimitiveType, TypeExpr};
 use crate::ir::{AbiContract, FfiContract};
 
 use super::{
@@ -198,6 +198,32 @@ pub fn primitive_write_method(primitive: PrimitiveType) -> &'static str {
     }
 }
 
+/// The WireReader method invocation for a blittable primitive `Vec<T>`,
+/// without the receiver. Bool, isize, and usize have dedicated methods
+/// because C# `bool` is not `unmanaged`-cast-safe against the 1-byte wire
+/// form, and the wire form of isize/usize is a fixed 8 bytes while C#
+/// `nint`/`nuint` are pointer-sized. Every other primitive flows through
+/// a generic `ReadBlittableArray<T>()` that bulk-casts via `MemoryMarshal`.
+pub fn primitive_vec_reader_call(primitive: PrimitiveType) -> String {
+    match primitive {
+        PrimitiveType::Bool => "ReadBoolArray()".to_string(),
+        PrimitiveType::ISize => "ReadNIntArray()".to_string(),
+        PrimitiveType::USize => "ReadNUIntArray()".to_string(),
+        other => format!("ReadBlittableArray<{}>()", super::mappings::csharp_type(other)),
+    }
+}
+
+/// The WireWriter method invocation for a blittable primitive `Vec<T>`,
+/// formatted as `"{method}({value})"` without the receiver.
+pub fn primitive_vec_writer_call(primitive: PrimitiveType, value: &str) -> String {
+    match primitive {
+        PrimitiveType::Bool => format!("WriteBoolArray({value})"),
+        PrimitiveType::ISize => format!("WriteNIntArray({value})"),
+        PrimitiveType::USize => format!("WriteNUIntArray({value})"),
+        _ => format!("WriteBlittableArray({value})"),
+    }
+}
+
 /// Names shadowed by a nested scope in the rendering site. Passed to
 /// [`emit_reader_read`] when emitting decode expressions inside a data
 /// enum body, where nested `sealed record Foo() : E` variants shadow
@@ -252,6 +278,19 @@ pub fn emit_reader_read(seq: &ReadSeq, scope: Option<&ShadowScope>) -> String {
             let class_name = NamingConvention::class_name(id.as_str());
             format!("{}.Decode(reader)", qualify_if_shadowed(&class_name, scope))
         }
+        ReadOp::Vec {
+            element_type: TypeExpr::Primitive(p),
+            layout: VecLayout::Blittable { .. },
+            ..
+        } => format!("reader.{}", primitive_vec_reader_call(*p)),
+        ReadOp::Vec {
+            element_type,
+            layout: VecLayout::Blittable { .. },
+            ..
+        } => todo!(
+            "blittable Vec with non-primitive element {:?} is not yet supported by the C# backend",
+            element_type
+        ),
         other => panic!("unsupported C# read op: {:?}", other),
     }
 }
@@ -299,6 +338,24 @@ pub fn emit_write_expr(seq: &WriteSeq, writer_name: &str) -> String {
             layout: EnumLayout::CStyle { .. } | EnumLayout::Data { .. },
             ..
         } => format!("{}.WireEncodeTo({})", render_value(value), writer_name),
+        WriteOp::Vec {
+            value,
+            element_type: TypeExpr::Primitive(p),
+            layout: VecLayout::Blittable { .. },
+            ..
+        } => format!(
+            "{}.{}",
+            writer_name,
+            primitive_vec_writer_call(*p, &render_value(value))
+        ),
+        WriteOp::Vec {
+            element_type,
+            layout: VecLayout::Blittable { .. },
+            ..
+        } => todo!(
+            "blittable Vec with non-primitive element {:?} is not yet supported by the C# backend",
+            element_type
+        ),
         other => panic!("unsupported C# write op: {:?}", other),
     }
 }
@@ -330,6 +387,15 @@ pub fn emit_size_expr(size: &SizeExpr) -> String {
                 .join(" + ");
             format!("({})", rendered)
         }
+        SizeExpr::VecSize {
+            value,
+            layout: VecLayout::Blittable { element_size },
+            ..
+        } => format!(
+            "(4 + {}.Length * {})",
+            render_value(value),
+            element_size
+        ),
         other => panic!("unsupported C# size expr: {:?}", other),
     }
 }

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -1269,6 +1269,75 @@ mod tests {
         );
     }
 
+    /// Each pinned record-array param needs its own `fixed` statement.
+    /// C# rejects comma-joined declarations here, so the wrapper must
+    /// nest the blocks when a function takes multiple
+    /// `Vec<BlittableRecord>` params.
+    #[test]
+    fn emit_blittable_record_vec_params_use_nested_fixed_blocks() {
+        let mut contract = empty_contract();
+        contract.catalog.insert_record(record_with_fields(
+            "point",
+            true,
+            vec![
+                ("x", TypeExpr::Primitive(PrimitiveType::F64)),
+                ("y", TypeExpr::Primitive(PrimitiveType::F64)),
+            ],
+        ));
+        contract.catalog.insert_record(record_with_fields(
+            "color",
+            true,
+            vec![
+                ("r", TypeExpr::Primitive(PrimitiveType::U8)),
+                ("g", TypeExpr::Primitive(PrimitiveType::U8)),
+                ("b", TypeExpr::Primitive(PrimitiveType::U8)),
+                ("a", TypeExpr::Primitive(PrimitiveType::U8)),
+            ],
+        ));
+        contract.functions.push(function_with_types(
+            "score_batches",
+            vec![
+                (
+                    "points",
+                    TypeExpr::Vec(Box::new(TypeExpr::Record(RecordId::new("point")))),
+                ),
+                (
+                    "colors",
+                    TypeExpr::Vec(Box::new(TypeExpr::Record(RecordId::new("color")))),
+                ),
+            ],
+            ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::I32)),
+        ));
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "fixed (Point* _pointsPtr = points)",
+            "the first pinned record vec param to get its own fixed statement",
+        );
+        assert_source_contains(
+            &src,
+            "fixed (Color* _colorsPtr = colors)",
+            "the second pinned record vec param to get a nested fixed statement instead of a comma-joined declaration",
+        );
+        assert_source_lacks(
+            &src,
+            "fixed (Point* _pointsPtr = points, Color* _colorsPtr = colors)",
+            "C# does not accept comma-joined fixed declarations across pinned params",
+        );
+        assert_source_contains(
+            &src,
+            "return NativeMethods.ScoreBatches((IntPtr)_pointsPtr, (UIntPtr)(points.Length * Unsafe.SizeOf<Point>()), (IntPtr)_colorsPtr, (UIntPtr)(colors.Length * Unsafe.SizeOf<Color>()));",
+            "the native call to use both pointer locals and byte lengths from the nested fixed blocks",
+        );
+        assert_source_contains(
+            &src,
+            "internal static extern int ScoreBatches(IntPtr points, UIntPtr pointsLen, IntPtr colors, UIntPtr colorsLen);",
+            "the DllImport signature to expose both pinned arrays as raw pointers plus byte lengths",
+        );
+    }
+
     /// A non-blittable record (one with a string field) must NOT carry
     /// `[StructLayout(Sequential)]` — its memory layout doesn't need to
     /// match Rust's because it travels as wire-encoded bytes, not as a
@@ -1691,6 +1760,63 @@ mod tests {
             &src,
             "internal static extern Direction DirectionOpposite(Direction self);",
             "the DllImport to declare the prefixed native name, return the enum type directly, and take the enum-typed self param",
+        );
+    }
+
+    /// Enum methods share the same value-type method template as enum
+    /// constructors. A blittable record vec param therefore needs the
+    /// same `unsafe { fixed (...) { ... } }` wrapper as a top-level
+    /// function so the generated pointer local exists at the native call
+    /// site and the array stays pinned for the duration of the call.
+    #[test]
+    fn emit_enum_method_with_blittable_record_vec_param_uses_fixed_block() {
+        let mut contract = empty_contract();
+        contract.catalog.insert_record(record_with_fields(
+            "point",
+            true,
+            vec![
+                ("x", TypeExpr::Primitive(PrimitiveType::F64)),
+                ("y", TypeExpr::Primitive(PrimitiveType::F64)),
+            ],
+        ));
+        let mut enum_def = c_style_enum("direction", vec!["North", "South"]);
+        enum_def.methods.push(MethodDef {
+            id: MethodId::new("from_points"),
+            receiver: Receiver::Static,
+            params: vec![ParamDef {
+                name: ParamName::new("points"),
+                type_expr: TypeExpr::Vec(Box::new(TypeExpr::Record(RecordId::new("point")))),
+                passing: ParamPassing::Value,
+                doc: None,
+            }],
+            returns: ReturnDef::Value(TypeExpr::Enum(EnumId::new("direction"))),
+            execution_kind: ExecutionKind::Sync,
+            doc: None,
+            deprecated: None,
+        });
+        contract.catalog.insert_enum(enum_def);
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "public static Direction FromPoints(Point[] points)",
+            "the enum companion method to expose the blittable record vec as Point[]",
+        );
+        assert_source_contains(
+            &src,
+            "fixed (Point* _pointsPtr = points)",
+            "the method body to pin the managed Point[] before the native call",
+        );
+        assert_source_contains(
+            &src,
+            "return NativeMethods.DirectionFromPoints((IntPtr)_pointsPtr, (UIntPtr)(points.Length * Unsafe.SizeOf<Point>()));",
+            "the native call to use the pointer local introduced by the fixed block",
+        );
+        assert_source_contains(
+            &src,
+            "internal static extern Direction DirectionFromPoints(IntPtr points, UIntPtr pointsLen);",
+            "the DllImport signature to take a raw pointer and byte length for the pinned array param",
         );
     }
 

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -198,12 +198,14 @@ pub fn primitive_write_method(primitive: PrimitiveType) -> &'static str {
     }
 }
 
-/// The WireReader method invocation for a blittable primitive `Vec<T>`,
-/// without the receiver. Bool, isize, and usize have dedicated methods
-/// because C# `bool` is not `unmanaged`-cast-safe against the 1-byte wire
-/// form, and the wire form of isize/usize is a fixed 8 bytes while C#
-/// `nint`/`nuint` are pointer-sized. Every other primitive flows through
-/// a generic `ReadBlittableArray<T>()` that bulk-casts via `MemoryMarshal`.
+/// The WireReader method invocation for a top-level blittable primitive
+/// `Vec<T>` return, without the receiver. Top-level vec returns carry no
+/// length prefix: the count comes from `FfiBuf.len`. Bool, isize, and
+/// usize have dedicated methods because C# `bool` is not `unmanaged`-cast-
+/// safe against the 1-byte wire form, and the wire form of isize/usize is
+/// a fixed 8 bytes while C# `nint`/`nuint` are pointer-sized. Every other
+/// primitive flows through a generic `ReadBlittableArray<T>()` that bulk-
+/// casts via `MemoryMarshal`.
 pub fn primitive_vec_reader_call(primitive: PrimitiveType) -> String {
     match primitive {
         PrimitiveType::Bool => "ReadBoolArray()".to_string(),
@@ -216,14 +218,136 @@ pub fn primitive_vec_reader_call(primitive: PrimitiveType) -> String {
     }
 }
 
+/// The WireReader method invocation for a nested blittable primitive
+/// `Vec<T>`, without the receiver. Nested reads carry a 4-byte length
+/// prefix because the outer encoded container needs to know how far to
+/// advance the cursor before decoding the next element.
+fn primitive_vec_nested_reader_call(primitive: PrimitiveType) -> String {
+    match primitive {
+        PrimitiveType::Bool => "ReadLengthPrefixedBoolArray()".to_string(),
+        PrimitiveType::ISize => "ReadLengthPrefixedNIntArray()".to_string(),
+        PrimitiveType::USize => "ReadLengthPrefixedNUIntArray()".to_string(),
+        other => format!(
+            "ReadLengthPrefixedBlittableArray<{}>()",
+            super::mappings::csharp_type(other)
+        ),
+    }
+}
+
 /// The WireWriter method invocation for a blittable primitive `Vec<T>`,
-/// formatted as `"{method}({value})"` without the receiver.
+/// formatted as `"{method}({value})"` without the receiver. The writer
+/// always prepends a 4-byte length prefix, which serves the nested
+/// position (inside an encoded outer vec) and the future record-field
+/// position. Top-level vec params go through `DirectArray` and never
+/// touch this code path.
 pub fn primitive_vec_writer_call(primitive: PrimitiveType, value: &str) -> String {
     match primitive {
         PrimitiveType::Bool => format!("WriteBoolArray({value})"),
         PrimitiveType::ISize => format!("WriteNIntArray({value})"),
         PrimitiveType::USize => format!("WriteNUIntArray({value})"),
         _ => format!("WriteBlittableArray({value})"),
+    }
+}
+
+/// Per-function rendering scratchpad. Hands out unique loop-variable and
+/// closure-argument names so nested `Vec<Vec<_>>` expressions don't
+/// shadow each other. One instance per top-level emit call; counters are
+/// consumed in the order read / write / size helpers encounter nested
+/// vecs, which is stable across renders of the same seq.
+#[derive(Default)]
+pub struct CSharpEmitContext {
+    write_loop_index: usize,
+    read_closure_index: usize,
+    size_loop_index: usize,
+}
+
+impl CSharpEmitContext {
+    fn next_write_loop_var(&mut self) -> String {
+        let i = self.write_loop_index;
+        self.write_loop_index += 1;
+        format!("item{}", i)
+    }
+
+    fn next_read_closure_var(&mut self) -> String {
+        let i = self.read_closure_index;
+        self.read_closure_index += 1;
+        format!("r{}", i)
+    }
+
+    fn next_size_loop_var(&mut self) -> String {
+        let i = self.size_loop_index;
+        self.size_loop_index += 1;
+        format!("sizeItem{}", i)
+    }
+}
+
+/// Replace every word-boundary occurrence of `identifier` in `expression`
+/// with `replacement`. A token inside another identifier (e.g. `item`
+/// inside `item0`) is left alone. Used to rename the ABI-provided loop
+/// variable `"item"` and closure receiver `"reader"` to per-nesting-level
+/// unique names without running a real parser.
+fn replace_identifier_occurrences(expression: &str, identifier: &str, replacement: &str) -> String {
+    if identifier.is_empty() {
+        return expression.to_string();
+    }
+    let mut result = String::with_capacity(expression.len());
+    let mut cursor = 0;
+    while let Some(rel) = expression[cursor..].find(identifier) {
+        let start = cursor + rel;
+        let end = start + identifier.len();
+        let prev = expression[..start].chars().next_back();
+        let next = expression[end..].chars().next();
+        let prev_is_id = prev.map(is_identifier_char).unwrap_or(false);
+        let next_is_id = next.map(is_identifier_char).unwrap_or(false);
+        if prev_is_id || next_is_id {
+            result.push_str(&expression[cursor..end]);
+        } else {
+            result.push_str(&expression[cursor..start]);
+            result.push_str(replacement);
+        }
+        cursor = end;
+    }
+    result.push_str(&expression[cursor..]);
+    result
+}
+
+fn is_identifier_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
+/// Render the `reader_call` portion (without the leading `new WireReader
+/// (_buf).` receiver) for a top-level `Vec<inner>` return. Primitive
+/// element vecs use the no-prefix fast path keyed off `FfiBuf.len`;
+/// encoded element vecs (strings, nested vecs) wrap `ReadEncodedArray<T>`
+/// around a closure that decodes one element.
+pub fn vec_return_reader_call(inner: &TypeExpr, element_seq: &ReadSeq) -> String {
+    match inner {
+        TypeExpr::Primitive(p) => primitive_vec_reader_call(*p),
+        _ => {
+            let mut ctx = CSharpEmitContext::default();
+            let inner_reader = emit_reader_read_with_context(element_seq, None, &mut ctx);
+            let closure_var = ctx.next_read_closure_var();
+            let remapped = replace_identifier_occurrences(&inner_reader, "reader", &closure_var);
+            let element_type = csharp_type_for_inner(inner);
+            format!(
+                "ReadEncodedArray<{}>({} => {})",
+                element_type, closure_var, remapped
+            )
+        }
+    }
+}
+
+/// C# type literal for a `Vec<_>` element. Used when stamping the generic
+/// parameter on `ReadEncodedArray<T>` at emit time.
+fn csharp_type_for_inner(ty: &TypeExpr) -> String {
+    match ty {
+        TypeExpr::Primitive(p) => super::mappings::csharp_type(*p).to_string(),
+        TypeExpr::String => "string".to_string(),
+        TypeExpr::Vec(inner) => format!("{}[]", csharp_type_for_inner(inner)),
+        other => todo!(
+            "csharp_type_for_inner: Vec element {:?} is not yet supported by the C# backend",
+            other
+        ),
     }
 }
 
@@ -249,6 +373,15 @@ pub struct ShadowScope<'a> {
 /// a primitive, a string, or a nested record/enum. Container ops (Option,
 /// Vec, Result) will land in follow-up PRs.
 pub fn emit_reader_read(seq: &ReadSeq, scope: Option<&ShadowScope>) -> String {
+    let mut ctx = CSharpEmitContext::default();
+    emit_reader_read_with_context(seq, scope, &mut ctx)
+}
+
+fn emit_reader_read_with_context(
+    seq: &ReadSeq,
+    scope: Option<&ShadowScope>,
+    ctx: &mut CSharpEmitContext,
+) -> String {
     let op = seq.ops.first().expect("read ops");
     match op {
         ReadOp::Primitive { primitive, .. } => {
@@ -267,7 +400,7 @@ pub fn emit_reader_read(seq: &ReadSeq, scope: Option<&ShadowScope>) -> String {
         } => {
             // The generated helper is `{Name}Wire`, not `{Name}`, so the
             // `Wire` suffix is already unambiguous against variant names
-            // that match `{Name}` alone — no shadowing fix needed here.
+            // that match `{Name}` alone; no shadowing fix needed here.
             format!(
                 "{}Wire.Decode(reader)",
                 NamingConvention::class_name(id.as_str())
@@ -285,7 +418,12 @@ pub fn emit_reader_read(seq: &ReadSeq, scope: Option<&ShadowScope>) -> String {
             element_type: TypeExpr::Primitive(p),
             layout: VecLayout::Blittable { .. },
             ..
-        } => format!("reader.{}", primitive_vec_reader_call(*p)),
+        } => {
+            // A Vec op reached through emit_reader_read is always nested
+            // (top-level vec returns go through vec_return_reader_call).
+            // Nested position means the wire shape is length-prefixed.
+            format!("reader.{}", primitive_vec_nested_reader_call(*p))
+        }
         ReadOp::Vec {
             element_type,
             layout: VecLayout::Blittable { .. },
@@ -294,7 +432,25 @@ pub fn emit_reader_read(seq: &ReadSeq, scope: Option<&ShadowScope>) -> String {
             "blittable Vec with non-primitive element {:?} is not yet supported by the C# backend",
             element_type
         ),
-        other => panic!("unsupported C# read op: {:?}", other),
+        ReadOp::Vec {
+            element_type,
+            element,
+            layout: VecLayout::Encoded,
+            ..
+        } => {
+            let inner_reader = emit_reader_read_with_context(element, scope, ctx);
+            let closure_var = ctx.next_read_closure_var();
+            let remapped = replace_identifier_occurrences(&inner_reader, "reader", &closure_var);
+            let element_type_str = csharp_type_for_inner(element_type);
+            format!(
+                "reader.ReadEncodedArray<{}>({} => {})",
+                element_type_str, closure_var, remapped
+            )
+        }
+        other => todo!(
+            "C# backend has not yet implemented read support for {:?}",
+            other
+        ),
     }
 }
 
@@ -317,6 +473,15 @@ fn qualify_if_shadowed(class_name: &str, scope: Option<&ShadowScope>) -> String 
 /// Render the first op of a [`WriteSeq`] as a statement that writes its
 /// value into the `WireWriter` named by `writer_name`.
 pub fn emit_write_expr(seq: &WriteSeq, writer_name: &str) -> String {
+    let mut ctx = CSharpEmitContext::default();
+    emit_write_expr_with_context(seq, writer_name, &mut ctx)
+}
+
+fn emit_write_expr_with_context(
+    seq: &WriteSeq,
+    writer_name: &str,
+    ctx: &mut CSharpEmitContext,
+) -> String {
     let op = seq.ops.first().expect("write ops");
     match op {
         WriteOp::Primitive { primitive, value } => {
@@ -359,7 +524,30 @@ pub fn emit_write_expr(seq: &WriteSeq, writer_name: &str) -> String {
             "blittable Vec with non-primitive element {:?} is not yet supported by the C# backend",
             element_type
         ),
-        other => panic!("unsupported C# write op: {:?}", other),
+        WriteOp::Vec {
+            value,
+            element_type,
+            element,
+            layout: VecLayout::Encoded,
+        } => {
+            let inner_write = emit_write_expr_with_context(element, writer_name, ctx);
+            let loop_var = ctx.next_write_loop_var();
+            let remapped = replace_identifier_occurrences(&inner_write, "item", &loop_var);
+            let iter_type = csharp_type_for_inner(element_type);
+            format!(
+                "{}.WriteI32({}.Length); foreach ({} {} in {}) {{ {}; }}",
+                writer_name,
+                render_value(value),
+                iter_type,
+                loop_var,
+                render_value(value),
+                remapped,
+            )
+        }
+        other => todo!(
+            "C# backend has not yet implemented write support for {:?}",
+            other
+        ),
     }
 }
 
@@ -373,6 +561,11 @@ pub fn emit_write_expr(seq: &WriteSeq, writer_name: &str) -> String {
 /// count. Doubling up (e.g. rendering `StringLen` as `4 + byte_count`)
 /// would over-count by 4 bytes per string.
 pub fn emit_size_expr(size: &SizeExpr) -> String {
+    let mut ctx = CSharpEmitContext::default();
+    emit_size_expr_with_context(size, &mut ctx)
+}
+
+fn emit_size_expr_with_context(size: &SizeExpr, ctx: &mut CSharpEmitContext) -> String {
     match size {
         SizeExpr::Fixed(value) => value.to_string(),
         SizeExpr::StringLen(value) => {
@@ -385,7 +578,7 @@ pub fn emit_size_expr(size: &SizeExpr) -> String {
         SizeExpr::Sum(parts) => {
             let rendered = parts
                 .iter()
-                .map(emit_size_expr)
+                .map(|p| emit_size_expr_with_context(p, ctx))
                 .collect::<Vec<_>>()
                 .join(" + ");
             format!("({})", rendered)
@@ -395,7 +588,25 @@ pub fn emit_size_expr(size: &SizeExpr) -> String {
             layout: VecLayout::Blittable { element_size },
             ..
         } => format!("(4 + {}.Length * {})", render_value(value), element_size),
-        other => panic!("unsupported C# size expr: {:?}", other),
+        SizeExpr::VecSize {
+            value,
+            inner,
+            layout: VecLayout::Encoded,
+        } => {
+            let inner_expr = emit_size_expr_with_context(inner, ctx);
+            let loop_var = ctx.next_size_loop_var();
+            let remapped = replace_identifier_occurrences(&inner_expr, "item", &loop_var);
+            format!(
+                "WireWriter.EncodedArraySize({}, {} => {})",
+                render_value(value),
+                loop_var,
+                remapped,
+            )
+        }
+        other => todo!(
+            "C# backend has not yet implemented size expression support for {:?}",
+            other
+        ),
     }
 }
 
@@ -773,6 +984,42 @@ mod tests {
             main_source,
             "Marshal.PtrToStringUTF8",
             "WireReader string decode still lives in the main file for record-only string usage",
+        );
+    }
+
+    /// Regression: `Vec<String>` params now encode through `WireWriter`
+    /// using `Encoding.UTF8`, even when the contract has no direct string
+    /// params or string-bearing records. The main file still needs
+    /// `System.Text` for that generated path to compile.
+    #[test]
+    fn emit_vec_string_param_imports_system_text_in_main_file() {
+        let mut contract = empty_contract();
+        contract.functions.push(function_with_types(
+            "vec_string_lengths",
+            vec![("v", TypeExpr::Vec(Box::new(TypeExpr::String)))],
+            ReturnDef::Value(TypeExpr::Vec(Box::new(TypeExpr::Primitive(
+                PrimitiveType::U32,
+            )))),
+        ));
+
+        let output = emit_contract(&contract);
+        let main_source = output
+            .files
+            .iter()
+            .find(|f| f.file_name == "DemoLib.cs")
+            .expect("DemoLib.cs")
+            .source
+            .as_str();
+
+        assert_source_contains(
+            main_source,
+            "using System.Text;",
+            "the main file needs System.Text when Vec<String> params make WireWriter size/write code call Encoding.UTF8",
+        );
+        assert_source_contains(
+            main_source,
+            "WireWriter.EncodedArraySize(v, sizeItem0 => (4 + Encoding.UTF8.GetByteCount(sizeItem0)))",
+            "the encoded Vec<String> param path uses Encoding.UTF8 inside the shared main-file helpers",
         );
     }
 
@@ -1561,6 +1808,158 @@ mod tests {
             &log_level_cs.1,
             "wire.WriteI32(value switch",
             "the encode helper to write a 4-byte i32 after mapping the variant to its ordinal",
+        );
+    }
+
+    // ----- Encoded Vec tests (Vec<String>, Vec<Vec<_>>) -----
+
+    /// `Vec<String>` as a param travels wire-encoded: a `WireWriter` sized
+    /// via `EncodedArraySize` writes a length-prefixed array of
+    /// length-prefixed UTF-8 strings. As a return it comes back through
+    /// `ReadEncodedArray<string>` wrapping `ReadString`.
+    #[test]
+    fn emit_vec_string_round_trips_through_encoded_array_helpers() {
+        let mut contract = empty_contract();
+        contract.functions.push(function_with_types(
+            "echo_vec_string",
+            vec![("v", TypeExpr::Vec(Box::new(TypeExpr::String)))],
+            ReturnDef::Value(TypeExpr::Vec(Box::new(TypeExpr::String))),
+        ));
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "public static string[] EchoVecString(string[] v)",
+            "the public wrapper exposes Vec<String> on both sides as string[]",
+        );
+        assert_source_contains(
+            &src,
+            "internal static extern FfiBuf EchoVecString(byte[] v, UIntPtr vLen);",
+            "the DllImport carries the wire-encoded buffer, not a raw string[]",
+        );
+        assert_source_contains(
+            &src,
+            "WireWriter.EncodedArraySize(v, sizeItem0 => (4 + Encoding.UTF8.GetByteCount(sizeItem0)))",
+            "the WireWriter size hint uses EncodedArraySize with a per-element UTF-8 byte-count lambda",
+        );
+        assert_source_contains(
+            &src,
+            "_wire_v.WriteI32(v.Length); foreach (string item0 in v) { _wire_v.WriteString(item0); }",
+            "the encode body writes the 4-byte count then loops WriteString over each element",
+        );
+        assert_source_contains(
+            &src,
+            "return new WireReader(_buf).ReadEncodedArray<string>(r0 => r0.ReadString());",
+            "the return decodes through ReadEncodedArray with a ReadString closure per element",
+        );
+    }
+
+    /// `Vec<Vec<i32>>` exercises the nested-encoded-over-blittable path:
+    /// outer layer is wire-encoded (count prefix + per-element bytes),
+    /// inner layer is length-prefixed blittable. Loop variables must be
+    /// unique across nesting (`item0` for the inner write, `item1` for the
+    /// outer) so inner references don't shadow the outer.
+    #[test]
+    fn emit_vec_vec_i32_nests_blittable_inside_encoded() {
+        let mut contract = empty_contract();
+        contract.functions.push(function_with_types(
+            "echo_vec_vec_i32",
+            vec![(
+                "v",
+                TypeExpr::Vec(Box::new(TypeExpr::Vec(Box::new(TypeExpr::Primitive(
+                    PrimitiveType::I32,
+                ))))),
+            )],
+            ReturnDef::Value(TypeExpr::Vec(Box::new(TypeExpr::Vec(Box::new(
+                TypeExpr::Primitive(PrimitiveType::I32),
+            ))))),
+        ));
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "public static int[][] EchoVecVecI32(int[][] v)",
+            "the public wrapper exposes Vec<Vec<i32>> as a jagged int[][]",
+        );
+        assert_source_contains(
+            &src,
+            "_wire_v.WriteI32(v.Length); foreach (int[] item0 in v) { _wire_v.WriteBlittableArray(item0); }",
+            "the outer write emits the count then loops WriteBlittableArray (which writes its own length prefix) over each inner array",
+        );
+        assert_source_contains(
+            &src,
+            "return new WireReader(_buf).ReadEncodedArray<int[]>(r0 => r0.ReadLengthPrefixedBlittableArray<int>());",
+            "the return decodes through ReadEncodedArray wrapping a nested ReadLengthPrefixedBlittableArray",
+        );
+    }
+
+    /// `Vec<Vec<String>>` doubles up the encoded path: both layers carry a
+    /// 4-byte count prefix, and the inner element is itself variable-width.
+    /// The decode closure name (`r1`) and inner closure (`r0`) must differ
+    /// so scopes don't shadow; the same property holds for write loop vars
+    /// (`item0` innermost, `item1` outer).
+    #[test]
+    fn emit_vec_vec_string_doubles_the_encoded_array_path() {
+        let mut contract = empty_contract();
+        contract.functions.push(function_with_types(
+            "echo_vec_vec_string",
+            vec![(
+                "v",
+                TypeExpr::Vec(Box::new(TypeExpr::Vec(Box::new(TypeExpr::String)))),
+            )],
+            ReturnDef::Value(TypeExpr::Vec(Box::new(TypeExpr::Vec(Box::new(
+                TypeExpr::String,
+            ))))),
+        ));
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "public static string[][] EchoVecVecString(string[][] v)",
+            "the public wrapper exposes Vec<Vec<String>> as a jagged string[][]",
+        );
+        assert_source_contains(
+            &src,
+            "return new WireReader(_buf).ReadEncodedArray<string[]>(r1 => r1.ReadEncodedArray<string>(r0 => r0.ReadString()));",
+            "the return decodes through two nested ReadEncodedArray closures with distinct receiver names",
+        );
+        assert_source_contains(
+            &src,
+            "_wire_v.WriteI32(v.Length); foreach (string[] item1 in v) { _wire_v.WriteI32(item1.Length); foreach (string item0 in item1) { _wire_v.WriteString(item0); }; }",
+            "the encode body nests two foreach loops with distinct loop variables",
+        );
+    }
+
+    /// A function that returns `Vec<i32>` by flattening a `Vec<Vec<i32>>`
+    /// param keeps the top-level return on the no-prefix blittable fast
+    /// path: the outer count comes from `FfiBuf.len`. This guards against
+    /// regressions that would route the return through
+    /// `ReadEncodedArray` or add a spurious length-prefixed helper.
+    #[test]
+    fn emit_flatten_vec_vec_i32_keeps_top_level_return_on_blittable_fast_path() {
+        let mut contract = empty_contract();
+        contract.functions.push(function_with_types(
+            "flatten_vec_vec_i32",
+            vec![(
+                "v",
+                TypeExpr::Vec(Box::new(TypeExpr::Vec(Box::new(TypeExpr::Primitive(
+                    PrimitiveType::I32,
+                ))))),
+            )],
+            ReturnDef::Value(TypeExpr::Vec(Box::new(TypeExpr::Primitive(
+                PrimitiveType::I32,
+            )))),
+        ));
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "return new WireReader(_buf).ReadBlittableArray<int>();",
+            "the top-level Vec<i32> return stays on the no-prefix fast path, count taken from FfiBuf.len",
         );
     }
 }

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -209,7 +209,10 @@ pub fn primitive_vec_reader_call(primitive: PrimitiveType) -> String {
         PrimitiveType::Bool => "ReadBoolArray()".to_string(),
         PrimitiveType::ISize => "ReadNIntArray()".to_string(),
         PrimitiveType::USize => "ReadNUIntArray()".to_string(),
-        other => format!("ReadBlittableArray<{}>()", super::mappings::csharp_type(other)),
+        other => format!(
+            "ReadBlittableArray<{}>()",
+            super::mappings::csharp_type(other)
+        ),
     }
 }
 
@@ -391,11 +394,7 @@ pub fn emit_size_expr(size: &SizeExpr) -> String {
             value,
             layout: VecLayout::Blittable { element_size },
             ..
-        } => format!(
-            "(4 + {}.Length * {})",
-            render_value(value),
-            element_size
-        ),
+        } => format!("(4 + {}.Length * {})", render_value(value), element_size),
         other => panic!("unsupported C# size expr: {:?}", other),
     }
 }

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -434,10 +434,17 @@ fn emit_reader_read_with_context(
             element_type,
             layout: VecLayout::Blittable { .. },
             ..
-        } => todo!(
-            "blittable Vec with non-primitive element {:?} is not yet supported by the C# backend",
-            element_type
-        ),
+        } => {
+            // Reached when a record field or enum-variant field carries
+            // a `Vec<BlittableRecord>`. Nested position so the wire shape
+            // is length-prefixed, same as nested primitive vecs. The C#
+            // struct generated for a blittable record is `unmanaged`, so
+            // it satisfies the generic helper's constraint.
+            format!(
+                "reader.ReadLengthPrefixedBlittableArray<{}>()",
+                csharp_type_for_inner(element_type)
+            )
+        }
         ReadOp::Vec {
             element_type,
             element,
@@ -523,13 +530,21 @@ fn emit_write_expr_with_context(
             primitive_vec_writer_call(*p, &render_value(value))
         ),
         WriteOp::Vec {
-            element_type,
+            value,
             layout: VecLayout::Blittable { .. },
             ..
-        } => todo!(
-            "blittable Vec with non-primitive element {:?} is not yet supported by the C# backend",
-            element_type
-        ),
+        } => {
+            // Reached when a record field or enum-variant field carries
+            // a `Vec<BlittableRecord>`. `WriteBlittableArray<T>` already
+            // emits the 4-byte length prefix followed by the raw element
+            // bytes, which is the nested wire shape Rust expects. The
+            // unmanaged constraint is satisfied by the generated struct.
+            format!(
+                "{}.WriteBlittableArray({})",
+                writer_name,
+                render_value(value),
+            )
+        }
         WriteOp::Vec {
             value,
             element_type,
@@ -2249,6 +2264,60 @@ mod tests {
             &src,
             "fixed (Person*",
             "non-blittable record vecs should not go through the pinned fast path",
+        );
+    }
+
+    /// `Polygon { points: Vec<Point> }` is the canonical record-with-
+    /// blittable-Vec-field shape. The field rides the length-prefixed
+    /// blittable path inside the enclosing record's wire buffer: the
+    /// codec emits `wire.WriteBlittableArray(this.Points)` on write
+    /// (which produces the 4-byte count + raw element bytes) and
+    /// `reader.ReadLengthPrefixedBlittableArray<Point>()` on read. The
+    /// size contribution is `(4 + this.Points.Length * 16)` because
+    /// Point is 16 bytes wide.
+    #[test]
+    fn emit_record_with_blittable_vec_field_uses_length_prefixed_blittable_codec() {
+        let mut contract = empty_contract();
+        contract.catalog.insert_record(record_with_fields(
+            "point",
+            true,
+            vec![
+                ("x", TypeExpr::Primitive(PrimitiveType::F64)),
+                ("y", TypeExpr::Primitive(PrimitiveType::F64)),
+            ],
+        ));
+        contract.catalog.insert_record(record_with_fields(
+            "polygon",
+            false,
+            vec![(
+                "points",
+                TypeExpr::Vec(Box::new(TypeExpr::Record(RecordId::new("point")))),
+            )],
+        ));
+        contract.functions.push(function_with_types(
+            "echo_polygon",
+            vec![("p", TypeExpr::Record(RecordId::new("polygon")))],
+            ReturnDef::Value(TypeExpr::Record(RecordId::new("polygon"))),
+        ));
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "wire.WriteBlittableArray(this.Points)",
+            "the record's encode body writes the Vec<Point> via WriteBlittableArray, \
+             which emits the 4-byte count and the raw element bytes",
+        );
+        assert_source_contains(
+            &src,
+            "reader.ReadLengthPrefixedBlittableArray<Point>()",
+            "the record's decode reads the Vec<Point> back through the length-prefixed blittable helper",
+        );
+        assert_source_contains(
+            &src,
+            "(4 + this.Points.Length * 16)",
+            "the size expression accounts for the 4-byte length prefix and the element stride \
+             (two f64s → 16 bytes per Point)",
         );
     }
 }

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -2107,9 +2107,10 @@ mod tests {
     #[test]
     fn emit_vec_c_style_enum_round_trips_through_encoded_array_helpers() {
         let mut contract = empty_contract();
-        contract
-            .catalog
-            .insert_enum(c_style_enum("status", vec!["Active", "Inactive", "Pending"]));
+        contract.catalog.insert_enum(c_style_enum(
+            "status",
+            vec!["Active", "Inactive", "Pending"],
+        ));
         contract.functions.push(function_with_types(
             "echo_vec_status",
             vec![(
@@ -2165,7 +2166,9 @@ mod tests {
                 "values",
                 TypeExpr::Vec(Box::new(TypeExpr::Enum(EnumId::new("shape")))),
             )],
-            ReturnDef::Value(TypeExpr::Vec(Box::new(TypeExpr::Enum(EnumId::new("shape"))))),
+            ReturnDef::Value(TypeExpr::Vec(Box::new(TypeExpr::Enum(EnumId::new(
+                "shape",
+            ))))),
         ));
 
         let src = emit_contract(&contract).combined_source();

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -338,11 +338,17 @@ pub fn vec_return_reader_call(inner: &TypeExpr, element_seq: &ReadSeq) -> String
 }
 
 /// C# type literal for a `Vec<_>` element. Used when stamping the generic
-/// parameter on `ReadEncodedArray<T>` at emit time.
+/// parameter on `ReadEncodedArray<T>` at emit time. Records and enums
+/// render as their PascalCase class name. Vec elements are only typed at
+/// the function-level wrapper, never inside a nested enum body, so the
+/// shadowing machinery that qualifies record decodes inside data-enum
+/// variants does not apply here.
 fn csharp_type_for_inner(ty: &TypeExpr) -> String {
     match ty {
         TypeExpr::Primitive(p) => super::mappings::csharp_type(*p).to_string(),
         TypeExpr::String => "string".to_string(),
+        TypeExpr::Record(id) => NamingConvention::class_name(id.as_str()),
+        TypeExpr::Enum(id) => NamingConvention::class_name(id.as_str()),
         TypeExpr::Vec(inner) => format!("{}[]", csharp_type_for_inner(inner)),
         other => todo!(
             "csharp_type_for_inner: Vec element {:?} is not yet supported by the C# backend",
@@ -2086,6 +2092,160 @@ mod tests {
             &src,
             "return new WireReader(_buf).ReadBlittableArray<int>();",
             "the top-level Vec<i32> return stays on the no-prefix fast path, count taken from FfiBuf.len",
+        );
+    }
+
+    // ----- Encoded Vec tests (Vec<Enum>, Vec<non-blittable Record>) -----
+
+    /// `Vec<CStyleEnum>` rides the wire-encoded path on both sides because
+    /// the Rust `#[export]` macro classifies C-style enums as `Scalar`
+    /// and its `supports_direct_vec` gate only admits `Blittable`. A
+    /// bulk-copy fast path would hand Rust raw enum bytes where it
+    /// expects a length-prefixed array of I32 tags. The generated
+    /// wrapper should encode via `{Name}Wire.WireEncodeTo` per element
+    /// and decode via `ReadEncodedArray<{Name}>(r => {Name}Wire.Decode(r))`.
+    #[test]
+    fn emit_vec_c_style_enum_round_trips_through_encoded_array_helpers() {
+        let mut contract = empty_contract();
+        contract
+            .catalog
+            .insert_enum(c_style_enum("status", vec!["Active", "Inactive", "Pending"]));
+        contract.functions.push(function_with_types(
+            "echo_vec_status",
+            vec![(
+                "values",
+                TypeExpr::Vec(Box::new(TypeExpr::Enum(EnumId::new("status")))),
+            )],
+            ReturnDef::Value(TypeExpr::Vec(Box::new(TypeExpr::Enum(EnumId::new(
+                "status",
+            ))))),
+        ));
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "public static Status[] EchoVecStatus(Status[] values)",
+            "the public wrapper exposes Vec<Status> on both sides as Status[]",
+        );
+        assert_source_contains(
+            &src,
+            "internal static extern FfiBuf EchoVecStatus(byte[] values, UIntPtr valuesLen);",
+            "the DllImport carries the wire-encoded buffer, matching the macro's WireEncoded classification for Vec<Scalar>",
+        );
+        assert_source_contains(
+            &src,
+            "_wire_values.WriteI32(values.Length); foreach (Status item0 in values) { item0.WireEncodeTo(_wire_values); }",
+            "the encode body writes the 4-byte count then loops WireEncodeTo over each enum value",
+        );
+        assert_source_contains(
+            &src,
+            "return new WireReader(_buf).ReadEncodedArray<Status>(r0 => StatusWire.Decode(r0));",
+            "the return decodes through ReadEncodedArray with the StatusWire.Decode helper per element",
+        );
+    }
+
+    /// `Vec<DataEnum>` rides the wire-encoded path. Each element carries
+    /// its own variant tag + payload, so the encode loop delegates to
+    /// the enum's own `WireEncodeTo` and decode delegates to its
+    /// `Decode` static. Same call shape as `Vec<CStyleEnum>` but the
+    /// inner decode is the data-enum entry point (`Shape.Decode`) rather
+    /// than the `Wire` helper.
+    #[test]
+    fn emit_vec_data_enum_round_trips_through_encoded_array_helpers() {
+        let mut contract = empty_contract();
+        contract.catalog.insert_enum(data_enum_single_variant(
+            "shape",
+            "Circle",
+            ("radius", TypeExpr::Primitive(PrimitiveType::F64)),
+        ));
+        contract.functions.push(function_with_types(
+            "echo_vec_shape",
+            vec![(
+                "values",
+                TypeExpr::Vec(Box::new(TypeExpr::Enum(EnumId::new("shape")))),
+            )],
+            ReturnDef::Value(TypeExpr::Vec(Box::new(TypeExpr::Enum(EnumId::new("shape"))))),
+        ));
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "public static Shape[] EchoVecShape(Shape[] values)",
+            "the public wrapper exposes Vec<Shape> on both sides as Shape[]",
+        );
+        assert_source_contains(
+            &src,
+            "internal static extern FfiBuf EchoVecShape(byte[] values, UIntPtr valuesLen);",
+            "the DllImport takes a wire-encoded buffer and returns an FfiBuf",
+        );
+        assert_source_contains(
+            &src,
+            "_wire_values.WriteI32(values.Length); foreach (Shape item0 in values) { item0.WireEncodeTo(_wire_values); }",
+            "the encode body writes the count and loops the data enum's WireEncodeTo over each element",
+        );
+        assert_source_contains(
+            &src,
+            "return new WireReader(_buf).ReadEncodedArray<Shape>(r0 => Shape.Decode(r0));",
+            "the return decodes through ReadEncodedArray with Shape.Decode per element",
+        );
+    }
+
+    /// `Vec<NonBlittableRecord>` rides the wire-encoded path: the record
+    /// carries a string field, so each element is a variable-width
+    /// payload that serialises via the record's own `WireEncodeTo` and
+    /// deserialises via its `Decode` static. Guards against regressions
+    /// that would route non-blittable record vecs onto the pinned
+    /// fast path (which only works for blittable records).
+    #[test]
+    fn emit_vec_non_blittable_record_round_trips_through_encoded_array_helpers() {
+        let mut contract = empty_contract();
+        contract.catalog.insert_record(record_with_fields(
+            "person",
+            false,
+            vec![
+                ("name", TypeExpr::String),
+                ("age", TypeExpr::Primitive(PrimitiveType::U32)),
+            ],
+        ));
+        contract.functions.push(function_with_types(
+            "echo_vec_person",
+            vec![(
+                "people",
+                TypeExpr::Vec(Box::new(TypeExpr::Record(RecordId::new("person")))),
+            )],
+            ReturnDef::Value(TypeExpr::Vec(Box::new(TypeExpr::Record(RecordId::new(
+                "person",
+            ))))),
+        ));
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "public static Person[] EchoVecPerson(Person[] people)",
+            "the public wrapper exposes Vec<Person> on both sides as Person[]",
+        );
+        assert_source_contains(
+            &src,
+            "internal static extern FfiBuf EchoVecPerson(byte[] people, UIntPtr peopleLen);",
+            "the DllImport takes a wire-encoded buffer and returns an FfiBuf",
+        );
+        assert_source_contains(
+            &src,
+            "_wire_people.WriteI32(people.Length); foreach (Person item0 in people) { item0.WireEncodeTo(_wire_people); }",
+            "the encode body writes the count and loops the record's WireEncodeTo over each element",
+        );
+        assert_source_contains(
+            &src,
+            "return new WireReader(_buf).ReadEncodedArray<Person>(r0 => Person.Decode(r0));",
+            "the return decodes through ReadEncodedArray with Person.Decode per element",
+        );
+        assert_source_lacks(
+            &src,
+            "fixed (Person*",
+            "non-blittable record vecs should not go through the pinned fast path",
         );
     }
 }

--- a/boltffi_bindgen/src/render/csharp/lower.rs
+++ b/boltffi_bindgen/src/render/csharp/lower.rs
@@ -328,16 +328,15 @@ impl<'a> CSharpLowerer<'a> {
     }
 
     /// Which element types the C# backend currently admits inside a
-    /// top-level `Vec<_>` param or return. Primitives and blittable
-    /// records ride the fast path via `DirectArray` / `ReadBlittableArray`;
-    /// strings and nested vecs ride the encoded wire form. Non-blittable
-    /// records and enums are still out of scope.
+    /// top-level `Vec<_>` param or return. This is only the admission
+    /// gate: primitives and blittable records can use the blittable
+    /// path; strings, enums, non-blittable records, and nested vecs
+    /// travel through the encoded wire form.
     fn is_supported_vec_element(&self, ty: &TypeExpr) -> bool {
         match ty {
             TypeExpr::Primitive(_) | TypeExpr::String => true,
-            TypeExpr::Record(id) => {
-                self.supported_records.contains(id.as_str()) && self.is_blittable_record(id)
-            }
+            TypeExpr::Record(id) => self.supported_records.contains(id.as_str()),
+            TypeExpr::Enum(id) => self.supported_enums.contains(id.as_str()),
             TypeExpr::Vec(inner) => self.is_supported_vec_element(inner),
             _ => false,
         }
@@ -348,8 +347,15 @@ impl<'a> CSharpLowerer<'a> {
     /// mapping is a blittable value type; blittable records qualify
     /// because `[StructLayout(Sequential)]` guarantees the same byte
     /// layout as Rust's `#[repr(C)]`, so the CLR can hand the native
-    /// side a pointer straight into the element buffer. Everything
-    /// else rides the wire-encoded path.
+    /// side a pointer straight into the element buffer. C-style enums
+    /// do NOT qualify even though their C# projection is a fixed-width
+    /// value type: the Rust `#[export]` macro classifies them as
+    /// `DataTypeCategory::Scalar` and routes `Vec<CStyleEnum>` through
+    /// the wire-encoded path (only `Blittable` survives the macro's
+    /// `supports_direct_vec` gate). Admitting them here would hand the
+    /// native side a raw enum byte array where it expects a
+    /// length-prefixed encoded array of I32 tags. Everything not
+    /// listed rides the wire-encoded path. Tracked: issue #196.
     fn is_blittable_vec_element(&self, ty: &TypeExpr) -> bool {
         match ty {
             TypeExpr::Primitive(_) => true,

--- a/boltffi_bindgen/src/render/csharp/lower.rs
+++ b/boltffi_bindgen/src/render/csharp/lower.rs
@@ -261,6 +261,10 @@ impl<'a> CSharpLowerer<'a> {
             ReturnDef::Value(TypeExpr::Vec(inner)) => {
                 let reader_call = match inner.as_ref() {
                     TypeExpr::Primitive(p) => emit::primitive_vec_reader_call(*p),
+                    TypeExpr::Record(id) if self.is_blittable_record(id) => format!(
+                        "ReadBlittableArray<{}>()",
+                        NamingConvention::class_name(id.as_str())
+                    ),
                     _ => {
                         let element_seq = Self::vec_element_read_seq(decode_ops)
                             .expect("encoded Vec return must carry decode_ops with a Vec ReadOp");
@@ -318,19 +322,38 @@ impl<'a> CSharpLowerer<'a> {
             TypeExpr::Primitive(_) | TypeExpr::String | TypeExpr::Void => true,
             TypeExpr::Record(id) => self.supported_records.contains(id.as_str()),
             TypeExpr::Enum(id) => self.supported_enums.contains(id.as_str()),
-            TypeExpr::Vec(inner) => Self::is_supported_vec_inner(inner),
+            TypeExpr::Vec(inner) => self.is_supported_vec_element(inner),
             _ => false,
         }
     }
 
     /// Which element types the C# backend currently admits inside a
-    /// top-level `Vec<_>` param or return. Primitives ride the blittable
-    /// fast path; strings and nested vecs ride the encoded wire form.
-    /// Records and enums are out of scope for this step.
-    fn is_supported_vec_inner(ty: &TypeExpr) -> bool {
+    /// top-level `Vec<_>` param or return. Primitives and blittable
+    /// records ride the fast path via `DirectArray` / `ReadBlittableArray`;
+    /// strings and nested vecs ride the encoded wire form. Non-blittable
+    /// records and enums are still out of scope.
+    fn is_supported_vec_element(&self, ty: &TypeExpr) -> bool {
         match ty {
             TypeExpr::Primitive(_) | TypeExpr::String => true,
-            TypeExpr::Vec(inner) => Self::is_supported_vec_inner(inner),
+            TypeExpr::Record(id) => {
+                self.supported_records.contains(id.as_str()) && self.is_blittable_record(id)
+            }
+            TypeExpr::Vec(inner) => self.is_supported_vec_element(inner),
+            _ => false,
+        }
+    }
+
+    /// Vec element types whose param form is a pinned `T[]` passed
+    /// directly across P/Invoke. Primitives qualify because their C#
+    /// mapping is a blittable value type; blittable records qualify
+    /// because `[StructLayout(Sequential)]` guarantees the same byte
+    /// layout as Rust's `#[repr(C)]`, so the CLR can hand the native
+    /// side a pointer straight into the element buffer. Everything
+    /// else rides the wire-encoded path.
+    fn is_blittable_vec_element(&self, ty: &TypeExpr) -> bool {
+        match ty {
+            TypeExpr::Primitive(_) => true,
+            TypeExpr::Record(id) => self.is_blittable_record(id),
             _ => false,
         }
     }
@@ -366,7 +389,23 @@ impl<'a> CSharpLowerer<'a> {
             TypeExpr::Vec(inner) if matches!(inner.as_ref(), TypeExpr::Primitive(_)) => {
                 CSharpParamKind::DirectArray
             }
-            TypeExpr::Vec(inner) if Self::is_supported_vec_inner(inner) => {
+            TypeExpr::Vec(inner) if self.is_blittable_vec_element(inner) => {
+                // The CLR can pin primitive arrays automatically but
+                // classifies any struct containing a `bool` (or `char`)
+                // as non-blittable, even when the struct's byte layout
+                // actually matches Rust's `#[repr(C)]`. Rather than let
+                // P/Invoke silently build a marshaled copy with a
+                // mismatched layout, the wrapper pins the managed array
+                // with `fixed` and hands Rust a raw pointer directly.
+                let element_type = match inner.as_ref() {
+                    TypeExpr::Record(id) => NamingConvention::class_name(id.as_str()),
+                    other => todo!(
+                        "C# backend pinned-array param support not yet implemented for {other:?}"
+                    ),
+                };
+                CSharpParamKind::PinnedArray { element_type }
+            }
+            TypeExpr::Vec(inner) if self.is_supported_vec_element(inner) => {
                 // Vec<String> and Vec<Vec<_>> carry variable-width elements, so
                 // the param travels wire-encoded rather than as a pinned T[].
                 let writer = wire_writers
@@ -409,7 +448,7 @@ impl<'a> CSharpLowerer<'a> {
                 let enum_def = self.ffi.catalog.resolve_enum(id)?;
                 Some(mappings::csharp_enum_type(enum_def))
             }
-            TypeExpr::Vec(inner) if Self::is_supported_vec_inner(inner) => {
+            TypeExpr::Vec(inner) if self.is_supported_vec_element(inner) => {
                 let inner_type = self.lower_type(inner)?;
                 Some(CSharpType::Array(Box::new(inner_type)))
             }

--- a/boltffi_bindgen/src/render/csharp/lower.rs
+++ b/boltffi_bindgen/src/render/csharp/lower.rs
@@ -212,7 +212,12 @@ impl<'a> CSharpLowerer<'a> {
         }
 
         let return_type = self.lower_return(&function.returns)?;
-        let return_kind = self.return_kind(&function.returns, &return_type);
+        let call = self.abi_call_for_function(function)?;
+        let return_kind = self.return_kind(
+            &function.returns,
+            &return_type,
+            call.returns.decode_ops.as_ref(),
+        );
 
         let wire_writers = self.wire_writers_for_params(function)?;
 
@@ -232,7 +237,12 @@ impl<'a> CSharpLowerer<'a> {
         })
     }
 
-    fn return_kind(&self, return_def: &ReturnDef, return_type: &CSharpType) -> CSharpReturnKind {
+    fn return_kind(
+        &self,
+        return_def: &ReturnDef,
+        return_type: &CSharpType,
+        decode_ops: Option<&ReadSeq>,
+    ) -> CSharpReturnKind {
         if return_type.is_void() {
             return CSharpReturnKind::Void;
         }
@@ -248,19 +258,33 @@ impl<'a> CSharpLowerer<'a> {
                     class_name: NamingConvention::class_name(id.as_str()),
                 }
             }
-            ReturnDef::Value(TypeExpr::Vec(inner)) => match inner.as_ref() {
-                TypeExpr::Primitive(p) => CSharpReturnKind::WireDecodeArray {
-                    reader_call: emit::primitive_vec_reader_call(*p),
-                },
-                other => todo!(
-                    "Vec return with non-primitive element {:?} is not yet supported by the C# backend",
-                    other
-                ),
-            },
+            ReturnDef::Value(TypeExpr::Vec(inner)) => {
+                let reader_call = match inner.as_ref() {
+                    TypeExpr::Primitive(p) => emit::primitive_vec_reader_call(*p),
+                    _ => {
+                        let element_seq = Self::vec_element_read_seq(decode_ops)
+                            .expect("encoded Vec return must carry decode_ops with a Vec ReadOp");
+                        emit::vec_return_reader_call(inner, &element_seq)
+                    }
+                };
+                CSharpReturnKind::WireDecodeArray { reader_call }
+            }
             // Primitives, bools, blittable records, and C-style enums
             // are all direct: the CLR marshals them across P/Invoke
             // without any wrapper help.
             _ => CSharpReturnKind::Direct,
+        }
+    }
+
+    /// Extract the per-element [`ReadSeq`] from a `ReadSeq` whose top op is
+    /// a `Vec`. Used to render the inner decode expression that gets wrapped
+    /// in `ReadEncodedArray<T>(r => ...)`. Primitive-element Vec returns
+    /// never call into this; they short-circuit on the no-prefix fast path.
+    fn vec_element_read_seq(decode_ops: Option<&ReadSeq>) -> Option<ReadSeq> {
+        let decode = decode_ops?;
+        match decode.ops.first()? {
+            ReadOp::Vec { element, .. } => Some((**element).clone()),
+            _ => None,
         }
     }
 
@@ -294,7 +318,19 @@ impl<'a> CSharpLowerer<'a> {
             TypeExpr::Primitive(_) | TypeExpr::String | TypeExpr::Void => true,
             TypeExpr::Record(id) => self.supported_records.contains(id.as_str()),
             TypeExpr::Enum(id) => self.supported_enums.contains(id.as_str()),
-            TypeExpr::Vec(inner) => matches!(inner.as_ref(), TypeExpr::Primitive(_)),
+            TypeExpr::Vec(inner) => Self::is_supported_vec_inner(inner),
+            _ => false,
+        }
+    }
+
+    /// Which element types the C# backend currently admits inside a
+    /// top-level `Vec<_>` param or return. Primitives ride the blittable
+    /// fast path; strings and nested vecs ride the encoded wire form.
+    /// Records and enums are out of scope for this step.
+    fn is_supported_vec_inner(ty: &TypeExpr) -> bool {
+        match ty {
+            TypeExpr::Primitive(_) | TypeExpr::String => true,
+            TypeExpr::Vec(inner) => Self::is_supported_vec_inner(inner),
             _ => false,
         }
     }
@@ -330,6 +366,16 @@ impl<'a> CSharpLowerer<'a> {
             TypeExpr::Vec(inner) if matches!(inner.as_ref(), TypeExpr::Primitive(_)) => {
                 CSharpParamKind::DirectArray
             }
+            TypeExpr::Vec(inner) if Self::is_supported_vec_inner(inner) => {
+                // Vec<String> and Vec<Vec<_>> carry variable-width elements, so
+                // the param travels wire-encoded rather than as a pinned T[].
+                let writer = wire_writers
+                    .iter()
+                    .find(|w| w.param_name == param.name.as_str())?;
+                CSharpParamKind::WireEncoded {
+                    binding_name: writer.bytes_binding_name.clone(),
+                }
+            }
             // Primitives, bools, blittable records, and C-style enums
             // pass directly. The CLR marshals them across P/Invoke with
             // no extra setup.
@@ -363,7 +409,7 @@ impl<'a> CSharpLowerer<'a> {
                 let enum_def = self.ffi.catalog.resolve_enum(id)?;
                 Some(mappings::csharp_enum_type(enum_def))
             }
-            TypeExpr::Vec(inner) if matches!(inner.as_ref(), TypeExpr::Primitive(_)) => {
+            TypeExpr::Vec(inner) if Self::is_supported_vec_inner(inner) => {
                 let inner_type = self.lower_type(inner)?;
                 Some(CSharpType::Array(Box::new(inner_type)))
             }
@@ -627,7 +673,11 @@ impl<'a> CSharpLowerer<'a> {
             ReturnDef::Value(type_expr) => self.lower_type(type_expr)?,
             ReturnDef::Result { .. } => return None,
         };
-        let return_kind = self.return_kind(&method_def.returns, &return_type);
+        let return_kind = self.return_kind(
+            &method_def.returns,
+            &return_type,
+            call.returns.decode_ops.as_ref(),
+        );
 
         let receiver = match method_def.receiver {
             Receiver::Static => CSharpReceiver::Static,

--- a/boltffi_bindgen/src/render/csharp/lower.rs
+++ b/boltffi_bindgen/src/render/csharp/lower.rs
@@ -6,7 +6,7 @@ use crate::ir::abi::{
     AbiCall, AbiEnum, AbiEnumField, AbiEnumPayload, AbiEnumVariant, AbiParam, AbiRecord, CallId,
     ParamRole,
 };
-use crate::ir::codec::EnumLayout;
+use crate::ir::codec::{EnumLayout, VecLayout};
 use crate::ir::definitions::{
     ConstructorDef, EnumDef, EnumRepr, FieldDef, FunctionDef, MethodDef, ParamDef, ParamPassing,
     Receiver, RecordDef, ReturnDef, VariantPayload,
@@ -144,6 +144,10 @@ impl<'a> CSharpLowerer<'a> {
             TypeExpr::Primitive(_) | TypeExpr::String | TypeExpr::Void => true,
             TypeExpr::Record(id) => records.contains(id.as_str()),
             TypeExpr::Enum(id) => enums.contains(id.as_str()),
+            // The current C# field surface excludes embedded vecs; only
+            // top-level primitive Vec params/returns participate in this
+            // backend path.
+            TypeExpr::Vec(_) => false,
             _ => false,
         }
     }
@@ -244,6 +248,15 @@ impl<'a> CSharpLowerer<'a> {
                     class_name: NamingConvention::class_name(id.as_str()),
                 }
             }
+            ReturnDef::Value(TypeExpr::Vec(inner)) => match inner.as_ref() {
+                TypeExpr::Primitive(p) => CSharpReturnKind::WireDecodeArray {
+                    reader_call: emit::primitive_vec_reader_call(*p),
+                },
+                other => todo!(
+                    "Vec return with non-primitive element {:?} is not yet supported by the C# backend",
+                    other
+                ),
+            },
             // Primitives, bools, blittable records, and C-style enums
             // are all direct: the CLR marshals them across P/Invoke
             // without any wrapper help.
@@ -281,6 +294,7 @@ impl<'a> CSharpLowerer<'a> {
             TypeExpr::Primitive(_) | TypeExpr::String | TypeExpr::Void => true,
             TypeExpr::Record(id) => self.supported_records.contains(id.as_str()),
             TypeExpr::Enum(id) => self.supported_enums.contains(id.as_str()),
+            TypeExpr::Vec(inner) => matches!(inner.as_ref(), TypeExpr::Primitive(_)),
             _ => false,
         }
     }
@@ -313,8 +327,11 @@ impl<'a> CSharpLowerer<'a> {
                     binding_name: writer.bytes_binding_name.clone(),
                 }
             }
+            TypeExpr::Vec(inner) if matches!(inner.as_ref(), TypeExpr::Primitive(_)) => {
+                CSharpParamKind::DirectArray
+            }
             // Primitives, bools, blittable records, and C-style enums
-            // pass directly — the CLR marshals them across P/Invoke with
+            // pass directly. The CLR marshals them across P/Invoke with
             // no extra setup.
             _ => CSharpParamKind::Direct,
         };
@@ -345,6 +362,10 @@ impl<'a> CSharpLowerer<'a> {
             TypeExpr::Enum(id) if self.supported_enums.contains(id.as_str()) => {
                 let enum_def = self.ffi.catalog.resolve_enum(id)?;
                 Some(mappings::csharp_enum_type(enum_def))
+            }
+            TypeExpr::Vec(inner) if matches!(inner.as_ref(), TypeExpr::Primitive(_)) => {
+                let inner_type = self.lower_type(inner)?;
+                Some(CSharpType::Array(Box::new(inner_type)))
             }
             _ => None,
         }
@@ -740,18 +761,36 @@ impl<'a> CSharpLowerer<'a> {
     }
 
     /// Whether a param's encode op requires a `WireWriter` setup block
-    /// before the native call. Strings keep their direct-byte[] path.
-    /// Blittable record and C-style enum params pass through P/Invoke as
-    /// value types. Non-blittable records and data enums need the
-    /// buffer because their payloads are variable-width.
+    /// before the native call.
+    ///
+    /// Primitives pass as value types, strings go through the UTF-8 byte
+    /// path, raw bytes ride as `byte[]` directly. Blittable records and
+    /// C-style enums also pass by value. Variable-width payloads
+    /// (non-blittable records, data enums, vecs) need a length-prefixed
+    /// buffer serialized up front.
     fn param_needs_wire_buffer(&self, op: &WriteOp) -> bool {
         match op {
+            WriteOp::Primitive { .. } | WriteOp::String { .. } | WriteOp::Bytes { .. } => false,
             WriteOp::Record { id, .. } => !self.is_blittable_record(id),
             WriteOp::Enum {
                 layout: EnumLayout::Data { .. },
                 ..
             } => true,
-            _ => false,
+            WriteOp::Enum { .. } => false,
+            WriteOp::Vec {
+                layout: VecLayout::Blittable { .. },
+                ..
+            } => false,
+            WriteOp::Vec {
+                layout: VecLayout::Encoded,
+                ..
+            } => true,
+            WriteOp::Option { .. }
+            | WriteOp::Result { .. }
+            | WriteOp::Builtin { .. }
+            | WriteOp::Custom { .. } => {
+                todo!("C# backend has not yet implemented param support for {op:?}")
+            }
         }
     }
 
@@ -1036,4 +1075,5 @@ mod tests {
             "expecting repr(usize) C-style enums to stay unsupported until the backend has a legal C# projection",
         );
     }
+
 }

--- a/boltffi_bindgen/src/render/csharp/lower.rs
+++ b/boltffi_bindgen/src/render/csharp/lower.rs
@@ -396,13 +396,14 @@ impl<'a> CSharpLowerer<'a> {
                 CSharpParamKind::DirectArray
             }
             TypeExpr::Vec(inner) if self.is_blittable_vec_element(inner) => {
-                // The CLR can pin primitive arrays automatically but
-                // classifies any struct containing a `bool` (or `char`)
-                // as non-blittable, even when the struct's byte layout
-                // actually matches Rust's `#[repr(C)]`. Rather than let
-                // P/Invoke silently build a marshaled copy with a
-                // mismatched layout, the wrapper pins the managed array
-                // with `fixed` and hands Rust a raw pointer directly.
+                // Primitive arrays can use the CLR's built-in direct-array
+                // path. Record arrays are less predictable once the element
+                // type stops being blittable to the marshaller, e.g. because
+                // it contains `bool` or `char`: P/Invoke may marshal through
+                // a temporary native buffer rather than exposing the managed
+                // array in place. `fixed` keeps this path zero-copy and
+                // makes the ABI contract explicit: Rust reads the actual
+                // managed element buffer, not a marshaled surrogate.
                 let element_type = match inner.as_ref() {
                     TypeExpr::Record(id) => NamingConvention::class_name(id.as_str()),
                     other => todo!(

--- a/boltffi_bindgen/src/render/csharp/lower.rs
+++ b/boltffi_bindgen/src/render/csharp/lower.rs
@@ -144,10 +144,10 @@ impl<'a> CSharpLowerer<'a> {
             TypeExpr::Primitive(_) | TypeExpr::String | TypeExpr::Void => true,
             TypeExpr::Record(id) => records.contains(id.as_str()),
             TypeExpr::Enum(id) => enums.contains(id.as_str()),
-            // The current C# field surface excludes embedded vecs; only
-            // top-level primitive Vec params/returns participate in this
-            // backend path.
-            TypeExpr::Vec(_) => false,
+            // Vec as a field walks its inner type through the same
+            // admission rules: any field-admissible type is also a valid
+            // Vec element, and vice versa.
+            TypeExpr::Vec(inner) => Self::is_field_type_supported(inner, records, enums),
             _ => false,
         }
     }
@@ -942,6 +942,22 @@ impl<'a> CSharpLowerer<'a> {
                 value: Self::prefix_value(value, binding),
                 layout: layout.clone(),
             },
+            WriteOp::Vec {
+                value,
+                element_type,
+                element,
+                layout,
+            } => WriteOp::Vec {
+                value: Self::prefix_value(value, binding),
+                element_type: element_type.clone(),
+                // `element` references the per-iteration loop binding
+                // (`item`), which belongs to the foreach the Vec writer
+                // emits around the enclosing variant scope. Rewriting it
+                // to `_v.item` would break the generated loop; leave the
+                // element seq untouched.
+                element: element.clone(),
+                layout: layout.clone(),
+            },
             other => panic!(
                 "prefix_write_op: unsupported op for C# variant fields: {:?}",
                 other
@@ -979,6 +995,18 @@ impl<'a> CSharpLowerer<'a> {
                     .map(|p| Self::prefix_size_expr(p, binding))
                     .collect(),
             ),
+            SizeExpr::VecSize {
+                value,
+                inner,
+                layout,
+            } => SizeExpr::VecSize {
+                value: Self::prefix_value(value, binding),
+                // `inner` uses the per-element loop variable (`item`) the
+                // encoded-array size lambda binds. The `_v` rewrite only
+                // applies to the enclosing variant field reference.
+                inner: inner.clone(),
+                layout: layout.clone(),
+            },
             other => panic!(
                 "prefix_size_expr: unsupported expr for C# variant fields: {:?}",
                 other

--- a/boltffi_bindgen/src/render/csharp/lower.rs
+++ b/boltffi_bindgen/src/render/csharp/lower.rs
@@ -1075,5 +1075,4 @@ mod tests {
             "expecting repr(usize) C-style enums to stay unsupported until the backend has a legal C# projection",
         );
     }
-
 }

--- a/boltffi_bindgen/src/render/csharp/plan.rs
+++ b/boltffi_bindgen/src/render/csharp/plan.rs
@@ -118,31 +118,14 @@ pub enum CSharpType {
     /// Always wire-encoded — never blittable — because variant payloads
     /// are variable-width.
     DataEnum(String),
+    /// A `Vec<T>` projected into the C# surface as a `T[]` jagged array.
+    /// Uniform representation across every element kind — primitives ride
+    /// the blittable bulk-copy path, composites walk element-by-element.
+    /// Nested vecs fall out naturally via recursive `Array(Array(...))`.
+    Array(Box<CSharpType>),
 }
 
 impl CSharpType {
-    pub fn display_name(&self) -> &str {
-        match self {
-            Self::Void => "void",
-            Self::Bool => "bool",
-            Self::SByte => "sbyte",
-            Self::Byte => "byte",
-            Self::Short => "short",
-            Self::UShort => "ushort",
-            Self::Int => "int",
-            Self::UInt => "uint",
-            Self::Long => "long",
-            Self::ULong => "ulong",
-            Self::NInt => "nint",
-            Self::NUInt => "nuint",
-            Self::Float => "float",
-            Self::Double => "double",
-            Self::String => "string",
-            Self::Record(name) => name.as_str(),
-            Self::CStyleEnum(name) => name.as_str(),
-            Self::DataEnum(name) => name.as_str(),
-        }
-    }
 
     pub fn is_void(&self) -> bool {
         matches!(self, Self::Void)
@@ -168,6 +151,18 @@ impl CSharpType {
         matches!(self, Self::DataEnum(_))
     }
 
+    pub fn is_array(&self) -> bool {
+        matches!(self, Self::Array(_))
+    }
+
+    /// If this is `Array(inner)`, returns `Some(inner)`; otherwise `None`.
+    pub fn array_element(&self) -> Option<&CSharpType> {
+        match self {
+            Self::Array(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
     /// If `self` is a user-defined named type (record or enum) whose
     /// class name is shadowed by an enclosing scope, return a variant
     /// wrapping the fully-qualified `global::{namespace}.{ClassName}`.
@@ -180,17 +175,19 @@ impl CSharpType {
         shadowed: &std::collections::HashSet<String>,
         namespace: &str,
     ) -> Self {
-        let needs_qualification = match &self {
-            Self::Record(n) | Self::CStyleEnum(n) | Self::DataEnum(n) => shadowed.contains(n),
-            _ => false,
-        };
-        if !needs_qualification {
-            return self;
-        }
         match self {
-            Self::Record(n) => Self::Record(format!("global::{}.{}", namespace, n)),
-            Self::CStyleEnum(n) => Self::CStyleEnum(format!("global::{}.{}", namespace, n)),
-            Self::DataEnum(n) => Self::DataEnum(format!("global::{}.{}", namespace, n)),
+            Self::Record(n) if shadowed.contains(&n) => {
+                Self::Record(format!("global::{}.{}", namespace, n))
+            }
+            Self::CStyleEnum(n) if shadowed.contains(&n) => {
+                Self::CStyleEnum(format!("global::{}.{}", namespace, n))
+            }
+            Self::DataEnum(n) if shadowed.contains(&n) => {
+                Self::DataEnum(format!("global::{}.{}", namespace, n))
+            }
+            Self::Array(inner) => {
+                Self::Array(Box::new((*inner).qualify_if_shadowed(shadowed, namespace)))
+            }
             other => other,
         }
     }
@@ -219,14 +216,39 @@ impl CSharpType {
             | Self::Float
             | Self::Double
             | Self::CStyleEnum(_) => true,
-            Self::Void | Self::Bool | Self::String | Self::Record(_) | Self::DataEnum(_) => false,
+            Self::Void
+            | Self::Bool
+            | Self::String
+            | Self::Record(_)
+            | Self::DataEnum(_)
+            | Self::Array(_) => false,
         }
     }
 }
 
 impl fmt::Display for CSharpType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.display_name())
+        match self {
+            Self::Void => f.write_str("void"),
+            Self::Bool => f.write_str("bool"),
+            Self::SByte => f.write_str("sbyte"),
+            Self::Byte => f.write_str("byte"),
+            Self::Short => f.write_str("short"),
+            Self::UShort => f.write_str("ushort"),
+            Self::Int => f.write_str("int"),
+            Self::UInt => f.write_str("uint"),
+            Self::Long => f.write_str("long"),
+            Self::ULong => f.write_str("ulong"),
+            Self::NInt => f.write_str("nint"),
+            Self::NUInt => f.write_str("nuint"),
+            Self::Float => f.write_str("float"),
+            Self::Double => f.write_str("double"),
+            Self::String => f.write_str("string"),
+            Self::Record(name) | Self::CStyleEnum(name) | Self::DataEnum(name) => {
+                f.write_str(name)
+            }
+            Self::Array(inner) => write!(f, "{inner}[]"),
+        }
     }
 }
 
@@ -674,6 +696,13 @@ pub enum CSharpReturnKind {
     /// enums, whose rendered C# types both expose the same `Decode` API
     /// at the call site.
     WireDecodeObject { class_name: String },
+    /// The native function returns an `FfiBuf` carrying a wire-encoded
+    /// `Vec<T>`. The wrapper wraps it in a `WireReader` and invokes
+    /// `reader_call` on the reader to reconstruct the managed `T[]`.
+    /// `reader_call` is the full method invocation without the receiver,
+    /// e.g. `ReadBlittableArray<int>()` for `Vec<i32>` or
+    /// `ReadBoolArray()` for `Vec<bool>`.
+    WireDecodeArray { reader_call: String },
 }
 
 impl CSharpReturnKind {
@@ -693,9 +722,16 @@ impl CSharpReturnKind {
         matches!(self, Self::WireDecodeObject { .. })
     }
 
+    pub fn is_wire_decode_array(&self) -> bool {
+        matches!(self, Self::WireDecodeArray { .. })
+    }
+
     /// Whether the native (DllImport) signature returns an `FfiBuf`.
     pub fn native_returns_ffi_buf(&self) -> bool {
-        matches!(self, Self::WireDecodeString | Self::WireDecodeObject { .. })
+        matches!(
+            self,
+            Self::WireDecodeString | Self::WireDecodeObject { .. } | Self::WireDecodeArray { .. }
+        )
     }
 
     /// For `WireDecodeObject`, the decoded C# class name (e.g., `"Point"`
@@ -721,6 +757,10 @@ impl CSharpReturnKind {
             Self::WireDecodeObject { class_name } => Some(format!(
                 "return {}.Decode(new WireReader({}));",
                 class_name, buf_var
+            )),
+            Self::WireDecodeArray { reader_call } => Some(format!(
+                "return new WireReader({}).{};",
+                buf_var, reader_call
             )),
             _ => None,
         }
@@ -763,6 +803,20 @@ impl CSharpParam {
             CSharpParamKind::Direct => {
                 format!("{} {}", self.csharp_type, self.name)
             }
+            CSharpParamKind::DirectArray => {
+                let element = self
+                    .csharp_type
+                    .array_element()
+                    .expect("DirectArray param must carry an Array type");
+                let decl = format!("{element}[] {name}, UIntPtr {name}Len", name = self.name);
+                if matches!(element, CSharpType::Bool) {
+                    format!(
+                        "[MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)] {decl}"
+                    )
+                } else {
+                    decl
+                }
+            }
         }
     }
 
@@ -777,6 +831,9 @@ impl CSharpParam {
             }
             CSharpParamKind::WireEncoded { binding_name } => {
                 format!("{binding_name}, (UIntPtr){binding_name}.Length")
+            }
+            CSharpParamKind::DirectArray => {
+                format!("{name}, (UIntPtr){name}.Length", name = self.name)
             }
         }
     }
@@ -809,6 +866,13 @@ pub enum CSharpParamKind {
     /// `WireWriter` and passed as `(byte[], UIntPtr)`. `binding_name`
     /// is the local variable holding the encoded byte array.
     WireEncoded { binding_name: String },
+    /// A managed array of a blittable primitive element type, passed
+    /// directly as `(T[], UIntPtr)` without any wire encoding. The CLR's
+    /// default P/Invoke marshaller pins the array and hands the native
+    /// side a pointer to the element buffer. `bool[]` gets an explicit
+    /// `[MarshalAs(LPArray, ArraySubType = U1)]` override so CLR emits
+    /// one byte per element instead of the 4-byte Win32 BOOL default.
+    DirectArray,
 }
 
 /// Bookkeeping for a single record param that must be wire-encoded into a

--- a/boltffi_bindgen/src/render/csharp/plan.rs
+++ b/boltffi_bindgen/src/render/csharp/plan.rs
@@ -126,7 +126,6 @@ pub enum CSharpType {
 }
 
 impl CSharpType {
-
     pub fn is_void(&self) -> bool {
         matches!(self, Self::Void)
     }
@@ -244,9 +243,7 @@ impl fmt::Display for CSharpType {
             Self::Float => f.write_str("float"),
             Self::Double => f.write_str("double"),
             Self::String => f.write_str("string"),
-            Self::Record(name) | Self::CStyleEnum(name) | Self::DataEnum(name) => {
-                f.write_str(name)
-            }
+            Self::Record(name) | Self::CStyleEnum(name) | Self::DataEnum(name) => f.write_str(name),
             Self::Array(inner) => write!(f, "{inner}[]"),
         }
     }

--- a/boltffi_bindgen/src/render/csharp/plan.rs
+++ b/boltffi_bindgen/src/render/csharp/plan.rs
@@ -978,15 +978,18 @@ pub enum CSharpParamKind {
     ///
     /// The struct layout of a blittable record matches Rust's `#[repr(C)]`
     /// exactly, so a pointer to the first element plus an element count
-    /// is everything Rust needs. The obstacle is that the CLR classifies
-    /// any struct containing a `bool` or `char` as non-blittable and
-    /// refuses to pin `T[]` through the default P/Invoke path — instead
-    /// it silently builds a marshaled copy with a different byte layout,
-    /// which mismatches what Rust expects. The wrapper sidesteps that by
-    /// taking a raw pointer with `fixed (T* _xPtr = x)`, which pins the
-    /// array in place for the duration of the native call, and passes
-    /// the pointer as `IntPtr`. Zero copy: C# and Rust read the same
-    /// block of managed heap memory.
+    /// is everything Rust needs. Primitive arrays can use the CLR's
+    /// built-in direct-array path, but record arrays are trickier once
+    /// the element type stops being blittable to the marshaller (for
+    /// example because it contains `bool` or `char`): P/Invoke may
+    /// marshal through a temporary native buffer instead of exposing the
+    /// managed array in place. With the right field-level marshalling
+    /// that copy can still be layout-compatible, but it is no longer the
+    /// zero-copy contract this fast path wants. The wrapper sidesteps the
+    /// marshaller entirely by taking a raw pointer with `fixed (T* _xPtr
+    /// = x)`, which pins the array in place for the duration of the
+    /// native call and passes the pointer as `IntPtr`. C# and Rust then
+    /// read the same block of managed heap memory.
     ///
     /// `element_type` is the C# type literal for `T` (e.g., `"Location"`)
     /// — threaded here so `pinned_fixed_args` can render

--- a/boltffi_bindgen/src/render/csharp/plan.rs
+++ b/boltffi_bindgen/src/render/csharp/plan.rs
@@ -560,6 +560,16 @@ impl CSharpMethod {
         }
     }
 
+    /// Declarations for nested `fixed` statements pinning every
+    /// [`CSharpParamKind::PinnedArray`] param in the signature.
+    pub fn pinned_fixed_args(&self) -> Vec<String> {
+        pinned_fixed_args(&self.params)
+    }
+
+    pub fn has_pinned_params(&self) -> bool {
+        !self.pinned_fixed_args().is_empty()
+    }
+
     /// Param list used in the DllImport signature, including the
     /// receiver-dependent self declaration prepended when the method is
     /// an instance method:
@@ -683,6 +693,29 @@ impl CSharpFunction {
         } else {
             self.return_type.to_string()
         }
+    }
+
+    /// Declarations for nested `fixed` statements pinning every
+    /// [`CSharpParamKind::PinnedArray`] param in the signature.
+    ///
+    /// Rendered shape for a function with two pinned params:
+    ///
+    /// ```ignore
+    /// [
+    ///   "Location* _locationsPtr = locations",
+    ///   "Trade* _tradesPtr = trades",
+    /// ]
+    /// ```
+    ///
+    /// The template wraps the call in `unsafe { fixed (...) { fixed (...)
+    /// { ... } } }` so Rust reads directly from the C# heap without the
+    /// GC relocating either managed array during the call.
+    pub fn pinned_fixed_args(&self) -> Vec<String> {
+        pinned_fixed_args(&self.params)
+    }
+
+    pub fn has_pinned_params(&self) -> bool {
+        !self.pinned_fixed_args().is_empty()
     }
 }
 
@@ -826,6 +859,13 @@ impl CSharpParam {
                     decl
                 }
             }
+            // The wrapper's `fixed` block takes the managed array and
+            // hands the native side a raw pointer, so the DllImport sees
+            // only `IntPtr` and a length — no element type, no P/Invoke
+            // marshaling.
+            CSharpParamKind::PinnedArray { .. } => {
+                format!("IntPtr {name}, UIntPtr {name}Len", name = self.name)
+            }
         }
     }
 
@@ -844,6 +884,27 @@ impl CSharpParam {
             CSharpParamKind::DirectArray => {
                 format!("{name}, (UIntPtr){name}.Length", name = self.name)
             }
+            // `_{name}Ptr` is the pointer local introduced by the
+            // enclosing `fixed` statement; see `pinned_fixed_args`. The
+            // cast to `IntPtr` matches the DllImport signature.
+            //
+            // The Rust FFI shim for `Vec<Passable>` takes a raw byte
+            // length and divides by `size_of::<T>()` to recover the
+            // element count — the opposite of `Vec<Primitive>`, which
+            // takes element count directly. The primitive path and this
+            // path therefore send different numbers across the same
+            // `UIntPtr` slot. `Unsafe.SizeOf<T>()` is a JIT-time constant
+            // for `unmanaged` struct types, so the multiply folds away.
+            CSharpParamKind::PinnedArray { element_type } => {
+                let ptr_name = self
+                    .pinned_ptr_name()
+                    .expect("PinnedArray params must have a pointer local");
+                format!(
+                    "(IntPtr){ptr_name}, (UIntPtr)({name}.Length * Unsafe.SizeOf<{element_type}>())",
+                    ptr_name = ptr_name,
+                    name = self.name,
+                )
+            }
         }
     }
 
@@ -861,6 +922,36 @@ impl CSharpParam {
             _ => None,
         }
     }
+
+    pub fn pinned_fixed_arg(&self) -> Option<String> {
+        match &self.kind {
+            CSharpParamKind::PinnedArray { element_type } => Some(format!(
+                "{element_type}* {ptr_name} = {name}",
+                ptr_name = self
+                    .pinned_ptr_name()
+                    .expect("PinnedArray params must have a pointer local"),
+                name = self.name,
+            )),
+            _ => None,
+        }
+    }
+
+    fn pinned_ptr_name(&self) -> Option<String> {
+        match self.kind {
+            CSharpParamKind::PinnedArray { .. } => {
+                let base_name = self.name.strip_prefix('@').unwrap_or(&self.name);
+                Some(format!("_{base_name}Ptr"))
+            }
+            _ => None,
+        }
+    }
+}
+
+fn pinned_fixed_args(params: &[CSharpParam]) -> Vec<String> {
+    params
+        .iter()
+        .filter_map(CSharpParam::pinned_fixed_arg)
+        .collect()
 }
 
 /// How a parameter is marshalled across the C# / C ABI boundary.
@@ -882,6 +973,25 @@ pub enum CSharpParamKind {
     /// `[MarshalAs(LPArray, ArraySubType = U1)]` override so CLR emits
     /// one byte per element instead of the 4-byte Win32 BOOL default.
     DirectArray,
+    /// A managed array of a blittable record element type, pinned with
+    /// a `fixed` statement so Rust can read directly from the C# heap.
+    ///
+    /// The struct layout of a blittable record matches Rust's `#[repr(C)]`
+    /// exactly, so a pointer to the first element plus an element count
+    /// is everything Rust needs. The obstacle is that the CLR classifies
+    /// any struct containing a `bool` or `char` as non-blittable and
+    /// refuses to pin `T[]` through the default P/Invoke path — instead
+    /// it silently builds a marshaled copy with a different byte layout,
+    /// which mismatches what Rust expects. The wrapper sidesteps that by
+    /// taking a raw pointer with `fixed (T* _xPtr = x)`, which pins the
+    /// array in place for the duration of the native call, and passes
+    /// the pointer as `IntPtr`. Zero copy: C# and Rust read the same
+    /// block of managed heap memory.
+    ///
+    /// `element_type` is the C# type literal for `T` (e.g., `"Location"`)
+    /// — threaded here so `pinned_fixed_args` can render
+    /// `Location* _xPtr = x` without re-deriving from `csharp_type`.
+    PinnedArray { element_type: String },
 }
 
 /// Bookkeeping for a single record param that must be wire-encoded into a

--- a/boltffi_bindgen/src/render/csharp/plan.rs
+++ b/boltffi_bindgen/src/render/csharp/plan.rs
@@ -37,13 +37,14 @@ impl CSharpModule {
     ///
     /// Top-level string params use `Encoding.UTF8.GetBytes` in the wrapper,
     /// and `WireWriter` uses `Encoding.UTF8.GetByteCount` / `GetBytes` when
-    /// encoding string fields of a record. Decoding no longer needs
+    /// encoding string-bearing params (including `Vec<String>` / nested
+    /// string vecs) or string fields of a record. Decoding no longer needs
     /// `System.Text` — `WireReader` reads strings through
     /// `Marshal.PtrToStringUTF8`.
     pub fn needs_system_text(&self) -> bool {
         self.functions
             .iter()
-            .any(|f| f.params.iter().any(|p| p.csharp_type.is_string()))
+            .any(|f| f.params.iter().any(|p| p.csharp_type.contains_string()))
             || self.records.iter().any(CSharpRecord::has_string_fields)
     }
 
@@ -136,6 +137,17 @@ impl CSharpType {
 
     pub fn is_string(&self) -> bool {
         matches!(self, Self::String)
+    }
+
+    /// Whether this type contains `string` at any nesting depth. Used for
+    /// import decisions where `string[]` / `string[][]` still require
+    /// `System.Text` because their encode path calls `Encoding.UTF8`.
+    pub fn contains_string(&self) -> bool {
+        match self {
+            Self::String => true,
+            Self::Array(inner) => inner.contains_string(),
+            _ => false,
+        }
     }
 
     pub fn is_record(&self) -> bool {

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/functions.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/functions.txt
@@ -14,6 +14,14 @@
             {{ writer.encode_expr }};
             byte[] {{ writer.bytes_binding_name }} = {{ writer.binding_name }}.ToArray();
 {%- endfor %}
+{%- if func.has_pinned_params() %}
+            unsafe
+            {
+{%- for fixed_arg in func.pinned_fixed_args() %}
+                fixed ({{ fixed_arg }})
+                {
+{%- endfor %}
+{%- endif %}
 {%- if let Some(body) = func.return_kind.wire_decode_return("_buf") %}
             FfiBuf _buf = NativeMethods.{{ func.name }}({{ func.native_call_args() }});
             try
@@ -28,6 +36,12 @@
             NativeMethods.{{ func.name }}({{ func.native_call_args() }});
 {%- else %}
             return NativeMethods.{{ func.name }}({{ func.native_call_args() }});
+{%- endif %}
+{%- if func.has_pinned_params() %}
+{%- for _fixed_arg in func.pinned_fixed_args() %}
+                }
+{%- endfor %}
+            }
 {%- endif %}
         }
 {% endfor %}

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
@@ -222,6 +222,97 @@
             return result;
         }
 
+        /// Reads a length-prefixed `T[]` whose bytes follow the 4-byte count.
+        /// Used for `Vec<T>` nested inside an encoded outer container, where
+        /// the outer codec needs an explicit count to know how far to advance
+        /// the cursor between sibling elements.
+        internal T[] ReadLengthPrefixedBlittableArray<T>() where T : unmanaged
+        {
+            int count = ReadI32();
+            if (count < 0) throw new InvalidOperationException("corrupt wire: negative array length");
+            if (count == 0) return Array.Empty<T>();
+            int elementSize = Unsafe.SizeOf<T>();
+            int byteCount = checked(count * elementSize);
+            Require(byteCount, "blittable array payload");
+            T[] result = new T[count];
+            switch (result)
+            {
+                case byte[] dst:
+                    Marshal.Copy(_ptr + _pos, dst, 0, byteCount);
+                    break;
+                case short[] dst:
+                    Marshal.Copy(_ptr + _pos, dst, 0, count);
+                    break;
+                case int[] dst:
+                    Marshal.Copy(_ptr + _pos, dst, 0, count);
+                    break;
+                case long[] dst:
+                    Marshal.Copy(_ptr + _pos, dst, 0, count);
+                    break;
+                case float[] dst:
+                    Marshal.Copy(_ptr + _pos, dst, 0, count);
+                    break;
+                case double[] dst:
+                    Marshal.Copy(_ptr + _pos, dst, 0, count);
+                    break;
+                default:
+                    byte[] scratch = new byte[byteCount];
+                    Marshal.Copy(_ptr + _pos, scratch, 0, byteCount);
+                    scratch.AsSpan().CopyTo(MemoryMarshal.AsBytes(result.AsSpan()));
+                    break;
+            }
+            _pos += byteCount;
+            return result;
+        }
+
+        internal bool[] ReadLengthPrefixedBoolArray()
+        {
+            int count = ReadI32();
+            if (count < 0) throw new InvalidOperationException("corrupt wire: negative array length");
+            if (count == 0) return Array.Empty<bool>();
+            Require(count, "bool array payload");
+            bool[] result = new bool[count];
+            for (int i = 0; i < count; i++)
+            {
+                result[i] = Marshal.ReadByte(_ptr, _pos + i) != 0;
+            }
+            _pos += count;
+            return result;
+        }
+
+        internal nint[] ReadLengthPrefixedNIntArray()
+        {
+            long[] raw = ReadLengthPrefixedBlittableArray<long>();
+            nint[] result = new nint[raw.Length];
+            for (int i = 0; i < raw.Length; i++) result[i] = (nint)raw[i];
+            return result;
+        }
+
+        internal nuint[] ReadLengthPrefixedNUIntArray()
+        {
+            long[] raw = ReadLengthPrefixedBlittableArray<long>();
+            nuint[] result = new nuint[raw.Length];
+            for (int i = 0; i < raw.Length; i++) result[i] = (nuint)(ulong)raw[i];
+            return result;
+        }
+
+        /// Reads a length-prefixed array whose elements are decoded by
+        /// invoking `read` once per slot. Used for `Vec<T>` where each
+        /// element has variable wire width (strings, nested encoded vecs,
+        /// records).
+        internal T[] ReadEncodedArray<T>(Func<WireReader, T> read)
+        {
+            int count = ReadI32();
+            if (count < 0) throw new InvalidOperationException("corrupt wire: negative array length");
+            if (count == 0) return Array.Empty<T>();
+            T[] result = new T[count];
+            for (int i = 0; i < count; i++)
+            {
+                result[i] = read(this);
+            }
+            return result;
+        }
+
         private void Require(int n, string kind)
         {
             if (n < 0 || n > _length - _pos) throw new InvalidOperationException("corrupt wire: truncated " + kind);
@@ -328,6 +419,18 @@
             long[] widened = new long[v.Length];
             for (int i = 0; i < v.Length; i++) widened[i] = (long)(ulong)v[i];
             WriteBlittableArray(widened);
+        }
+
+        /// Byte size of an encoded `T[]`: the `sizeof(int)` length prefix
+        /// plus the per-element size. Size expressions for `Vec<T>` with
+        /// variable-width elements (strings, nested vecs, records) use this
+        /// helper to drive the `WireWriter` pre-size so its initial
+        /// capacity matches the payload and no growth copy is needed.
+        internal static int EncodedArraySize<T>(T[] v, Func<T, int> sizer)
+        {
+            int total = sizeof(int);
+            for (int i = 0; i < v.Length; i++) total += sizer(v[i]);
+            return total;
         }
 
         private void EnsureCapacity(int additional)

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
@@ -140,6 +140,88 @@
             return v;
         }
 
+        /// Reads the remaining bytes of this buffer as a `T[]`, assuming
+        /// the buffer holds a raw element array with no length prefix.
+        /// This matches the wire shape of a top-level `Vec<T>` return,
+        /// where the FfiBuf's own `len` provides the element count.
+        internal T[] ReadBlittableArray<T>() where T : unmanaged
+        {
+            int byteCount = _length - _pos;
+            if (byteCount < 0)
+                throw new InvalidOperationException("corrupt wire: read position past end");
+            int elementSize = Unsafe.SizeOf<T>();
+            if (byteCount % elementSize != 0)
+                throw new InvalidOperationException(
+                    "corrupt wire: blittable array byte count is not a multiple of element size");
+            if (byteCount == 0) return Array.Empty<T>();
+            int count = byteCount / elementSize;
+            T[] result = new T[count];
+            // Fast path via Marshal.Copy's per-type overloads for the types
+            // that ship with one (byte, short, int, long, float, double).
+            // Unsigned primitives and any other unmanaged T fall through to
+            // a byte scratch buffer reinterpreted via MemoryMarshal.AsBytes.
+            // Little-endian hosts only; big-endian would need byte-swap.
+            switch (result)
+            {
+                case byte[] dst:
+                    Marshal.Copy(_ptr + _pos, dst, 0, byteCount);
+                    break;
+                case short[] dst:
+                    Marshal.Copy(_ptr + _pos, dst, 0, count);
+                    break;
+                case int[] dst:
+                    Marshal.Copy(_ptr + _pos, dst, 0, count);
+                    break;
+                case long[] dst:
+                    Marshal.Copy(_ptr + _pos, dst, 0, count);
+                    break;
+                case float[] dst:
+                    Marshal.Copy(_ptr + _pos, dst, 0, count);
+                    break;
+                case double[] dst:
+                    Marshal.Copy(_ptr + _pos, dst, 0, count);
+                    break;
+                default:
+                    byte[] scratch = new byte[byteCount];
+                    Marshal.Copy(_ptr + _pos, scratch, 0, byteCount);
+                    scratch.AsSpan().CopyTo(MemoryMarshal.AsBytes(result.AsSpan()));
+                    break;
+            }
+            _pos += byteCount;
+            return result;
+        }
+
+        internal bool[] ReadBoolArray()
+        {
+            int count = _length - _pos;
+            if (count < 0)
+                throw new InvalidOperationException("corrupt wire: read position past end");
+            if (count == 0) return Array.Empty<bool>();
+            bool[] result = new bool[count];
+            for (int i = 0; i < count; i++)
+            {
+                result[i] = Marshal.ReadByte(_ptr, _pos + i) != 0;
+            }
+            _pos += count;
+            return result;
+        }
+
+        internal nint[] ReadNIntArray()
+        {
+            long[] raw = ReadBlittableArray<long>();
+            nint[] result = new nint[raw.Length];
+            for (int i = 0; i < raw.Length; i++) result[i] = (nint)raw[i];
+            return result;
+        }
+
+        internal nuint[] ReadNUIntArray()
+        {
+            long[] raw = ReadBlittableArray<long>();
+            nuint[] result = new nuint[raw.Length];
+            for (int i = 0; i < raw.Length; i++) result[i] = (nuint)(ulong)raw[i];
+            return result;
+        }
+
         private void Require(int n, string kind)
         {
             if (n < 0 || n > _length - _pos) throw new InvalidOperationException("corrupt wire: truncated " + kind);
@@ -207,6 +289,45 @@
             EnsureCapacity(v.Length);
             Buffer.BlockCopy(v, 0, _buffer, _pos, v.Length);
             _pos += v.Length;
+        }
+
+        internal void WriteBlittableArray<T>(T[] v) where T : unmanaged
+        {
+            WriteI32(v.Length);
+            if (v.Length == 0) return;
+            int byteCount = checked(v.Length * Unsafe.SizeOf<T>());
+            EnsureCapacity(byteCount);
+            // Reinterpret the source T[] as bytes and block-copy into the
+            // managed buffer. Zero extra allocations, one copy. Little-endian
+            // hosts only; big-endian would need byte-swap.
+            MemoryMarshal.AsBytes(v.AsSpan()).CopyTo(_buffer.AsSpan(_pos, byteCount));
+            _pos += byteCount;
+        }
+
+        internal void WriteBoolArray(bool[] v)
+        {
+            WriteI32(v.Length);
+            if (v.Length == 0) return;
+            EnsureCapacity(v.Length);
+            for (int i = 0; i < v.Length; i++)
+            {
+                _buffer[_pos + i] = (byte)(v[i] ? 1 : 0);
+            }
+            _pos += v.Length;
+        }
+
+        internal void WriteNIntArray(nint[] v)
+        {
+            long[] widened = new long[v.Length];
+            for (int i = 0; i < v.Length; i++) widened[i] = (long)v[i];
+            WriteBlittableArray(widened);
+        }
+
+        internal void WriteNUIntArray(nuint[] v)
+        {
+            long[] widened = new long[v.Length];
+            for (int i = 0; i < v.Length; i++) widened[i] = (long)(ulong)v[i];
+            WriteBlittableArray(widened);
         }
 
         private void EnsureCapacity(int additional)

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/preamble.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/preamble.txt
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 {%- if module.needs_wire_reader() || module.needs_wire_writer() %}
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
 {%- endif %}
 {%- if module.needs_system_text() %}
 using System.Text;

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/value_type_method.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/value_type_method.txt
@@ -21,6 +21,14 @@
             {{ writer.encode_expr }};
             byte[] {{ writer.bytes_binding_name }} = {{ writer.binding_name }}.ToArray();
 {%- endfor %}
+{%- if method.has_pinned_params() %}
+            unsafe
+            {
+{%- for fixed_arg in method.pinned_fixed_args() %}
+                fixed ({{ fixed_arg }})
+                {
+{%- endfor %}
+{%- endif %}
 {%- if method.return_kind.is_void() %}
             NativeMethods.{{ method.native_method_name }}({{ method.full_native_call_args() }});
 {%- else if method.return_kind.is_direct() %}
@@ -34,6 +42,12 @@
             finally
             {
                 NativeMethods.FreeBuf(_buf);
+            }
+{%- endif %}
+{%- if method.has_pinned_params() %}
+{%- for _fixed_arg in method.pinned_fixed_args() %}
+                }
+{%- endfor %}
             }
 {%- endif %}
         }

--- a/boltffi_bindgen/src/render/kotlin/emit.rs
+++ b/boltffi_bindgen/src/render/kotlin/emit.rs
@@ -244,32 +244,29 @@ pub fn emit_reader_read(seq: &ReadSeq) -> String {
 }
 
 fn emit_reader_vec(element_type: &TypeExpr, element: &ReadSeq, layout: &VecLayout) -> String {
+    if let TypeExpr::Primitive(primitive) = element_type {
+        return format!("reader.{}()", primitive_array_read_method(*primitive));
+    }
     match layout {
-        VecLayout::Blittable { .. } => match element_type {
-            TypeExpr::Primitive(primitive) => {
-                let method = match primitive {
-                    PrimitiveType::I32 | PrimitiveType::U32 => "readIntArray",
-                    PrimitiveType::I16 | PrimitiveType::U16 => "readShortArray",
-                    PrimitiveType::I64
-                    | PrimitiveType::U64
-                    | PrimitiveType::ISize
-                    | PrimitiveType::USize => "readLongArray",
-                    PrimitiveType::F32 => "readFloatArray",
-                    PrimitiveType::F64 => "readDoubleArray",
-                    PrimitiveType::U8 | PrimitiveType::I8 => "readBytes",
-                    PrimitiveType::Bool => "readBooleanArray",
-                };
-                format!("reader.{}()", method)
-            }
-            _ => {
-                let inner = emit_reader_read(element);
-                format!("reader.readList {{ {} }}", inner)
-            }
-        },
-        VecLayout::Encoded => {
+        VecLayout::Blittable { .. } | VecLayout::Encoded => {
             let inner = emit_reader_read(element);
             format!("reader.readList {{ {} }}", inner)
         }
+    }
+}
+
+fn primitive_array_read_method(primitive: PrimitiveType) -> &'static str {
+    match primitive {
+        PrimitiveType::I32 | PrimitiveType::U32 => "readIntArray",
+        PrimitiveType::I16 | PrimitiveType::U16 => "readShortArray",
+        PrimitiveType::I64
+        | PrimitiveType::U64
+        | PrimitiveType::ISize
+        | PrimitiveType::USize => "readLongArray",
+        PrimitiveType::F32 => "readFloatArray",
+        PrimitiveType::F64 => "readDoubleArray",
+        PrimitiveType::U8 | PrimitiveType::I8 => "readBytes",
+        PrimitiveType::Bool => "readBooleanArray",
     }
 }
 
@@ -360,11 +357,11 @@ pub fn emit_write_expr(seq: &WriteSeq) -> String {
 }
 
 fn emit_vec_size(value: &str, inner: &SizeExpr, layout: &VecLayout) -> String {
-    match layout {
-        VecLayout::Blittable { .. } => {
+    match (layout, inner) {
+        (VecLayout::Blittable { .. }, _) | (_, SizeExpr::Fixed(_)) => {
             format!("(4 + {}.size * {})", value, emit_size_expr(inner))
         }
-        VecLayout::Encoded => {
+        (VecLayout::Encoded, _) => {
             format!(
                 "(4 + {}.sumOf {{ item -> ({}).toInt() }})",
                 value,
@@ -404,24 +401,15 @@ fn emit_write_vec(
     element: &WriteSeq,
     layout: &VecLayout,
 ) -> String {
-    match layout {
-        VecLayout::Blittable { .. } => match element_type {
-            TypeExpr::Primitive(_) => format!("wire.writePrimitiveList({})", value),
-            TypeExpr::Record(id) => format!(
-                "wire.writeU32({}.size.toUInt()); {}Writer.writeAllToWire(wire, {})",
-                value,
-                id.as_str(),
-                value
-            ),
-            _ => {
-                let inner = emit_write_expr(element);
-                format!(
-                    "wire.writeU32({}.size.toUInt()); {}.forEach {{ item -> {} }}",
-                    value, value, inner
-                )
-            }
-        },
-        VecLayout::Encoded => {
+    match (layout, element_type) {
+        (_, TypeExpr::Primitive(_)) => format!("wire.writePrimitiveList({})", value),
+        (VecLayout::Blittable { .. }, TypeExpr::Record(id)) => format!(
+            "wire.writeU32({}.size.toUInt()); {}Writer.writeAllToWire(wire, {})",
+            value,
+            id.as_str(),
+            value
+        ),
+        _ => {
             let inner = emit_write_expr(element);
             format!(
                 "wire.writeU32({}.size.toUInt()); {}.forEach {{ item -> {} }}",

--- a/boltffi_bindgen/src/render/kotlin/emit.rs
+++ b/boltffi_bindgen/src/render/kotlin/emit.rs
@@ -259,10 +259,9 @@ fn primitive_array_read_method(primitive: PrimitiveType) -> &'static str {
     match primitive {
         PrimitiveType::I32 | PrimitiveType::U32 => "readIntArray",
         PrimitiveType::I16 | PrimitiveType::U16 => "readShortArray",
-        PrimitiveType::I64
-        | PrimitiveType::U64
-        | PrimitiveType::ISize
-        | PrimitiveType::USize => "readLongArray",
+        PrimitiveType::I64 | PrimitiveType::U64 | PrimitiveType::ISize | PrimitiveType::USize => {
+            "readLongArray"
+        }
         PrimitiveType::F32 => "readFloatArray",
         PrimitiveType::F64 => "readDoubleArray",
         PrimitiveType::U8 | PrimitiveType::I8 => "readBytes",

--- a/examples/demo/src/async_fns/mod.rs
+++ b/examples/demo/src/async_fns/mod.rs
@@ -1,5 +1,5 @@
-use boltffi::*;
 use crate::results::ComputeError;
+use boltffi::*;
 
 /// Adds two numbers asynchronously.
 #[export]

--- a/examples/demo/src/classes/constructor_matrix.rs
+++ b/examples/demo/src/classes/constructor_matrix.rs
@@ -234,6 +234,7 @@ impl ConstructorCoverageMatrix {
             Filter::ByName { name } => format!("name:{name}"),
             Filter::ByRange { min, max } => format!("range:{min:.1}-{max:.1}"),
             Filter::ByTags { tags } => format!("tags:{}", tags.join("|")),
+            Filter::ByGroups { groups } => format!("groups:{}", groups.len()),
             Filter::ByPoints { anchors } => format!("points:{}", anchors.len()),
         }
     }

--- a/examples/demo/src/enums/complex_variants.rs
+++ b/examples/demo/src/enums/complex_variants.rs
@@ -9,6 +9,7 @@ pub enum Filter {
     ByName { name: String },
     ByRange { min: f64, max: f64 },
     ByTags { tags: Vec<String> },
+    ByGroups { groups: Vec<Vec<String>> },
     ByPoints { anchors: Vec<Point> },
 }
 
@@ -24,6 +25,7 @@ pub fn describe_filter(f: Filter) -> String {
         Filter::ByName { name } => format!("filter by name: {}", name),
         Filter::ByRange { min, max } => format!("filter by range: {}..{}", min, max),
         Filter::ByTags { tags } => format!("filter by {} tags", tags.len()),
+        Filter::ByGroups { groups } => format!("filter by {} groups", groups.len()),
         Filter::ByPoints { anchors } => format!("filter by {} anchor points", anchors.len()),
     }
 }

--- a/examples/demo/src/primitives/vecs.rs
+++ b/examples/demo/src/primitives/vecs.rs
@@ -139,6 +139,21 @@ pub fn echo_vec_vec_i32(v: Vec<Vec<i32>>) -> Vec<Vec<i32>> {
 }
 
 #[export]
+pub fn echo_vec_vec_bool(v: Vec<Vec<bool>>) -> Vec<Vec<bool>> {
+    v
+}
+
+#[export]
+pub fn echo_vec_vec_isize(v: Vec<Vec<isize>>) -> Vec<Vec<isize>> {
+    v
+}
+
+#[export]
+pub fn echo_vec_vec_usize(v: Vec<Vec<usize>>) -> Vec<Vec<usize>> {
+    v
+}
+
+#[export]
 pub fn echo_vec_vec_string(v: Vec<Vec<String>>) -> Vec<Vec<String>> {
     v
 }

--- a/examples/demo/src/primitives/vecs.rs
+++ b/examples/demo/src/primitives/vecs.rs
@@ -132,3 +132,18 @@ pub fn inc_u64(values: &mut [u64]) {
 pub fn inc_u64_value(value: u64) -> u64 {
     value + 1
 }
+
+#[export]
+pub fn echo_vec_vec_i32(v: Vec<Vec<i32>>) -> Vec<Vec<i32>> {
+    v
+}
+
+#[export]
+pub fn echo_vec_vec_string(v: Vec<Vec<String>>) -> Vec<Vec<String>> {
+    v
+}
+
+#[export]
+pub fn flatten_vec_vec_i32(v: Vec<Vec<i32>>) -> Vec<i32> {
+    v.into_iter().flatten().collect()
+}

--- a/examples/demo/src/records/blittable.rs
+++ b/examples/demo/src/records/blittable.rs
@@ -350,6 +350,14 @@ pub fn sum_trade_volumes(trades: Vec<Trade>) -> i64 {
 
 #[export]
 #[benchmark_candidate(function, uniffi, wasm_bindgen)]
+pub fn aggregate_location_trade_stats(locations: Vec<Location>, trades: Vec<Trade>) -> i64 {
+    let open_locations = locations.iter().filter(|location| location.is_open).count() as i64;
+    let total_trade_volume: i64 = trades.iter().map(|trade| trade.volume).sum();
+    open_locations + total_trade_volume
+}
+
+#[export]
+#[benchmark_candidate(function, uniffi, wasm_bindgen)]
 pub fn generate_particles(count: i32) -> Vec<Particle> {
     (0..count)
         .map(|index| Particle {

--- a/examples/platforms/apple/Tests/DemoConsumerTests/classes/ConstructorCoverageMatrixTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/classes/ConstructorCoverageMatrixTests.swift
@@ -45,9 +45,9 @@ final class ConstructorCoverageMatrixTests: XCTestCase {
         XCTAssertEqual(collectionRecords.payloadChecksum(), 0)
         XCTAssertEqual(collectionRecords.vectorCount(), 7)
 
-        let enumMix = ConstructorCoverageMatrix(withEnumMix: .byTags(tags: ["ffi", "jni"]), message: .image(url: "https://example.com/image.png", width: 640, height: 480), task: Task(title: "ship", priority: .critical, completed: false))
+        let enumMix = ConstructorCoverageMatrix(withEnumMix: .byGroups(groups: [["café", "🌍"], [], ["common"]]), message: .image(url: "https://example.com/image.png", width: 640, height: 480), task: Task(title: "ship", priority: .critical, completed: false))
         XCTAssertEqual(enumMix.constructorVariant(), "with_enum_mix")
-        XCTAssertEqual(enumMix.summary(), "filter=tags:ffi|jni;message=image:https://example.com/image.png#640x480;task=ship#critical")
+        XCTAssertEqual(enumMix.summary(), "filter=groups:3;message=image:https://example.com/image.png#640x480;task=ship#critical")
         XCTAssertEqual(enumMix.payloadChecksum(), 0)
         XCTAssertEqual(enumMix.vectorCount(), 1)
 

--- a/examples/platforms/apple/Tests/DemoConsumerTests/enums/ComplexVariantsEnumsTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/enums/ComplexVariantsEnumsTests.swift
@@ -5,11 +5,14 @@ final class ComplexVariantsEnumsTests: XCTestCase {
     func testFilterFns() {
         let nameFilter = Filter.byName(name: "ali")
         let pointFilter = Filter.byPoints(anchors: [Point(x: 0.0, y: 0.0), Point(x: 1.0, y: 1.0)])
+        let groupFilter = Filter.byGroups(groups: [["café", "🌍"], [], ["common"]])
         XCTAssertEqual(echoFilter(f: .none), .none)
         XCTAssertEqual(echoFilter(f: nameFilter), nameFilter)
+        XCTAssertEqual(echoFilter(f: groupFilter), groupFilter)
         XCTAssertEqual(describeFilter(f: nameFilter), "filter by name: ali")
         XCTAssertEqual(describeFilter(f: pointFilter), "filter by 2 anchor points")
         XCTAssertEqual(describeFilter(f: .byTags(tags: ["ffi", "jni"])), "filter by 2 tags")
+        XCTAssertEqual(describeFilter(f: groupFilter), "filter by 3 groups")
         XCTAssertEqual(describeFilter(f: .byRange(min: 1.0, max: 5.0)), "filter by range: 1..5")
     }
 
@@ -22,4 +25,3 @@ final class ComplexVariantsEnumsTests: XCTestCase {
         XCTAssertEqual(isSuccess(response: .empty), false)
     }
 }
-

--- a/examples/platforms/apple/Tests/DemoConsumerTests/primitives/VecsTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/primitives/VecsTests.swift
@@ -35,6 +35,9 @@ final class VecsTests: XCTestCase {
     func testNestedVecFns() {
         XCTAssertEqual(echoVecVecI32(v: [[1, 2, 3], [], [4, 5]]), [[1, 2, 3], [], [4, 5]])
         XCTAssertEqual(echoVecVecI32(v: []), [])
+        XCTAssertEqual(echoVecVecBool(v: [[true, false, true], [], [false]]), [[true, false, true], [], [false]])
+        XCTAssertEqual(echoVecVecIsize(v: [[-2, 0, 5], [], [9]]), [[-2, 0, 5], [], [9]])
+        XCTAssertEqual(echoVecVecUsize(v: [[0, 2, 4], [], [8]]), [[0, 2, 4], [], [8]])
 
         let strings = [["hello", "world"], [], ["café", "🌍"]]
         XCTAssertEqual(echoVecVecString(v: strings), strings)

--- a/examples/platforms/apple/Tests/DemoConsumerTests/primitives/VecsTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/primitives/VecsTests.swift
@@ -31,4 +31,15 @@ final class VecsTests: XCTestCase {
         XCTAssertEqual(incrementedValues, [2, 2])
         XCTAssertEqual(incU64Value(value: 9), 10)
     }
+
+    func testNestedVecFns() {
+        XCTAssertEqual(echoVecVecI32(v: [[1, 2, 3], [], [4, 5]]), [[1, 2, 3], [], [4, 5]])
+        XCTAssertEqual(echoVecVecI32(v: []), [])
+
+        let strings = [["hello", "world"], [], ["café", "🌍"]]
+        XCTAssertEqual(echoVecVecString(v: strings), strings)
+
+        XCTAssertEqual(flattenVecVecI32(v: [[1, 2], [3], [], [4, 5]]), [1, 2, 3, 4, 5])
+        XCTAssertEqual(flattenVecVecI32(v: []), [])
+    }
 }

--- a/examples/platforms/apple/Tests/DemoConsumerTests/records/BlittableRecordsTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/records/BlittableRecordsTests.swift
@@ -29,22 +29,23 @@ final class BlittableRecordsTests: XCTestCase {
     }
 
     func testBenchmarkRecordFns() {
-        let locations = generateLocations(count: 2)
-        XCTAssertEqual(locations.count, 2)
-        XCTAssertEqual(processLocations(locations: locations), 2)
-        XCTAssertEqual(sumRatings(locations: locations), 6.1, accuracy: 1e-9)
+        let locations = generateLocations(count: 3)
+        XCTAssertEqual(locations.count, 3)
+        XCTAssertEqual(processLocations(locations: locations), 3)
+        XCTAssertEqual(sumRatings(locations: locations), 9.3, accuracy: 1e-9)
 
         let trades = generateTrades(count: 3)
         XCTAssertEqual(trades.count, 3)
         XCTAssertEqual(sumTradeVolumes(trades: trades), 3000)
+        XCTAssertEqual(aggregateLocationTradeStats(locations: locations, trades: trades), 3002)
 
         let particles = generateParticles(count: 3)
         XCTAssertEqual(particles.count, 3)
         XCTAssertEqual(sumParticleMasses(particles: particles), 3.003, accuracy: 1e-9)
 
-        let readings = generateSensorReadings(count: 2)
-        XCTAssertEqual(readings.count, 2)
-        XCTAssertEqual(avgSensorTemperature(readings: readings), 20.5, accuracy: 1e-9)
+        let readings = generateSensorReadings(count: 3)
+        XCTAssertEqual(readings.count, 3)
+        XCTAssertEqual(avgSensorTemperature(readings: readings), 21.0, accuracy: 1e-9)
 
         XCTAssertEqual(
             findLocation(id: 7),

--- a/examples/platforms/csharp/DemoTest/DemoTest.csproj
+++ b/examples/platforms/csharp/DemoTest/DemoTest.csproj
@@ -8,6 +8,9 @@
     <Nullable>disable</Nullable>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Generated BoltFFI wrappers use `fixed` to pin managed memory
+         for zero-copy P/Invoke calls. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -29,6 +29,7 @@ public static class DemoTest
         TestCStyleEnums();
         TestDataEnums();
         TestRecordsWithEnumFields();
+        TestPrimitiveVecs();
         Console.WriteLine("All tests passed!");
         return 0;
     }
@@ -534,6 +535,39 @@ public static class DemoTest
         Require(entry.Code == 42, "MakeErrorLogEntry.Code");
         LogEntry echoedEntry = EchoLogEntry(entry);
         Require(echoedEntry == entry, "EchoLogEntry round-trip");
+
+        Console.WriteLine("  PASS\n");
+    }
+
+    private static void TestPrimitiveVecs()
+    {
+        Console.WriteLine("Testing primitive vecs...");
+
+        int[] echoedI32 = EchoVecI32(new int[] { 1, 2, 3 });
+        Require(echoedI32.SequenceEqual(new[] { 1, 2, 3 }), "echoVecI32");
+        Require(EchoVecI32(Array.Empty<int>()).Length == 0, "echoVecI32 empty");
+
+        Require(EchoVecI8(new sbyte[] { -1, 0, 7 }).SequenceEqual(new sbyte[] { -1, 0, 7 }), "echoVecI8");
+        Require(EchoVecU8(new byte[] { 0, 1, 2, 3 }).SequenceEqual(new byte[] { 0, 1, 2, 3 }), "echoVecU8");
+        Require(EchoVecI16(new short[] { -3, 0, 9 }).SequenceEqual(new short[] { -3, 0, 9 }), "echoVecI16");
+        Require(EchoVecU16(new ushort[] { 0, 10, 20 }).SequenceEqual(new ushort[] { 0, 10, 20 }), "echoVecU16");
+        Require(EchoVecU32(new uint[] { 0, 10, 20 }).SequenceEqual(new uint[] { 0, 10, 20 }), "echoVecU32");
+        Require(EchoVecI64(new long[] { -5L, 0L, 8L }).SequenceEqual(new long[] { -5L, 0L, 8L }), "echoVecI64");
+        Require(EchoVecU64(new ulong[] { 0UL, 1UL, 2UL }).SequenceEqual(new ulong[] { 0UL, 1UL, 2UL }), "echoVecU64");
+        Require(EchoVecIsize(new nint[] { -2, 0, 5 }).SequenceEqual(new nint[] { -2, 0, 5 }), "echoVecIsize");
+        Require(EchoVecUsize(new nuint[] { 0, 2, 4 }).SequenceEqual(new nuint[] { 0, 2, 4 }), "echoVecUsize");
+        Require(EchoVecF32(new float[] { 1.25f, -2.5f }).SequenceEqual(new float[] { 1.25f, -2.5f }), "echoVecF32");
+        Require(EchoVecF64(new double[] { 1.5, 2.5 }).SequenceEqual(new double[] { 1.5, 2.5 }), "echoVecF64");
+        Require(EchoVecBool(new bool[] { true, false, true }).SequenceEqual(new bool[] { true, false, true }), "echoVecBool");
+
+        Require(SumVecI32(new int[] { 10, 20, 30 }) == 60L, "sumVecI32");
+        Require(SumVecI32(Array.Empty<int>()) == 0L, "sumVecI32 empty");
+
+        Require(MakeRange(0, 5).SequenceEqual(new int[] { 0, 1, 2, 3, 4 }), "makeRange");
+        Require(ReverseVecI32(new int[] { 1, 2, 3 }).SequenceEqual(new int[] { 3, 2, 1 }), "reverseVecI32");
+        Require(GenerateI32Vec(4).SequenceEqual(new int[] { 0, 1, 2, 3 }), "generateI32Vec");
+        Require(GenerateF64Vec(3).Length == 3, "generateF64Vec length");
+        Require(Math.Abs(SumF64Vec(new double[] { 0.5, 1.5, 2.0 }) - 4.0) < 1e-9, "sumF64Vec");
 
         Console.WriteLine("  PASS\n");
     }

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -31,6 +31,7 @@ public static class DemoTest
         TestRecordsWithEnumFields();
         TestPrimitiveVecs();
         TestStringAndNestedVecs();
+        TestBlittableRecordVecs();
         Console.WriteLine("All tests passed!");
         return 0;
     }
@@ -661,6 +662,61 @@ public static class DemoTest
         {
             Require(echoedStrings[i].SequenceEqual(nestedStrings[i]), $"echoVecVecString inner[{i}]");
         }
+
+        Console.WriteLine("  PASS\n");
+    }
+
+    /// <summary>
+    /// Vec&lt;BlittableRecord&gt; rides the fast path: returns reinterpret the
+    /// FfiBuf as a T[] via ReadBlittableArray&lt;T&gt;, params pin a T[] and
+    /// hand a pointer across P/Invoke. No wire encoding on either side.
+    /// The generate_* and reduce_* demo pairs cross the boundary in both
+    /// directions with the same struct layout on each side, so any mismatch
+    /// between Rust's #[repr(C)] and C#'s [StructLayout(Sequential)] would
+    /// surface as a wrong sum or a segfault.
+    /// </summary>
+    private static void TestBlittableRecordVecs()
+    {
+        Console.WriteLine("Testing blittable record vecs (Location, Trade, Particle, SensorReading)...");
+
+        Location[] locations = GenerateLocations(3);
+        Require(locations.Length == 3, "generateLocations length");
+        Require(locations[0].Id == 0L, "locations[0].Id");
+        Require(locations[0].Rating == 3.0, "locations[0].Rating");
+        Require(locations[0].IsOpen, "locations[0].IsOpen");
+        Require(locations[1].Id == 1L, "locations[1].Id");
+        Require(!locations[1].IsOpen, "locations[1].IsOpen");
+        Require(locations[2].ReviewCount == 20, "locations[2].ReviewCount");
+
+        Require(ProcessLocations(locations) == 3, "processLocations roundtrip");
+        Require(ProcessLocations(Array.Empty<Location>()) == 0, "processLocations empty");
+        Require(Math.Abs(SumRatings(locations) - (3.0 + 3.1 + 3.2)) < 1e-9, "sumRatings roundtrip");
+
+        Trade[] trades = GenerateTrades(3);
+        Require(trades.Length == 3, "generateTrades length");
+        Require(trades[0].Volume == 0L && trades[1].Volume == 1000L && trades[2].Volume == 2000L, "trades volumes");
+        Require(SumTradeVolumes(trades) == 3000L, "sumTradeVolumes roundtrip");
+        Require(AggregateLocationTradeStats(locations, trades) == 3002L, "aggregateLocationTradeStats two pinned arrays");
+
+        Particle[] particles = GenerateParticles(3);
+        Require(particles.Length == 3, "generateParticles length");
+        Require(Math.Abs(SumParticleMasses(particles) - (1.0 + 1.001 + 1.002)) < 1e-9, "sumParticleMasses roundtrip");
+
+        SensorReading[] readings = GenerateSensorReadings(3);
+        Require(readings.Length == 3, "generateSensorReadings length");
+        Require(Math.Abs(AvgSensorTemperature(readings) - 21.0) < 1e-9, "avgSensorTemperature roundtrip");
+        Require(AvgSensorTemperature(Array.Empty<SensorReading>()) == 0.0, "avgSensorTemperature empty");
+
+        // Construct a Location[] in C# and pass it to native code. Exercises
+        // the param direction independently of the round-trip: if the CLR's
+        // struct layout drifts from Rust's, SumRatings will see garbage.
+        Location[] handmade = new[]
+        {
+            new Location(100L, 40.0, -70.0, 2.5, 5, true),
+            new Location(101L, 40.5, -70.5, 4.0, 50, false),
+        };
+        Require(ProcessLocations(handmade) == 2, "processLocations handmade");
+        Require(Math.Abs(SumRatings(handmade) - 6.5) < 1e-9, "sumRatings handmade");
 
         Console.WriteLine("  PASS\n");
     }

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -32,6 +32,7 @@ public static class DemoTest
         TestPrimitiveVecs();
         TestStringAndNestedVecs();
         TestBlittableRecordVecs();
+        TestEnumVecs();
         Console.WriteLine("All tests passed!");
         return 0;
     }
@@ -717,6 +718,49 @@ public static class DemoTest
         };
         Require(ProcessLocations(handmade) == 2, "processLocations handmade");
         Require(Math.Abs(SumRatings(handmade) - 6.5) < 1e-9, "sumRatings handmade");
+
+        Console.WriteLine("  PASS\n");
+    }
+
+    /// <summary>
+    /// Vec&lt;CStyleEnum&gt; and Vec&lt;DataEnum&gt; both ride the wire-encoded path:
+    /// the Rust macro classifies C-style enums as Scalar (not Blittable),
+    /// so Vec&lt;Status&gt; and Vec&lt;Direction&gt; cross the boundary the same
+    /// way Vec&lt;Shape&gt; does — a length-prefixed encoded buffer. The
+    /// C# side decodes with ReadEncodedArray&lt;T&gt; and per-element
+    /// {Name}Wire.Decode or {Name}.Decode.
+    /// </summary>
+    private static void TestEnumVecs()
+    {
+        Console.WriteLine("Testing Vec<CStyleEnum> and Vec<DataEnum>...");
+
+        Status[] statuses = new[] { Status.Active, Status.Inactive, Status.Pending, Status.Active };
+        Status[] echoedStatuses = EchoVecStatus(statuses);
+        Require(echoedStatuses.SequenceEqual(statuses), "echoVecStatus round-trip");
+        Require(EchoVecStatus(Array.Empty<Status>()).Length == 0, "echoVecStatus empty");
+
+        Direction[] generated = GenerateDirections(6);
+        Require(generated.Length == 6, "generateDirections length");
+        Require(generated[0] == Direction.North && generated[4] == Direction.North, "generateDirections wraps the 4-direction cycle");
+        Require(CountNorth(generated) == 2, "countNorth on generateDirections(6)");
+        Require(CountNorth(Array.Empty<Direction>()) == 0, "countNorth empty");
+
+        LogLevel[] levels = new[] { LogLevel.Trace, LogLevel.Warn, LogLevel.Error, LogLevel.Debug };
+        LogLevel[] echoedLevels = EchoVecLogLevel(levels);
+        Require(echoedLevels.SequenceEqual(levels), "echoVecLogLevel round-trip");
+        Require(EchoVecLogLevel(Array.Empty<LogLevel>()).Length == 0, "echoVecLogLevel empty");
+
+        Shape[] shapes = new Shape[]
+        {
+            new Shape.Circle(2.5),
+            new Shape.Rectangle(3.0, 4.0),
+            new Shape.Triangle(new Point(0.0, 0.0), new Point(4.0, 0.0), new Point(0.0, 3.0)),
+            new Shape.Point(),
+        };
+        Shape[] echoedShapes = EchoVecShape(shapes);
+        Require(echoedShapes.Length == shapes.Length, "echoVecShape length");
+        Require(echoedShapes.SequenceEqual(shapes), "echoVecShape round-trip preserves each variant");
+        Require(EchoVecShape(Array.Empty<Shape>()).Length == 0, "echoVecShape empty");
 
         Console.WriteLine("  PASS\n");
     }

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -30,6 +30,7 @@ public static class DemoTest
         TestDataEnums();
         TestRecordsWithEnumFields();
         TestPrimitiveVecs();
+        TestStringAndNestedVecs();
         Console.WriteLine("All tests passed!");
         return 0;
     }
@@ -568,6 +569,98 @@ public static class DemoTest
         Require(GenerateI32Vec(4).SequenceEqual(new int[] { 0, 1, 2, 3 }), "generateI32Vec");
         Require(GenerateF64Vec(3).Length == 3, "generateF64Vec length");
         Require(Math.Abs(SumF64Vec(new double[] { 0.5, 1.5, 2.0 }) - 4.0) < 1e-9, "sumF64Vec");
+
+        Console.WriteLine("  PASS\n");
+    }
+
+    /// <summary>
+    /// Vec&lt;String&gt; and Vec&lt;Vec&lt;_&gt;&gt; travel wire-encoded: the param
+    /// side builds a length-prefixed buffer via WireWriter, the return
+    /// side walks the buffer through ReadEncodedArray. Exercises the
+    /// 2-byte ("café") and 4-byte ("🌍") UTF-8 boundaries at the element
+    /// level so truncation or mis-sized length prefixes surface loudly.
+    /// </summary>
+    private static void TestStringAndNestedVecs()
+    {
+        Console.WriteLine("Testing Vec<String> and Vec<Vec<_>>...");
+
+        string[] words = new[] { "hello", "", "café", "🌍" };
+        string[] echoedWords = EchoVecString(words);
+        Require(echoedWords.SequenceEqual(words), "echoVecString round-trip");
+        Require(EchoVecString(Array.Empty<string>()).Length == 0, "echoVecString empty");
+
+        uint[] lengths = VecStringLengths(new[] { "", "a", "café", "🌍" });
+        Require(lengths.SequenceEqual(new uint[] { 0u, 1u, 5u, 4u }), "vecStringLengths UTF-8 byte counts");
+
+        int[][] nestedInts = new[]
+        {
+            new[] { 1, 2, 3 },
+            Array.Empty<int>(),
+            new[] { -1 },
+        };
+        int[][] echoedInts = EchoVecVecI32(nestedInts);
+        Require(echoedInts.Length == nestedInts.Length, "echoVecVecI32 outer length");
+        for (int i = 0; i < nestedInts.Length; i++)
+        {
+            Require(echoedInts[i].SequenceEqual(nestedInts[i]), $"echoVecVecI32 inner[{i}]");
+        }
+        Require(EchoVecVecI32(Array.Empty<int[]>()).Length == 0, "echoVecVecI32 empty outer");
+
+        bool[][] nestedBools = new[]
+        {
+            new[] { true, false, true },
+            Array.Empty<bool>(),
+            new[] { false },
+        };
+        bool[][] echoedBools = EchoVecVecBool(nestedBools);
+        Require(echoedBools.Length == nestedBools.Length, "echoVecVecBool outer length");
+        for (int i = 0; i < nestedBools.Length; i++)
+        {
+            Require(echoedBools[i].SequenceEqual(nestedBools[i]), $"echoVecVecBool inner[{i}]");
+        }
+
+        nint[][] nestedIsizes = new[]
+        {
+            new nint[] { -2, 0, 5 },
+            Array.Empty<nint>(),
+            new nint[] { 9 },
+        };
+        nint[][] echoedIsizes = EchoVecVecIsize(nestedIsizes);
+        Require(echoedIsizes.Length == nestedIsizes.Length, "echoVecVecIsize outer length");
+        for (int i = 0; i < nestedIsizes.Length; i++)
+        {
+            Require(echoedIsizes[i].SequenceEqual(nestedIsizes[i]), $"echoVecVecIsize inner[{i}]");
+        }
+
+        nuint[][] nestedUsizes = new[]
+        {
+            new nuint[] { 0, 2, 4 },
+            Array.Empty<nuint>(),
+            new nuint[] { 8 },
+        };
+        nuint[][] echoedUsizes = EchoVecVecUsize(nestedUsizes);
+        Require(echoedUsizes.Length == nestedUsizes.Length, "echoVecVecUsize outer length");
+        for (int i = 0; i < nestedUsizes.Length; i++)
+        {
+            Require(echoedUsizes[i].SequenceEqual(nestedUsizes[i]), $"echoVecVecUsize inner[{i}]");
+        }
+
+        int[] flattened = FlattenVecVecI32(nestedInts);
+        Require(flattened.SequenceEqual(new[] { 1, 2, 3, -1 }), "flattenVecVecI32");
+
+        string[][] nestedStrings = new[]
+        {
+            new[] { "café", "🌍" },
+            Array.Empty<string>(),
+            new[] { "" },
+            new[] { "one", "two", "three" },
+        };
+        string[][] echoedStrings = EchoVecVecString(nestedStrings);
+        Require(echoedStrings.Length == nestedStrings.Length, "echoVecVecString outer length");
+        for (int i = 0; i < nestedStrings.Length; i++)
+        {
+            Require(echoedStrings[i].SequenceEqual(nestedStrings[i]), $"echoVecVecString inner[{i}]");
+        }
 
         Console.WriteLine("  PASS\n");
     }

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -769,8 +769,9 @@ public static class DemoTest
     /// <summary>
     /// Vec fields inside records and data-enum variants. Polygon.Points and
     /// Filter.ByPoints.Anchors ride the length-prefixed blittable path;
-    /// Team.Members, Classroom.Students, TaggedScores.Scores, Filter.ByTags.Tags,
-    /// and BenchmarkUserProfile.Tags/Scores mix the encoded and blittable
+    /// Team.Members, Classroom.Students, Filter.ByTags.Tags,
+    /// Filter.ByGroups.Groups, TaggedScores.Scores, and
+    /// BenchmarkUserProfile.Tags/Scores mix the encoded and blittable
     /// paths inside the enclosing record's wire buffer. UTF-8 sentinels
     /// (café, 🌍) ride through any Vec&lt;String&gt; position to exercise
     /// 2-byte and 4-byte codepoints across the boundary.
@@ -824,6 +825,25 @@ public static class DemoTest
         Filter echoedTags = EchoFilter(byTags);
         Require(echoedTags is Filter.ByTags t && t.Tags.SequenceEqual(((Filter.ByTags)byTags).Tags), "echoFilter ByTags");
         Require(DescribeFilter(byTags) == "filter by 2 tags", "describeFilter ByTags");
+
+        Filter byGroups = new Filter.ByGroups(
+            new[]
+            {
+                new[] { "café", "🌍" },
+                Array.Empty<string>(),
+                new[] { "common" },
+            }
+        );
+        Filter echoedGroups = EchoFilter(byGroups);
+        Require(echoedGroups is Filter.ByGroups g && g.Groups.Length == 3, "echoFilter ByGroups outer length");
+        Require(
+            echoedGroups is Filter.ByGroups g0
+                && g0.Groups[0].SequenceEqual(((Filter.ByGroups)byGroups).Groups[0])
+                && g0.Groups[1].SequenceEqual(((Filter.ByGroups)byGroups).Groups[1])
+                && g0.Groups[2].SequenceEqual(((Filter.ByGroups)byGroups).Groups[2]),
+            "echoFilter ByGroups nested strings"
+        );
+        Require(DescribeFilter(byGroups) == "filter by 3 groups", "describeFilter ByGroups");
 
         Filter byPoints = new Filter.ByPoints(new[] { new Point(1.0, 2.0), new Point(3.0, 4.0) });
         Filter echoedPts = EchoFilter(byPoints);

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -33,6 +33,7 @@ public static class DemoTest
         TestStringAndNestedVecs();
         TestBlittableRecordVecs();
         TestEnumVecs();
+        TestVecFields();
         Console.WriteLine("All tests passed!");
         return 0;
     }
@@ -761,6 +762,82 @@ public static class DemoTest
         Require(echoedShapes.Length == shapes.Length, "echoVecShape length");
         Require(echoedShapes.SequenceEqual(shapes), "echoVecShape round-trip preserves each variant");
         Require(EchoVecShape(Array.Empty<Shape>()).Length == 0, "echoVecShape empty");
+
+        Console.WriteLine("  PASS\n");
+    }
+
+    /// <summary>
+    /// Vec fields inside records and data-enum variants. Polygon.Points and
+    /// Filter.ByPoints.Anchors ride the length-prefixed blittable path;
+    /// Team.Members, Classroom.Students, TaggedScores.Scores, Filter.ByTags.Tags,
+    /// and BenchmarkUserProfile.Tags/Scores mix the encoded and blittable
+    /// paths inside the enclosing record's wire buffer. UTF-8 sentinels
+    /// (café, 🌍) ride through any Vec&lt;String&gt; position to exercise
+    /// 2-byte and 4-byte codepoints across the boundary.
+    /// </summary>
+    private static void TestVecFields()
+    {
+        Console.WriteLine("Testing Vec fields inside records and enum variants...");
+
+        Polygon triangle = new Polygon(new[]
+        {
+            new Point(0.0, 0.0),
+            new Point(4.0, 0.0),
+            new Point(0.0, 3.0),
+        });
+        Polygon echoedTriangle = EchoPolygon(triangle);
+        Require(echoedTriangle.Points.SequenceEqual(triangle.Points), "echoPolygon round-trip");
+        Require(PolygonVertexCount(triangle) == 3u, "polygonVertexCount");
+        Point centroid = PolygonCentroid(triangle);
+        Require(Math.Abs(centroid.X - 4.0 / 3.0) < 1e-9 && Math.Abs(centroid.Y - 1.0) < 1e-9, "polygonCentroid");
+        Polygon built = MakePolygon(triangle.Points);
+        Require(built.Points.SequenceEqual(triangle.Points), "makePolygon");
+        Require(EchoPolygon(new Polygon(Array.Empty<Point>())).Points.Length == 0, "echoPolygon empty");
+
+        Team team = new Team("Alpha", new[] { "café", "🌍", "common" });
+        Team echoedTeam = EchoTeam(team);
+        Require(echoedTeam.Name == team.Name, "echoTeam name");
+        Require(echoedTeam.Members.SequenceEqual(team.Members), "echoTeam members utf-8 round-trip");
+        Require(TeamSize(team) == 3u, "teamSize");
+        Team built2 = MakeTeam("Beta", new[] { "x", "y" });
+        Require(built2.Name == "Beta" && built2.Members.SequenceEqual(new[] { "x", "y" }), "makeTeam");
+        Require(EchoTeam(new Team("Empty", Array.Empty<string>())).Members.Length == 0, "echoTeam empty members");
+
+        Classroom classroom = new Classroom(new[]
+        {
+            new Person("café", 7u),
+            new Person("🌍", 42u),
+        });
+        Classroom echoedClass = EchoClassroom(classroom);
+        Require(echoedClass.Students.SequenceEqual(classroom.Students), "echoClassroom utf-8 round-trip");
+        Classroom built3 = MakeClassroom(classroom.Students);
+        Require(built3.Students.SequenceEqual(classroom.Students), "makeClassroom (Vec<NonBlittableRecord> param)");
+        Require(EchoClassroom(new Classroom(Array.Empty<Person>())).Students.Length == 0, "echoClassroom empty");
+
+        TaggedScores scores = new TaggedScores("quiz", new[] { 10.0, 20.0, 30.0 });
+        TaggedScores echoedScores = EchoTaggedScores(scores);
+        Require(echoedScores.Label == "quiz" && echoedScores.Scores.SequenceEqual(scores.Scores), "echoTaggedScores");
+        Require(Math.Abs(AverageScore(scores) - 20.0) < 1e-9, "averageScore");
+        Require(AverageScore(new TaggedScores("empty", Array.Empty<double>())) == 0.0, "averageScore empty");
+
+        Filter byTags = new Filter.ByTags(new[] { "café", "🌍" });
+        Filter echoedTags = EchoFilter(byTags);
+        Require(echoedTags is Filter.ByTags t && t.Tags.SequenceEqual(((Filter.ByTags)byTags).Tags), "echoFilter ByTags");
+        Require(DescribeFilter(byTags) == "filter by 2 tags", "describeFilter ByTags");
+
+        Filter byPoints = new Filter.ByPoints(new[] { new Point(1.0, 2.0), new Point(3.0, 4.0) });
+        Filter echoedPts = EchoFilter(byPoints);
+        Require(echoedPts is Filter.ByPoints p2 && p2.Anchors.SequenceEqual(((Filter.ByPoints)byPoints).Anchors), "echoFilter ByPoints");
+        Require(DescribeFilter(byPoints) == "filter by 2 anchor points", "describeFilter ByPoints");
+
+        BenchmarkUserProfile[] profiles = GenerateUserProfiles(4);
+        Require(profiles.Length == 4, "generateUserProfiles length");
+        Require(profiles[0].Tags.Length == 3 && profiles[0].Scores.Length == 3, "generateUserProfiles inner vec shapes");
+        Require(profiles[0].IsActive && !profiles[1].IsActive, "generateUserProfiles is_active pattern");
+        double expectedSum = 0.0 + 1.5 + 3.0 + 4.5;
+        Require(Math.Abs(SumUserScores(profiles) - expectedSum) < 1e-9, "sumUserScores round-trip");
+        Require(CountActiveUsers(profiles) == 2, "countActiveUsers (even indices active)");
+        Require(SumUserScores(Array.Empty<BenchmarkUserProfile>()) == 0.0, "sumUserScores empty");
 
         Console.WriteLine("  PASS\n");
     }

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -536,6 +536,33 @@ public final class DemoTest {
         List<int[]> vviEmpty = Demo.echoVecVecI32(Collections.emptyList());
         assert vviEmpty.isEmpty() : "echoVecVecI32 empty outer";
 
+        List<boolean[]> vvb = Demo.echoVecVecBool(Arrays.asList(
+                new boolean[]{true, false, true},
+                new boolean[]{},
+                new boolean[]{false}));
+        assert vvb.size() == 3 : "echoVecVecBool outer size";
+        assert vvb.get(0).length == 3 && vvb.get(0)[0] && !vvb.get(0)[1] && vvb.get(0)[2] : "echoVecVecBool[0]";
+        assert vvb.get(1).length == 0 : "echoVecVecBool[1] empty";
+        assert vvb.get(2).length == 1 && !vvb.get(2)[0] : "echoVecVecBool[2]";
+
+        List<long[]> vvisize = Demo.echoVecVecIsize(Arrays.asList(
+                new long[]{-2L, 0L, 5L},
+                new long[]{},
+                new long[]{9L}));
+        assert vvisize.size() == 3 : "echoVecVecIsize outer size";
+        assert vvisize.get(0).length == 3 && vvisize.get(0)[0] == -2L && vvisize.get(0)[2] == 5L : "echoVecVecIsize[0]";
+        assert vvisize.get(1).length == 0 : "echoVecVecIsize[1] empty";
+        assert vvisize.get(2).length == 1 && vvisize.get(2)[0] == 9L : "echoVecVecIsize[2]";
+
+        List<long[]> vvusize = Demo.echoVecVecUsize(Arrays.asList(
+                new long[]{0L, 2L, 4L},
+                new long[]{},
+                new long[]{8L}));
+        assert vvusize.size() == 3 : "echoVecVecUsize outer size";
+        assert vvusize.get(0).length == 3 && vvusize.get(0)[0] == 0L && vvusize.get(0)[2] == 4L : "echoVecVecUsize[0]";
+        assert vvusize.get(1).length == 0 : "echoVecVecUsize[1] empty";
+        assert vvusize.get(2).length == 1 && vvusize.get(2)[0] == 8L : "echoVecVecUsize[2]";
+
         List<List<String>> vvs = Demo.echoVecVecString(Arrays.asList(
                 Arrays.asList("hello", "world"),
                 Collections.emptyList(),

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -311,6 +311,16 @@ public final class DemoTest {
         assert logEntry.code() == (short) 42 : "LogEntry.code";
         assert Demo.echoLogEntry(logEntry).equals(logEntry) : "echoLogEntry round-trip";
 
+        Filter groupFilter = new Filter.ByGroups(
+            Arrays.asList(
+                Arrays.asList("café", "🌍"),
+                Collections.emptyList(),
+                Arrays.asList("common")
+            )
+        );
+        assert Demo.echoFilter(groupFilter).equals(groupFilter) : "echoFilter(ByGroups)";
+        assert Demo.describeFilter(groupFilter).equals("filter by 3 groups") : "describeFilter(ByGroups)";
+
         Shape circle = Demo.makeCircle(5.0);
         assert circle instanceof Shape.Circle : "makeCircle returns Circle";
         assert ((Shape.Circle) circle).radius == 5.0 : "makeCircle.radius";
@@ -798,13 +808,17 @@ public final class DemoTest {
         }
 
         try (ConstructorCoverageMatrix enumMix = new ConstructorCoverageMatrix(
-            new Filter.ByTags(Arrays.asList("ffi", "jni")),
+            new Filter.ByGroups(Arrays.asList(
+                Arrays.asList("café", "🌍"),
+                Collections.emptyList(),
+                Arrays.asList("common")
+            )),
             new Message.Image("https://example.com/image.png", 640, 480),
             new Task("ship", Priority.CRITICAL, false)
         )) {
             assert enumMix.constructorVariant().equals("with_enum_mix") : "with_enum_mix variant";
             assert enumMix.summary().equals(
-                "filter=tags:ffi|jni;message=image:https://example.com/image.png#640x480;task=ship#critical"
+                "filter=groups:3;message=image:https://example.com/image.png#640x480;task=ship#critical"
             ) : "with_enum_mix summary";
             assert enumMix.payloadChecksum() == 0 : "with_enum_mix checksum";
             assert enumMix.vectorCount() == 1 : "with_enum_mix vectorCount";

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -27,6 +27,7 @@ public final class DemoTest {
         testBytesVecs();
         testPrimitiveVecs();
         testVecStrings();
+        testNestedVecs();
         testOptions();
         testRecordsWithVecs();
         testConstructorCoverageMatrix();
@@ -519,6 +520,36 @@ public final class DemoTest {
         assert lengths.length == 2 : "vecStringLengths size";
         assert lengths[0] == 2 : "vecStringLengths[0]";
         assert lengths[1] == 5 : "vecStringLengths[1] (utf8)";
+
+        System.out.println("  PASS\n");
+    }
+
+    private static void testNestedVecs() {
+        System.out.println("Testing nested vecs...");
+
+        List<int[]> vvi = Demo.echoVecVecI32(Arrays.asList(new int[]{1, 2, 3}, new int[]{}, new int[]{4, 5}));
+        assert vvi.size() == 3 : "echoVecVecI32 outer size";
+        assert vvi.get(0).length == 3 && vvi.get(0)[0] == 1 && vvi.get(0)[2] == 3 : "echoVecVecI32[0]";
+        assert vvi.get(1).length == 0 : "echoVecVecI32[1] empty";
+        assert vvi.get(2).length == 2 && vvi.get(2)[0] == 4 && vvi.get(2)[1] == 5 : "echoVecVecI32[2]";
+
+        List<int[]> vviEmpty = Demo.echoVecVecI32(Collections.emptyList());
+        assert vviEmpty.isEmpty() : "echoVecVecI32 empty outer";
+
+        List<List<String>> vvs = Demo.echoVecVecString(Arrays.asList(
+                Arrays.asList("hello", "world"),
+                Collections.emptyList(),
+                Arrays.asList("café", "🌍")));
+        assert vvs.size() == 3 : "echoVecVecString outer size";
+        assert vvs.get(0).equals(Arrays.asList("hello", "world")) : "echoVecVecString[0]";
+        assert vvs.get(1).isEmpty() : "echoVecVecString[1] empty";
+        assert vvs.get(2).equals(Arrays.asList("café", "🌍")) : "echoVecVecString[2]";
+
+        int[] flat = Demo.flattenVecVecI32(Arrays.asList(new int[]{1, 2}, new int[]{3}, new int[]{}, new int[]{4, 5}));
+        assert flat.length == 5 : "flattenVecVecI32 length";
+        assert flat[0] == 1 && flat[1] == 2 && flat[2] == 3 && flat[3] == 4 && flat[4] == 5 : "flattenVecVecI32 values";
+
+        assert Demo.flattenVecVecI32(Collections.emptyList()).length == 0 : "flattenVecVecI32 empty";
 
         System.out.println("  PASS\n");
     }

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -28,6 +28,7 @@ public final class DemoTest {
         testPrimitiveVecs();
         testVecStrings();
         testNestedVecs();
+        testBlittableRecordVecs();
         testOptions();
         testRecordsWithVecs();
         testConstructorCoverageMatrix();
@@ -577,6 +578,30 @@ public final class DemoTest {
         assert flat[0] == 1 && flat[1] == 2 && flat[2] == 3 && flat[3] == 4 && flat[4] == 5 : "flattenVecVecI32 values";
 
         assert Demo.flattenVecVecI32(Collections.emptyList()).length == 0 : "flattenVecVecI32 empty";
+
+        System.out.println("  PASS\n");
+    }
+
+    private static void testBlittableRecordVecs() {
+        System.out.println("Testing blittable record vecs...");
+
+        List<Location> locations = Demo.generateLocations(3);
+        assert locations.size() == 3 : "generateLocations size";
+        assert Demo.processLocations(locations) == 3 : "processLocations";
+        assert Math.abs(Demo.sumRatings(locations) - 9.3) < 0.0001 : "sumRatings";
+
+        List<Trade> trades = Demo.generateTrades(3);
+        assert trades.size() == 3 : "generateTrades size";
+        assert Demo.sumTradeVolumes(trades) == 3000L : "sumTradeVolumes";
+        assert Demo.aggregateLocationTradeStats(locations, trades) == 3002L : "aggregateLocationTradeStats";
+
+        List<Particle> particles = Demo.generateParticles(3);
+        assert particles.size() == 3 : "generateParticles size";
+        assert Math.abs(Demo.sumParticleMasses(particles) - 3.003) < 0.0001 : "sumParticleMasses";
+
+        List<SensorReading> readings = Demo.generateSensorReadings(3);
+        assert readings.size() == 3 : "generateSensorReadings size";
+        assert Math.abs(Demo.avgSensorTemperature(readings) - 21.0) < 0.0001 : "avgSensorTemperature";
 
         System.out.println("  PASS\n");
     }

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoConstructorCoverageMatrixTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoConstructorCoverageMatrixTest.kt
@@ -68,13 +68,13 @@ class DemoConstructorCoverageMatrixTest {
         }
 
         ConstructorCoverageMatrix(
-            Filter.ByTags(listOf("ffi", "jni")),
+            Filter.ByGroups(listOf(listOf("café", "🌍"), emptyList(), listOf("common"))),
             Message.Image("https://example.com/image.png", 640u, 480u),
             Task("ship", Priority.CRITICAL, false),
         ).use { matrix ->
             assertEquals("with_enum_mix", matrix.constructorVariant())
             assertEquals(
-                "filter=tags:ffi|jni;message=image:https://example.com/image.png#640x480;task=ship#critical",
+                "filter=groups:3;message=image:https://example.com/image.png#640x480;task=ship#critical",
                 matrix.summary(),
             )
             assertEquals(0u, matrix.payloadChecksum())

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
@@ -106,6 +106,27 @@ class DemoValueTypesTest {
         }
         assertEquals(0, echoVecVecI32(emptyList()).size)
 
+        val bools = listOf(booleanArrayOf(true, false, true), booleanArrayOf(), booleanArrayOf(false))
+        val roundTrippedBools = echoVecVecBool(bools)
+        assertEquals(bools.size, roundTrippedBools.size)
+        for (i in bools.indices) {
+            assertContentEquals(bools[i], roundTrippedBools[i])
+        }
+
+        val isizes = listOf(longArrayOf(-2L, 0L, 5L), longArrayOf(), longArrayOf(9L))
+        val roundTrippedIsizes = echoVecVecIsize(isizes)
+        assertEquals(isizes.size, roundTrippedIsizes.size)
+        for (i in isizes.indices) {
+            assertContentEquals(isizes[i], roundTrippedIsizes[i])
+        }
+
+        val usizes = listOf(longArrayOf(0L, 2L, 4L), longArrayOf(), longArrayOf(8L))
+        val roundTrippedUsizes = echoVecVecUsize(usizes)
+        assertEquals(usizes.size, roundTrippedUsizes.size)
+        for (i in usizes.indices) {
+            assertContentEquals(usizes[i], roundTrippedUsizes[i])
+        }
+
         val strings = listOf(listOf("hello", "world"), emptyList(), listOf("café", "🌍"))
         assertEquals(strings, echoVecVecString(strings))
 

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
@@ -263,11 +263,14 @@ class DemoValueTypesTest {
 
         val nameFilter = Filter.ByName("ali")
         val pointFilter = Filter.ByPoints(listOf(Point(0.0, 0.0), Point(1.0, 1.0)))
+        val groupFilter = Filter.ByGroups(listOf(listOf("café", "🌍"), emptyList(), listOf("common")))
         assertEquals(Filter.None, echoFilter(Filter.None))
         assertEquals(nameFilter, echoFilter(nameFilter))
+        assertEquals(groupFilter, echoFilter(groupFilter))
         assertEquals("filter by name: ali", describeFilter(nameFilter))
         assertEquals("filter by 2 anchor points", describeFilter(pointFilter))
         assertEquals("filter by 2 tags", describeFilter(Filter.ByTags(listOf("ffi", "jni"))))
+        assertEquals("filter by 3 groups", describeFilter(groupFilter))
         assertEquals("filter by range: 1..5", describeFilter(Filter.ByRange(1.0, 5.0)))
 
         val success = ApiResponse.Success("ok")

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
@@ -138,6 +138,27 @@ class DemoValueTypesTest {
     }
 
     @Test
+    fun blittableRecordVecsRoundTrip() {
+        val locations = generateLocations(3)
+        assertEquals(3, locations.size)
+        assertEquals(3, processLocations(locations))
+        assertDoubleEquals(9.3, sumRatings(locations))
+
+        val trades = generateTrades(3)
+        assertEquals(3, trades.size)
+        assertEquals(3000L, sumTradeVolumes(trades))
+        assertEquals(3002L, aggregateLocationTradeStats(locations, trades))
+
+        val particles = generateParticles(3)
+        assertEquals(3, particles.size)
+        assertDoubleEquals(3.003, sumParticleMasses(particles))
+
+        val readings = generateSensorReadings(3)
+        assertEquals(3, readings.size)
+        assertDoubleEquals(21.0, avgSensorTemperature(readings))
+    }
+
+    @Test
     fun optionFunctionsUseCorrectKotlinSurface() {
         assertEquals(7, echoOptionalI32(7))
         assertNull(echoOptionalI32(null))

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
@@ -97,6 +97,26 @@ class DemoValueTypesTest {
     }
 
     @Test
+    fun nestedVecsRoundTrip() {
+        val input = listOf(intArrayOf(1, 2, 3), intArrayOf(), intArrayOf(4, 5))
+        val roundTripped = echoVecVecI32(input)
+        assertEquals(input.size, roundTripped.size)
+        for (i in input.indices) {
+            assertContentEquals(input[i], roundTripped[i])
+        }
+        assertEquals(0, echoVecVecI32(emptyList()).size)
+
+        val strings = listOf(listOf("hello", "world"), emptyList(), listOf("café", "🌍"))
+        assertEquals(strings, echoVecVecString(strings))
+
+        assertContentEquals(
+            intArrayOf(1, 2, 3, 4, 5),
+            flattenVecVecI32(listOf(intArrayOf(1, 2), intArrayOf(3), intArrayOf(), intArrayOf(4, 5))),
+        )
+        assertContentEquals(intArrayOf(), flattenVecVecI32(emptyList()))
+    }
+
+    @Test
     fun optionFunctionsUseCorrectKotlinSurface() {
         assertEquals(7, echoOptionalI32(7))
         assertNull(echoOptionalI32(null))

--- a/examples/platforms/python/tests/primitives/test_vecs.py
+++ b/examples/platforms/python/tests/primitives/test_vecs.py
@@ -55,24 +55,6 @@ class PrimitiveVecsTests(unittest.TestCase):
         self.assertTrue(math.isclose(values[0], 1.25, rel_tol=0.0, abs_tol=1e-6))
         self.assertTrue(math.isclose(values[1], -2.5, rel_tol=0.0, abs_tol=1e-6))
 
-    def test_echo_vec_vec_bool(self) -> None:
-        self.assertEqual(
-            demo.echo_vec_vec_bool([[True, False, True], [], [False]]),
-            [[True, False, True], [], [False]],
-        )
-
-    def test_echo_vec_vec_isize(self) -> None:
-        self.assertEqual(
-            demo.echo_vec_vec_isize([[-2, 0, 5], [], [9]]),
-            [[-2, 0, 5], [], [9]],
-        )
-
-    def test_echo_vec_vec_usize(self) -> None:
-        self.assertEqual(
-            demo.echo_vec_vec_usize([[0, 2, 4], [], [8]]),
-            [[0, 2, 4], [], [8]],
-        )
-
     def test_make_range(self) -> None:
         self.assertEqual(demo.make_range(0, 5), [0, 1, 2, 3, 4])
 

--- a/examples/platforms/python/tests/primitives/test_vecs.py
+++ b/examples/platforms/python/tests/primitives/test_vecs.py
@@ -55,6 +55,24 @@ class PrimitiveVecsTests(unittest.TestCase):
         self.assertTrue(math.isclose(values[0], 1.25, rel_tol=0.0, abs_tol=1e-6))
         self.assertTrue(math.isclose(values[1], -2.5, rel_tol=0.0, abs_tol=1e-6))
 
+    def test_echo_vec_vec_bool(self) -> None:
+        self.assertEqual(
+            demo.echo_vec_vec_bool([[True, False, True], [], [False]]),
+            [[True, False, True], [], [False]],
+        )
+
+    def test_echo_vec_vec_isize(self) -> None:
+        self.assertEqual(
+            demo.echo_vec_vec_isize([[-2, 0, 5], [], [9]]),
+            [[-2, 0, 5], [], [9]],
+        )
+
+    def test_echo_vec_vec_usize(self) -> None:
+        self.assertEqual(
+            demo.echo_vec_vec_usize([[0, 2, 4], [], [8]]),
+            [[0, 2, 4], [], [8]],
+        )
+
     def test_make_range(self) -> None:
         self.assertEqual(demo.make_range(0, 5), [0, 1, 2, 3, 4])
 

--- a/examples/platforms/wasm/tests/classes/constructor_matrix.test.mjs
+++ b/examples/platforms/wasm/tests/classes/constructor_matrix.test.mjs
@@ -66,12 +66,12 @@ export async function run() {
   );
   assertMatrix(
     demo.ConstructorCoverageMatrix.withEnumMix(
-      { tag: "ByTags", tags: ["ffi", "jni"] },
+      { tag: "ByGroups", groups: [["café", "🌍"], [], ["common"]] },
       { tag: "Image", url: "https://example.com/image.png", width: 640, height: 480 },
       { title: "ship", priority: demo.Priority.Critical, completed: false },
     ),
     "with_enum_mix",
-    "filter=tags:ffi|jni;message=image:https://example.com/image.png#640x480;task=ship#critical",
+    "filter=groups:3;message=image:https://example.com/image.png#640x480;task=ship#critical",
     0,
     1,
   );

--- a/examples/platforms/wasm/tests/contract.test.mjs
+++ b/examples/platforms/wasm/tests/contract.test.mjs
@@ -10,7 +10,12 @@ const repositoryRoot = dirname(dirname(dirname(wasmRoot)));
 const rustSourceRoot = join(repositoryRoot, "examples", "demo", "src");
 const generatedDeclarationPath = join(wasmRoot, "dist", "demo.d.ts");
 
-const unsupportedTopLevelFunctions = new Set();
+// Blocked on #203: nested Vec<Vec<isize>>/Vec<Vec<usize>> writer passes
+// plain Number to setBigInt64; re-enable once the TS/WASM lowering coerces.
+const unsupportedTopLevelFunctions = new Set([
+  "primitives/vecs.rs::echoVecVecIsize",
+  "primitives/vecs.rs::echoVecVecUsize",
+]);
 
 const unsupportedTypeMembers = new Set([
   "classes/streams.rs::EventBus::subscribeValues",

--- a/examples/platforms/wasm/tests/enums/complex_variants.test.mjs
+++ b/examples/platforms/wasm/tests/enums/complex_variants.test.mjs
@@ -6,12 +6,18 @@ export async function run() {
     tag: "ByPoints",
     anchors: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
   };
+  const groupFilter = {
+    tag: "ByGroups",
+    groups: [["café", "🌍"], [], ["common"]],
+  };
 
   assert.deepEqual(demo.echoFilter({ tag: "None" }), { tag: "None" });
   assert.deepEqual(demo.echoFilter(nameFilter), nameFilter);
+  assert.deepEqual(demo.echoFilter(groupFilter), groupFilter);
   assert.equal(demo.describeFilter(nameFilter), "filter by name: ali");
   assert.equal(demo.describeFilter(pointFilter), "filter by 2 anchor points");
   assert.equal(demo.describeFilter({ tag: "ByTags", tags: ["ffi", "jni"] }), "filter by 2 tags");
+  assert.equal(demo.describeFilter(groupFilter), "filter by 3 groups");
   assert.equal(demo.describeFilter({ tag: "ByRange", min: 1, max: 5 }), "filter by range: 1..5");
 
   const success = { tag: "Success", data: "ok" };

--- a/examples/platforms/wasm/tests/primitives/vecs.test.mjs
+++ b/examples/platforms/wasm/tests/primitives/vecs.test.mjs
@@ -34,18 +34,6 @@ export async function run() {
   assertArrayEqual(vvb[1], []);
   assertArrayEqual(vvb[2], [false]);
 
-  const vvisize = demo.echoVecVecIsize([[-2, 0, 5], [], [9]]);
-  assert.equal(vvisize.length, 3);
-  assertArrayEqual(vvisize[0], [-2, 0, 5]);
-  assertArrayEqual(vvisize[1], []);
-  assertArrayEqual(vvisize[2], [9]);
-
-  const vvusize = demo.echoVecVecUsize([[0, 2, 4], [], [8]]);
-  assert.equal(vvusize.length, 3);
-  assertArrayEqual(vvusize[0], [0, 2, 4]);
-  assertArrayEqual(vvusize[1], []);
-  assertArrayEqual(vvusize[2], [8]);
-
   assert.deepEqual(
     demo.echoVecVecString([["hello", "world"], [], ["café", "🌍"]]),
     [["hello", "world"], [], ["café", "🌍"]],

--- a/examples/platforms/wasm/tests/primitives/vecs.test.mjs
+++ b/examples/platforms/wasm/tests/primitives/vecs.test.mjs
@@ -20,4 +20,19 @@ export async function run() {
   assertArrayEqual(demo.makeRange(0, 5), [0, 1, 2, 3, 4]);
   assertArrayEqual(demo.reverseVecI32([1, 2, 3]), [3, 2, 1]);
   assert.equal(demo.incU64(BigUint64Array.from([1n, 2n])), undefined);
+
+  const vvi = demo.echoVecVecI32([[1, 2, 3], [], [4, 5]]);
+  assert.equal(vvi.length, 3);
+  assertArrayEqual(vvi[0], [1, 2, 3]);
+  assertArrayEqual(vvi[1], []);
+  assertArrayEqual(vvi[2], [4, 5]);
+  assert.equal(demo.echoVecVecI32([]).length, 0);
+
+  assert.deepEqual(
+    demo.echoVecVecString([["hello", "world"], [], ["café", "🌍"]]),
+    [["hello", "world"], [], ["café", "🌍"]],
+  );
+
+  assertArrayEqual(demo.flattenVecVecI32([[1, 2], [3], [], [4, 5]]), [1, 2, 3, 4, 5]);
+  assertArrayEqual(demo.flattenVecVecI32([]), []);
 }

--- a/examples/platforms/wasm/tests/primitives/vecs.test.mjs
+++ b/examples/platforms/wasm/tests/primitives/vecs.test.mjs
@@ -28,6 +28,24 @@ export async function run() {
   assertArrayEqual(vvi[2], [4, 5]);
   assert.equal(demo.echoVecVecI32([]).length, 0);
 
+  const vvb = demo.echoVecVecBool([[true, false, true], [], [false]]);
+  assert.equal(vvb.length, 3);
+  assertArrayEqual(vvb[0], [true, false, true]);
+  assertArrayEqual(vvb[1], []);
+  assertArrayEqual(vvb[2], [false]);
+
+  const vvisize = demo.echoVecVecIsize([[-2, 0, 5], [], [9]]);
+  assert.equal(vvisize.length, 3);
+  assertArrayEqual(vvisize[0], [-2, 0, 5]);
+  assertArrayEqual(vvisize[1], []);
+  assertArrayEqual(vvisize[2], [9]);
+
+  const vvusize = demo.echoVecVecUsize([[0, 2, 4], [], [8]]);
+  assert.equal(vvusize.length, 3);
+  assertArrayEqual(vvusize[0], [0, 2, 4]);
+  assertArrayEqual(vvusize[1], []);
+  assertArrayEqual(vvusize[2], [8]);
+
   assert.deepEqual(
     demo.echoVecVecString([["hello", "world"], [], ["café", "🌍"]]),
     [["hello", "world"], [], ["café", "🌍"]],


### PR DESCRIPTION
This addresses Vec<T> support for C# in #146.

Included in this PR:

1. This PR includes additional tests `Vec<Vec<T>>` to expand coverage.
2. We convert to `T[]` (and not `List<T>`) to best represent the rust `Vec<T>` (as not variable, just a laid out array). This allows us to represent primitives in a blittable P/Invoke way.
3. To maximize performance, I make C# unsafe, as it is in `uniffi-bindgen-cs` so that I can pin a set of memory in the GC (with `fixed`) in order to avoid a temporary copy of blittable records that need to be sent to Rust.
4. I expanded test coverage as a part of this, and where there were failures that I could opt out of I created tickets for follow ups: #202 #203, but Kotlin had a generation-oriented bug so I fixed that in this PR because not doing so would have prevented _any_ of the backends from running the tests.
5. Converted to using `todo!()` to keep it clear where we're purposefully leaving things out instead of accommodating a poor enum structure.