### PR TITLE
Introduce a dedicated AST crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["boltffi", "boltffi_core", "boltffi_macros", "boltffi_bindgen", "boltffi_cli", "boltffi_ffi_rules", "boltffi_verify", "boltffi_tests"]
+members = ["boltffi", "boltffi_core", "boltffi_macros", "boltffi_bindgen", "boltffi_cli", "boltffi_ffi_rules", "boltffi_ast", "boltffi_verify", "boltffi_tests"]
 exclude = ["benchmarks/adapters/uniffi", "examples/demo"]
 
 [workspace.package]
@@ -16,6 +16,7 @@ boltffi_core = { version = "0.24.1", path = "boltffi_core" }
 boltffi_macros = { version = "0.24.1", path = "boltffi_macros" }
 boltffi_bindgen = { version = "0.24.1", path = "boltffi_bindgen" }
 boltffi_ffi_rules = { version = "0.24.1", path = "boltffi_ffi_rules" }
+boltffi_ast = { version = "0.24.1", path = "boltffi_ast" }
 boltffi_verify = { version = "0.24.1", path = "boltffi_verify" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/boltffi_ast/Cargo.toml
+++ b/boltffi_ast/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "boltffi_ast"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Canonical source AST for BoltFFI exported Rust APIs"
+keywords = ["ffi", "ast", "metadata", "bindings"]
+categories = ["development-tools::ffi"]
+
+[dependencies]
+serde.workspace = true
+
+[lints]
+workspace = true

--- a/boltffi_ast/src/attribute.rs
+++ b/boltffi_ast/src/attribute.rs
@@ -1,0 +1,96 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{ConstExpr, Path, Primitive};
+
+/// A Rust attribute that BoltFFI keeps with the item it was written on.
+///
+/// Some attributes are meaningful to BoltFFI today, while others are useful
+/// context for generated documentation and validation. Keeping the path and
+/// input together lets consumers inspect attributes without reparsing the
+/// original token stream.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct UserAttr {
+    /// Attribute path, such as `serde::rename`.
+    pub path: Path,
+    /// Attribute input after the path.
+    pub input: AttributeInput,
+}
+
+impl UserAttr {
+    /// Builds an attribute from its path and input.
+    ///
+    /// The `path` parameter identifies the attribute. The `input` parameter
+    /// stores the tokens or structured constant expression written after it.
+    ///
+    /// Returns the attribute exactly at the level the scanner understands it.
+    pub fn new(path: Path, input: AttributeInput) -> Self {
+        Self { path, input }
+    }
+}
+
+/// The input written after an attribute path.
+///
+/// Common forms use structured values. More complex forms can stay as tokens
+/// until a consumer needs to understand them.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum AttributeInput {
+    /// An attribute without input, such as `#[data]`.
+    Empty,
+    /// A name-value attribute input.
+    Value(ConstExpr),
+    /// A parenthesized list of nested attribute inputs.
+    List(Vec<AttributeInput>),
+    /// Raw tokens kept for attribute forms outside the structured subset.
+    Tokens(String),
+}
+
+/// Representation hints written with `#[repr(...)]`.
+///
+/// Rust permits more than one `repr` attribute on the same item and more than
+/// one argument inside a single attribute. `ReprAttr` stores the parsed items in
+/// source order so callers can inspect the whole representation request without
+/// walking raw attributes again.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ReprAttr {
+    /// Items written inside all `repr` attributes attached to the declaration.
+    pub items: Vec<ReprItem>,
+}
+
+impl ReprAttr {
+    /// Builds representation hints from parsed `repr` items.
+    ///
+    /// The `items` parameter keeps items in source order across every `repr`
+    /// attribute on the same declaration.
+    ///
+    /// Returns representation metadata in the same order it was written.
+    pub fn new(items: Vec<ReprItem>) -> Self {
+        Self { items }
+    }
+
+    /// Returns a representation with no `repr` hints.
+    ///
+    /// Use this for declarations where the author did not write `#[repr(...)]`.
+    pub fn none() -> Self {
+        Self::default()
+    }
+}
+
+/// One argument inside `#[repr(...)]`.
+///
+/// Each variant mirrors a spelling Rust accepts in representation attributes,
+/// while `Other` keeps uncommon or future arguments visible to diagnostics.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum ReprItem {
+    /// `repr(C)`.
+    C,
+    /// `repr(transparent)`.
+    Transparent,
+    /// An integer representation such as `repr(u8)` or `repr(i32)`.
+    Primitive(Primitive),
+    /// `repr(packed)` or `repr(packed(N))`.
+    Packed(Option<u16>),
+    /// `repr(align(N))`.
+    Align(u16),
+    /// A repr item outside the structured subset.
+    Other(String),
+}

