### PR TITLE
Add Discord community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ A high-performance multi-language bindings generator for Rust. Up to 1,000x fast
   <img src="docs/assets/demo.gif" width="700" />
 </p>
 
+<p align="center">
+  <a href="https://discord.gg/udqGGXA4">
+    <img src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join our Discord" />
+  </a>
+</p>
+
 Quick links: [User Guide](https://boltffi.dev/docs/overview) | [Tutorial](https://boltffi.dev/docs/tutorial) | [Getting Started](https://boltffi.dev/docs/getting-started)
 
 ## Performance


### PR DESCRIPTION
Boltffi has now its own Discord server: https://discord.gg/udqGGXA4, for discussions and quicker communication 