### PR TITLE
feat(kotlin): add configurable desktop native loader mode

### DIFF
--- a/BOLTFFI_TOML_SPEC.md
+++ b/BOLTFFI_TOML_SPEC.md
@@ -183,6 +183,11 @@ Companion archive output for Apple slice libraries collected by `boltffi pack ap
   - Default: `PascalCase(package.name)`
 - `library_name` (string, optional): Native library name for `System.loadLibrary`.
   - Default: inferred from crate name
+- `desktop_loader` (`bundled` | `system` | `none`): How generated Kotlin loads the native library on non-Android JVMs.
+  - Default: `bundled`
+  - `bundled`: extract bundled desktop natives when present, otherwise fall back to `System.loadLibrary`
+  - `system`: call `System.loadLibrary` on desktop JVMs
+  - `none`: skip desktop JVM loading and assume the host process has already loaded the native library
 - `api_style` (`top_level` | `module_object`): How functions are exposed.
   - Default: `top_level`
 - `factory_style` (`constructors` | `companion_methods`): How factory constructors are exposed.

--- a/boltffi_bindgen/src/render/kotlin/lower.rs
+++ b/boltffi_bindgen/src/render/kotlin/lower.rs
@@ -31,7 +31,8 @@ use crate::render::kotlin::emit;
 use crate::render::kotlin::plan::*;
 use crate::render::kotlin::templates::{AsyncMethodTemplate, WireMethodTemplate};
 use crate::render::kotlin::{
-    FactoryStyle, KotlinApiStyle as KotlinInputApiStyle, KotlinOptions, NamingConvention,
+    FactoryStyle, KotlinApiStyle as KotlinInputApiStyle, KotlinDesktopLoader, KotlinOptions,
+    NamingConvention,
 };
 use crate::render::{TypeConversion, TypeMappings};
 use askama::Template;
@@ -2541,7 +2542,14 @@ impl<'a> KotlinLowerer<'a> {
                 .library_name
                 .clone()
                 .unwrap_or_else(|| naming::library_name(&self.contract.package.name)),
-            desktop_loader: self.options.desktop_loader,
+            desktop_loader_bundled: matches!(
+                self.options.desktop_loader,
+                KotlinDesktopLoader::Bundled
+            ),
+            desktop_loader_system: matches!(
+                self.options.desktop_loader,
+                KotlinDesktopLoader::System
+            ),
             prefix: naming::ffi_prefix().to_string(),
             functions,
             wire_functions,

--- a/boltffi_bindgen/src/render/kotlin/mod.rs
+++ b/boltffi_bindgen/src/render/kotlin/mod.rs
@@ -27,11 +27,19 @@ pub enum KotlinApiStyle {
     ModuleObject,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum KotlinDesktopLoader {
+    #[default]
+    Bundled,
+    System,
+    None,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct KotlinOptions {
     pub factory_style: FactoryStyle,
     pub api_style: KotlinApiStyle,
     pub module_object_name: Option<String>,
     pub library_name: Option<Name<LibraryName>>,
-    pub desktop_loader: bool,
+    pub desktop_loader: KotlinDesktopLoader,
 }

--- a/boltffi_bindgen/src/render/kotlin/plan.rs
+++ b/boltffi_bindgen/src/render/kotlin/plan.rs
@@ -392,7 +392,8 @@ pub struct KotlinCallbackReturn {
 #[derive(Clone)]
 pub struct KotlinNative {
     pub lib_name: Name<LibraryName>,
-    pub desktop_loader: bool,
+    pub desktop_loader_bundled: bool,
+    pub desktop_loader_system: bool,
     pub prefix: String,
     pub functions: Vec<KotlinNativeFunction>,
     pub wire_functions: Vec<KotlinNativeWireFunction>,

--- a/boltffi_bindgen/src/render/kotlin/templates.rs
+++ b/boltffi_bindgen/src/render/kotlin/templates.rs
@@ -61,7 +61,8 @@ pub struct PreambleTemplate<'a> {
 #[template(path = "render_kotlin/native.txt", escape = "none")]
 pub struct NativeTemplate<'a> {
     pub lib_name: &'a str,
-    pub desktop_loader: bool,
+    pub desktop_loader_bundled: bool,
+    pub desktop_loader_system: bool,
     pub prefix: &'a str,
     pub functions: &'a [super::plan::KotlinNativeFunction],
     pub wire_functions: &'a [super::plan::KotlinNativeWireFunction],
@@ -475,7 +476,8 @@ impl KotlinEmitter {
 
         let native = NativeTemplate {
             lib_name: module.native.lib_name.as_str(),
-            desktop_loader: module.native.desktop_loader,
+            desktop_loader_bundled: module.native.desktop_loader_bundled,
+            desktop_loader_system: module.native.desktop_loader_system,
             prefix: &module.native.prefix,
             functions: &module.native.functions,
             wire_functions: &module.native.wire_functions,
@@ -949,7 +951,8 @@ mod tests {
     fn native_without_async_runtime_omits_future_continuation_callback() {
         let rendered = NativeTemplate {
             lib_name: "repro",
-            desktop_loader: false,
+            desktop_loader_bundled: false,
+            desktop_loader_system: false,
             prefix: "boltffi",
             functions: &[],
             wire_functions: &[],
@@ -968,7 +971,8 @@ mod tests {
     fn native_template_keeps_android_safe_runtime_branch() {
         let rendered = NativeTemplate {
             lib_name: "repro",
-            desktop_loader: true,
+            desktop_loader_bundled: true,
+            desktop_loader_system: false,
             prefix: "boltffi",
             functions: &[],
             wire_functions: &[],
@@ -988,7 +992,8 @@ mod tests {
     fn native_template_keeps_desktop_loader_for_non_android_runtime() {
         let rendered = NativeTemplate {
             lib_name: "repro",
-            desktop_loader: true,
+            desktop_loader_bundled: true,
+            desktop_loader_system: false,
             prefix: "boltffi",
             functions: &[],
             wire_functions: &[],
@@ -1009,6 +1014,52 @@ mod tests {
                 .contains("if (preferredFailure == null) {\n                return\n            }")
         );
         assert!(rendered.contains("throw preferredFailure"));
+    }
+
+    #[test]
+    fn native_template_can_use_system_loader_for_desktop_runtime() {
+        let rendered = NativeTemplate {
+            lib_name: "repro",
+            desktop_loader_bundled: false,
+            desktop_loader_system: true,
+            prefix: "boltffi",
+            functions: &[],
+            wire_functions: &[],
+            classes: &[],
+            callbacks: &[],
+            async_callback_invokers: &[],
+            has_async_runtime: false,
+        }
+        .render()
+        .unwrap();
+
+        assert!(rendered.contains("if (isAndroidRuntime) {"));
+        assert!(rendered.contains("} else {\n            System.loadLibrary(fallbackLibrary)"));
+        assert!(!rendered.contains("loadDesktopLibraries(preferredLibrary, fallbackLibrary)"));
+        assert!(!rendered.contains("bundledLibraryResourceCandidates"));
+    }
+
+    #[test]
+    fn native_template_can_skip_desktop_loading() {
+        let rendered = NativeTemplate {
+            lib_name: "repro",
+            desktop_loader_bundled: false,
+            desktop_loader_system: false,
+            prefix: "boltffi",
+            functions: &[],
+            wire_functions: &[],
+            classes: &[],
+            callbacks: &[],
+            async_callback_invokers: &[],
+            has_async_runtime: false,
+        }
+        .render()
+        .unwrap();
+
+        assert!(rendered.contains("if (isAndroidRuntime) {"));
+        assert!(!rendered.contains("} else {"));
+        assert!(!rendered.contains("loadDesktopLibraries(preferredLibrary, fallbackLibrary)"));
+        assert!(!rendered.contains("bundledLibraryResourceCandidates"));
     }
 
     #[test]

--- a/boltffi_bindgen/src/render/kotlin/templates/render_kotlin/native.txt
+++ b/boltffi_bindgen/src/render/kotlin/templates/render_kotlin/native.txt
@@ -3,22 +3,24 @@ private object Native {
     init {
         val preferredLibrary = "{{ lib_name }}_jni"
         val fallbackLibrary = "{{ lib_name }}"
-{%- if desktop_loader %}
         val vmName = System.getProperty("java.vm.name").orEmpty()
         val isAndroidRuntime =
             vmName.contains("dalvik", ignoreCase = true) ||
             vmName.contains("art", ignoreCase = true)
         if (isAndroidRuntime) {
             System.loadLibrary(fallbackLibrary)
+{%- if desktop_loader_bundled %}
         } else {
             loadDesktopLibraries(preferredLibrary, fallbackLibrary)
         }
-{%- else %}
-        System.loadLibrary(fallbackLibrary)
+{%- elif desktop_loader_system %}
+        } else {
+            System.loadLibrary(fallbackLibrary)
+        }
 {%- endif %}
     }
 
-{%- if desktop_loader %}
+{%- if desktop_loader_bundled %}
     @Volatile
     private var bundledLibraryDirectory: java.io.File? = null
 

--- a/boltffi_cli/src/commands/generate/languages/kotlin.rs
+++ b/boltffi_cli/src/commands/generate/languages/kotlin.rs
@@ -1,15 +1,17 @@
 use boltffi_bindgen::render::jni::{JniEmitter, JniLowerer, JvmBindingStyle};
-use boltffi_bindgen::render::kotlin::{KotlinEmitter, KotlinLowerer};
-use boltffi_bindgen::{
-    FactoryStyle as BindgenFactoryStyle, KotlinApiStyle as BindgenKotlinApiStyle, KotlinOptions,
+use boltffi_bindgen::render::kotlin::{
+    KotlinApiStyle as BindgenKotlinApiStyle, KotlinDesktopLoader as BindgenKotlinDesktopLoader,
+    KotlinEmitter, KotlinLowerer,
 };
+use boltffi_bindgen::{FactoryStyle as BindgenFactoryStyle, KotlinOptions};
 
 use crate::cli::{CliError, Result};
 use crate::commands::generate::generator::{
     GenerateRequest, LanguageGenerator, ScanPointerWidth, bindgen_type_mappings,
 };
 use crate::config::{
-    FactoryStyle as ConfigFactoryStyle, KotlinApiStyle as ConfigKotlinApiStyle, Target,
+    FactoryStyle as ConfigFactoryStyle, KotlinApiStyle as ConfigKotlinApiStyle,
+    KotlinDesktopLoader as ConfigKotlinDesktopLoader, Target,
 };
 
 pub struct KotlinGenerator;
@@ -32,7 +34,11 @@ impl KotlinGenerator {
                 .config()
                 .android_kotlin_library_name()
                 .map(boltffi_bindgen::library_name),
-            desktop_loader: true,
+            desktop_loader: match request.config().android_kotlin_desktop_loader() {
+                ConfigKotlinDesktopLoader::Bundled => BindgenKotlinDesktopLoader::Bundled,
+                ConfigKotlinDesktopLoader::System => BindgenKotlinDesktopLoader::System,
+                ConfigKotlinDesktopLoader::None => BindgenKotlinDesktopLoader::None,
+            },
         }
     }
 }

--- a/boltffi_cli/src/commands/init.rs
+++ b/boltffi_cli/src/commands/init.rs
@@ -118,6 +118,7 @@ fn create_default_config(package_name: &str) -> Config {
                     output: None,
                     module_name: None,
                     library_name: None,
+                    desktop_loader: Default::default(),
                     api_style: Default::default(),
                     error_style: ErrorStyle::default(),
                     factory_style: FactoryStyle::default(),

--- a/boltffi_cli/src/config.rs
+++ b/boltffi_cli/src/config.rs
@@ -224,6 +224,8 @@ pub struct AndroidKotlinConfig {
     pub module_name: Option<String>,
     pub library_name: Option<String>,
     #[serde(default)]
+    pub desktop_loader: KotlinDesktopLoader,
+    #[serde(default)]
     pub api_style: KotlinApiStyle,
     #[serde(default)]
     pub error_style: ErrorStyle,
@@ -239,6 +241,15 @@ pub enum KotlinApiStyle {
     #[default]
     TopLevel,
     ModuleObject,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum KotlinDesktopLoader {
+    #[default]
+    Bundled,
+    System,
+    None,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -1043,6 +1054,10 @@ impl Config {
 
     pub fn android_kotlin_library_name(&self) -> Option<&str> {
         self.targets.android.kotlin.library_name.as_deref()
+    }
+
+    pub fn android_kotlin_desktop_loader(&self) -> KotlinDesktopLoader {
+        self.targets.android.kotlin.desktop_loader
     }
 
     pub fn android_kotlin_api_style(&self) -> KotlinApiStyle {


### PR DESCRIPTION
Adds a Kotlin generator option for desktop JVM native loading policy.

Motivation: the current Kotlin bindings always enable BoltFFI’s desktop loader on non-Android JVMs. That works for bundled desktop artifacts, but it does not fit hosts that already manage native library loading before the generated bindings are initialized. This change makes the behavior explicit and configurable with `targets.android.kotlin.desktop_loader`, while preserving existing behavior as the default.

Supported modes:
- `bundled` (default): current BoltFFI behavior
- `system`: use `System.loadLibrary` on desktop JVMs
- `none`: skip desktop loading and assume the host already loaded the native library