--- a/boltffi_ast/src/callable.rs
+++ b/boltffi_ast/src/callable.rs
@@ -1,0 +1,273 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{DeprecationInfo, DocComment, MethodId, Source, SourceSpan, TypeExpr, UserAttr};
+
+/// The place where a callable appears in the Rust API.
+///
+/// Free functions, methods with receivers, and associated functions without
+/// receivers are all callable, but they live in different parts of Rust source.
+/// This enum keeps that source placement close to the signature.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum CallableForm {
+    /// A free function.
+    Function,
+    /// A method with a receiver.
+    Method,
+    /// An associated function without a receiver.
+    AssociatedFunction,
+}
+
+/// Whether a callable was written as synchronous or asynchronous Rust.
+///
+/// The value comes directly from the Rust signature. A function written with
+/// `async fn` is `Async`; every other callable is `Sync`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum ExecutionKind {
+    /// A callable without `async`.
+    Sync,
+    /// A callable written with `async`.
+    Async,
+}
+
+/// A parameter in a function, method, or callback method.
+///
+/// The parameter records both the type and the way it was accepted by Rust,
+/// such as by value, by shared reference, or by mutable reference.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ParamDef {
+    /// Canonical parameter name.
+    pub name: crate::CanonicalName,
+    /// Source type expression after known FFI names have been identified.
+    pub ty: TypeExpr,
+    /// How the parameter was accepted by the Rust callable.
+    pub passing: ParamPassing,
+    /// Documentation attached to the parameter when the source provides it.
+    pub doc: Option<DocComment>,
+    /// Default value written for bindings that expose default arguments.
+    pub default: Option<crate::DefaultValue>,
+    /// User attributes preserved from the source parameter.
+    pub user_attrs: Vec<UserAttr>,
+    /// Visibility and source location for diagnostics.
+    pub source: Source,
+}
+
+impl ParamDef {
+    /// Builds a value parameter with no documentation, attributes, or default.
+    ///
+    /// The `name` parameter is the canonical parameter name. The `ty` parameter
+    /// is the scanned source type expression.
+    ///
+    /// Returns a parameter that was passed by value in Rust source.
+    pub fn value(name: crate::CanonicalName, ty: TypeExpr) -> Self {
+        Self {
+            name,
+            ty,
+            passing: ParamPassing::Value,
+            doc: None,
+            default: None,
+            user_attrs: Vec::new(),
+            source: Source::exported(),
+        }
+    }
+}
+
+/// The Rust passing form used by a parameter.
+///
+/// The variants mirror the forms BoltFFI accepts in exported signatures. A
+/// consumer can distinguish `&T`, `&mut T`, `impl Trait`, and `Box<dyn Trait>`
+/// without inspecting raw Rust syntax.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum ParamPassing {
+    /// A value parameter such as `value: T`.
+    Value,
+    /// A shared reference parameter such as `value: &T`.
+    Ref,
+    /// A mutable reference parameter such as `value: &mut T`.
+    RefMut,
+    /// An `impl Trait` callback parameter.
+    ImplTrait,
+    /// A boxed trait object callback parameter.
+    BoxedDyn,
+}
+
+/// The outermost return type of a callable.
+///
+/// Fallible callables get their own variant. Everything else the callable can
+/// return, including `Option<T>`, `(A, B)`, `Vec<T>`, records, enums, classes,
+/// callbacks, and custom types, is represented as `Value(TypeExpr)`.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum ReturnDef {
+    /// The callable returns `()`.
+    Void,
+    /// The callable returns one non-fallible value.
+    ///
+    /// This includes tuples and options. For example, `fn pair() -> (u32,
+    /// String)` is `Value(TypeExpr::Tuple(_))`, and `fn maybe() -> Option<T>`
+    /// is `Value(TypeExpr::Option(_))`.
+    Value(TypeExpr),
+    /// The callable returns `Result<T, E>`.
+    ///
+    /// The success type may itself be any ordinary type expression, including a
+    /// tuple or option.
+    Result {
+        /// Success type written by the Rust callable.
+        ok: TypeExpr,
+        /// Error type written by the Rust callable.
+        err: TypeExpr,
+    },
+}
+
+impl ReturnDef {
+    /// Builds a return definition from an optional value type.
+    ///
+    /// The `ty` parameter is `None` for `()` and `Some` for a returned value.
+    ///
+    /// Returns `Void` for no value and `Value` for a present type expression.
+    pub fn from_value(ty: Option<TypeExpr>) -> Self {
+        match ty {
+            Some(ty) => Self::Value(ty),
+            None => Self::Void,
+        }
+    }
+}
+
+/// The receiver written on a Rust method.
+///
+/// This is the part of the method signature before the ordinary parameters:
+/// no receiver, `&self`, `&mut self`, or `self`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum Receiver {
+    /// A method with no receiver.
+    None,
+    /// A method taking `&self`.
+    Shared,
+    /// A method taking `&mut self`.
+    Mutable,
+    /// A method taking `self`.
+    Owned,
+}
+
+impl Receiver {
+    /// Returns the callable form implied by the receiver.
+    ///
+    /// The return value is the callable form implied by the receiver alone.
+    pub const fn callable_form(self) -> CallableForm {
+        match self {
+            Self::None => CallableForm::AssociatedFunction,
+            Self::Shared | Self::Mutable | Self::Owned => CallableForm::Method,
+        }
+    }
+}
+
+/// A free function exported from the source contract.
+///
+/// Functions are top-level callable declarations. Methods attached to records,
+/// enums, classes, and callbacks use their own node types so ownership remains
+/// explicit.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct FunctionDef {
+    /// Stable function identity derived from its canonical source path.
+    pub id: crate::FunctionId,
+    /// Canonical function name.
+    pub name: crate::CanonicalName,
+    /// Source callable form. For free functions this is always `Function`.
+    pub form: CallableForm,
+    /// Whether the Rust source used `async`.
+    pub execution: ExecutionKind,
+    /// Parameters written by the Rust function.
+    pub params: Vec<ParamDef>,
+    /// Return type written by the Rust function.
+    pub returns: ReturnDef,
+    /// Documentation attached to the function.
+    pub doc: Option<DocComment>,
+    /// Deprecation metadata attached to the function.
+    pub deprecated: Option<DeprecationInfo>,
+    /// User attributes preserved from the function.
+    pub user_attrs: Vec<UserAttr>,
+    /// Visibility and source location for diagnostics.
+    pub source: Source,
+    /// Span available during macro expansion.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub source_span: Option<SourceSpan>,
+}
+
+impl FunctionDef {
+    /// Builds a synchronous free function with no parameters and no return value.
+    ///
+    /// The `id` parameter is the stable function ID. The `name` parameter is the
+    /// canonical source name.
+    ///
+    /// Returns a function definition ready for the scanner to fill with source
+    /// details.
+    pub fn new(id: crate::FunctionId, name: crate::CanonicalName) -> Self {
+        Self {
+            id,
+            name,
+            form: CallableForm::Function,
+            execution: ExecutionKind::Sync,
+            params: Vec::new(),
+            returns: ReturnDef::Void,
+            doc: None,
+            deprecated: None,
+            user_attrs: Vec::new(),
+            source: Source::exported(),
+            source_span: None,
+        }
+    }
+}
+
+/// A method attached to a record, enum, class, or callback trait.
+///
+/// The owning declaration contains the method, so the method itself only needs
+/// its local identity, receiver, signature, attributes, and documentation.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct MethodDef {
+    /// Stable method identity within the owning declaration.
+    pub id: MethodId,
+    /// Canonical method name.
+    pub name: crate::CanonicalName,
+    /// Receiver written on the Rust method.
+    pub receiver: Receiver,
+    /// Whether the Rust source used `async`.
+    pub execution: ExecutionKind,
+    /// Parameters after the receiver.
+    pub params: Vec<ParamDef>,
+    /// Return type written by the Rust method.
+    pub returns: ReturnDef,
+    /// Documentation attached to the method.
+    pub doc: Option<DocComment>,
+    /// Deprecation metadata attached to the method.
+    pub deprecated: Option<DeprecationInfo>,
+    /// User attributes preserved from the method.
+    pub user_attrs: Vec<UserAttr>,
+    /// Visibility and source location for diagnostics.
+    pub source: Source,
+    /// Span available during macro expansion.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub source_span: Option<SourceSpan>,
+}
+
+impl MethodDef {
+    /// Builds a synchronous method with no parameters and no return value.
+    ///
+    /// The `id` parameter is stable within the owning declaration. The `name`
+    /// parameter is the canonical source method name. The `receiver` parameter
+    /// records how `self` was written.
+    ///
+    /// Returns a method definition ready for scan-time details.
+    pub fn new(id: MethodId, name: crate::CanonicalName, receiver: Receiver) -> Self {
+        Self {
+            id,
+            name,
+            receiver,
+            execution: ExecutionKind::Sync,
+            params: Vec::new(),
+            returns: ReturnDef::Void,
+            doc: None,
+            deprecated: None,
+            user_attrs: Vec::new(),
+            source: Source::exported(),
+            source_span: None,
+        }
+    }
+}

--- a/boltffi_ast/src/callback.rs
+++ b/boltffi_ast/src/callback.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CallbackId, CanonicalName, DeprecationInfo, DocComment, MethodDef, Source, SourceSpan, UserAttr,
+};
+
+/// A callback trait exported through BoltFFI.
+///
+/// This represents a Rust trait whose methods can be implemented outside Rust.
+/// Inline closure parameters use [`TypeExpr::Closure`](crate::TypeExpr::Closure)
+/// instead of pretending to be trait declarations.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct CallbackTraitDef {
+    /// Stable callback trait identity derived from the canonical Rust path.
+    pub id: CallbackId,
+    /// Canonical trait name.
+    pub name: CanonicalName,
+    /// Methods that the callback implementer must provide.
+    pub methods: Vec<MethodDef>,
+    /// User attributes preserved from the callback declaration.
+    pub user_attrs: Vec<UserAttr>,
+    /// Documentation attached to the callback.
+    pub doc: Option<DocComment>,
+    /// Deprecation metadata attached to the callback.
+    pub deprecated: Option<DeprecationInfo>,
+    /// Visibility and source location for diagnostics.
+    pub source: Source,
+    /// Span available during macro expansion.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub source_span: Option<SourceSpan>,
+}
+
+impl CallbackTraitDef {
+    /// Builds an empty callback trait definition.
+    ///
+    /// The `id` parameter is the stable callback ID. The `name` parameter is the
+    /// canonical callback trait name.
+    ///
+    /// Returns a callback definition with no methods or attributes.
+    pub fn new(id: CallbackId, name: CanonicalName) -> Self {
+        Self {
+            id,
+            name,
+            methods: Vec::new(),
+            user_attrs: Vec::new(),
+            doc: None,
+            deprecated: None,
+            source: Source::exported(),
+            source_span: None,
+        }
+    }
+}

