### PR TITLE
C# newtypes

### DIFF
--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -2589,4 +2589,136 @@ mod tests {
             "Class static methods do not prepend a receiver to the DllImport",
         );
     }
+
+    /// Pins the shape of the C# bindings for the demo crate's custom
+    /// types: `Email` (`#[custom_ffi]`, repr = String), `UtcDateTime`
+    /// (`custom_type!`, repr = i64), and `Event` (a `#[data]` record
+    /// holding a `DateTime<Utc>` field). Custom types erase to their
+    /// repr in the foreign API, but the macro always exposes them as
+    /// wire-encoded across the C ABI — even Custom<i64> ships
+    /// length-prefixed. The asserts below pin both halves of that
+    /// contract: the public C# surface uses repr types, the DllImport
+    /// signatures use `byte[] + UIntPtr`, and the wrapper bodies wire-
+    /// encode every Custom-typed param (including `Vec<Custom<i64>>`,
+    /// where the IR codec disagrees with the substituted ABI shape).
+    #[test]
+    fn emit_demo_crate_renders_custom_types_through_their_repr() {
+        use std::path::PathBuf;
+
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let demo_crate_path = repo_root.join("examples").join("demo");
+        let mut module = crate::scan::scan_crate(&demo_crate_path, "demo").unwrap();
+        let contract = crate::ir::build_contract(&mut module);
+        let abi = IrLowerer::new(&contract).to_abi_contract();
+        let output = CSharpEmitter::emit(&contract, &abi, &CSharpOptions::default());
+
+        let main = output
+            .files
+            .iter()
+            .find(|f| f.file_name.ends_with(".cs") && f.source.contains("class NativeMethods"))
+            .expect("main wrapper file with NativeMethods");
+
+        // Email (Custom<String>): public surface erases to `string`,
+        // but the param wire-encodes (length-prefixed) — sending raw
+        // UTF-8 would misalign the Rust decoder.
+        assert_source_contains(
+            &main.source,
+            "public static string EchoEmail(string email)",
+            "Email param/return erases to string in the public API",
+        );
+        assert_source_contains(
+            &main.source,
+            "_wire_email.WriteString(email);",
+            "Email param wire-encodes via WriteString (length-prefixed UTF-8)",
+        );
+        assert_source_contains(
+            &main.source,
+            "internal static extern FfiBuf EchoEmail(byte[] email, UIntPtr emailLen);",
+            "Custom<String> DllImport takes a byte buffer, not a raw string",
+        );
+
+        // UtcDateTime (Custom<i64>): public surface is `long`, but the
+        // boundary still wire-encodes to keep the C ABI uniform across
+        // Custom types. Return decode goes through the new
+        // WireDecodeValue path: `var reader = ...; return reader.ReadI64();`
+        assert_source_contains(
+            &main.source,
+            "public static long EchoDatetime(long dt)",
+            "UtcDateTime param/return erases to long in the public API",
+        );
+        assert_source_contains(
+            &main.source,
+            "_wire_dt.WriteI64(dt);",
+            "UtcDateTime param wire-encodes the i64 even though it's fixed-width",
+        );
+        assert_source_contains(
+            &main.source,
+            "var reader = new WireReader(_buf); return reader.ReadI64();",
+            "Custom<Primitive> return reads through WireReader, not the direct primitive path",
+        );
+        assert_source_contains(
+            &main.source,
+            "internal static extern FfiBuf EchoDatetime(byte[] dt, UIntPtr dtLen);",
+            "Custom<i64> DllImport takes a byte buffer, not raw long",
+        );
+
+        // Event (record with a DateTime<Utc> field): admission has to
+        // see through Custom or the whole record gets dropped. Field
+        // type erases to `long` in the rendered class.
+        let event_file = output
+            .files
+            .iter()
+            .find(|f| f.file_name == "Event.cs")
+            .expect("Event.cs from demo crate (record with a Custom field admits)");
+        assert_source_contains(
+            &event_file.source,
+            "long Timestamp",
+            "Event.timestamp field surfaces as long, mirroring the repr of UtcDateTime",
+        );
+        assert_source_contains(
+            &event_file.source,
+            "wire.WriteI64(this.Timestamp);",
+            "Event encodes the Custom field through its primitive repr writer",
+        );
+
+        // Vec<Email>: encoded path. The encoded-array writer iterates
+        // emails as `string` (not `Custom<Email>`), so `from_type_expr`
+        // never sees a Custom — entry-point normalization prevents
+        // the latent todo!.
+        assert_source_contains(
+            &main.source,
+            "foreach (string item0 in emails) { _wire_emails.WriteString(item0); };",
+            "Vec<Email> wire-encodes element-wise with string (repr), not Custom",
+        );
+        assert_source_contains(
+            &main.source,
+            "return new WireReader(_buf).ReadEncodedArray<string>(r0 => r0.ReadString());",
+            "Vec<Email> return reads as encoded array of strings",
+        );
+
+        // Vec<UtcDateTime>: the macro's substituted ABI is blittable
+        // (`*const i64, usize`) but the codec layout sets `Encoded` for
+        // any Vec whose element isn't a bare Primitive. The macro
+        // wins — every `Vec<Custom<_>>` ships length-prefixed both
+        // ways. Pinning that here so a future change can't regress
+        // back to the asymmetric DirectArray-in / encoded-out shape.
+        assert_source_contains(
+            &main.source,
+            "foreach (long item0 in dts) { _wire_dts.WriteI64(item0); };",
+            "Vec<UtcDateTime> wire-encodes element-wise as long, not raw long[]",
+        );
+        assert_source_contains(
+            &main.source,
+            "return new WireReader(_buf).ReadEncodedArray<long>(r0 => r0.ReadI64());",
+            "Vec<UtcDateTime> return reads as encoded array, not raw blittable",
+        );
+        assert_source_contains(
+            &main.source,
+            "internal static extern FfiBuf EchoDatetimes(byte[] dts, UIntPtr dtsLen);",
+            "Vec<Custom<i64>> DllImport takes a byte buffer regardless of repr blittability",
+        );
+    }
 }

