### PR TITLE
Fix: Widen renovatebot schedule

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,7 +6,7 @@
     ":semanticCommitTypeAll(chore)",
   ],
   timezone: "UTC",
-  schedule: ["after 6am and before 9am on Wednesday"],
+  schedule: ["on Wednesday"],
   prConcurrentLimit: 5,
   minimumReleaseAge: "5 days",
   labels: ["dependencies"],


### PR DESCRIPTION
I noticed renovatebot didn't run and that's because the selected schedule 6-9am UTC was too narrow; renovatebot will guarantee a daily update but can't guarantee 3 hours.

So this PR widens it to "anytime on Wednesday" so update proposals in PRs are guaranteed to run.