--- a/boltffi_ast/src/class.rs
+++ b/boltffi_ast/src/class.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CanonicalName, ClassId, DeprecationInfo, DocComment, MethodDef, Source, SourceSpan, UserAttr,
+};
+
+/// A class-style Rust object exported through BoltFFI.
+///
+/// A class groups associated functions and methods around an owned
+/// Rust value. Associated functions that return `Self` stay as methods here;
+/// binding layers can present them as creation entry points later.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ClassDef {
+    /// Stable class identity derived from the canonical Rust path.
+    pub id: ClassId,
+    /// Canonical class name.
+    pub name: CanonicalName,
+    /// Methods attached to the class.
+    pub methods: Vec<MethodDef>,
+    /// User attributes preserved from the class declaration.
+    pub user_attrs: Vec<UserAttr>,
+    /// Documentation attached to the class.
+    pub doc: Option<DocComment>,
+    /// Deprecation metadata attached to the class.
+    pub deprecated: Option<DeprecationInfo>,
+    /// Visibility and source location for diagnostics.
+    pub source: Source,
+    /// Span available during macro expansion.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub source_span: Option<SourceSpan>,
+}
+
+impl ClassDef {
+    /// Builds an empty class definition.
+    ///
+    /// The `id` parameter is the stable class ID. The `name` parameter is the
+    /// canonical source name.
+    ///
+    /// Returns a class with no methods, attributes, or docs.
+    pub fn new(id: ClassId, name: CanonicalName) -> Self {
+        Self {
+            id,
+            name,
+            methods: Vec::new(),
+            user_attrs: Vec::new(),
+            doc: None,
+            deprecated: None,
+            source: Source::exported(),
+            source_span: None,
+        }
+    }
+}

--- a/boltffi_ast/src/constant.rs
+++ b/boltffi_ast/src/constant.rs
@@ -1,0 +1,57 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CanonicalName, ConstExpr, ConstantId, DeprecationInfo, DocComment, Source, SourceSpan,
+    TypeExpr, UserAttr,
+};
+
+/// A constant exported in the source contract.
+///
+/// Constants keep the declared type and the expression the scanner was able to
+/// preserve. This lets generated bindings expose named values without treating
+/// them as zero-argument functions.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ConstantDef {
+    /// Stable constant identity derived from the canonical Rust path.
+    pub id: ConstantId,
+    /// Canonical constant name.
+    pub name: CanonicalName,
+    /// Declared source type.
+    pub ty: TypeExpr,
+    /// Source expression used as the constant value.
+    pub value: ConstExpr,
+    /// User attributes preserved from the constant.
+    pub user_attrs: Vec<UserAttr>,
+    /// Documentation attached to the constant.
+    pub doc: Option<DocComment>,
+    /// Deprecation metadata attached to the constant.
+    pub deprecated: Option<DeprecationInfo>,
+    /// Visibility and source location for diagnostics.
+    pub source: Source,
+    /// Span available during macro expansion.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub source_span: Option<SourceSpan>,
+}
+
+impl ConstantDef {
+    /// Builds a constant definition.
+    ///
+    /// The `id` parameter is the stable constant ID. The `name` parameter is the
+    /// canonical constant name. The `ty` and `value` parameters record the
+    /// source declaration.
+    ///
+    /// Returns a constant with no attributes, documentation, or deprecation.
+    pub fn new(id: ConstantId, name: CanonicalName, ty: TypeExpr, value: ConstExpr) -> Self {
+        Self {
+            id,
+            name,
+            ty,
+            value,
+            user_attrs: Vec::new(),
+            doc: None,
+            deprecated: None,
+            source: Source::exported(),
+            source_span: None,
+        }
+    }
+}

--- a/boltffi_ast/src/contract.rs
+++ b/boltffi_ast/src/contract.rs
@@ -1,0 +1,82 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CallbackTraitDef, ClassDef, ConstantDef, CustomTypeDef, EnumDef, FunctionDef, RecordDef,
+    StreamDef,
+};
+
+/// Package metadata for the crate that produced a source contract.
+///
+/// The package name and version travel with the declarations, so a serialized
+/// contract can still say which Rust crate produced it.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct PackageInfo {
+    /// Cargo package name.
+    pub name: String,
+    /// Cargo package version, when the scanner has it.
+    pub version: Option<String>,
+}
+
+impl PackageInfo {
+    /// Builds package metadata.
+    ///
+    /// The `name` parameter is the Cargo package name. The `version` parameter
+    /// is the optional Cargo package version.
+    ///
+    /// Returns package information suitable for the top-level source contract.
+    pub fn new(name: impl Into<String>, version: Option<String>) -> Self {
+        Self {
+            name: name.into(),
+            version,
+        }
+    }
+}
+
+/// The source contract produced by scanning one Rust crate.
+///
+/// This is the top-level value of `boltffi_ast`: every exported declaration
+/// grouped by kind, with package metadata next to it. Separate lists keep each
+/// declaration family in its own strongly typed collection.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SourceContract {
+    /// Package that owns the exported declarations.
+    pub package: PackageInfo,
+    /// Records exported by the crate.
+    pub records: Vec<RecordDef>,
+    /// Enums exported by the crate.
+    pub enums: Vec<EnumDef>,
+    /// Free functions exported by the crate.
+    pub functions: Vec<FunctionDef>,
+    /// Class-style objects exported by the crate.
+    pub classes: Vec<ClassDef>,
+    /// Callback traits and synthesized closure callbacks visible to the FFI surface.
+    pub callbacks: Vec<CallbackTraitDef>,
+    /// Streams exported by the crate.
+    pub streams: Vec<StreamDef>,
+    /// Constants exported by the crate.
+    pub constants: Vec<ConstantDef>,
+    /// Custom type declarations exported by the crate.
+    pub customs: Vec<CustomTypeDef>,
+}
+
+impl SourceContract {
+    /// Builds an empty source contract for a package.
+    ///
+    /// The `package` parameter identifies the Cargo package that produced the
+    /// contract.
+    ///
+    /// Returns a contract ready for the scanner to fill with declarations.
+    pub fn new(package: PackageInfo) -> Self {
+        Self {
+            package,
+            records: Vec::new(),
+            enums: Vec::new(),
+            functions: Vec::new(),
+            classes: Vec::new(),
+            callbacks: Vec::new(),
+            streams: Vec::new(),
+            constants: Vec::new(),
+            customs: Vec::new(),
+        }
+    }
+}

--- a/boltffi_ast/src/custom.rs
+++ b/boltffi_ast/src/custom.rs
@@ -1,0 +1,94 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CanonicalName, CustomTypeId, DeprecationInfo, DocComment, Path, Source, SourceSpan, TypeExpr,
+    UserAttr,
+};
+
+/// A user-declared custom type.
+///
+/// Custom types describe a Rust type that should be exposed through a different
+/// representation type, together with the Rust functions that convert between
+/// the two.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct CustomTypeDef {
+    /// Stable custom type identity derived from the canonical Rust path.
+    pub id: CustomTypeId,
+    /// Canonical custom type name.
+    pub name: CanonicalName,
+    /// Remote Rust type being represented.
+    pub remote: TypeExpr,
+    /// Source representation type used at the FFI surface.
+    pub repr: TypeExpr,
+    /// Converter functions supplied by the source declaration.
+    pub converters: CustomTypeConverters,
+    /// User attributes preserved from the custom type declaration.
+    pub user_attrs: Vec<UserAttr>,
+    /// Documentation attached to the custom type.
+    pub doc: Option<DocComment>,
+    /// Deprecation metadata attached to the custom type.
+    pub deprecated: Option<DeprecationInfo>,
+    /// Visibility and source location for diagnostics.
+    pub source: Source,
+    /// Span available during macro expansion.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub source_span: Option<SourceSpan>,
+}
+
+impl CustomTypeDef {
+    /// Builds a custom type definition.
+    ///
+    /// The `id` parameter is the stable custom type ID. The `name` parameter is
+    /// the canonical source name. The `remote`, `repr`, and `converters`
+    /// parameters record the user-declared conversion surface.
+    ///
+    /// Returns a custom type with no user attributes or documentation.
+    pub fn new(
+        id: CustomTypeId,
+        name: CanonicalName,
+        remote: TypeExpr,
+        repr: TypeExpr,
+        converters: CustomTypeConverters,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            remote,
+            repr,
+            converters,
+            user_attrs: Vec::new(),
+            doc: None,
+            deprecated: None,
+            source: Source::exported(),
+            source_span: None,
+        }
+    }
+}
+
+/// Converter functions attached to a custom type declaration.
+///
+/// The paths name the Rust functions used to cross between the remote type and
+/// the representation type.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct CustomTypeConverters {
+    /// Function that turns the remote Rust value into the representation type.
+    pub into_ffi: Path,
+    /// Function that attempts to rebuild the remote Rust value from the representation type.
+    pub try_from_ffi: Path,
+}
+
+impl CustomTypeConverters {
+    /// Builds a pair of custom type converter paths.
+    ///
+    /// The `into_ffi` parameter names the conversion into the representation.
+    /// The `try_from_ffi` parameter names the fallible conversion back into the
+    /// remote Rust type.
+    ///
+    /// Returns converter metadata for the custom type declaration.
+    pub fn new(into_ffi: Path, try_from_ffi: Path) -> Self {
+        Self {
+            into_ffi,
+            try_from_ffi,
+        }
+    }
+}