--- a/boltffi_bindgen/src/render/csharp/lower/admission.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/admission.rs
@@ -51,7 +51,7 @@ impl<'a> CSharpLowerer<'a> {
                 .filter(|r| {
                     r.fields
                         .iter()
-                        .all(|f| is_field_type_supported(&f.type_expr, &records, &enums))
+                        .all(|f| is_field_type_supported(ffi, &f.type_expr, &records, &enums))
                 })
                 .map(|r| r.id.clone())
                 .collect();
@@ -60,7 +60,7 @@ impl<'a> CSharpLowerer<'a> {
                 .all_enums()
                 .filter(|e| matches!(e.repr, EnumRepr::Data { .. }))
                 .filter(|e| !enums.contains(&e.id))
-                .filter(|e| enum_variant_fields_supported(e, &records, &enums))
+                .filter(|e| enum_variant_fields_supported(ffi, e, &records, &enums))
                 .map(|e| e.id.clone())
                 .collect();
             if record_additions.is_empty() && enum_additions.is_empty() {
@@ -76,6 +76,7 @@ impl<'a> CSharpLowerer<'a> {
 /// Whether every variant's payload field type is supported. Vacuously
 /// true for non-Data enums.
 fn enum_variant_fields_supported(
+    ffi: &FfiContract,
     enum_def: &EnumDef,
     records: &HashSet<RecordId>,
     enums: &HashSet<EnumId>,
@@ -87,16 +88,18 @@ fn enum_variant_fields_supported(
         VariantPayload::Unit => true,
         VariantPayload::Tuple(types) => types
             .iter()
-            .all(|t| is_field_type_supported(t, records, enums)),
+            .all(|t| is_field_type_supported(ffi, t, records, enums)),
         VariantPayload::Struct(fields) => fields
             .iter()
-            .all(|f| is_field_type_supported(&f.type_expr, records, enums)),
+            .all(|f| is_field_type_supported(ffi, &f.type_expr, records, enums)),
     })
 }
 
 /// Whether `ty` is a supported field/element type, given the current
-/// admission state of records and enums.
+/// admission state of records and enums. `Custom` resolves through to
+/// its `repr` so the gate matches what the lowerer will normalize to.
 fn is_field_type_supported(
+    ffi: &FfiContract,
     ty: &TypeExpr,
     records: &HashSet<RecordId>,
     enums: &HashSet<EnumId>,
@@ -105,13 +108,17 @@ fn is_field_type_supported(
         TypeExpr::Primitive(_) | TypeExpr::String | TypeExpr::Void => true,
         TypeExpr::Record(id) => records.contains(id),
         TypeExpr::Enum(id) => enums.contains(id),
-        TypeExpr::Vec(inner) => is_field_type_supported(inner, records, enums),
+        TypeExpr::Custom(id) => ffi
+            .catalog
+            .resolve_custom(id)
+            .is_some_and(|custom| is_field_type_supported(ffi, &custom.repr, records, enums)),
+        TypeExpr::Vec(inner) => is_field_type_supported(ffi, inner, records, enums),
         // C# models `Option<T>` as `T?`, so `Option<Option<T>>` would
         // need `T??`, which the language rejects and which can't be
         // flattened without losing the `Some(None)` state.
         TypeExpr::Option(inner) => {
             !matches!(inner.as_ref(), TypeExpr::Option(_))
-                && is_field_type_supported(inner, records, enums)
+                && is_field_type_supported(ffi, inner, records, enums)
         }
         _ => false,
     }
@@ -123,12 +130,27 @@ mod tests {
     use super::*;
     use crate::ir::Lowerer as IrLowerer;
     use crate::ir::contract::PackageInfo;
-    use crate::ir::definitions::{CStyleVariant, FunctionDef, ParamDef, ParamPassing, ReturnDef};
-    use crate::ir::ids::{FunctionId, ParamName};
+    use crate::ir::definitions::{
+        CStyleVariant, CustomTypeDef, FunctionDef, ParamDef, ParamPassing, ReturnDef,
+    };
+    use crate::ir::ids::{ConverterPath, CustomTypeId, FunctionId, ParamName, QualifiedName};
     use crate::ir::types::PrimitiveType;
     use boltffi_ffi_rules::callable::ExecutionKind;
 
     use super::super::super::CSharpOptions;
+
+    fn datetime_custom_type() -> CustomTypeDef {
+        CustomTypeDef {
+            id: CustomTypeId::new("UtcDateTime"),
+            rust_type: QualifiedName::new("chrono::DateTime<Utc>"),
+            repr: TypeExpr::Primitive(PrimitiveType::I64),
+            converters: ConverterPath {
+                into_ffi: QualifiedName::new("test_into_ffi"),
+                try_from_ffi: QualifiedName::new("test_try_from_ffi"),
+            },
+            doc: None,
+        }
+    }
 
     /// A record field that points at a data enum must still let the
     /// record qualify as supported. Records and data enums are computed
@@ -303,6 +325,72 @@ mod tests {
         assert!(
             lowerer.lower_function(&contract.functions[0]).is_none(),
             "expecting a function with nested Option param/return to be dropped rather than emitting int??",
+        );
+    }
+
+    /// A record carrying a `Custom` field (here `UtcDateTime`, repr =
+    /// i64) must admit. The lowerer normalizes `Custom` to `repr` before
+    /// emitting, so the admission gate has to see through the wrapper or
+    /// the entire record gets silently dropped — which is the pre-fix
+    /// behavior issue #146 calls out.
+    #[test]
+    fn record_with_custom_field_is_admitted() {
+        let mut contract = FfiContract {
+            package: PackageInfo {
+                name: "demo_lib".to_string(),
+                version: None,
+            },
+            functions: vec![],
+            catalog: Default::default(),
+        };
+        contract.catalog.insert_custom(datetime_custom_type());
+        contract.catalog.insert_record(record_with_one_field(
+            "event",
+            "timestamp",
+            TypeExpr::Custom(CustomTypeId::new("UtcDateTime")),
+        ));
+
+        let (records, _enums) = CSharpLowerer::compute_supported_sets(&contract);
+
+        assert!(
+            records.contains(&RecordId::new("event")),
+            "expecting a record with a Custom<i64> field to be admitted",
+        );
+    }
+
+    /// `Vec<Custom>` whose underlying repr is a primitive must take the
+    /// blittable pinned-array fast path. The macro already classifies
+    /// `Vec<UtcDateTime>` as `Vec<i64>` ABI-side; if `is_blittable_vec_element`
+    /// didn't look through `Custom`, the C# side would mismatch by trying
+    /// to wire-encode a buffer the macro emits as a direct `*const i64`.
+    #[test]
+    fn blittable_vec_element_resolves_through_custom() {
+        let mut contract = FfiContract {
+            package: PackageInfo {
+                name: "demo_lib".to_string(),
+                version: None,
+            },
+            functions: vec![],
+            catalog: Default::default(),
+        };
+        contract.catalog.insert_custom(datetime_custom_type());
+
+        let abi = IrLowerer::new(&contract).to_abi_contract();
+        let options = CSharpOptions::default();
+        let lowerer = CSharpLowerer::new(&contract, &abi, &options);
+
+        let custom = TypeExpr::Custom(CustomTypeId::new("UtcDateTime"));
+        assert!(
+            lowerer.is_blittable_vec_element(&custom),
+            "expecting Vec<Custom<i64>> to qualify for the pinned-array fast path",
+        );
+        assert!(
+            lowerer.is_supported_type(&custom),
+            "expecting bare Custom<i64> to admit as a param/return type",
+        );
+        assert!(
+            lowerer.is_supported_vec_element(&custom),
+            "expecting Custom<i64> to admit as a Vec element",
         );
     }
 }

--- a/boltffi_bindgen/src/render/csharp/lower/custom.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/custom.rs
@@ -1,0 +1,307 @@
+//! Custom-type erasure for the C# backend.
+//!
+//! `#[custom_ffi]` and `custom_type!` introduce Rust-side wrapper types
+//! (`Email`, `UtcDateTime`) whose wire form is a different `TypeExpr`
+//! (`String`, `i64`). The macro already substitutes `Custom` for `repr`
+//! when emitting the ABI, so by the time codegen runs `Vec<UtcDateTime>`
+//! is classified the same as `Vec<i64>`. The C# backend mirrors that:
+//! every entry point that pattern-matches on `TypeExpr` / `ReadOp` /
+//! `WriteOp` / `SizeExpr` first runs the value through the helpers
+//! below, replacing each `Custom { underlying }` with what's inside.
+//! Downstream lowering then never sees a `Custom` variant.
+
+use crate::ir::definitions::CustomTypeDef;
+use crate::ir::ids::CustomTypeId;
+use crate::ir::ops::{FieldReadOp, FieldWriteOp, ReadOp, ReadSeq, SizeExpr, WriteOp, WriteSeq};
+use crate::ir::types::TypeExpr;
+
+use super::lowerer::CSharpLowerer;
+
+impl<'a> CSharpLowerer<'a> {
+    pub(super) fn resolve_custom_type(&self, id: &CustomTypeId) -> &CustomTypeDef {
+        self.ffi
+            .catalog
+            .resolve_custom(id)
+            .unwrap_or_else(|| panic!("custom type should be in the catalog: {id:?}"))
+    }
+
+    pub(super) fn custom_repr_type(&self, id: &CustomTypeId) -> &TypeExpr {
+        &self.resolve_custom_type(id).repr
+    }
+
+    /// Resolves `Custom` recursively through compound types so a
+    /// `Vec<Custom<UtcDateTime>>` flattens to `Vec<i64>` and a chained
+    /// `Custom<X>` whose repr is itself `Custom<Y>` lands on the leaf
+    /// repr in one call.
+    pub(super) fn normalize_custom_type_expr(&self, ty: &TypeExpr) -> TypeExpr {
+        match ty {
+            TypeExpr::Custom(id) => self.normalize_custom_type_expr(self.custom_repr_type(id)),
+            TypeExpr::Option(inner) => {
+                TypeExpr::Option(Box::new(self.normalize_custom_type_expr(inner)))
+            }
+            TypeExpr::Vec(inner) => TypeExpr::Vec(Box::new(self.normalize_custom_type_expr(inner))),
+            TypeExpr::Result { ok, err } => TypeExpr::Result {
+                ok: Box::new(self.normalize_custom_type_expr(ok)),
+                err: Box::new(self.normalize_custom_type_expr(err)),
+            },
+            _ => ty.clone(),
+        }
+    }
+
+    /// `SizeExpr` carries no `Custom` variant directly; it just needs to
+    /// recurse through the compound shapes so a normalized `WriteSeq`
+    /// stays internally consistent. Static because it never inspects the
+    /// catalog.
+    pub(super) fn normalize_custom_size_expr(size: &SizeExpr) -> SizeExpr {
+        match size {
+            SizeExpr::OptionSize { value, inner } => SizeExpr::OptionSize {
+                value: value.clone(),
+                inner: Box::new(Self::normalize_custom_size_expr(inner)),
+            },
+            SizeExpr::VecSize {
+                value,
+                inner,
+                layout,
+            } => SizeExpr::VecSize {
+                value: value.clone(),
+                inner: Box::new(Self::normalize_custom_size_expr(inner)),
+                layout: layout.clone(),
+            },
+            SizeExpr::ResultSize { value, ok, err } => SizeExpr::ResultSize {
+                value: value.clone(),
+                ok: Box::new(Self::normalize_custom_size_expr(ok)),
+                err: Box::new(Self::normalize_custom_size_expr(err)),
+            },
+            SizeExpr::Sum(parts) => {
+                SizeExpr::Sum(parts.iter().map(Self::normalize_custom_size_expr).collect())
+            }
+            _ => size.clone(),
+        }
+    }
+
+    pub(super) fn normalize_custom_read_seq(&self, seq: &ReadSeq) -> ReadSeq {
+        if let Some(ReadOp::Custom { underlying, .. }) = seq.ops.first() {
+            return self.normalize_custom_read_seq(underlying);
+        }
+        ReadSeq {
+            size: Self::normalize_custom_size_expr(&seq.size),
+            ops: seq
+                .ops
+                .iter()
+                .map(|op| self.normalize_custom_read_op(op))
+                .collect(),
+            shape: seq.shape,
+        }
+    }
+
+    fn normalize_custom_read_op(&self, op: &ReadOp) -> ReadOp {
+        match op {
+            ReadOp::Option { tag_offset, some } => ReadOp::Option {
+                tag_offset: tag_offset.clone(),
+                some: Box::new(self.normalize_custom_read_seq(some)),
+            },
+            ReadOp::Vec {
+                len_offset,
+                element_type,
+                element,
+                layout,
+            } => ReadOp::Vec {
+                len_offset: len_offset.clone(),
+                element_type: self.normalize_custom_type_expr(element_type),
+                element: Box::new(self.normalize_custom_read_seq(element)),
+                layout: layout.clone(),
+            },
+            ReadOp::Record { id, offset, fields } => ReadOp::Record {
+                id: id.clone(),
+                offset: offset.clone(),
+                fields: fields
+                    .iter()
+                    .map(|field| FieldReadOp {
+                        name: field.name.clone(),
+                        seq: self.normalize_custom_read_seq(&field.seq),
+                    })
+                    .collect(),
+            },
+            ReadOp::Result {
+                tag_offset,
+                ok,
+                err,
+            } => ReadOp::Result {
+                tag_offset: tag_offset.clone(),
+                ok: Box::new(self.normalize_custom_read_seq(ok)),
+                err: Box::new(self.normalize_custom_read_seq(err)),
+            },
+            ReadOp::Custom { underlying, .. } => self
+                .normalize_custom_read_seq(underlying)
+                .ops
+                .into_iter()
+                .next()
+                .expect("normalized custom read seq cannot be empty"),
+            _ => op.clone(),
+        }
+    }
+
+    pub(super) fn normalize_custom_write_seq(&self, seq: &WriteSeq) -> WriteSeq {
+        if let Some(WriteOp::Custom { underlying, .. }) = seq.ops.first() {
+            return self.normalize_custom_write_seq(underlying);
+        }
+        WriteSeq {
+            size: Self::normalize_custom_size_expr(&seq.size),
+            ops: seq
+                .ops
+                .iter()
+                .map(|op| self.normalize_custom_write_op(op))
+                .collect(),
+            shape: seq.shape,
+        }
+    }
+
+    fn normalize_custom_write_op(&self, op: &WriteOp) -> WriteOp {
+        match op {
+            WriteOp::Option { value, some } => WriteOp::Option {
+                value: value.clone(),
+                some: Box::new(self.normalize_custom_write_seq(some)),
+            },
+            WriteOp::Vec {
+                value,
+                element_type,
+                element,
+                layout,
+            } => WriteOp::Vec {
+                value: value.clone(),
+                element_type: self.normalize_custom_type_expr(element_type),
+                element: Box::new(self.normalize_custom_write_seq(element)),
+                layout: layout.clone(),
+            },
+            WriteOp::Record { id, value, fields } => WriteOp::Record {
+                id: id.clone(),
+                value: value.clone(),
+                fields: fields
+                    .iter()
+                    .map(|field| FieldWriteOp {
+                        name: field.name.clone(),
+                        accessor: field.accessor.clone(),
+                        seq: self.normalize_custom_write_seq(&field.seq),
+                    })
+                    .collect(),
+            },
+            WriteOp::Result { value, ok, err } => WriteOp::Result {
+                value: value.clone(),
+                ok: Box::new(self.normalize_custom_write_seq(ok)),
+                err: Box::new(self.normalize_custom_write_seq(err)),
+            },
+            WriteOp::Custom { underlying, .. } => self
+                .normalize_custom_write_seq(underlying)
+                .ops
+                .into_iter()
+                .next()
+                .expect("normalized custom write seq cannot be empty"),
+            _ => op.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::Lowerer as IrLowerer;
+    use crate::ir::contract::{FfiContract, PackageInfo};
+    use crate::ir::ids::{ConverterPath, CustomTypeId, QualifiedName};
+    use crate::ir::types::{PrimitiveType, TypeExpr};
+
+    use super::super::super::CSharpOptions;
+
+    fn stub_converters() -> ConverterPath {
+        ConverterPath {
+            into_ffi: QualifiedName::new("test_into_ffi"),
+            try_from_ffi: QualifiedName::new("test_try_from_ffi"),
+        }
+    }
+
+    fn datetime_custom() -> CustomTypeDef {
+        CustomTypeDef {
+            id: CustomTypeId::new("UtcDateTime"),
+            rust_type: QualifiedName::new("chrono::DateTime<Utc>"),
+            repr: TypeExpr::Primitive(PrimitiveType::I64),
+            converters: stub_converters(),
+            doc: None,
+        }
+    }
+
+    fn email_custom() -> CustomTypeDef {
+        CustomTypeDef {
+            id: CustomTypeId::new("Email"),
+            rust_type: QualifiedName::new("demo::Email"),
+            repr: TypeExpr::String,
+            converters: stub_converters(),
+            doc: None,
+        }
+    }
+
+    fn empty_contract_with(customs: Vec<CustomTypeDef>) -> FfiContract {
+        let mut contract = FfiContract {
+            package: PackageInfo {
+                name: "demo".into(),
+                version: None,
+            },
+            functions: vec![],
+            catalog: Default::default(),
+        };
+        for c in customs {
+            contract.catalog.insert_custom(c);
+        }
+        contract
+    }
+
+    #[test]
+    fn custom_resolves_to_primitive_repr() {
+        let contract = empty_contract_with(vec![datetime_custom()]);
+        let abi = IrLowerer::new(&contract).to_abi_contract();
+        let options = CSharpOptions::default();
+        let lowerer = CSharpLowerer::new(&contract, &abi, &options);
+
+        let normalized =
+            lowerer.normalize_custom_type_expr(&TypeExpr::Custom(CustomTypeId::new("UtcDateTime")));
+
+        assert!(matches!(
+            normalized,
+            TypeExpr::Primitive(PrimitiveType::I64)
+        ));
+    }
+
+    #[test]
+    fn vec_of_custom_resolves_to_vec_of_repr() {
+        let contract = empty_contract_with(vec![datetime_custom()]);
+        let abi = IrLowerer::new(&contract).to_abi_contract();
+        let options = CSharpOptions::default();
+        let lowerer = CSharpLowerer::new(&contract, &abi, &options);
+
+        let normalized = lowerer.normalize_custom_type_expr(&TypeExpr::Vec(Box::new(
+            TypeExpr::Custom(CustomTypeId::new("UtcDateTime")),
+        )));
+
+        match normalized {
+            TypeExpr::Vec(inner) => {
+                assert!(matches!(*inner, TypeExpr::Primitive(PrimitiveType::I64)))
+            }
+            other => panic!("expected Vec<i64>, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn option_of_custom_string_resolves_to_option_string() {
+        let contract = empty_contract_with(vec![email_custom()]);
+        let abi = IrLowerer::new(&contract).to_abi_contract();
+        let options = CSharpOptions::default();
+        let lowerer = CSharpLowerer::new(&contract, &abi, &options);
+
+        let normalized = lowerer.normalize_custom_type_expr(&TypeExpr::Option(Box::new(
+            TypeExpr::Custom(CustomTypeId::new("Email")),
+        )));
+
+        match normalized {
+            TypeExpr::Option(inner) => assert!(matches!(*inner, TypeExpr::String)),
+            other => panic!("expected Option<String>, got {other:?}"),
+        }
+    }
+}

--- a/boltffi_bindgen/src/render/csharp/lower/decode.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/decode.rs
@@ -200,6 +200,12 @@ pub(crate) fn lower_decode_expr(
                 .into(),
             }
         }
+        ReadOp::Custom { underlying, .. } => {
+            // Custom types erase to their wire repr: the underlying
+            // ReadSeq carries the actual ops, so recurse into it and
+            // the foreign side never sees Custom.
+            lower_decode_expr(underlying, reader, shadowed, namespace, locals)
+        }
         other => todo!(
             "C# backend has not yet implemented decode support for {:?}",
             other

--- a/boltffi_bindgen/src/render/csharp/lower/encode.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/encode.rs
@@ -197,6 +197,12 @@ pub(crate) fn lower_encode_expr(
             };
             vec![length_stmt, foreach_stmt]
         }
+        WriteOp::Custom { underlying, .. } => {
+            // Custom types erase to their wire repr: the underlying
+            // WriteSeq carries the actual ops, so recurse into it and
+            // the foreign side never sees Custom.
+            lower_encode_expr(underlying, writer, renames, locals)
+        }
         other => todo!(
             "C# backend has not yet implemented write support for {:?}",
             other

--- a/boltffi_bindgen/src/render/csharp/lower/functions.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/functions.rs
@@ -67,19 +67,77 @@ impl<'a> CSharpLowerer<'a> {
         if return_type.is_void() {
             return CSharpReturnKind::Void;
         }
-        match return_def {
-            ReturnDef::Value(TypeExpr::String) => CSharpReturnKind::WireDecodeString,
-            ReturnDef::Value(TypeExpr::Record(id)) if !self.is_blittable_record(id) => {
+        let raw_type = match return_def {
+            ReturnDef::Value(t) => t,
+            _ => return CSharpReturnKind::Direct,
+        };
+        // Custom returns always cross as wire-encoded FfiBuf (the macro
+        // wraps the underlying value uniformly). For repr shapes that
+        // already have a wire-decode path (String, Record, Enum, Vec,
+        // Option) the normalized dispatch below produces the right
+        // kind; for Custom<Primitive> the dispatch would otherwise fall
+        // through to Direct, so synthesize a single-op wire decode.
+        let is_custom = matches!(raw_type, TypeExpr::Custom(_));
+        let normalized = self.normalize_custom_type_expr(raw_type);
+        if is_custom && matches!(normalized, TypeExpr::Primitive(_)) {
+            let decode_seq = decode_ops.expect("Custom return must carry decode_ops");
+            let mut locals = decode::DecodeLocalCounters::default();
+            let reader =
+                CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new("reader")));
+            let decode_expr = decode::lower_decode_expr(
+                decode_seq,
+                &reader,
+                shadowed,
+                &self.namespace,
+                &mut locals,
+            );
+            return CSharpReturnKind::WireDecodeValue { decode_expr };
+        }
+        // The macro emits `Vec<Custom<_>>` returns as wire-encoded
+        // (length-prefixed) regardless of repr — Custom is treated as
+        // opaque on the return path, so even `Vec<Custom<i64>>` ships
+        // as `[len][i64][i64]...` rather than the raw blittable layout
+        // a bare `Vec<i64>` would use. Force the encoded-array path
+        // (length-prefix + per-element decode) instead of the
+        // top-level blittable shortcut the normalized dispatch below
+        // would otherwise pick.
+        if let TypeExpr::Vec(raw_inner) = raw_type
+            && matches!(raw_inner.as_ref(), TypeExpr::Custom(_))
+        {
+            let normalized_inner = self.normalize_custom_type_expr(raw_inner);
+            let element_seq = vec_element_read_seq(decode_ops)
+                .expect("Vec<Custom> return must carry decode_ops with a Vec ReadOp");
+            let mut locals = decode::DecodeLocalCounters::default();
+            let closure_var = locals.next_closure_var();
+            let closure_receiver =
+                CSharpExpression::Identity(CSharpIdentity::Local(closure_var.clone()));
+            let body = decode::lower_decode_expr(
+                &element_seq,
+                &closure_receiver,
+                shadowed,
+                &self.namespace,
+                &mut locals,
+            );
+            return CSharpReturnKind::WireDecodeEncodedArray {
+                element_type: CSharpType::from_type_expr(&normalized_inner)
+                    .qualify_if_shadowed_opt(shadowed, &self.namespace),
+                decode_lambda: CSharpExpression::Lambda {
+                    param: closure_var,
+                    body: Box::new(body),
+                },
+            };
+        }
+        match &normalized {
+            TypeExpr::String => CSharpReturnKind::WireDecodeString,
+            TypeExpr::Record(id) if !self.is_blittable_record(id) => {
                 CSharpReturnKind::WireDecodeObject {
                     class_name: id.into(),
                 }
             }
-            ReturnDef::Value(TypeExpr::Enum(id)) if self.is_data_enum(id) => {
-                CSharpReturnKind::WireDecodeObject {
-                    class_name: id.into(),
-                }
-            }
-            ReturnDef::Value(TypeExpr::Vec(inner)) => match inner.as_ref() {
+            TypeExpr::Enum(id) if self.is_data_enum(id) => CSharpReturnKind::WireDecodeObject {
+                class_name: id.into(),
+            },
+            TypeExpr::Vec(inner) => match inner.as_ref() {
                 TypeExpr::Primitive(p) => CSharpReturnKind::WireDecodeBlittablePrimitiveArray {
                     method: decode::top_level_blittable_primitive_array_method(*p),
                     type_arg: decode::top_level_blittable_primitive_array_type_arg(*p),
@@ -111,7 +169,7 @@ impl<'a> CSharpLowerer<'a> {
                     }
                 }
             },
-            ReturnDef::Value(TypeExpr::Option(_)) => {
+            TypeExpr::Option(_) => {
                 let decode_seq = decode_ops.expect("Option return must carry decode_ops");
                 let mut locals = decode::DecodeLocalCounters::default();
                 let reader = CSharpExpression::Identity(CSharpIdentity::Local(

--- a/boltffi_bindgen/src/render/csharp/lower/mod.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/mod.rs
@@ -5,6 +5,7 @@
 mod abi;
 mod admission;
 mod classes;
+mod custom;
 mod decode;
 mod encode;
 mod enumerations;

--- a/boltffi_bindgen/src/render/csharp/lower/predicates.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/predicates.rs
@@ -33,11 +33,14 @@ impl<'a> CSharpLowerer<'a> {
     /// Whether the type can appear as a function param or return today.
     /// Records and enums must be admitted via the supported-set fixed
     /// point; nested options are rejected because C# can't express `T??`.
+    /// `Custom` resolves through to its `repr` since the lowerer erases
+    /// it before emit.
     pub(super) fn is_supported_type(&self, ty: &TypeExpr) -> bool {
         match ty {
             TypeExpr::Primitive(_) | TypeExpr::String | TypeExpr::Void => true,
             TypeExpr::Record(id) => self.supported_records.contains(id),
             TypeExpr::Enum(id) => self.supported_enums.contains(id),
+            TypeExpr::Custom(id) => self.is_supported_type(self.custom_repr_type(id)),
             TypeExpr::Vec(inner) => self.is_supported_vec_element(inner),
             TypeExpr::Option(inner) => {
                 !matches!(inner.as_ref(), TypeExpr::Option(_)) && self.is_supported_type(inner)
@@ -56,6 +59,7 @@ impl<'a> CSharpLowerer<'a> {
             TypeExpr::Primitive(_) | TypeExpr::String => true,
             TypeExpr::Record(id) => self.supported_records.contains(id),
             TypeExpr::Enum(id) => self.supported_enums.contains(id),
+            TypeExpr::Custom(id) => self.is_supported_vec_element(self.custom_repr_type(id)),
             TypeExpr::Vec(inner) => self.is_supported_vec_element(inner),
             TypeExpr::Option(inner) => {
                 !matches!(inner.as_ref(), TypeExpr::Option(_))
@@ -68,14 +72,18 @@ impl<'a> CSharpLowerer<'a> {
     /// Vec element types that pass directly as a pinned `T[]` across
     /// P/Invoke. Primitives qualify (blittable C# value types). Blittable
     /// records qualify (`[StructLayout(Sequential)]` matches Rust
-    /// `#[repr(C)]`). C-style enums do NOT qualify: the Rust `#[export]`
-    /// macro classifies them as `DataTypeCategory::Scalar` and routes
-    /// `Vec<CStyleEnum>` through the wire-encoded path. Admitting them
-    /// here would mismatch the ABI. Tracked in issue #196.
+    /// `#[repr(C)]`). `Custom` resolves through to its `repr` so a
+    /// `Vec<UtcDateTime>` (i64 underneath) rides the pinned-array path
+    /// the macro already produced ABI-side. C-style enums do NOT qualify:
+    /// the Rust `#[export]` macro classifies them as
+    /// `DataTypeCategory::Scalar` and routes `Vec<CStyleEnum>` through
+    /// the wire-encoded path. Admitting them here would mismatch the
+    /// ABI. Tracked in issue #196.
     pub(super) fn is_blittable_vec_element(&self, ty: &TypeExpr) -> bool {
         match ty {
             TypeExpr::Primitive(_) => true,
             TypeExpr::Record(id) => self.is_blittable_record(id),
+            TypeExpr::Custom(id) => self.is_blittable_vec_element(self.custom_repr_type(id)),
             _ => false,
         }
     }

--- a/boltffi_bindgen/src/render/csharp/lower/types.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/types.rs
@@ -22,7 +22,26 @@ impl<'a> CSharpLowerer<'a> {
 
         let csharp_type = self.lower_type(&param.type_expr)?;
         let csharp_param_name: CSharpParamName = (&param.name).into();
-        let kind = match &param.type_expr {
+        // The macro exposes Custom-typed params (and Vec<Custom<_>>
+        // params) as wire-buffer C ABIs regardless of repr — Custom is
+        // treated as opaque on the boundary, so even Vec<Custom<i64>>
+        // ships as a length-prefixed buffer, not a raw `long[]`. Force
+        // the wire-encoded path here so the call site uses the
+        // `_xBytes` local rather than the raw param.
+        let is_custom_boundary = match &param.type_expr {
+            TypeExpr::Custom(_) => true,
+            TypeExpr::Vec(inner) => matches!(inner.as_ref(), TypeExpr::Custom(_)),
+            _ => false,
+        };
+        if is_custom_boundary {
+            return Some(CSharpParamPlan {
+                name: csharp_param_name.clone(),
+                csharp_type,
+                kind: wire_encoded_kind(wire_writers, &param.name)?,
+            });
+        }
+        let normalized = self.normalize_custom_type_expr(&param.type_expr);
+        let kind = match &normalized {
             TypeExpr::String => CSharpParamKind::Utf8Bytes,
             TypeExpr::Record(id) if !self.is_blittable_record(id) => {
                 wire_encoded_kind(wire_writers, &param.name)?
@@ -91,7 +110,8 @@ impl<'a> CSharpLowerer<'a> {
 
     /// Maps a Rust [`TypeExpr`] to its C# equivalent. Returns `None` if
     /// the type isn't admitted by the backend (callbacks, streams,
-    /// records/enums outside the supported sets).
+    /// records/enums outside the supported sets). `Custom` resolves to
+    /// its `repr` so foreign code only sees the wire type.
     pub(super) fn lower_type(&self, type_expr: &TypeExpr) -> Option<CSharpType> {
         match type_expr {
             TypeExpr::Void => Some(CSharpType::Void),
@@ -105,6 +125,7 @@ impl<'a> CSharpLowerer<'a> {
                 let enum_def = self.ffi.catalog.resolve_enum(id)?;
                 Some(CSharpType::for_enum(enum_def))
             }
+            TypeExpr::Custom(id) => self.lower_type(self.custom_repr_type(id)),
             TypeExpr::Vec(inner) if self.is_supported_vec_element(inner) => {
                 let inner_type = self.lower_type(inner)?;
                 Some(CSharpType::Array(Box::new(inner_type)))

--- a/boltffi_bindgen/src/render/csharp/lower/wire_writers.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/wire_writers.rs
@@ -46,16 +46,21 @@ impl<'a> CSharpLowerer<'a> {
         size_locals: &mut size::SizeLocalCounters,
         encode_locals: &mut encode::EncodeLocalCounters,
     ) -> Option<CSharpWireWriterPlan> {
-        let encode_ops = match &param.role {
+        let raw_encode_ops = match &param.role {
             ParamRole::Input {
                 encode_ops: Some(encode_ops),
                 ..
             } => encode_ops.clone(),
             _ => return None,
         };
-        if !self.param_needs_wire_buffer(encode_ops.ops.first()?) {
+        if !self.param_needs_wire_buffer(raw_encode_ops.ops.first()?) {
             return None;
         }
+        // Strip Custom wrappers so downstream encode/size walkers see
+        // only the repr ops; otherwise nested `WriteOp::Vec` whose
+        // element_type is `Custom` would feed a Custom TypeExpr into
+        // `from_type_expr` for the foreach element-type annotation.
+        let encode_ops = self.normalize_custom_write_seq(&raw_encode_ops);
         let param_name: CSharpParamName = (&param.name).into();
         let binding_name = CSharpLocalName::for_wire_writer(&param_name);
         let bytes_binding_name = CSharpLocalName::for_bytes(&param_name);
@@ -97,7 +102,13 @@ impl<'a> CSharpLowerer<'a> {
                 ..
             } => true,
             WriteOp::Option { .. } => true,
-            WriteOp::Result { .. } | WriteOp::Builtin { .. } | WriteOp::Custom { .. } => {
+            // The macro exposes every Custom-typed param as a wire-
+            // buffer signature on the C ABI, even when the repr is a
+            // fixed-width primitive — so we always allocate and write
+            // through the wire path. Sending the underlying value raw
+            // would misalign the Rust decoder.
+            WriteOp::Custom { .. } => true,
+            WriteOp::Result { .. } | WriteOp::Builtin { .. } => {
                 todo!("C# backend has not yet implemented param support for {op:?}")
             }
         }

--- a/boltffi_bindgen/src/render/csharp/plan/callable/function.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callable/function.rs
@@ -110,6 +110,13 @@ pub enum CSharpReturnKind {
     /// expression, evaluated against a `reader` local the template
     /// introduces.
     WireDecodeOption { decode_expr: CSharpExpression },
+    /// `FfiBuf` carrying a single wire-encoded value whose decode is
+    /// not captured by the more specific shapes above. Used today for
+    /// `Custom<Primitive>` returns: the macro side wraps the primitive
+    /// in a wire buffer (so the C ABI is uniform across Custom types),
+    /// and we reuse the same `var reader = ...; return ...;` shape as
+    /// `WireDecodeOption` with a pre-rendered single-op decode.
+    WireDecodeValue { decode_expr: CSharpExpression },
 }
 
 impl CSharpReturnKind {
@@ -131,6 +138,7 @@ impl CSharpReturnKind {
                 | Self::WireDecodeBlittableRecordArray { .. }
                 | Self::WireDecodeEncodedArray { .. }
                 | Self::WireDecodeOption { .. }
+                | Self::WireDecodeValue { .. }
         )
     }
 }

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/class_method.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/class_method.txt
@@ -57,6 +57,8 @@
                 return new WireReader(_buf).ReadEncodedArray<{{ element_type }}>({{ decode_lambda }});
                 {%- when CSharpReturnKind::WireDecodeOption with { decode_expr } %}
                 var reader = new WireReader(_buf); return {{ decode_expr }};
+                {%- when CSharpReturnKind::WireDecodeValue with { decode_expr } %}
+                var reader = new WireReader(_buf); return {{ decode_expr }};
                 {%- when _ %}
                 {%- endmatch %}
             }

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/functions.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/functions.txt
@@ -53,6 +53,8 @@
                 return new WireReader(_buf).ReadEncodedArray<{{ element_type }}>({{ decode_lambda }});
                 {%- when CSharpReturnKind::WireDecodeOption with { decode_expr } %}
                 var reader = new WireReader(_buf); return {{ decode_expr }};
+                {%- when CSharpReturnKind::WireDecodeValue with { decode_expr } %}
+                var reader = new WireReader(_buf); return {{ decode_expr }};
                 {%- when _ %}
                 {%- endmatch %}
             }

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/value_type_method.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/value_type_method.txt
@@ -55,6 +55,8 @@
                 return new WireReader(_buf).ReadEncodedArray<{{ element_type }}>({{ decode_lambda }});
                 {%- when CSharpReturnKind::WireDecodeOption with { decode_expr } %}
                 var reader = new WireReader(_buf); return {{ decode_expr }};
+                {%- when CSharpReturnKind::WireDecodeValue with { decode_expr } %}
+                var reader = new WireReader(_buf); return {{ decode_expr }};
                 {%- when _ %}
                 {%- endmatch %}
             }

--- a/examples/demo/src/custom_types/mod.rs
+++ b/examples/demo/src/custom_types/mod.rs
@@ -88,3 +88,13 @@ pub fn echo_event(event: Event) -> Event {
 pub fn event_timestamp(event: Event) -> i64 {
     event.timestamp.timestamp_millis()
 }
+
+#[export]
+pub fn echo_emails(emails: Vec<Email>) -> Vec<Email> {
+    emails
+}
+
+#[export]
+pub fn echo_datetimes(dts: Vec<DateTime<Utc>>) -> Vec<DateTime<Utc>> {
+    dts
+}

--- a/examples/platforms/apple/Tests/DemoConsumerTests/custom_types/CustomTypesTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/custom_types/CustomTypesTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class CustomTypesTests: XCTestCase {
     func testCustomTypesRoundTrip() {
-        let email = "ali@example.com"
+        let email = "café@example.com"
         XCTAssertEqual(echoEmail(email: email), email)
         XCTAssertEqual(emailDomain(email: email), "example.com")
 
@@ -17,5 +17,11 @@ final class CustomTypesTests: XCTestCase {
         let echoedEvent = echoEvent(event: event)
         XCTAssertEqual(echoedEvent, event)
         XCTAssertEqual(eventTimestamp(event: event), datetime)
+
+        let emails = ["café@example.com", "user@example.org"]
+        XCTAssertEqual(echoEmails(emails: emails), emails)
+
+        let dts: [UtcDateTime] = [1_710_000_000_000, 1_710_000_001_000, 1_710_000_002_000]
+        XCTAssertEqual(echoDatetimes(dts: dts), dts)
     }
 }

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -199,6 +199,18 @@ public static class DemoTest
         Require(echoed.Timestamp == ts, "EchoEvent.Timestamp");
         Require(EventTimestamp(evt) == ts, "EventTimestamp");
 
+        string[] emails = new[] { "café@example.com", "user@example.org" };
+        string[] echoedEmails = EchoEmails(emails);
+        Require(echoedEmails.Length == 2, "EchoEmails length");
+        Require(echoedEmails[0] == "café@example.com", "EchoEmails[0] roundtrip (utf-8)");
+        Require(echoedEmails[1] == "user@example.org", "EchoEmails[1] roundtrip");
+
+        long[] dts = new[] { 1_710_000_000_000L, 1_710_000_001_000L, 1_710_000_002_000L };
+        long[] echoedDts = EchoDatetimes(dts);
+        Require(echoedDts.Length == 3, "EchoDatetimes length");
+        Require(echoedDts[0] == dts[0] && echoedDts[1] == dts[1] && echoedDts[2] == dts[2],
+            "EchoDatetimes roundtrip (blittable)");
+
         Console.WriteLine("  PASS\n");
     }
 

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -24,6 +24,7 @@ public static class DemoTest
         TestUsize();
         TestIsize();
         TestStrings();
+        TestCustomTypes();
         TestBlittableRecords();
         TestRecordsWithStrings();
         TestNestedRecords();
@@ -176,6 +177,28 @@ public static class DemoTest
         Require(RepeatString("ab", 3u) == "ababab", "repeatString(ab, 3)");
         Require(RepeatString("x", 0u) == "", "repeatString(x, 0)");
         Require(RepeatString("🌟", 2u) == "🌟🌟", "repeatString(emoji, 2)");
+        Console.WriteLine("  PASS\n");
+    }
+
+    private static void TestCustomTypes()
+    {
+        Console.WriteLine("Testing custom types (Email, UtcDateTime, Event)...");
+
+        string email = "café@example.com";
+        Require(EchoEmail(email) == email, "EchoEmail roundtrip");
+        Require(EmailDomain(email) == "example.com", "EmailDomain");
+
+        long ts = 1_710_000_000_000L;
+        Require(EchoDatetime(ts) == ts, "EchoDatetime");
+        Require(DatetimeToMillis(ts) == ts, "DatetimeToMillis");
+        Require(FormatTimestamp(ts).StartsWith("2024-03-"), "FormatTimestamp");
+
+        Event evt = new Event("launch", ts);
+        Event echoed = EchoEvent(evt);
+        Require(echoed.Name == "launch", "EchoEvent.Name");
+        Require(echoed.Timestamp == ts, "EchoEvent.Timestamp");
+        Require(EventTimestamp(evt) == ts, "EventTimestamp");
+
         Console.WriteLine("  PASS\n");
     }
 

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -116,6 +116,23 @@ public final class DemoTest {
         assert echoed.name().equals("launch") : "echoEvent.name";
         assert echoed.timestamp() == timestamp : "echoEvent.timestamp";
         assert Demo.eventTimestamp(event) == timestamp : "eventTimestamp";
+
+        String email = "café@example.com";
+        assert Demo.echoEmail(email).equals(email) : "echoEmail roundtrip";
+        assert Demo.emailDomain(email).equals("example.com") : "emailDomain";
+
+        List<String> emails = Arrays.asList("café@example.com", "user@example.org");
+        List<String> echoedEmails = Demo.echoEmails(emails);
+        assert echoedEmails.size() == 2 : "echoEmails length";
+        assert echoedEmails.get(0).equals("café@example.com") : "echoEmails[0] (utf-8)";
+        assert echoedEmails.get(1).equals("user@example.org") : "echoEmails[1]";
+
+        long[] dts = { 1_710_000_000_000L, 1_710_000_001_000L, 1_710_000_002_000L };
+        long[] echoedDts = Demo.echoDatetimes(dts);
+        assert echoedDts.length == 3 : "echoDatetimes length";
+        assert echoedDts[0] == dts[0] && echoedDts[1] == dts[1] && echoedDts[2] == dts[2]
+            : "echoDatetimes roundtrip";
+
         System.out.println("  PASS\n");
     }
 

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
@@ -45,7 +45,7 @@ class DemoValueTypesTest {
         val emails = listOf("café@example.com", "user@example.org")
         assertContentEquals(emails, echoEmails(emails))
 
-        val datetimes = longArrayOf(1_710_000_000_000L, 1_710_000_001_000L, 1_710_000_002_000L)
+        val datetimes = listOf<Long>(1_710_000_000_000L, 1_710_000_001_000L, 1_710_000_002_000L)
         assertContentEquals(datetimes, echoDatetimes(datetimes))
     }
 

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
@@ -34,7 +34,7 @@ class DemoValueTypesTest {
         assertEquals(url, echoUrl(url))
         assertEquals(url.toString(), urlToString(url))
 
-        val email = "ali@example.com"
+        val email = "café@example.com"
         assertEquals(email, echoEmail(email))
         assertEquals("example.com", emailDomain(email))
 
@@ -42,6 +42,11 @@ class DemoValueTypesTest {
         assertEquals(datetime, echoDatetime(datetime))
         assertEquals(1_701_234_567_890L, datetimeToMillis(datetime))
 
+        val emails = listOf("café@example.com", "user@example.org")
+        assertContentEquals(emails, echoEmails(emails))
+
+        val datetimes = longArrayOf(1_710_000_000_000L, 1_710_000_001_000L, 1_710_000_002_000L)
+        assertContentEquals(datetimes, echoDatetimes(datetimes))
     }
 
     @Test

--- a/examples/platforms/wasm/tests/custom_types/mod.test.mjs
+++ b/examples/platforms/wasm/tests/custom_types/mod.test.mjs
@@ -1,7 +1,7 @@
 import { assert, demo } from "../support/index.mjs";
 
 export async function run() {
-  const email = "ali@example.com";
+  const email = "café@example.com";
   assert.equal(demo.echoEmail(email), email);
   assert.equal(demo.emailDomain(email), "example.com");
 
@@ -13,4 +13,10 @@ export async function run() {
   const event = { name: "launch", timestamp: datetime };
   assert.deepEqual(demo.echoEvent(event), event);
   assert.equal(demo.eventTimestamp(event), datetime);
+
+  const emails = ["café@example.com", "user@example.org"];
+  assert.deepEqual(demo.echoEmails(emails), emails);
+
+  const dts = [1_710_000_000_000n, 1_710_000_001_000n, 1_710_000_002_000n];
+  assert.deepEqual(demo.echoDatetimes(dts), dts);
 }


### PR DESCRIPTION
This implements new types as a part of #146 through the `#[custom_ffi]` attribute, which passes over a wire encoded line even if it's a primitive, which threw me off at first. I wonder if we could squeeze some performance out of it by supporting primitives, but I followed Java as an example.

I also found a couple of additional test cases that I added to demo and extended to the others.