--- a/boltffi_ast/src/documentation.rs
+++ b/boltffi_ast/src/documentation.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+
+/// Documentation collected from Rust doc comments.
+///
+/// The text is the body of the Rust documentation after the leading doc markers
+/// have been removed. It stays as text in the Rustdoc-flavored Markdown format
+/// the author wrote.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DocComment(String);
+
+impl DocComment {
+    /// Builds documentation from scanner-collected text.
+    ///
+    /// The `text` parameter should be the doc comment body after Rust has
+    /// stripped the leading doc markers. The text is stored unchanged.
+    ///
+    /// Returns a doc comment value suitable for attaching to declarations,
+    /// fields, variants, parameters, and callables.
+    pub fn new(text: impl Into<String>) -> Self {
+        Self(text.into())
+    }
+
+    /// Returns the documentation body.
+    ///
+    /// The returned value is the documentation body.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Deprecation metadata collected from Rust attributes.
+///
+/// This mirrors the useful parts of Rust's `deprecated` attribute: an optional
+/// human note and an optional version string.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeprecationInfo {
+    /// Optional message supplied by the Rust author.
+    pub note: Option<String>,
+    /// Optional version string supplied by the Rust author.
+    pub since: Option<String>,
+}
+
+impl DeprecationInfo {
+    /// Builds deprecation metadata from optional attribute parts.
+    ///
+    /// The `note` parameter carries the human-facing deprecation reason. The
+    /// `since` parameter carries the version string when the attribute included
+    /// one.
+    ///
+    /// Returns deprecation metadata with the note and version string preserved.
+    pub fn new(note: Option<String>, since: Option<String>) -> Self {
+        Self { note, since }
+    }
+}

--- a/boltffi_ast/src/enumeration.rs
+++ b/boltffi_ast/src/enumeration.rs
@@ -1,0 +1,114 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CanonicalName, DeprecationInfo, DocComment, EnumId, FieldDef, ReprAttr, Source, SourceSpan,
+    TypeExpr, UserAttr,
+};
+
+/// A Rust enum exported through BoltFFI.
+///
+/// An enum keeps the public shape of the Rust declaration: variants,
+/// discriminants, payloads, representation hints, methods, and documentation.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct EnumDef {
+    /// Stable enum identity derived from the canonical Rust path.
+    pub id: EnumId,
+    /// Canonical enum name.
+    pub name: CanonicalName,
+    /// Variants written on the Rust enum.
+    pub variants: Vec<VariantDef>,
+    /// `repr` attributes written on the enum.
+    pub repr: ReprAttr,
+    /// User attributes preserved from the enum.
+    pub user_attrs: Vec<UserAttr>,
+    /// Documentation attached to the enum.
+    pub doc: Option<DocComment>,
+    /// Deprecation metadata attached to the enum.
+    pub deprecated: Option<DeprecationInfo>,
+    /// Methods attached to the enum.
+    pub methods: Vec<crate::MethodDef>,
+    /// Visibility and source location for diagnostics.
+    pub source: Source,
+    /// Proc-macro span available while scanning the user crate.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub source_span: Option<SourceSpan>,
+}
+
+impl EnumDef {
+    /// Builds an empty enum definition.
+    ///
+    /// The `id` parameter is the stable enum ID. The `name` parameter is the
+    /// canonical source name.
+    ///
+    /// Returns an enum with no variants, attributes, or methods.
+    pub fn new(id: EnumId, name: CanonicalName) -> Self {
+        Self {
+            id,
+            name,
+            variants: Vec::new(),
+            repr: ReprAttr::none(),
+            user_attrs: Vec::new(),
+            doc: None,
+            deprecated: None,
+            methods: Vec::new(),
+            source: Source::exported(),
+            source_span: None,
+        }
+    }
+}
+
+/// A variant written inside an exported Rust enum.
+///
+/// Variants preserve the user-facing enum shape, including discriminants and
+/// whether the payload was unit, tuple, or struct style.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct VariantDef {
+    /// Canonical variant name.
+    pub name: CanonicalName,
+    /// Discriminant written in source, when one exists.
+    pub discriminant: Option<i128>,
+    /// Payload shape written by the variant.
+    pub payload: VariantPayload,
+    /// Documentation attached to the variant.
+    pub doc: Option<DocComment>,
+    /// User attributes preserved from the variant.
+    pub user_attrs: Vec<UserAttr>,
+    /// Visibility and source location for diagnostics.
+    pub source: Source,
+    /// Proc-macro span available while scanning the user crate.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub source_span: Option<SourceSpan>,
+}
+
+impl VariantDef {
+    /// Builds a unit variant.
+    ///
+    /// The `name` parameter is the canonical variant name.
+    ///
+    /// Returns a variant with no payload and no discriminant.
+    pub fn unit(name: CanonicalName) -> Self {
+        Self {
+            name,
+            discriminant: None,
+            payload: VariantPayload::Unit,
+            doc: None,
+            user_attrs: Vec::new(),
+            source: Source::exported(),
+            source_span: None,
+        }
+    }
+}
+
+/// The payload shape written on an enum variant.
+///
+/// Tuple and struct variants both carry fields, but they are different public
+/// APIs. The AST keeps that distinction explicit.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum VariantPayload {
+    /// A variant without fields.
+    Unit,
+    /// A tuple variant such as `Value(u32, String)`.
+    Tuple(Vec<TypeExpr>),
+    /// A struct variant such as `Value { id: u32 }`.
+    Struct(Vec<FieldDef>),
+}

--- a/boltffi_ast/src/ids.rs
+++ b/boltffi_ast/src/ids.rs
@@ -1,0 +1,93 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+macro_rules! define_id {
+    ($name:ident, $doc:expr) => {
+        #[doc = $doc]
+        ///
+        /// IDs are stable names for declarations inside a [`SourceContract`](crate::SourceContract).
+        /// They are derived from canonical Rust paths, which lets separate
+        /// metadata entries refer to the same declaration without relying on
+        /// list position.
+        #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+        pub struct $name(String);
+
+        impl $name {
+            /// Builds an ID from a scanner-produced canonical path.
+            ///
+            /// The `value` parameter is stored exactly as supplied. Callers
+            /// should pass the canonical Rust path they use for declaration
+            /// identity.
+            ///
+            /// Returns a declaration ID suitable for references inside the
+            /// source contract.
+            pub fn new(value: impl Into<String>) -> Self {
+                Self(value.into())
+            }
+
+            /// Returns the canonical ID text.
+            ///
+            /// The returned value is the identity string used inside the source
+            /// contract.
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(&self.0)
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(value: String) -> Self {
+                Self::new(value)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(value: &str) -> Self {
+                Self::new(value)
+            }
+        }
+    };
+}
+
+define_id!(
+    RecordId,
+    "Identifies a record declaration in the source contract."
+);
+define_id!(
+    EnumId,
+    "Identifies an enum declaration in the source contract."
+);
+define_id!(
+    FunctionId,
+    "Identifies a free function exported by the source contract."
+);
+define_id!(
+    MethodId,
+    "Identifies a method-like callable attached to a record, enum, class, or callback."
+);
+define_id!(
+    ClassId,
+    "Identifies an exported class-style object declaration."
+);
+define_id!(
+    CallbackId,
+    "Identifies a callback trait or closure signature visible to the FFI surface."
+);
+define_id!(
+    StreamId,
+    "Identifies a stream declaration exposed by a class or by a future top-level stream export."
+);
+define_id!(
+    ConstantId,
+    "Identifies a constant declaration exported into the source contract."
+);
+define_id!(
+    CustomTypeId,
+    "Identifies a custom type declaration and its conversion hooks."
+);

--- a/boltffi_ast/src/lib.rs
+++ b/boltffi_ast/src/lib.rs
@@ -1,0 +1,54 @@
+//! Canonical source AST for exported BoltFFI APIs.
+//!
+//! The values in this crate are the handoff from macro scanning to resolution.
+//! They describe the exported Rust surface in a stable, serializable vocabulary:
+//! records, enums, functions, classes, callbacks, streams, constants, custom
+//! types, attributes, documentation, and type expressions.
+//!
+//! A record here can carry `#[repr(C)]`, named fields, and methods. The crate
+//! stops at that source description; resolved ABI and binding shapes live in
+//! the next pipeline stages.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+mod attribute;
+mod callable;
+mod callback;
+mod class;
+mod constant;
+mod contract;
+mod custom;
+mod documentation;
+mod enumeration;
+mod ids;
+mod literal;
+mod name;
+mod primitive;
+mod record;
+mod source;
+mod stream;
+mod type_expr;
+
+pub use attribute::{AttributeInput, ReprAttr, ReprItem, UserAttr};
+pub use callable::{
+    CallableForm, ExecutionKind, FunctionDef, MethodDef, ParamDef, ParamPassing, Receiver,
+    ReturnDef,
+};
+pub use callback::CallbackTraitDef;
+pub use class::ClassDef;
+pub use constant::ConstantDef;
+pub use contract::{PackageInfo, SourceContract};
+pub use custom::{CustomTypeConverters, CustomTypeDef};
+pub use documentation::{DeprecationInfo, DocComment};
+pub use enumeration::{EnumDef, VariantDef, VariantPayload};
+pub use ids::{
+    CallbackId, ClassId, ConstantId, CustomTypeId, EnumId, FunctionId, MethodId, RecordId, StreamId,
+};
+pub use literal::{ConstExpr, DefaultValue, FloatLiteral, IntegerLiteral, Literal};
+pub use name::{CanonicalName, GenericArgument, NamePart, Path, PathRoot, PathSegment};
+pub use primitive::Primitive;
+pub use record::{FieldDef, RecordDef};
+pub use source::{Source, SourceFile, SourceSpan, Visibility};
+pub use stream::{StreamDef, StreamMode};
+pub use type_expr::{ClosureType, TypeExpr, TypeParameter};

--- a/boltffi_ast/src/literal.rs
+++ b/boltffi_ast/src/literal.rs
@@ -1,0 +1,116 @@
+use serde::{Deserialize, Serialize};
+
+use crate::Path;
+
+/// An integer literal written in Rust source.
+///
+/// Rust integer literals can carry suffixes and bases. Keeping both the parsed
+/// value and the original spelling preserves what the author wrote while still
+/// giving consumers a numeric value to compare.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct IntegerLiteral {
+    /// Parsed integer value after Rust literal parsing.
+    pub value: i128,
+    /// Source spelling of the literal.
+    pub source: String,
+}
+
+impl IntegerLiteral {
+    /// Builds an integer literal from its parsed value and source spelling.
+    ///
+    /// The `value` parameter is the numeric value. The `source` parameter is the
+    /// literal spelling collected from Rust source.
+    ///
+    /// Returns an integer literal suitable for discriminants, defaults, and
+    /// constants.
+    pub fn new(value: i128, source: impl Into<String>) -> Self {
+        Self {
+            value,
+            source: source.into(),
+        }
+    }
+}
+
+/// A floating-point literal written in Rust source.
+///
+/// Floating literals are kept by spelling so suffixes, exponent notation, and
+/// precision remain available alongside the declaration type.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct FloatLiteral {
+    /// Source spelling of the floating-point literal.
+    pub source: String,
+}
+
+impl FloatLiteral {
+    /// Builds a floating-point literal from source text.
+    ///
+    /// The `source` parameter is stored unchanged so suffixes and exponent
+    /// spelling remain visible to diagnostics.
+    ///
+    /// Returns a floating literal from its source spelling.
+    pub fn new(source: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}
+
+/// A literal value written in source.
+///
+/// Literals appear in enum discriminants, defaults, and constants. The variants
+/// mirror the literal families BoltFFI needs to preserve today.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum Literal {
+    /// A boolean literal.
+    Bool(bool),
+    /// An integer literal.
+    Integer(IntegerLiteral),
+    /// A floating-point literal.
+    Float(FloatLiteral),
+    /// A string literal after Rust escape processing.
+    String(String),
+    /// A byte string literal after Rust escape processing.
+    Bytes(Vec<u8>),
+}
+
+/// A constant expression small enough to preserve structurally.
+///
+/// The AST models the expression forms that commonly appear in exported
+/// metadata, while `Raw` keeps uncommon expressions available for error
+/// reporting and future support.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum ConstExpr {
+    /// A literal constant.
+    Literal(Literal),
+    /// A path constant such as an enum variant.
+    Path(Path),
+    /// An array constant.
+    Array(Vec<ConstExpr>),
+    /// A tuple constant.
+    Tuple(Vec<ConstExpr>),
+    /// A raw expression kept for diagnostics until the scanner grows a richer
+    /// representation for it.
+    Raw(String),
+}
+
+/// A default value written on a field or parameter.
+///
+/// Defaults have call-site meaning: generated bindings may expose them as
+/// default arguments or initializer values.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum DefaultValue {
+    /// The Rust `true` or `false` literal.
+    Bool(bool),
+    /// An integer default.
+    Integer(IntegerLiteral),
+    /// A floating-point default.
+    Float(FloatLiteral),
+    /// A string default.
+    String(String),
+    /// A byte string default.
+    Bytes(Vec<u8>),
+    /// A default that names another item, most often an enum variant.
+    Path(Path),
+    /// A `None` default for optional values.
+    None,
+}

--- a/boltffi_ast/src/name.rs
+++ b/boltffi_ast/src/name.rs
@@ -1,0 +1,229 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ConstExpr, TypeExpr};
+
+/// One normalized part of a canonical BoltFFI name.
+///
+/// A source name can be written in Rust as `HTTPRequest`, `http_request`, or
+/// through a future naming attribute. `NamePart` stores the scanner's canonical
+/// part after that spelling has been normalized.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct NamePart(String);
+
+impl NamePart {
+    /// Builds a canonical name part.
+    ///
+    /// The `part` parameter is expected to be the scanner's normalized spelling
+    /// for one segment of a declaration name. This function keeps the value
+    /// unchanged so normalization remains visible and testable at the scan
+    /// layer.
+    ///
+    /// Returns a name part that can be reused by canonical names, paths, and
+    /// attributes.
+    pub fn new(part: impl Into<String>) -> Self {
+        Self(part.into())
+    }
+
+    /// Returns the stored canonical spelling.
+    ///
+    /// The returned value is the canonical part text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for NamePart {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl From<String> for NamePart {
+    fn from(part: String) -> Self {
+        Self::new(part)
+    }
+}
+
+impl From<&str> for NamePart {
+    fn from(part: &str) -> Self {
+        Self::new(part)
+    }
+}
+
+/// A canonical source name used by declarations, fields, parameters, and variants.
+///
+/// Names are stored as parts so `http_request` and `HTTPRequest` can share one
+/// normalized representation while still allowing consumers to choose their own
+/// display spelling.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct CanonicalName {
+    /// Normalized parts in declaration order.
+    pub parts: Vec<NamePart>,
+}
+
+impl CanonicalName {
+    /// Builds a canonical name from normalized parts.
+    ///
+    /// The `parts` parameter should already be split and normalized by the
+    /// scanner. Empty names are allowed here so scan errors can still carry a
+    /// partially built AST with useful spans.
+    ///
+    /// Returns a canonical name built from the provided parts.
+    pub fn new(parts: Vec<NamePart>) -> Self {
+        Self { parts }
+    }
+
+    /// Builds a canonical name from one source part.
+    ///
+    /// The `part` parameter becomes the only part of the name.
+    ///
+    /// Returns the shape used for simple field names and single-segment item
+    /// names.
+    pub fn single(part: impl Into<NamePart>) -> Self {
+        Self {
+            parts: vec![part.into()],
+        }
+    }
+
+    /// Iterates over the canonical parts.
+    ///
+    /// The iterator yields the parts in source order and performs no allocation.
+    pub fn parts(&self) -> impl Iterator<Item = &NamePart> {
+        self.parts.iter()
+    }
+
+    /// Joins the canonical parts with `::` for diagnostics and stable IDs.
+    ///
+    /// This is a display helper for humans and metadata keys.
+    pub fn as_path_string(&self) -> String {
+        self.parts
+            .iter()
+            .map(NamePart::as_str)
+            .collect::<Vec<_>>()
+            .join("::")
+    }
+}
+
+/// The root qualifier used by a Rust path.
+///
+/// `Foo`, `crate::Foo`, `self::Foo`, `super::Foo`, and `::foo::Foo` can name
+/// different things. The qualifier keeps that spelling visible.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum PathRoot {
+    /// A relative path such as `Foo` or `module::Foo`.
+    Relative,
+    /// A path starting at the current crate.
+    Crate,
+    /// A path starting at the current module.
+    Self_,
+    /// A path starting at the parent module.
+    Super,
+    /// A path starting at the extern prelude.
+    Absolute,
+}
+
+/// A Rust path with generic arguments preserved on each segment.
+///
+/// Paths appear in user attributes, custom converters, const expressions, and
+/// generic type syntax. Segment-level arguments preserve shapes such as
+/// `std::borrow::Cow<'a, str>` without flattening them into a string.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct Path {
+    /// Where path resolution starts.
+    pub root: PathRoot,
+    /// Segments from root to leaf.
+    pub segments: Vec<PathSegment>,
+}
+
+impl Path {
+    /// Builds a path from its root qualifier and segments.
+    ///
+    /// The `root` parameter records how the path was written. The `segments`
+    /// parameter stores the named path components in source order.
+    ///
+    /// Returns an unresolved source path.
+    pub fn new(root: PathRoot, segments: Vec<PathSegment>) -> Self {
+        Self { root, segments }
+    }
+
+    /// Builds a relative path with a single segment.
+    ///
+    /// The `name` parameter becomes the final path segment and carries no
+    /// generic arguments.
+    ///
+    /// Returns the path form for simple names such as `Point`.
+    pub fn single(name: impl Into<NamePart>) -> Self {
+        Self {
+            root: PathRoot::Relative,
+            segments: vec![PathSegment::new(name)],
+        }
+    }
+
+    /// Returns the final segment, if the path has one.
+    ///
+    /// This is useful for diagnostics where the final name is the clearest part
+    /// of a path.
+    pub fn last(&self) -> Option<&PathSegment> {
+        self.segments.last()
+    }
+}
+
+/// One segment of a Rust path.
+///
+/// Generic arguments live on the segment that owns them, so `Result<T, E>` is a
+/// single segment named `Result` with two arguments.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct PathSegment {
+    /// The canonical spelling of this path segment.
+    pub name: NamePart,
+    /// Generic arguments attached to this segment.
+    pub arguments: Vec<GenericArgument>,
+}
+
+impl PathSegment {
+    /// Builds a path segment without generic arguments.
+    ///
+    /// The `name` parameter is stored as the segment name.
+    ///
+    /// Returns a segment for non-generic path components.
+    pub fn new(name: impl Into<NamePart>) -> Self {
+        Self {
+            name: name.into(),
+            arguments: Vec::new(),
+        }
+    }
+
+    /// Builds a path segment with explicit generic arguments.
+    ///
+    /// The `name` parameter identifies the segment. The `arguments` parameter
+    /// preserves the generic argument list in source order.
+    ///
+    /// Returns a segment for path components such as `Vec<T>`.
+    pub fn with_arguments(name: impl Into<NamePart>, arguments: Vec<GenericArgument>) -> Self {
+        Self {
+            name: name.into(),
+            arguments,
+        }
+    }
+}
+
+/// A generic argument attached to a path segment.
+///
+/// Type, const, and associated-type arguments carry different Rust meaning, so
+/// each gets its own variant.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum GenericArgument {
+    /// A type argument such as `T` in `Vec<T>`.
+    Type(TypeExpr),
+    /// A const argument such as `N` in `[u8; N]`.
+    Const(ConstExpr),
+    /// An associated type equality such as `Item = String`.
+    AssociatedType {
+        /// The associated type being assigned.
+        name: NamePart,
+        /// The type written on the right side of the equality.
+        ty: TypeExpr,
+    },
+}

--- a/boltffi_ast/src/primitive.rs
+++ b/boltffi_ast/src/primitive.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+
+/// A Rust primitive type that BoltFFI accepts at the source boundary.
+///
+/// The variants follow Rust's primitive names so scanned types can use a compact
+/// enum instead of keeping primitive spellings as strings.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub enum Primitive {
+    /// The Rust `bool` type.
+    Bool,
+    /// The Rust `i8` type.
+    I8,
+    /// The Rust `u8` type.
+    U8,
+    /// The Rust `i16` type.
+    I16,
+    /// The Rust `u16` type.
+    U16,
+    /// The Rust `i32` type.
+    I32,
+    /// The Rust `u32` type.
+    U32,
+    /// The Rust `i64` type.
+    I64,
+    /// The Rust `u64` type.
+    U64,
+    /// The Rust `isize` type.
+    ISize,
+    /// The Rust `usize` type.
+    USize,
+    /// The Rust `f32` type.
+    F32,
+    /// The Rust `f64` type.
+    F64,
+}
+
+impl Primitive {
+    /// Returns the Rust spelling of the primitive.
+    ///
+    /// The returned string is the Rust keyword or primitive type name.
+    pub const fn rust_name(self) -> &'static str {
+        match self {
+            Self::Bool => "bool",
+            Self::I8 => "i8",
+            Self::U8 => "u8",
+            Self::I16 => "i16",
+            Self::U16 => "u16",
+            Self::I32 => "i32",
+            Self::U32 => "u32",
+            Self::I64 => "i64",
+            Self::U64 => "u64",
+            Self::ISize => "isize",
+            Self::USize => "usize",
+            Self::F32 => "f32",
+            Self::F64 => "f64",
+        }
+    }
+}

--- a/boltffi_ast/src/record.rs
+++ b/boltffi_ast/src/record.rs
@@ -1,0 +1,104 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CanonicalName, DefaultValue, DeprecationInfo, DocComment, RecordId, ReprAttr, Source,
+    SourceSpan, TypeExpr, UserAttr,
+};
+
+/// A Rust struct exported as a BoltFFI record.
+///
+/// A record keeps the struct-shaped API a binding author sees: fields,
+/// representation hints, methods, attributes, documentation, and source
+/// location. Layout-specific data is supplied by the resolved contract that
+/// follows this source model.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct RecordDef {
+    /// Stable record identity derived from the canonical Rust path.
+    pub id: RecordId,
+    /// Canonical record name.
+    pub name: CanonicalName,
+    /// Fields written on the Rust struct.
+    pub fields: Vec<FieldDef>,
+    /// `repr` attributes written on the struct.
+    pub repr: ReprAttr,
+    /// User attributes preserved from the struct.
+    pub user_attrs: Vec<UserAttr>,
+    /// Documentation attached to the record.
+    pub doc: Option<DocComment>,
+    /// Deprecation metadata attached to the record.
+    pub deprecated: Option<DeprecationInfo>,
+    /// Methods attached to the record.
+    pub methods: Vec<crate::MethodDef>,
+    /// Visibility and source location for diagnostics.
+    pub source: Source,
+    /// Proc-macro span available while scanning the user crate.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub source_span: Option<SourceSpan>,
+}
+
+impl RecordDef {
+    /// Builds an empty record definition.
+    ///
+    /// The `id` parameter is the stable record ID. The `name` parameter is the
+    /// canonical source name.
+    ///
+    /// Returns a record with no fields, attributes, or methods.
+    pub fn new(id: RecordId, name: CanonicalName) -> Self {
+        Self {
+            id,
+            name,
+            fields: Vec::new(),
+            repr: ReprAttr::none(),
+            user_attrs: Vec::new(),
+            doc: None,
+            deprecated: None,
+            methods: Vec::new(),
+            source: Source::exported(),
+            source_span: None,
+        }
+    }
+}
+
+/// A named field written inside a record or a struct-style enum variant.
+///
+/// Fields carry the API name, the source type expression, optional
+/// documentation, an optional default, and any attributes written directly on
+/// the field.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct FieldDef {
+    /// Canonical field name.
+    pub name: CanonicalName,
+    /// Source type expression written for the field.
+    pub ty: TypeExpr,
+    /// Documentation attached to the field.
+    pub doc: Option<DocComment>,
+    /// Default value written for the field.
+    pub default: Option<DefaultValue>,
+    /// User attributes preserved from the field.
+    pub user_attrs: Vec<UserAttr>,
+    /// Visibility and source location for diagnostics.
+    pub source: Source,
+    /// Proc-macro span available while scanning the user crate.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub source_span: Option<SourceSpan>,
+}
+
+impl FieldDef {
+    /// Builds a field without documentation, attributes, or default value.
+    ///
+    /// The `name` parameter is the canonical field name. The `ty` parameter is
+    /// the field's source type expression.
+    ///
+    /// Returns a field definition that can be attached to records and variants.
+    pub fn new(name: CanonicalName, ty: TypeExpr) -> Self {
+        Self {
+            name,
+            ty,
+            doc: None,
+            default: None,
+            user_attrs: Vec::new(),
+            source: Source::exported(),
+            source_span: None,
+        }
+    }
+}

--- a/boltffi_ast/src/source.rs
+++ b/boltffi_ast/src/source.rs
@@ -1,0 +1,107 @@
+use serde::{Deserialize, Serialize};
+
+/// A Rust source file that contributed to the source contract.
+///
+/// The path is stored as scanner-provided text, which works for absolute paths,
+/// workspace-relative paths, and fixture paths.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SourceFile(String);
+
+impl SourceFile {
+    /// Builds a source file reference.
+    ///
+    /// The `path` parameter is stored exactly as the scanner reported it.
+    ///
+    /// Returns a source file value.
+    pub fn new(path: impl Into<String>) -> Self {
+        Self(path.into())
+    }
+
+    /// Returns the stored source path.
+    ///
+    /// The returned path is the same text passed to [`SourceFile::new`].
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A byte span in a Rust source file.
+///
+/// Spans use byte offsets, the common unit shared by parsers, diagnostics, and
+/// source maps.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SourceSpan {
+    /// Source file that owns the byte range.
+    pub file: SourceFile,
+    /// Inclusive byte offset where the span starts.
+    pub start: usize,
+    /// Exclusive byte offset where the span ends.
+    pub end: usize,
+}
+
+impl SourceSpan {
+    /// Builds a source span from a file and byte range.
+    ///
+    /// The `file` parameter identifies the source file. The `start` and `end`
+    /// parameters are byte offsets in that file, with `end` excluded.
+    ///
+    /// Returns a source span with the provided byte offsets.
+    pub fn new(file: SourceFile, start: usize, end: usize) -> Self {
+        Self { file, start, end }
+    }
+}
+
+/// The source visibility written on an exported Rust item.
+///
+/// Visibility lets diagnostics say whether the original Rust item was private,
+/// public, or restricted to a smaller scope.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum Visibility {
+    /// A private item.
+    Private,
+    /// A public item written as `pub`.
+    Public,
+    /// A restricted public item such as `pub(crate)` or `pub(super)`.
+    Restricted(String),
+}
+
+/// Common source metadata shared by AST nodes.
+///
+/// Declarations and members embed this value when they need both Rust
+/// visibility and optional span information.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct Source {
+    /// Visibility written on the source item.
+    pub visibility: Visibility,
+    /// Span available during macro expansion.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub span: Option<SourceSpan>,
+}
+
+impl Source {
+    /// Creates source metadata for an exported AST node.
+    ///
+    /// Use this when a builder helper is constructing an exported declaration
+    /// before the scanner has attached the exact Rust span. The scanner can
+    /// still replace the value with `pub(crate)`, `pub(super)`, or any other
+    /// source visibility it actually saw.
+    ///
+    /// Returns public source metadata without a span.
+    pub fn exported() -> Self {
+        Self {
+            visibility: Visibility::Public,
+            span: None,
+        }
+    }
+
+    /// Builds source metadata from visibility and an optional span.
+    ///
+    /// The `visibility` parameter records the source visibility. The `span`
+    /// parameter is kept only in macro memory and is stripped from serialized
+    /// metadata.
+    ///
+    /// Returns source metadata that can be attached to a declaration or member.
+    pub fn new(visibility: Visibility, span: Option<SourceSpan>) -> Self {
+        Self { visibility, span }
+    }
+}

--- a/boltffi_ast/src/stream.rs
+++ b/boltffi_ast/src/stream.rs
@@ -1,0 +1,75 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CanonicalName, ClassId, DeprecationInfo, DocComment, Source, SourceSpan, StreamId, TypeExpr,
+    UserAttr,
+};
+
+/// A stream-producing export in the source contract.
+///
+/// Streams describe an exported Rust operation that yields values over time.
+/// The item type says what each yield produces; the mode says how the author
+/// wants the stream surfaced conceptually.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct StreamDef {
+    /// Stable stream identity derived from the canonical Rust path.
+    pub id: StreamId,
+    /// Canonical stream name.
+    pub name: CanonicalName,
+    /// Class owner when the stream is attached to a class.
+    pub owner: Option<ClassId>,
+    /// Item type yielded by the stream.
+    pub item_type: TypeExpr,
+    /// Source stream mode requested by the author.
+    pub mode: StreamMode,
+    /// User attributes preserved from the stream declaration.
+    pub user_attrs: Vec<UserAttr>,
+    /// Documentation attached to the stream.
+    pub doc: Option<DocComment>,
+    /// Deprecation metadata attached to the stream.
+    pub deprecated: Option<DeprecationInfo>,
+    /// Visibility and source location for diagnostics.
+    pub source: Source,
+    /// Span available during macro expansion.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub source_span: Option<SourceSpan>,
+}
+
+impl StreamDef {
+    /// Builds a stream definition.
+    ///
+    /// The `id` parameter is the stable stream ID. The `name` parameter is the
+    /// canonical stream name. The `item_type` parameter is the yielded source
+    /// type.
+    ///
+    /// Returns an async stream with no owner, attributes, or documentation.
+    pub fn new(id: StreamId, name: CanonicalName, item_type: TypeExpr) -> Self {
+        Self {
+            id,
+            name,
+            owner: None,
+            item_type,
+            mode: StreamMode::Async,
+            user_attrs: Vec::new(),
+            doc: None,
+            deprecated: None,
+            source: Source::exported(),
+            source_span: None,
+        }
+    }
+}
+
+/// The source mode requested for a stream.
+///
+/// The modes are intentionally high level: async iteration, batched reads, or
+/// callback delivery.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum StreamMode {
+    /// Values are produced through an asynchronous stream.
+    #[default]
+    Async,
+    /// Values are produced in batches.
+    Batch,
+    /// Values are delivered through callbacks.
+    Callback,
+}

--- a/boltffi_ast/src/type_expr.rs
+++ b/boltffi_ast/src/type_expr.rs
@@ -1,0 +1,185 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{CallbackId, ClassId, CustomTypeId, EnumId, Primitive, RecordId, ReturnDef};
+
+/// A type expression in the exported Rust surface.
+///
+/// This is the shape you get after scanning a Rust type from a field,
+/// parameter, or non-fallible return. Known exported names have been turned into
+/// IDs, and ordinary Rust containers remain as a tree. For example,
+/// `Option<Vec<Point>>` becomes `Option(Vec(Record(point_id)))`, `(u32,
+/// String)` becomes `Tuple([Primitive(U32), String])`, inline closure
+/// signatures become `Closure`, and `Self` stays explicit when it appears
+/// inside an impl block.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum TypeExpr {
+    /// A primitive Rust scalar.
+    Primitive(Primitive),
+    /// A record declaration by ID.
+    Record(RecordId),
+    /// An enum declaration by ID.
+    Enum(EnumId),
+    /// A class-style object declaration by ID.
+    Class(ClassId),
+    /// A callback trait or closure signature by ID.
+    Callback(CallbackId),
+    /// An inline closure signature such as `impl Fn(u32) -> String`.
+    Closure(Box<ClosureType>),
+    /// A custom type declaration by ID.
+    Custom(CustomTypeId),
+    /// The Rust `Self` type inside an impl, trait, or callback context.
+    SelfType,
+    /// A `Vec<T>` source type.
+    Vec(Box<TypeExpr>),
+    /// An `Option<T>` source type.
+    Option(Box<TypeExpr>),
+    /// A `Result<T, E>` source type inside a larger type expression.
+    ///
+    /// The outermost return type of a callable uses [`ReturnDef::Result`](crate::ReturnDef)
+    /// instead, so callable fallibility is visible without inspecting this
+    /// generic tree. This variant is for places where `Result` is just another
+    /// type expression.
+    Result {
+        /// Success type written as the first `Result` argument.
+        ok: Box<TypeExpr>,
+        /// Error type written as the second `Result` argument.
+        err: Box<TypeExpr>,
+    },
+    /// A tuple type such as `(u32, String)`.
+    ///
+    /// Tuples are ordinary value types in the AST. A function returning
+    /// `(u32, String)` is represented as `ReturnDef::Value(TypeExpr::Tuple(_))`,
+    /// while a function returning `Result<(u32, String), Error>` is represented
+    /// as `ReturnDef::Result { ok: TypeExpr::Tuple(_), err: ... }`.
+    Tuple(Vec<TypeExpr>),
+    /// A map-like source type.
+    Map {
+        /// Key type written by the source map.
+        key: Box<TypeExpr>,
+        /// Value type written by the source map.
+        value: Box<TypeExpr>,
+    },
+    /// A UTF-8 string source type.
+    String,
+    /// A byte buffer source type.
+    Bytes,
+    /// A type parameter used by a generic declaration the scanner chose to keep.
+    Parameter(TypeParameter),
+}
+
+impl TypeExpr {
+    /// Builds a `Vec<T>` type expression.
+    ///
+    /// The `element` parameter is the source type written inside the vector.
+    ///
+    /// Returns a vector type expression.
+    pub fn vec(element: TypeExpr) -> Self {
+        Self::Vec(Box::new(element))
+    }
+
+    /// Builds an `Option<T>` type expression.
+    ///
+    /// The `inner` parameter is the source type written inside the option.
+    ///
+    /// Returns an optional type expression.
+    pub fn option(inner: TypeExpr) -> Self {
+        Self::Option(Box::new(inner))
+    }
+
+    /// Builds a `Result<T, E>` type expression.
+    ///
+    /// The `ok` parameter is the success type. The `err` parameter is the error
+    /// type.
+    ///
+    /// Returns a result type expression for nested or non-callable positions.
+    pub fn result(ok: TypeExpr, err: TypeExpr) -> Self {
+        Self::Result {
+            ok: Box::new(ok),
+            err: Box::new(err),
+        }
+    }
+
+    /// Builds an inline closure type expression.
+    ///
+    /// The `closure` parameter contains the callable signature written inside a
+    /// closure-like parameter type.
+    ///
+    /// Returns a closure type expression that can be paired with
+    /// [`ParamPassing::ImplTrait`](crate::ParamPassing::ImplTrait) or
+    /// [`ParamPassing::BoxedDyn`](crate::ParamPassing::BoxedDyn).
+    pub fn closure(closure: ClosureType) -> Self {
+        Self::Closure(Box::new(closure))
+    }
+
+    /// Builds a tuple type expression.
+    ///
+    /// The `elements` parameter preserves the tuple element types in source
+    /// order. A one-element tuple still has one element here; the scanner does
+    /// not need a special case for Rust's trailing-comma syntax once parsing is
+    /// finished.
+    ///
+    /// Returns a tuple value type, suitable for fields, parameters, nested
+    /// containers, and `ReturnDef::Value`.
+    pub fn tuple(elements: Vec<TypeExpr>) -> Self {
+        Self::Tuple(elements)
+    }
+
+    /// Builds a map type expression.
+    ///
+    /// The `key` parameter is the source key type. The `value` parameter is the
+    /// source value type.
+    ///
+    /// Returns a map type expression.
+    pub fn map(key: TypeExpr, value: TypeExpr) -> Self {
+        Self::Map {
+            key: Box::new(key),
+            value: Box::new(value),
+        }
+    }
+}
+
+/// An inline closure signature used as a type expression.
+///
+/// Closure parameters are not named declarations in Rust source. The scanner
+/// stores their parameter and return types here so the callback shape remains
+/// local to the parameter that introduced it.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ClosureType {
+    /// Types accepted by the closure in source order.
+    pub params: Vec<TypeExpr>,
+    /// Return type written by the closure signature.
+    pub returns: ReturnDef,
+}
+
+impl ClosureType {
+    /// Builds an inline closure signature.
+    ///
+    /// The `params` parameter preserves closure parameter types in source order.
+    /// The `returns` parameter is the closure return type.
+    ///
+    /// Returns a closure signature suitable for [`TypeExpr::Closure`].
+    pub fn new(params: Vec<TypeExpr>, returns: ReturnDef) -> Self {
+        Self { params, returns }
+    }
+}
+
+/// A named type parameter referenced by a source type expression.
+///
+/// Generic exports may be rejected or specialized after scanning. Preserving
+/// the parameter name gives those errors the original source shape.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct TypeParameter {
+    /// Parameter name as written in Rust source.
+    pub name: String,
+}
+
+impl TypeParameter {
+    /// Builds a type parameter reference.
+    ///
+    /// The `name` parameter is stored exactly as the scanner reported it.
+    ///
+    /// Returns a type parameter expression for generic source syntax.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}


### PR DESCRIPTION
Introduces `boltffi_ast` as a leaf crate holding the pure AST types describing what the user wrote in Rust,  the crate models exported Rust declarations, type expressions, names, source metadata, docs, attributes, and IDs without wiring it into the existing bindgen pipeline yet.