### PR TITLE
Support C# callbacks

### DIFF
--- a/boltffi_bindgen/src/render/csharp/ast/code.rs
+++ b/boltffi_bindgen/src/render/csharp/ast/code.rs
@@ -65,6 +65,7 @@ impl From<CSharpParamName> for CSharpIdentity {
 pub(crate) enum CSharpLiteral {
     Int(i64),
     Null,
+    Default,
 }
 
 impl fmt::Display for CSharpLiteral {
@@ -72,6 +73,7 @@ impl fmt::Display for CSharpLiteral {
         match self {
             Self::Int(v) => write!(f, "{v}"),
             Self::Null => f.write_str("null"),
+            Self::Default => f.write_str("default"),
         }
     }
 }
@@ -87,6 +89,7 @@ impl fmt::Display for CSharpLiteral {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CSharpBinaryOp {
     Eq,
+    Ne,
     Add,
     Mul,
 }
@@ -95,6 +98,7 @@ impl fmt::Display for CSharpBinaryOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Eq => f.write_str("=="),
+            Self::Ne => f.write_str("!="),
             Self::Add => f.write_str("+"),
             Self::Mul => f.write_str("*"),
         }
@@ -390,6 +394,11 @@ mod tests {
         fn null_literal_renders_as_keyword() {
             assert_eq!(CSharpLiteral::Null.to_string(), "null");
         }
+
+        #[test]
+        fn default_literal_renders_as_keyword() {
+            assert_eq!(CSharpLiteral::Default.to_string(), "default");
+        }
     }
 
     mod binary_op {
@@ -397,6 +406,7 @@ mod tests {
 
         #[rstest]
         #[case(CSharpBinaryOp::Eq, "==")]
+        #[case(CSharpBinaryOp::Ne, "!=")]
         #[case(CSharpBinaryOp::Add, "+")]
         #[case(CSharpBinaryOp::Mul, "*")]
         fn operator_renders_as_source_token(#[case] op: CSharpBinaryOp, #[case] expected: &str) {

--- a/boltffi_bindgen/src/render/csharp/ast/code.rs
+++ b/boltffi_bindgen/src/render/csharp/ast/code.rs
@@ -64,6 +64,7 @@ impl From<CSharpParamName> for CSharpIdentity {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CSharpLiteral {
     Int(i64),
+    Bool(bool),
     Null,
     Default,
 }
@@ -72,6 +73,7 @@ impl fmt::Display for CSharpLiteral {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Int(v) => write!(f, "{v}"),
+            Self::Bool(v) => write!(f, "{v}"),
             Self::Null => f.write_str("null"),
             Self::Default => f.write_str("default"),
         }
@@ -216,6 +218,17 @@ impl fmt::Display for CSharpExpression {
             Self::IsBindingPattern { value, binding } => write!(f, "{value} is {{ }} {binding}"),
             Self::New { target, args } => write!(f, "new {target}({args})"),
         }
+    }
+}
+
+#[cfg(test)]
+mod expression_tests {
+    use super::*;
+
+    #[test]
+    fn bool_literals_render_as_csharp_keywords() {
+        assert_eq!(CSharpLiteral::Bool(false).to_string(), "false");
+        assert_eq!(CSharpLiteral::Bool(true).to_string(), "true");
     }
 }
 

--- a/boltffi_bindgen/src/render/csharp/ast/identifier.rs
+++ b/boltffi_bindgen/src/render/csharp/ast/identifier.rs
@@ -219,6 +219,13 @@ impl From<&MethodId> for CSharpMethodName {
 pub(crate) struct CSharpPropertyName(String);
 
 impl CSharpPropertyName {
+    /// Wraps a pre-formed member name. Runtime structs occasionally expose
+    /// lower-case fields (for example `_handle.handle`) that should not go
+    /// through the public-property PascalCase transform.
+    pub(crate) fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
     /// Builds from a snake_case source name. `my_prop` → `"MyProp"`.
     pub(crate) fn from_source(source: &str) -> Self {
         Self(naming::to_upper_camel_case(source))
@@ -578,6 +585,12 @@ mod tests {
     fn csharp_property_name_from_snake_case_produces_pascal_case() {
         let name = CSharpPropertyName::from_source("my_prop");
         assert_eq!(name.to_string(), "MyProp");
+    }
+
+    #[test]
+    fn csharp_property_name_new_wraps_pre_formed_name_verbatim() {
+        let name = CSharpPropertyName::new("handle");
+        assert_eq!(name.to_string(), "handle");
     }
 
     #[test]

--- a/boltffi_bindgen/src/render/csharp/ast/identifier.rs
+++ b/boltffi_bindgen/src/render/csharp/ast/identifier.rs
@@ -348,6 +348,12 @@ impl CSharpLocalName {
         Self(format!("_{}Ptr", param.stripped()))
     }
 
+    /// `_{param}Callback`: the scoped owner that keeps an inline closure
+    /// rooted while the native call executes.
+    pub(crate) fn for_inline_callback_scope(param: &CSharpParamName) -> Self {
+        Self(format!("_{}Callback", param.stripped()))
+    }
+
     /// `sizeOpt{n}`: the pattern binding introduced inside a
     /// `SizeExpr::OptionSize` ternary so the option's non-null payload
     /// can be referenced while summing its byte size. The prefix is

--- a/boltffi_bindgen/src/render/csharp/ast/parameter_list.rs
+++ b/boltffi_bindgen/src/render/csharp/ast/parameter_list.rs
@@ -17,6 +17,7 @@ use super::{CSharpAttribute, CSharpParamName, CSharpType};
 #[derive(Debug, Clone)]
 pub(crate) struct CSharpParameter {
     pub(crate) attributes: Vec<CSharpAttribute>,
+    pub(crate) modifier: Option<CSharpParameterModifier>,
     pub(crate) csharp_type: CSharpType,
     pub(crate) name: CSharpParamName,
 }
@@ -27,8 +28,32 @@ impl CSharpParameter {
     pub(crate) fn bare(csharp_type: CSharpType, name: CSharpParamName) -> Self {
         Self {
             attributes: vec![],
+            modifier: None,
             csharp_type,
             name,
+        }
+    }
+
+    /// An `out` parameter in a generated native delegate signature.
+    pub(crate) fn out(csharp_type: CSharpType, name: CSharpParamName) -> Self {
+        Self {
+            attributes: vec![],
+            modifier: Some(CSharpParameterModifier::Out),
+            csharp_type,
+            name,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CSharpParameterModifier {
+    Out,
+}
+
+impl fmt::Display for CSharpParameterModifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Out => f.write_str("out"),
         }
     }
 }
@@ -37,6 +62,9 @@ impl fmt::Display for CSharpParameter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for attr in &self.attributes {
             write!(f, "{attr} ")?;
+        }
+        if let Some(modifier) = self.modifier {
+            write!(f, "{modifier} ")?;
         }
         write!(f, "{} {}", self.csharp_type, self.name)
     }
@@ -137,10 +165,17 @@ mod tests {
     fn parameter_with_attribute_renders_attribute_then_type_name() {
         let p = CSharpParameter {
             attributes: vec![marshal_as("I1")],
+            modifier: None,
             csharp_type: CSharpType::Bool,
             name: CSharpParamName::from_source("flag"),
         };
         assert_eq!(p.to_string(), "[MarshalAs(UnmanagedType.I1)] bool flag");
+    }
+
+    #[test]
+    fn out_parameter_renders_modifier_before_type() {
+        let p = CSharpParameter::out(CSharpType::IntPtr, CSharpParamName::from_source("ptr"));
+        assert_eq!(p.to_string(), "out IntPtr ptr");
     }
 
     #[test]
@@ -162,6 +197,7 @@ mod tests {
         let list: CSharpParameterList = vec![
             CSharpParameter {
                 attributes: vec![marshal_as("I1")],
+                modifier: None,
                 csharp_type: CSharpType::Bool,
                 name: CSharpParamName::from_source("flag"),
             },

--- a/boltffi_bindgen/src/render/csharp/ast/type_shape.rs
+++ b/boltffi_bindgen/src/render/csharp/ast/type_shape.rs
@@ -50,6 +50,9 @@ pub(crate) enum CSharpType {
     /// A user-defined enum whose variants carry payload data, modeled as
     /// an `abstract record` with nested `sealed record` variants.
     DataEnum(CSharpTypeReference),
+    /// A named runtime/helper type that is not sourced from user IR, such as
+    /// `GCHandle` or `WireReader`.
+    Named(CSharpTypeReference),
     /// `T[]`: a single-dimensional array of `T`.
     Array(Box<CSharpType>),
     /// `T?`: a value or reference type that may be `null`.
@@ -98,6 +101,7 @@ impl CSharpType {
             Self::Record(r) => Self::Record(r.qualify_if_shadowed(shadowed, namespace)),
             Self::CStyleEnum(r) => Self::CStyleEnum(r.qualify_if_shadowed(shadowed, namespace)),
             Self::DataEnum(r) => Self::DataEnum(r.qualify_if_shadowed(shadowed, namespace)),
+            Self::Named(r) => Self::Named(r.qualify_if_shadowed(shadowed, namespace)),
             Self::Array(inner) => {
                 Self::Array(Box::new((*inner).qualify_if_shadowed(shadowed, namespace)))
             }
@@ -244,7 +248,7 @@ impl fmt::Display for CSharpType {
             Self::Float => f.write_str("float"),
             Self::Double => f.write_str("double"),
             Self::String => f.write_str("string"),
-            Self::Record(r) | Self::CStyleEnum(r) | Self::DataEnum(r) => r.fmt(f),
+            Self::Record(r) | Self::CStyleEnum(r) | Self::DataEnum(r) | Self::Named(r) => r.fmt(f),
             Self::Array(inner) => write!(f, "{inner}[]"),
             Self::Nullable(inner) => write!(f, "{inner}?"),
         }
@@ -267,6 +271,10 @@ mod tests {
         CSharpType::DataEnum(CSharpClassName::from_source(name).into())
     }
 
+    fn named_type(name: &str) -> CSharpType {
+        CSharpType::Named(CSharpTypeReference::Plain(CSharpClassName::new(name)))
+    }
+
     #[test]
     fn record_type_display_uses_class_name() {
         assert_eq!(record_type("point").to_string(), "Point");
@@ -280,6 +288,24 @@ mod tests {
     #[test]
     fn data_enum_type_display_uses_class_name() {
         assert_eq!(data_enum_type("shape").to_string(), "Shape");
+    }
+
+    #[test]
+    fn named_runtime_type_display_uses_class_name() {
+        assert_eq!(named_type("GCHandle").to_string(), "GCHandle");
+    }
+
+    #[test]
+    fn named_runtime_type_qualifies_when_shadowed() {
+        let shadowed: HashSet<CSharpClassName> =
+            std::iter::once(CSharpClassName::new("WireReader")).collect();
+        let namespace = CSharpNamespace::from_source("demo");
+        assert_eq!(
+            named_type("WireReader")
+                .qualify_if_shadowed(&shadowed, &namespace)
+                .to_string(),
+            "global::Demo.WireReader"
+        );
     }
 
     /// `Nullable` renders as `{inner}?`, uniform for value-type inners

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -13,8 +13,9 @@ use super::{
     lower::CSharpLowerer,
     plan::CSharpEnumKind,
     templates::{
-        ClassTemplate, EnumCStyleTemplate, EnumDataTemplate, FunctionsTemplate, NativeTemplate,
-        PreambleTemplate, RecordTemplate,
+        CallbackBridgeTemplate, CallbackInterfaceTemplate, ClassTemplate, ClosureBridgeTemplate,
+        ClosureDelegateTemplate, EnumCStyleTemplate, EnumDataTemplate, FunctionsTemplate,
+        NativeTemplate, PreambleTemplate, RecordTemplate,
     },
 };
 
@@ -111,6 +112,18 @@ impl CSharpEmitter {
         let mut main_source = String::new();
         main_source.push_str(&PreambleTemplate { module: &module }.render().unwrap());
         main_source.push('\n');
+        for closure in &module.closures {
+            main_source.push_str(&ClosureDelegateTemplate { closure }.render().unwrap());
+            main_source.push('\n');
+            main_source.push_str(&ClosureBridgeTemplate { closure }.render().unwrap());
+            main_source.push('\n');
+        }
+        for callback in &module.callbacks {
+            main_source.push_str(&CallbackInterfaceTemplate { callback }.render().unwrap());
+            main_source.push('\n');
+            main_source.push_str(&CallbackBridgeTemplate { callback }.render().unwrap());
+            main_source.push('\n');
+        }
         main_source.push_str(&FunctionsTemplate { module: &module }.render().unwrap());
         main_source.push_str(&NativeTemplate { module: &module }.render().unwrap());
         main_source.push('\n');

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -13,9 +13,9 @@ use super::{
     lower::CSharpLowerer,
     plan::CSharpEnumKind,
     templates::{
-        CallbackBridgeTemplate, CallbackInterfaceTemplate, ClassTemplate, ClosureBridgeTemplate,
-        ClosureDelegateTemplate, EnumCStyleTemplate, EnumDataTemplate, FunctionsTemplate,
-        NativeTemplate, PreambleTemplate, RecordTemplate,
+        CallbackBridgeTemplate, CallbackInterfaceTemplate, CallbackProxyTemplate, ClassTemplate,
+        ClosureBridgeTemplate, ClosureDelegateTemplate, EnumCStyleTemplate, EnumDataTemplate,
+        FunctionsTemplate, NativeTemplate, PreambleTemplate, RecordTemplate,
     },
 };
 
@@ -121,6 +121,8 @@ impl CSharpEmitter {
         for callback in &module.callbacks {
             main_source.push_str(&CallbackInterfaceTemplate { callback }.render().unwrap());
             main_source.push('\n');
+            main_source.push_str(&CallbackProxyTemplate { callback }.render().unwrap());
+            main_source.push('\n');
             main_source.push_str(&CallbackBridgeTemplate { callback }.render().unwrap());
             main_source.push('\n');
         }
@@ -143,10 +145,13 @@ mod tests {
     use crate::ir::Lowerer as IrLowerer;
     use crate::ir::contract::{FfiContract, PackageInfo};
     use crate::ir::definitions::{
-        CStyleVariant, ClassDef, DataVariant, EnumDef, EnumRepr, FieldDef, FunctionDef, MethodDef,
-        ParamDef, ParamPassing, Receiver, RecordDef, ReturnDef, VariantPayload,
+        CStyleVariant, CallbackKind, CallbackMethodDef, CallbackTraitDef, ClassDef, DataVariant,
+        EnumDef, EnumRepr, FieldDef, FunctionDef, MethodDef, ParamDef, ParamPassing, Receiver,
+        RecordDef, ReturnDef, VariantPayload,
     };
-    use crate::ir::ids::{ClassId, EnumId, FieldName, FunctionId, MethodId, ParamName, RecordId};
+    use crate::ir::ids::{
+        CallbackId, ClassId, EnumId, FieldName, FunctionId, MethodId, ParamName, RecordId,
+    };
     use crate::ir::types::{PrimitiveType, TypeExpr};
     use boltffi_ffi_rules::callable::ExecutionKind;
 
@@ -319,6 +324,101 @@ mod tests {
         let mut function = function_with_types(name, params, returns);
         function.execution_kind = ExecutionKind::Async;
         function
+    }
+
+    #[test]
+    fn emit_callback_return_uses_disposable_proxy_surface() {
+        let callback_id = CallbackId::new("ValueCallback");
+        let callback_type = TypeExpr::Callback(callback_id.clone());
+        let callback = CallbackTraitDef {
+            id: callback_id,
+            methods: vec![CallbackMethodDef {
+                id: MethodId::new("on_value"),
+                params: vec![ParamDef {
+                    name: ParamName::new("value"),
+                    type_expr: TypeExpr::Primitive(PrimitiveType::I32),
+                    passing: ParamPassing::Value,
+                    doc: None,
+                }],
+                returns: ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::I32)),
+                execution_kind: ExecutionKind::Sync,
+                doc: None,
+            }],
+            kind: CallbackKind::Trait,
+            doc: None,
+        };
+
+        let mut contract = empty_contract();
+        contract.catalog.insert_callback(callback);
+        contract.functions.push(function_with_types(
+            "make_value_callback",
+            vec![],
+            ReturnDef::Value(callback_type.clone()),
+        ));
+        contract.functions.push(FunctionDef {
+            id: FunctionId::new("invoke_value_callback"),
+            params: vec![
+                ParamDef {
+                    name: ParamName::new("callback"),
+                    type_expr: callback_type,
+                    passing: ParamPassing::ImplTrait,
+                    doc: None,
+                },
+                ParamDef {
+                    name: ParamName::new("input"),
+                    type_expr: TypeExpr::Primitive(PrimitiveType::I32),
+                    passing: ParamPassing::Value,
+                    doc: None,
+                },
+            ],
+            returns: ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::I32)),
+            execution_kind: ExecutionKind::Sync,
+            doc: None,
+            deprecated: None,
+        });
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "public sealed class ValueCallbackProxy : ValueCallback, global::System.IDisposable",
+            "returned callbacks to expose an owning disposable proxy",
+        );
+        assert_source_contains(
+            &src,
+            "public static ValueCallbackProxy MakeValueCallback()",
+            "callback-returning functions to return the concrete proxy type",
+        );
+        assert_source_contains(
+            &src,
+            "return ValueCallbackBridge.Wrap(NativeMethods.MakeValueCallback());",
+            "callback handles to be wrapped into the owning proxy",
+        );
+        assert_source_contains(
+            &src,
+            "internal static ValueCallbackProxy Wrap(BoltFFICallbackHandle handle)",
+            "bridge Wrap to return the concrete proxy",
+        );
+        assert_source_contains(
+            &src,
+            "if (impl_ is ValueCallbackProxy proxy) return proxy.CloneHandle();",
+            "passing a returned proxy back to Rust to clone its native handle",
+        );
+        assert_source_contains(
+            &src,
+            "public void Dispose()",
+            "proxy to provide explicit release",
+        );
+        assert_source_contains(
+            &src,
+            "public static int InvokeValueCallback(ValueCallback callback, int input)",
+            "callback params to keep accepting the public callback interface",
+        );
+        assert_source_contains(
+            &src,
+            "internal static extern BoltFFICallbackHandle MakeValueCallback();",
+            "native return to remain a callback handle under the public proxy surface",
+        );
     }
 
     /// C# P/Invoke marshals `bool` as a 4-byte Win32 BOOL by default, but

--- a/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
@@ -223,20 +223,12 @@ impl<'a> CSharpLowerer<'a> {
         for param in &params {
             native_params.extend(param.native_params());
         }
-        let marshals_return_bool = matches!(
-            ret,
-            CallbackReturn::Direct {
-                marshals_bool: true,
-                ..
-            }
-        );
 
         CSharpClosureMethodPlan {
             return_type: self.callback_public_return_type(&method.returns),
             public_params: self.public_param_plans(&method.params),
             native_return_type,
             native_params,
-            marshals_return_bool,
             bridge_params: params.clone(),
             invoke: self.closure_invoke(&ret, &params),
         }

--- a/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
@@ -286,7 +286,7 @@ impl<'a> CSharpLowerer<'a> {
             CallbackReturnMode::CallbackVtable,
         );
         if method.is_async() {
-            CSharpCallbackEntryPlan::Async(CSharpAsyncCallbackEntryPlan {
+            CSharpCallbackEntryPlan::Async(Box::new(CSharpAsyncCallbackEntryPlan {
                 native_params: self.async_callback_native_params(&method_name, &params),
                 bridge_params: params.clone(),
                 decoded_args: decoded_arg_list(&params),
@@ -295,15 +295,15 @@ impl<'a> CSharpLowerer<'a> {
                 faulted_completion: self.async_fault_completion(&ret),
                 success_completion: self.async_success_completion(&ret),
                 catch_completion: self.async_failure_completion(&ret),
-            })
+            }))
         } else {
             let success = self.sync_callback_success(&method_name, &params, &ret);
-            CSharpCallbackEntryPlan::Sync(CSharpSyncCallbackEntryPlan {
+            CSharpCallbackEntryPlan::Sync(Box::new(CSharpSyncCallbackEntryPlan {
                 native_params: self.sync_callback_native_params(&params, &ret),
                 out_initializer: self.sync_out_initializer(&ret),
                 bridge_params: params,
                 success,
-            })
+            }))
         }
     }
 
@@ -334,13 +334,13 @@ impl<'a> CSharpLowerer<'a> {
             .iter()
             .any(CSharpCallbackBridgeParamPlan::needs_wire_writer);
         let call = self.proxy_call(&params, &ret);
-        CSharpCallbackProxyPlan::Sync(CSharpSyncCallbackProxyPlan {
+        CSharpCallbackProxyPlan::Sync(Box::new(CSharpSyncCallbackProxyPlan {
             public_params,
             return_type: ret.public_type(),
             bridge_params: params,
             has_cleanup,
             call,
-        })
+        }))
     }
 
     fn lower_callback_delegates(
@@ -426,8 +426,8 @@ impl<'a> CSharpLowerer<'a> {
                 CSharpClosureInvokePlan::Encoded {
                     is_result: *is_result,
                     decoded_args,
-                    result_assignment,
-                    writer,
+                    result_assignment: result_assignment.map(Box::new),
+                    writer: Box::new(writer),
                 }
             }
         }
@@ -492,21 +492,19 @@ impl<'a> CSharpLowerer<'a> {
                     .expect("encoded callback param must have encode ops"),
             );
             let writer = self.callback_param_wire_writer_plan(&encode_ops, &name);
+            let pin_local =
+                CSharpLocalName::new(format!("_{}Pin", stripped_name(&writer.param_name)));
+            let ptr_local =
+                CSharpLocalName::new(format!("_{}Ptr", stripped_name(&writer.param_name)));
             CSharpCallbackBridgeParamPlan::WireEncoded {
                 public_param,
                 native_ptr_param: CSharpParameter::bare(CSharpType::IntPtr, name),
                 native_len_param: CSharpParameter::bare(CSharpType::UIntPtr, len_name),
                 reader_local: reader_name,
                 decoded_arg: decode_expr,
-                pin_local: CSharpLocalName::new(format!(
-                    "_{}Pin",
-                    stripped_name(&writer.param_name)
-                )),
-                ptr_local: CSharpLocalName::new(format!(
-                    "_{}Ptr",
-                    stripped_name(&writer.param_name)
-                )),
-                writer,
+                writer: Box::new(writer),
+                pin_local,
+                ptr_local,
             }
         } else {
             let decode_expr = self.direct_decode_expr(&param.type_expr, &name);
@@ -556,8 +554,10 @@ impl<'a> CSharpLowerer<'a> {
         match returns {
             ReturnDef::Void => CSharpType::Void,
             ReturnDef::Value(ty) => self.lower_type(ty).expect("callback return type"),
-            ReturnDef::Result { ok, .. } if matches!(ok, TypeExpr::Void) => CSharpType::Void,
-            ReturnDef::Result { ok, .. } => self.lower_type(ok).expect("result ok type"),
+            ReturnDef::Result { ok, .. } => match ok {
+                TypeExpr::Void => CSharpType::Void,
+                ok => self.lower_type(ok).expect("result ok type"),
+            },
         }
     }
 
@@ -902,7 +902,7 @@ impl<'a> CSharpLowerer<'a> {
             CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(reader_name)));
         let mut locals = decode::DecodeLocalCounters::default();
         let err_expr = decode::lower_decode_expr(err, &reader, None, &self.namespace, &mut locals);
-        let ok_expr = if matches!(ok.ops.first(), None) {
+        let ok_expr = if ok.ops.is_empty() {
             None
         } else {
             Some(decode::lower_decode_expr(
@@ -971,8 +971,8 @@ impl<'a> CSharpLowerer<'a> {
                 CSharpSyncCallbackSuccessPlan::Encoded {
                     is_result: *is_result,
                     decoded_args,
-                    result_assignment,
-                    writer,
+                    result_assignment: result_assignment.map(Box::new),
+                    writer: Box::new(writer),
                 }
             }
         }
@@ -1206,7 +1206,7 @@ impl<'a> CSharpLowerer<'a> {
                 CSharpAsyncCallbackSuccessPlan::Encoded {
                     is_result: *is_result,
                     result_type: self.result_type_for_encode_ops(encode_ops),
-                    writer,
+                    writer: Box::new(writer),
                 }
             }
         }
@@ -1232,23 +1232,23 @@ impl<'a> CSharpLowerer<'a> {
             if let Some(exception_ty) = self.error_exception_for_write_seq(err) {
                 (
                     Some(exception_ty),
-                    CSharpExpression::MemberAccess {
+                    Box::new(CSharpExpression::MemberAccess {
                         receiver: Box::new(CSharpExpression::Identity(CSharpIdentity::Local(
                             CSharpLocalName::new("__boltffiTypedException"),
                         ))),
                         name: CSharpPropertyName::from_source("error"),
-                    },
+                    }),
                     Some(self.async_failure_completion(ret)),
                 )
             } else if err_type == CSharpType::String {
                 (
                     None,
-                    CSharpExpression::MemberAccess {
+                    Box::new(CSharpExpression::MemberAccess {
                         receiver: Box::new(CSharpExpression::Identity(CSharpIdentity::Local(
                             CSharpLocalName::new(ASYNC_EXCEPTION),
                         ))),
                         name: CSharpPropertyName::from_source("message"),
-                    },
+                    }),
                     None,
                 )
             } else {
@@ -1263,8 +1263,8 @@ impl<'a> CSharpLowerer<'a> {
         CSharpAsyncCallbackFaultPlan::EncodedResult {
             exception_type,
             error_value_expr,
-            result_type: result_ty,
-            writer,
+            result_type: Box::new(result_ty),
+            writer: Box::new(writer),
             fallback,
         }
     }

--- a/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
@@ -7,16 +7,18 @@ use crate::ir::types::{PrimitiveType, TypeExpr};
 
 use super::super::ast::{
     CSharpArgumentList, CSharpAttribute, CSharpAttributeArg, CSharpClassName, CSharpExpression,
-    CSharpIdentity, CSharpLocalName, CSharpMethodName, CSharpParamName, CSharpParameter,
-    CSharpParameterList, CSharpPropertyName, CSharpType, CSharpTypeReference,
+    CSharpIdentity, CSharpLiteral, CSharpLocalName, CSharpMethodName, CSharpParamName,
+    CSharpParameter, CSharpParameterList, CSharpPropertyName, CSharpType, CSharpTypeReference,
 };
 use super::super::plan::{
     CFunctionName, CSharpAsyncCallbackEntryPlan, CSharpAsyncCallbackFailurePlan,
     CSharpAsyncCallbackFaultPlan, CSharpAsyncCallbackSuccessPlan, CSharpCallbackBridgeParamPlan,
     CSharpCallbackDelegatePlan, CSharpCallbackEntryPlan, CSharpCallbackMethodPlan,
     CSharpCallbackParamPlan, CSharpCallbackPlan, CSharpCallbackProxyCallPlan,
-    CSharpCallbackProxyPlan, CSharpClosureInvokePlan, CSharpClosureMethodPlan, CSharpClosurePlan,
-    CSharpSyncCallbackEntryPlan, CSharpSyncCallbackOutInitializerPlan, CSharpSyncCallbackProxyPlan,
+    CSharpCallbackProxyPlan, CSharpCallbackResultAssignmentPlan, CSharpCallbackResultCatchPlan,
+    CSharpCallbackResultDecodePlan, CSharpCallbackResultOkPlan, CSharpClosureInvokePlan,
+    CSharpClosureMethodPlan, CSharpClosurePlan, CSharpResultTypePlan, CSharpSyncCallbackEntryPlan,
+    CSharpSyncCallbackOutInitializerPlan, CSharpSyncCallbackProxyPlan,
     CSharpSyncCallbackSuccessPlan, CSharpWireWriterPlan,
 };
 use super::lowerer::CSharpLowerer;
@@ -41,7 +43,7 @@ const ERROR_OUT_LEN: &str = "__boltffiErrorOutLen";
 enum CallbackReturn {
     Void,
     Direct {
-        public_type: String,
+        public_type: CSharpType,
         native_type: CSharpType,
         native_out_type: CSharpType,
         default_value: String,
@@ -50,7 +52,7 @@ enum CallbackReturn {
         marshals_bool: bool,
     },
     Encoded {
-        public_type: String,
+        public_type: CSharpType,
         decode_expr: Option<CSharpExpression>,
         encode_ops: WriteSeq,
         decode_ops: Option<ReadSeq>,
@@ -79,24 +81,15 @@ impl CallbackReturn {
         matches!(self, Self::Encoded { .. })
     }
 
-    fn public_type(&self) -> String {
+    fn public_type(&self) -> CSharpType {
         match self {
-            Self::Void => "void".to_string(),
+            Self::Void => CSharpType::Void,
             Self::Direct { public_type, .. } | Self::Encoded { public_type, .. } => {
                 public_type.clone()
             }
         }
     }
 
-    fn async_task_type(&self) -> String {
-        match self {
-            Self::Void => "global::System.Threading.Tasks.Task".to_string(),
-            other => format!(
-                "global::System.Threading.Tasks.Task<{}>",
-                other.public_type()
-            ),
-        }
-    }
 }
 
 impl<'a> CSharpLowerer<'a> {
@@ -314,7 +307,6 @@ impl<'a> CSharpLowerer<'a> {
         if method.is_async() {
             return CSharpCallbackProxyPlan::AsyncUnsupported {
                 public_params,
-                return_type: ret.async_task_type(),
                 result_type: if matches!(ret, CallbackReturn::Void) {
                     None
                 } else {
@@ -393,18 +385,17 @@ impl<'a> CSharpLowerer<'a> {
                 is_result,
                 ..
             } => {
-                let result_assignment_lines = if *is_result {
-                    unindented_lines(
-                        &self.render_result_assignment(
+                let result_assignment = if *is_result {
+                    Some(self.result_assignment_plan(
+                        CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(
                             "impl_",
-                            "Invoke",
-                            &decoded_args.to_string(),
-                            encode_ops,
-                        ),
-                        "            ",
-                    )
+                        ))),
+                        CSharpMethodName::new("Invoke"),
+                        decoded_args.clone(),
+                        encode_ops,
+                    ))
                 } else {
-                    vec![]
+                    None
                 };
                 let writer = self.return_wire_writer_plan(
                     encode_ops,
@@ -422,7 +413,7 @@ impl<'a> CSharpLowerer<'a> {
                 CSharpClosureInvokePlan::Encoded {
                     is_result: *is_result,
                     decoded_args,
-                    result_assignment_lines,
+                    result_assignment,
                     writer,
                 }
             }
@@ -528,9 +519,9 @@ impl<'a> CSharpLowerer<'a> {
             ReturnDef::Value(ty) => self.callback_value_return(ty, ret_shape, mode),
             ReturnDef::Result { ok, err: _ } => {
                 let public_type = if matches!(ok, TypeExpr::Void) {
-                    "void".to_string()
+                    CSharpType::Void
                 } else {
-                    self.lower_type(ok).expect("result ok type").to_string()
+                    self.lower_type(ok).expect("result ok type")
                 };
                 CallbackReturn::Encoded {
                     public_type,
@@ -563,10 +554,7 @@ impl<'a> CSharpLowerer<'a> {
         ret_shape: &ReturnShape,
         mode: CallbackReturnMode,
     ) -> CallbackReturn {
-        let public_type = self
-            .lower_type(ty)
-            .expect("callback return type")
-            .to_string();
+        let public_type = self.lower_type(ty).expect("callback return type");
         match &ret_shape.transport {
             None => CallbackReturn::Void,
             Some(Transport::Scalar(origin)) => {
@@ -691,76 +679,73 @@ impl<'a> CSharpLowerer<'a> {
             .collect()
     }
 
-    fn render_result_assignment(
+    fn result_assignment_plan(
         &self,
-        receiver: &str,
-        method_name: &str,
-        decoded_args: &str,
+        receiver: CSharpExpression,
+        method_name: CSharpMethodName,
+        decoded_args: CSharpArgumentList,
         encode_ops: &WriteSeq,
-    ) -> String {
-        let mut out = String::new();
-        let result_ty = self.result_type_for_encode_ops(encode_ops);
-        out.push_str(&format!("            {result_ty} {RESULT_VALUE};\n"));
-        out.push_str("            try\n            {\n");
-        if result_ty.starts_with("BoltFFIResult<BoltFFIUnit,") {
-            out.push_str(&format!(
-                "                {receiver}.{method_name}({decoded_args});\n"
-            ));
-            out.push_str(&format!(
-                "                {RESULT_VALUE} = BoltFFIResult<BoltFFIUnit, "
-            ));
-            out.push_str(
-                result_ty
-                    .split_once(", ")
-                    .map(|(_, tail)| tail.trim_end_matches('>'))
-                    .unwrap_or("object"),
-            );
-            out.push_str(">.Ok(default);\n");
-        } else {
-            out.push_str(&format!(
-                "                {RESULT_VALUE} = {result_ty}.Ok({receiver}.{method_name}({decoded_args}));\n"
-            ));
+    ) -> CSharpCallbackResultAssignmentPlan {
+        let result_type = self.result_type_for_encode_ops(encode_ops);
+        let ok =
+            if result_type.ok_type.is_void() || result_type.ok_type == named_type("BoltFFIUnit") {
+                CSharpCallbackResultOkPlan::Void {
+                    receiver,
+                    method_name,
+                    args: decoded_args,
+                }
+            } else {
+                CSharpCallbackResultOkPlan::Value {
+                    receiver,
+                    method_name,
+                    args: decoded_args,
+                }
+            };
+        CSharpCallbackResultAssignmentPlan {
+            result_type,
+            ok,
+            catch: self.result_catch_for_encode_ops(encode_ops),
         }
-        out.push_str("            }\n");
-        out.push_str(&self.result_expected_catches_from_encode_ops(
-            encode_ops,
-            RESULT_VALUE,
-            "            ",
-        ));
-        out
     }
 
-    fn result_type_for_encode_ops(&self, encode_ops: &WriteSeq) -> String {
+    fn result_type_for_encode_ops(&self, encode_ops: &WriteSeq) -> CSharpResultTypePlan {
         let Some(crate::ir::ops::WriteOp::Result { ok, err, .. }) = encode_ops.ops.first() else {
-            return "BoltFFIResult<object, object>".to_string();
+            return CSharpResultTypePlan {
+                ok_type: named_type("object"),
+                err_type: named_type("object"),
+            };
         };
         let ok_type = self
             .result_branch_type(ok)
-            .unwrap_or_else(|| "BoltFFIUnit".to_string());
+            .unwrap_or_else(|| named_type("BoltFFIUnit"));
         let err_type = self
             .result_branch_type(err)
-            .unwrap_or_else(|| "object".to_string());
-        format!("BoltFFIResult<{ok_type}, {err_type}>")
+            .unwrap_or_else(|| named_type("object"));
+        CSharpResultTypePlan { ok_type, err_type }
     }
 
-    fn result_branch_type(&self, seq: &WriteSeq) -> Option<String> {
+    fn result_branch_type(&self, seq: &WriteSeq) -> Option<CSharpType> {
         let op = seq.ops.first()?;
         match op {
             crate::ir::ops::WriteOp::Primitive { primitive, .. } => {
-                Some(CSharpType::from(*primitive).to_string())
+                Some(CSharpType::from(*primitive))
             }
-            crate::ir::ops::WriteOp::String { .. } => Some("string".to_string()),
-            crate::ir::ops::WriteOp::Bytes { .. } => Some("byte[]".to_string()),
+            crate::ir::ops::WriteOp::String { .. } => Some(CSharpType::String),
+            crate::ir::ops::WriteOp::Bytes { .. } => {
+                Some(CSharpType::Array(Box::new(CSharpType::Byte)))
+            }
             crate::ir::ops::WriteOp::Record { id, .. } => {
-                Some(CSharpClassName::from(id).to_string())
+                Some(CSharpType::Record(CSharpClassName::from(id).into()))
             }
-            crate::ir::ops::WriteOp::Enum { id, .. } => Some(CSharpClassName::from(id).to_string()),
+            crate::ir::ops::WriteOp::Enum { id, .. } => {
+                Some(CSharpType::DataEnum(CSharpClassName::from(id).into()))
+            }
             crate::ir::ops::WriteOp::Option { some, .. } => self
                 .result_branch_type(some)
-                .map(|inner| format!("{inner}?")),
+                .map(|inner| CSharpType::Nullable(Box::new(inner))),
             crate::ir::ops::WriteOp::Vec { element_type, .. } => {
-                let inner = self.lower_type(element_type)?.to_string();
-                Some(format!("{inner}[]"))
+                let inner = self.lower_type(element_type)?;
+                Some(CSharpType::Array(Box::new(inner)))
             }
             crate::ir::ops::WriteOp::Custom { underlying, .. } => {
                 self.result_branch_type(underlying)
@@ -769,50 +754,28 @@ impl<'a> CSharpLowerer<'a> {
         }
     }
 
-    fn result_expected_catches_from_encode_ops(
+    fn result_catch_for_encode_ops(
         &self,
         encode_ops: &WriteSeq,
-        result_name: &str,
-        indent: &str,
-    ) -> String {
+    ) -> Option<CSharpCallbackResultCatchPlan> {
         let Some(crate::ir::ops::WriteOp::Result { err, .. }) = encode_ops.ops.first() else {
-            return String::new();
+            return None;
         };
         let err_type = self
             .result_branch_type(err)
-            .unwrap_or_else(|| "object".to_string());
-        let mut out = String::new();
+            .unwrap_or_else(|| named_type("object"));
         if let Some(exception) = self.error_exception_for_write_seq(err) {
-            out.push_str(&format!(
-                "{indent}catch ({exception} {ASYNC_EXCEPTION})\n{indent}{{\n"
-            ));
-            out.push_str(&format!(
-                "{indent}    {result_name} = BoltFFIResult<{}, {err_type}>.Err({ASYNC_EXCEPTION}.Error);\n",
-                self.result_type_for_encode_ops(encode_ops)
-                    .trim_start_matches("BoltFFIResult<")
-                    .split_once(", ")
-                    .map(|(ok, _)| ok)
-                    .unwrap_or("object")
-            ));
-            out.push_str(&format!("{indent}}}\n"));
-        } else if err_type == "string" {
-            out.push_str(&format!(
-                "{indent}catch (Exception {ASYNC_EXCEPTION})\n{indent}{{\n"
-            ));
-            out.push_str(&format!(
-                "{indent}    {result_name} = BoltFFIResult<{}, string>.Err({ASYNC_EXCEPTION}.Message);\n",
-                self.result_type_for_encode_ops(encode_ops)
-                    .trim_start_matches("BoltFFIResult<")
-                    .split_once(", ")
-                    .map(|(ok, _)| ok)
-                    .unwrap_or("object")
-            ));
-            out.push_str(&format!("{indent}}}\n"));
+            Some(CSharpCallbackResultCatchPlan::TypedException {
+                exception_type: exception,
+            })
+        } else if err_type == CSharpType::String {
+            Some(CSharpCallbackResultCatchPlan::ExceptionMessage)
+        } else {
+            None
         }
-        out
     }
 
-    fn error_exception_for_write_seq(&self, seq: &WriteSeq) -> Option<String> {
+    fn error_exception_for_write_seq(&self, seq: &WriteSeq) -> Option<CSharpType> {
         match seq.ops.first()? {
             crate::ir::ops::WriteOp::Record { id, .. }
                 if self
@@ -821,7 +784,10 @@ impl<'a> CSharpLowerer<'a> {
                     .resolve_record(id)
                     .is_some_and(|record| record.is_error) =>
             {
-                Some(format!("{}Exception", CSharpClassName::from(id)))
+                Some(named_type(&format!(
+                    "{}Exception",
+                    CSharpClassName::from(id)
+                )))
             }
             crate::ir::ops::WriteOp::Enum { id, .. }
                 if self
@@ -830,7 +796,10 @@ impl<'a> CSharpLowerer<'a> {
                     .resolve_enum(id)
                     .is_some_and(|enumeration| enumeration.is_error) =>
             {
-                Some(format!("{}Exception", CSharpClassName::from(id)))
+                Some(named_type(&format!(
+                    "{}Exception",
+                    CSharpClassName::from(id)
+                )))
             }
             crate::ir::ops::WriteOp::Custom { underlying, .. } => {
                 self.error_exception_for_write_seq(underlying)
@@ -896,40 +865,33 @@ impl<'a> CSharpLowerer<'a> {
         }
     }
 
-    fn render_result_decode_from_ops(
+    fn result_decode_plan(
         &self,
         decode_ops: &ReadSeq,
         reader_name: &str,
-        indent: &str,
-    ) -> String {
+    ) -> CSharpCallbackResultDecodePlan {
         let Some(crate::ir::ops::ReadOp::Result { ok, err, .. }) = decode_ops.ops.first() else {
-            return String::new();
+            return CSharpCallbackResultDecodePlan {
+                err_expr: CSharpExpression::Literal(CSharpLiteral::Null),
+                ok_expr: None,
+            };
         };
         let reader =
             CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(reader_name)));
         let mut locals = decode::DecodeLocalCounters::default();
-        let err_expr =
-            decode::lower_decode_expr(err, &reader, None, &self.namespace, &mut locals).to_string();
+        let err_expr = decode::lower_decode_expr(err, &reader, None, &self.namespace, &mut locals);
         let ok_expr = if matches!(ok.ops.first(), None) {
             None
         } else {
-            Some(
-                decode::lower_decode_expr(ok, &reader, None, &self.namespace, &mut locals)
-                    .to_string(),
-            )
+            Some(decode::lower_decode_expr(
+                ok,
+                &reader,
+                None,
+                &self.namespace,
+                &mut locals,
+            ))
         };
-        let mut out = String::new();
-        out.push_str(&format!(
-            "{indent}if ({reader_name}.ReadU8() != 0)\n{indent}{{\n"
-        ));
-        out.push_str(&format!(
-            "{indent}    throw new InvalidOperationException({err_expr}.ToString());\n"
-        ));
-        out.push_str(&format!("{indent}}}\n"));
-        if let Some(ok_expr) = ok_expr {
-            out.push_str(&format!("{indent}return {ok_expr};\n"));
-        }
-        out
+        CSharpCallbackResultDecodePlan { err_expr, ok_expr }
     }
 
     fn decode_expr_from_reader(
@@ -959,18 +921,17 @@ impl<'a> CSharpLowerer<'a> {
                 is_result,
                 ..
             } => {
-                let result_assignment_lines = if *is_result {
-                    unindented_lines(
-                        &self.render_result_assignment(
+                let result_assignment = if *is_result {
+                    Some(self.result_assignment_plan(
+                        CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(
                             "impl_",
-                            &method_name.to_string(),
-                            &decoded_args.to_string(),
-                            encode_ops,
-                        ),
-                        "            ",
-                    )
+                        ))),
+                        method_name.clone(),
+                        decoded_args.clone(),
+                        encode_ops,
+                    ))
                 } else {
-                    vec![]
+                    None
                 };
                 let writer = self.return_wire_writer_plan(
                     encode_ops,
@@ -988,7 +949,7 @@ impl<'a> CSharpLowerer<'a> {
                 CSharpSyncCallbackSuccessPlan::Encoded {
                     is_result: *is_result,
                     decoded_args,
-                    result_assignment_lines,
+                    result_assignment,
                     writer,
                 }
             }
@@ -1027,23 +988,22 @@ impl<'a> CSharpLowerer<'a> {
                 is_result,
                 ..
             } => {
-                let result_decode_lines = if *is_result {
-                    source_lines(
-                        &self.render_result_decode_from_ops(
+                let result_decode = if *is_result {
+                    Some(
+                        self.result_decode_plan(
                             decode_ops
                                 .as_ref()
                                 .expect("result callback return decode ops"),
                             RETURN_READER,
-                            "",
                         ),
                     )
                 } else {
-                    vec![]
+                    None
                 };
                 CSharpCallbackProxyCallPlan::Encoded {
                     args,
                     decode_expr: decode_expr.clone(),
-                    result_decode_lines,
+                    result_decode,
                 }
             }
         }
@@ -1242,7 +1202,7 @@ impl<'a> CSharpLowerer<'a> {
         };
         let err_type = self
             .result_branch_type(err)
-            .unwrap_or_else(|| "object".to_string());
+            .unwrap_or_else(|| named_type("object"));
         let (exception_type, error_value_expr, fallback) =
             if let Some(exception_ty) = self.error_exception_for_write_seq(err) {
                 (
@@ -1255,7 +1215,7 @@ impl<'a> CSharpLowerer<'a> {
                     },
                     Some(self.async_failure_completion(ret)),
                 )
-            } else if err_type == "string" {
+            } else if err_type == CSharpType::String {
                 (
                     None,
                     CSharpExpression::MemberAccess {
@@ -1507,16 +1467,6 @@ fn callback_public_param_list(params: &[CSharpCallbackBridgeParamPlan]) -> CShar
         .map(|param| param.public_param().clone())
         .collect::<Vec<_>>()
         .into()
-}
-
-fn source_lines(text: &str) -> Vec<String> {
-    text.lines().map(str::to_string).collect()
-}
-
-fn unindented_lines(text: &str, prefix: &str) -> Vec<String> {
-    text.lines()
-        .map(|line| line.strip_prefix(prefix).unwrap_or(line).to_string())
-        .collect()
 }
 
 fn stripped_name(name: &CSharpParamName) -> &str {

--- a/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
@@ -124,6 +124,7 @@ impl<'a> CSharpLowerer<'a> {
             .collect();
         CSharpCallbackPlan {
             public_name: self.callback_public_class_name(&callback.id),
+            proxy_name: self.callback_proxy_class_name(&callback.id),
             bridge_name: self.callback_bridge_class_name(&callback.id),
             methods,
             register_fn: CFunctionName::new(abi_callback.register_fn.as_str().to_string()),
@@ -263,6 +264,11 @@ impl<'a> CSharpLowerer<'a> {
                 CSharpClassName::from_source(callback_id.as_str())
             )),
         }
+    }
+
+    pub(super) fn callback_proxy_class_name(&self, callback_id: &CallbackId) -> CSharpClassName {
+        let public_name = self.callback_public_class_name(callback_id);
+        CSharpClassName::new(format!("{}Proxy", public_name.as_str()))
     }
 
     fn lower_callback_entry(

--- a/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
@@ -1,0 +1,1685 @@
+use crate::ir::abi::{AbiCallbackInvocation, AbiCallbackMethod, AbiParam, ParamRole, ReturnShape};
+use crate::ir::definitions::{CallbackKind, CallbackMethodDef, CallbackTraitDef, ReturnDef};
+use crate::ir::ids::CallbackId;
+use crate::ir::ops::{ReadSeq, WriteSeq};
+use crate::ir::plan::{AbiType, Transport};
+use crate::ir::types::{PrimitiveType, TypeExpr};
+
+use super::super::ast::{
+    CSharpClassName, CSharpExpression, CSharpIdentity, CSharpLocalName, CSharpMethodName,
+    CSharpParamName, CSharpType,
+};
+use super::super::plan::{
+    CFunctionName, CSharpCallbackMethodPlan, CSharpCallbackParamPlan, CSharpCallbackPlan,
+    CSharpClosureMethodPlan, CSharpClosurePlan,
+};
+use super::lowerer::CSharpLowerer;
+use super::{decode, encode, size, value};
+
+const STATUS_OK: &str = "new FfiStatus { code = 0 }";
+const STATUS_INTERNAL_ERROR: &str = "new FfiStatus { code = 100 }";
+const STATUS_OUT: &str = "__boltffiStatus";
+const OUT_PTR: &str = "__boltffiOutPtr";
+const OUT_LEN: &str = "__boltffiOutLen";
+const RETURN_VALUE: &str = "__boltffiValue";
+const RESULT_VALUE: &str = "__boltffiResult";
+const ERROR_RESULT_VALUE: &str = "__boltffiErrorResult";
+const RETURN_READER: &str = "__boltffiReader";
+const INVOKE_LOCAL: &str = "__boltffiInvoke";
+const ASYNC_TASK: &str = "__boltffiTask";
+const ASYNC_COMPLETED: &str = "__boltffiCompleted";
+const ASYNC_EXCEPTION: &str = "__boltffiException";
+const ERROR_OUT_PTR: &str = "__boltffiErrorOutPtr";
+const ERROR_OUT_LEN: &str = "__boltffiErrorOutLen";
+
+#[derive(Debug, Clone)]
+struct BridgeParam {
+    public_decl: String,
+    native_decls: Vec<String>,
+    decode_setup: Vec<String>,
+    decode_expr: String,
+    proxy_arg_exprs: Vec<String>,
+    proxy_setup: Vec<String>,
+    proxy_pin: Vec<String>,
+    proxy_cleanup: Vec<String>,
+    needs_wire_reader: bool,
+    needs_wire_writer: bool,
+}
+
+#[derive(Debug, Clone)]
+enum CallbackReturn {
+    Void,
+    Direct {
+        public_type: String,
+        native_type: String,
+        native_out_type: String,
+        default_value: String,
+        native_expr: String,
+        public_expr: String,
+        marshals_bool: bool,
+    },
+    Encoded {
+        public_type: String,
+        decode_expr: Option<String>,
+        encode_ops: WriteSeq,
+        decode_ops: Option<ReadSeq>,
+        is_result: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CallbackReturnMode {
+    CallbackVtable,
+    InlineClosure,
+}
+
+impl CallbackReturn {
+    fn needs_wire_reader(&self) -> bool {
+        matches!(
+            self,
+            Self::Encoded {
+                decode_ops: Some(_),
+                ..
+            }
+        )
+    }
+
+    fn needs_wire_writer(&self) -> bool {
+        matches!(self, Self::Encoded { .. })
+    }
+
+    fn public_type(&self) -> String {
+        match self {
+            Self::Void => "void".to_string(),
+            Self::Direct { public_type, .. } | Self::Encoded { public_type, .. } => {
+                public_type.clone()
+            }
+        }
+    }
+
+    fn async_task_type(&self) -> String {
+        match self {
+            Self::Void => "global::System.Threading.Tasks.Task".to_string(),
+            other => format!(
+                "global::System.Threading.Tasks.Task<{}>",
+                other.public_type()
+            ),
+        }
+    }
+}
+
+impl<'a> CSharpLowerer<'a> {
+    pub(super) fn lower_callback(&self, callback: &CallbackTraitDef) -> CSharpCallbackPlan {
+        let abi_callback = self
+            .abi_callback_for(&callback.id)
+            .expect("callback abi invocation missing");
+        let methods = callback
+            .methods
+            .iter()
+            .map(|method| {
+                let abi_method = self
+                    .abi_method_for(abi_callback, method)
+                    .expect("callback abi method missing");
+                self.lower_callback_method(callback, method, abi_method)
+            })
+            .collect();
+        CSharpCallbackPlan {
+            public_name: self.callback_public_class_name(&callback.id),
+            bridge_name: self.callback_bridge_class_name(&callback.id),
+            methods,
+            register_fn: CFunctionName::new(abi_callback.register_fn.as_str().to_string()),
+            create_fn: CFunctionName::new(abi_callback.create_fn.as_str().to_string()),
+            has_async_methods: callback.methods.iter().any(CallbackMethodDef::is_async),
+            needs_wire_reader: callback.methods.iter().any(|method| {
+                self.callback_method_needs_wire_reader(
+                    method,
+                    abi_callback,
+                    CallbackReturnMode::CallbackVtable,
+                )
+            }),
+            needs_wire_writer: callback.methods.iter().any(|method| {
+                self.callback_method_needs_wire_writer(
+                    method,
+                    abi_callback,
+                    CallbackReturnMode::CallbackVtable,
+                )
+            }),
+            needs_ffi_buf: callback.methods.iter().any(|method| {
+                self.callback_method_needs_ffi_buf(
+                    method,
+                    abi_callback,
+                    CallbackReturnMode::CallbackVtable,
+                )
+            }),
+        }
+    }
+
+    pub(super) fn lower_closure(&self, callback: &CallbackTraitDef) -> CSharpClosurePlan {
+        let abi_callback = self
+            .abi_callback_for(&callback.id)
+            .expect("closure abi invocation missing");
+        let method = callback
+            .methods
+            .first()
+            .expect("closure callback must have one method");
+        let abi_method = self
+            .abi_method_for(abi_callback, method)
+            .expect("closure abi method missing");
+        CSharpClosurePlan {
+            public_name: self.callback_public_class_name(&callback.id),
+            bridge_name: self.callback_bridge_class_name(&callback.id),
+            method: self.lower_closure_method(method, abi_method),
+            needs_wire_reader: self.callback_method_needs_wire_reader(
+                method,
+                abi_callback,
+                CallbackReturnMode::InlineClosure,
+            ),
+            needs_wire_writer: self.callback_method_needs_wire_writer(
+                method,
+                abi_callback,
+                CallbackReturnMode::InlineClosure,
+            ),
+            needs_ffi_buf: self.callback_method_needs_ffi_buf(
+                method,
+                abi_callback,
+                CallbackReturnMode::InlineClosure,
+            ),
+        }
+    }
+
+    fn lower_callback_method(
+        &self,
+        callback: &CallbackTraitDef,
+        method: &CallbackMethodDef,
+        abi_method: &AbiCallbackMethod,
+    ) -> CSharpCallbackMethodPlan {
+        let entry_source = if method.is_async() {
+            self.render_async_callback_entry(callback, method, abi_method)
+        } else {
+            self.render_sync_callback_entry(callback, method, abi_method)
+        };
+
+        CSharpCallbackMethodPlan {
+            name: (&method.id).into(),
+            vtable_field: CSharpLocalName::new(abi_method.vtable_field.as_str()),
+            return_type: self.callback_public_return_type(&method.returns),
+            is_async: method.is_async(),
+            public_params: self.public_param_plans(&method.params),
+            entry_source,
+            proxy_source: self.render_proxy_method(method, abi_method),
+            delegate_source: self.render_callback_delegate_types(method, abi_method),
+        }
+    }
+
+    fn lower_closure_method(
+        &self,
+        method: &CallbackMethodDef,
+        abi_method: &AbiCallbackMethod,
+    ) -> CSharpClosureMethodPlan {
+        let params = self.bridge_params(method, abi_method);
+        let ret = self.callback_return(
+            &method.returns,
+            &abi_method.returns,
+            CallbackReturnMode::InlineClosure,
+        );
+        let native_return_type = self.inline_callback_native_return_type(&ret);
+        let native_decls = std::iter::once("IntPtr context".to_string())
+            .chain(params.iter().flat_map(|p| p.native_decls.clone()))
+            .collect::<Vec<_>>();
+        let decoded_args = params
+            .iter()
+            .map(|p| p.decode_expr.clone())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let marshals_return_bool = matches!(
+            ret,
+            CallbackReturn::Direct {
+                marshals_bool: true,
+                ..
+            }
+        );
+
+        CSharpClosureMethodPlan {
+            return_type: self.callback_public_return_type(&method.returns),
+            public_params: self.public_param_plans(&method.params),
+            native_return_type,
+            native_decls,
+            marshals_return_bool,
+            decode_setup: params
+                .iter()
+                .flat_map(|param| param.decode_setup.clone())
+                .collect(),
+            invoke_body: self.render_closure_invoke_return(&ret, &decoded_args),
+        }
+    }
+
+    pub(super) fn callback_public_class_name(&self, callback_id: &CallbackId) -> CSharpClassName {
+        let callback = self.ffi.catalog.resolve_callback(callback_id);
+        match callback {
+            Some(cb) if matches!(cb.kind, CallbackKind::Closure) => {
+                let signature_id = callback_id
+                    .as_str()
+                    .strip_prefix("__Closure_")
+                    .unwrap_or(callback_id.as_str());
+                CSharpClassName::new(format!("Closure{signature_id}"))
+            }
+            _ => CSharpClassName::from_source(callback_id.as_str()),
+        }
+    }
+
+    pub(super) fn callback_bridge_class_name(&self, callback_id: &CallbackId) -> CSharpClassName {
+        let callback = self.ffi.catalog.resolve_callback(callback_id);
+        match callback {
+            Some(cb) if matches!(cb.kind, CallbackKind::Closure) => {
+                let signature_id = callback_id
+                    .as_str()
+                    .strip_prefix("__Closure_")
+                    .unwrap_or(callback_id.as_str());
+                CSharpClassName::new(format!("Closure{signature_id}Bridge"))
+            }
+            _ => CSharpClassName::new(format!(
+                "{}Bridge",
+                CSharpClassName::from_source(callback_id.as_str())
+            )),
+        }
+    }
+
+    fn render_closure_invoke_return(&self, ret: &CallbackReturn, decoded_args: &str) -> String {
+        match ret {
+            CallbackReturn::Void => {
+                format!("            impl_({decoded_args});\n")
+            }
+            CallbackReturn::Direct {
+                native_expr,
+                marshals_bool,
+                ..
+            } => {
+                let return_expr = if *marshals_bool {
+                    RETURN_VALUE.to_string()
+                } else {
+                    native_expr.replace("value", RETURN_VALUE)
+                };
+                format!(
+                    "            var {RETURN_VALUE} = impl_({decoded_args});\n            return {return_expr};\n"
+                )
+            }
+            CallbackReturn::Encoded {
+                encode_ops,
+                is_result,
+                ..
+            } => {
+                let mut out = String::new();
+                if *is_result {
+                    out.push_str(&self.render_result_assignment(
+                        "impl_",
+                        "Invoke",
+                        decoded_args,
+                        encode_ops,
+                    ));
+                } else {
+                    out.push_str(&format!(
+                        "            var {RETURN_VALUE} = impl_({decoded_args});\n"
+                    ));
+                }
+                out.push_str(&indent_block(
+                    &self.render_encode_to_bytes_with_renames(
+                        encode_ops,
+                        "_returnWire",
+                        "_returnBytes",
+                        "            ",
+                        &root_local_rename(
+                            if *is_result { "result" } else { "value" },
+                            if *is_result {
+                                RESULT_VALUE
+                            } else {
+                                RETURN_VALUE
+                            },
+                        ),
+                    ),
+                    "",
+                ));
+                out.push_str("            return FfiBuf.FromBytes(_returnBytes);\n");
+                out
+            }
+        }
+    }
+
+    fn render_sync_callback_entry(
+        &self,
+        _callback: &CallbackTraitDef,
+        method: &CallbackMethodDef,
+        abi_method: &AbiCallbackMethod,
+    ) -> String {
+        let method_name: CSharpMethodName = (&method.id).into();
+        let params = self.bridge_params(method, abi_method);
+        let ret = self.callback_return(
+            &method.returns,
+            &abi_method.returns,
+            CallbackReturnMode::CallbackVtable,
+        );
+        let native_decls = self.sync_callback_native_decls(&params, &ret);
+        let decoded_args = params
+            .iter()
+            .map(|p| p.decode_expr.clone())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let mut out =
+            format!("        private static void {method_name}({native_decls})\n        {{\n");
+        for line in self.sync_out_initializers(&ret) {
+            out.push_str(&format!("            {line}\n"));
+        }
+        out.push_str(&format!(
+            "            {STATUS_OUT} = {STATUS_INTERNAL_ERROR};\n"
+        ));
+        out.push_str("            try\n            {\n");
+        out.push_str("                if (!Handles.TryGetValue(handle, out var impl_)) throw new InvalidOperationException(\"invalid callback handle\");\n");
+        for param in &params {
+            for line in &param.decode_setup {
+                out.push_str(&format!("                {line}\n"));
+            }
+        }
+        match &ret {
+            CallbackReturn::Void => {
+                out.push_str(&format!(
+                    "                impl_.{method_name}({decoded_args});\n"
+                ));
+                out.push_str(&format!("                {STATUS_OUT} = {STATUS_OK};\n"));
+            }
+            CallbackReturn::Direct { native_expr, .. } => {
+                out.push_str(&format!(
+                    "                var {RETURN_VALUE} = impl_.{method_name}({decoded_args});\n"
+                ));
+                out.push_str(&format!(
+                    "                {OUT_PTR} = {};\n",
+                    native_expr.replace("value", RETURN_VALUE)
+                ));
+                out.push_str(&format!("                {STATUS_OUT} = {STATUS_OK};\n"));
+            }
+            CallbackReturn::Encoded {
+                encode_ops,
+                is_result,
+                ..
+            } => {
+                if *is_result {
+                    out.push_str(&indent_block(
+                        &self.render_result_assignment(
+                            "impl_",
+                            &method_name.to_string(),
+                            &decoded_args,
+                            encode_ops,
+                        ),
+                        "                ",
+                    ));
+                } else {
+                    out.push_str(&format!(
+                        "                var {RETURN_VALUE} = impl_.{method_name}({decoded_args});\n"
+                    ));
+                }
+                out.push_str(&indent_block(
+                    &self.render_encode_to_bytes_with_renames(
+                        encode_ops,
+                        "_returnWire",
+                        "_returnBytes",
+                        "                ",
+                        &root_local_rename(
+                            if *is_result { "result" } else { "value" },
+                            if *is_result {
+                                RESULT_VALUE
+                            } else {
+                                RETURN_VALUE
+                            },
+                        ),
+                    ),
+                    "",
+                ));
+                out.push_str(&format!(
+                    "                BoltFFICallbackReturn.Store(_returnBytes, out {OUT_PTR}, out {OUT_LEN});\n"
+                ));
+                out.push_str(&format!("                {STATUS_OUT} = {STATUS_OK};\n"));
+            }
+        }
+        out.push_str("            }\n");
+        out.push_str("            catch\n            {\n");
+        for line in self.sync_out_initializers(&ret) {
+            out.push_str(&format!("                {line}\n"));
+        }
+        out.push_str(&format!(
+            "                {STATUS_OUT} = {STATUS_INTERNAL_ERROR};\n"
+        ));
+        out.push_str("            }\n");
+        out.push_str("        }\n");
+        out
+    }
+
+    fn render_async_callback_entry(
+        &self,
+        _callback: &CallbackTraitDef,
+        method: &CallbackMethodDef,
+        abi_method: &AbiCallbackMethod,
+    ) -> String {
+        let method_name: CSharpMethodName = (&method.id).into();
+        let params = self.bridge_params(method, abi_method);
+        let ret = self.callback_return(
+            &method.returns,
+            &abi_method.returns,
+            CallbackReturnMode::CallbackVtable,
+        );
+        let mut native_decls = vec!["ulong handle".to_string()];
+        native_decls.extend(params.iter().flat_map(|p| p.native_decls.clone()));
+        native_decls.push(format!("{method_name}Completion callback"));
+        native_decls.push("ulong callbackData".to_string());
+        let decoded_args = params
+            .iter()
+            .map(|p| p.decode_expr.clone())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let mut out = format!(
+            "        private static void {method_name}({})\n        {{\n",
+            native_decls.join(", ")
+        );
+        out.push_str(
+            "            if (!Handles.TryGetValue(handle, out var impl_))\n            {\n",
+        );
+        out.push_str(&self.async_complete_failure(
+            &ret,
+            "callback",
+            "callbackData",
+            "                ",
+        ));
+        out.push_str("                return;\n            }\n");
+        out.push_str("            try\n            {\n");
+        for param in &params {
+            for line in &param.decode_setup {
+                out.push_str(&format!("                {line}\n"));
+            }
+        }
+        out.push_str(&format!(
+            "                var {ASYNC_TASK} = impl_.{method_name}({decoded_args});\n"
+        ));
+        out.push_str(&format!(
+            "                _ = {ASYNC_TASK}.ContinueWith({ASYNC_COMPLETED} =>\n                {{\n"
+        ));
+        out.push_str(&format!(
+            "                    if ({ASYNC_COMPLETED}.IsCanceled)\n                    {{\n"
+        ));
+        out.push_str(&self.async_complete_failure(
+            &ret,
+            "callback",
+            "callbackData",
+            "                        ",
+        ));
+        out.push_str("                        return;\n                    }\n");
+        out.push_str(&format!(
+            "                    if ({ASYNC_COMPLETED}.IsFaulted)\n                    {{\n"
+        ));
+        out.push_str(&format!(
+            "                        Exception {ASYNC_EXCEPTION} = UnwrapTaskException({ASYNC_COMPLETED}.Exception!);\n"
+        ));
+        out.push_str(&self.async_complete_exception(
+            &ret,
+            "callback",
+            "callbackData",
+            "                        ",
+        ));
+        out.push_str("                        return;\n                    }\n");
+        out.push_str(&self.async_complete_success(
+            &ret,
+            "callback",
+            "callbackData",
+            ASYNC_COMPLETED,
+            "                    ",
+        ));
+        out.push_str("                }, global::System.Threading.Tasks.TaskScheduler.Default);\n");
+        out.push_str("            }\n");
+        out.push_str("            catch\n            {\n");
+        out.push_str(&self.async_complete_failure(
+            &ret,
+            "callback",
+            "callbackData",
+            "                ",
+        ));
+        out.push_str("            }\n");
+        out.push_str("        }\n");
+        out
+    }
+
+    fn render_proxy_method(
+        &self,
+        method: &CallbackMethodDef,
+        abi_method: &AbiCallbackMethod,
+    ) -> String {
+        let method_name: CSharpMethodName = (&method.id).into();
+        let params = self.bridge_params(method, abi_method);
+        let ret = self.callback_return(
+            &method.returns,
+            &abi_method.returns,
+            CallbackReturnMode::CallbackVtable,
+        );
+        let public_params = params
+            .iter()
+            .map(|p| p.public_decl.clone())
+            .collect::<Vec<_>>()
+            .join(", ");
+        if method.is_async() {
+            let return_type = ret.async_task_type();
+            let not_supported = "new NotSupportedException(\"async callback proxies are not implemented for C# yet\")";
+            return match ret {
+                CallbackReturn::Void => format!(
+                    "            public {return_type} {method_name}({public_params}) => global::System.Threading.Tasks.Task.FromException({not_supported});\n"
+                ),
+                _ => format!(
+                    "            public {return_type} {method_name}({public_params}) => global::System.Threading.Tasks.Task.FromException<{}>({not_supported});\n",
+                    ret.public_type()
+                ),
+            };
+        }
+
+        let mut out = format!(
+            "            public {} {method_name}({public_params})\n            {{\n",
+            ret.public_type()
+        );
+        out.push_str("                if (_handle.IsNull) throw new ObjectDisposedException(nameof(Proxy));\n");
+        out.push_str(
+            "                VTable __boltffiTable = Marshal.PtrToStructure<VTable>(_handle.vtable);\n",
+        );
+        out.push_str(&format!(
+            "                var {INVOKE_LOCAL} = Marshal.GetDelegateForFunctionPointer<{method_name}ProxyFn>(__boltffiTable.{});\n",
+            abi_method.vtable_field.as_str()
+        ));
+        for param in &params {
+            for line in &param.proxy_setup {
+                out.push_str(&format!("                {line}\n"));
+            }
+        }
+        let has_cleanup = params.iter().any(|p| !p.proxy_cleanup.is_empty());
+        if has_cleanup {
+            out.push_str("                try\n                {\n");
+        }
+        for param in &params {
+            for line in &param.proxy_pin {
+                out.push_str(&format!(
+                    "{}{line}\n",
+                    if has_cleanup {
+                        "                    "
+                    } else {
+                        "                "
+                    }
+                ));
+            }
+        }
+        let call_indent = if has_cleanup {
+            "                    "
+        } else {
+            "                "
+        };
+        let args = std::iter::once("_handle.handle".to_string())
+            .chain(params.iter().flat_map(|p| p.proxy_arg_exprs.clone()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        match &ret {
+            CallbackReturn::Void => {
+                out.push_str(&format!("{call_indent}FfiStatus {STATUS_OUT};\n"));
+                out.push_str(&format!(
+                    "{call_indent}{INVOKE_LOCAL}({args}, out {STATUS_OUT});\n"
+                ));
+                out.push_str(&format!(
+                    "{call_indent}ThrowIfCallbackStatus({STATUS_OUT});\n"
+                ));
+            }
+            CallbackReturn::Direct {
+                native_out_type,
+                public_expr,
+                ..
+            } => {
+                out.push_str(&format!("{call_indent}{native_out_type} {OUT_PTR};\n"));
+                out.push_str(&format!("{call_indent}FfiStatus {STATUS_OUT};\n"));
+                out.push_str(&format!(
+                    "{call_indent}{INVOKE_LOCAL}({args}, out {OUT_PTR}, out {STATUS_OUT});\n"
+                ));
+                out.push_str(&format!(
+                    "{call_indent}ThrowIfCallbackStatus({STATUS_OUT});\n"
+                ));
+                out.push_str(&format!("{call_indent}return {public_expr};\n"));
+            }
+            CallbackReturn::Encoded {
+                decode_expr,
+                decode_ops,
+                is_result,
+                ..
+            } => {
+                out.push_str(&format!("{call_indent}IntPtr {OUT_PTR};\n"));
+                out.push_str(&format!("{call_indent}UIntPtr {OUT_LEN};\n"));
+                out.push_str(&format!("{call_indent}FfiStatus {STATUS_OUT};\n"));
+                out.push_str(&format!(
+                    "{call_indent}{INVOKE_LOCAL}({args}, out {OUT_PTR}, out {OUT_LEN}, out {STATUS_OUT});\n"
+                ));
+                out.push_str(&format!("{call_indent}try\n{call_indent}{{\n"));
+                out.push_str(&format!(
+                    "{call_indent}    ThrowIfCallbackStatus({STATUS_OUT});\n"
+                ));
+                out.push_str(&format!(
+                    "{call_indent}    var {RETURN_READER} = new WireReader({OUT_PTR}, {OUT_LEN});\n"
+                ));
+                if *is_result {
+                    let result_body = self.render_result_decode_from_ops(
+                        decode_ops
+                            .as_ref()
+                            .expect("result callback return decode ops"),
+                        RETURN_READER,
+                        &(call_indent.to_string() + "    "),
+                    );
+                    out.push_str(&result_body);
+                } else if let Some(expr) = decode_expr {
+                    out.push_str(&format!("{call_indent}    return {expr};\n"));
+                }
+                out.push_str(&format!("{call_indent}}}\n"));
+                out.push_str(&format!("{call_indent}finally\n{call_indent}{{\n"));
+                out.push_str(&format!(
+                    "{call_indent}    BoltFFICallbackReturn.Free({OUT_PTR});\n"
+                ));
+                out.push_str(&format!("{call_indent}}}\n"));
+            }
+        }
+        if has_cleanup {
+            out.push_str("                }\n                finally\n                {\n");
+            for param in &params {
+                for line in &param.proxy_cleanup {
+                    out.push_str(&format!("                    {line}\n"));
+                }
+            }
+            out.push_str("                }\n");
+        }
+        out.push_str("            }\n");
+        out
+    }
+
+    fn render_callback_delegate_types(
+        &self,
+        method: &CallbackMethodDef,
+        abi_method: &AbiCallbackMethod,
+    ) -> String {
+        let method_name: CSharpMethodName = (&method.id).into();
+        let params = self.bridge_params(method, abi_method);
+        let ret = self.callback_return(
+            &method.returns,
+            &abi_method.returns,
+            CallbackReturnMode::CallbackVtable,
+        );
+        let mut out = String::new();
+        out.push_str("        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]\n");
+        out.push_str(&format!(
+            "        private delegate void {method_name}Fn({});\n",
+            if method.is_async() {
+                let mut decls = vec!["ulong handle".to_string()];
+                decls.extend(params.iter().flat_map(|p| p.native_decls.clone()));
+                decls.push(format!("{method_name}Completion callback"));
+                decls.push("ulong callbackData".to_string());
+                decls.join(", ")
+            } else {
+                self.sync_callback_native_decls(&params, &ret)
+            }
+        ));
+        out.push_str(&format!(
+            "        private static readonly {method_name}Fn {method_name}Delegate = {method_name};\n\n"
+        ));
+        if method.is_async() {
+            out.push_str("        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]\n");
+            out.push_str(&format!(
+                "        private delegate void {method_name}Completion({});\n\n",
+                self.async_completion_decls(&ret)
+            ));
+        } else {
+            out.push_str("        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]\n");
+            out.push_str(&format!(
+                "        private delegate void {method_name}ProxyFn({});\n\n",
+                self.sync_proxy_native_decls(&params, &ret)
+            ));
+        }
+        out
+    }
+
+    fn bridge_params(
+        &self,
+        method: &CallbackMethodDef,
+        abi_method: &AbiCallbackMethod,
+    ) -> Vec<BridgeParam> {
+        method
+            .params
+            .iter()
+            .filter_map(|param| {
+                let abi_param = abi_method.params.iter().find(|abi_param| {
+                    matches!(&abi_param.role, ParamRole::Input { .. })
+                        && abi_param.name == param.name
+                })?;
+                Some(self.bridge_param(param, abi_param))
+            })
+            .collect()
+    }
+
+    fn bridge_param(
+        &self,
+        param: &crate::ir::definitions::ParamDef,
+        abi_param: &AbiParam,
+    ) -> BridgeParam {
+        let name: CSharpParamName = (&param.name).into();
+        let public_type = self
+            .lower_type(&param.type_expr)
+            .expect("callback param type")
+            .to_string();
+        let public_decl = format!("{public_type} {name}");
+        let ParamRole::Input {
+            transport,
+            len_param,
+            decode_ops,
+            encode_ops,
+            ..
+        } = &abi_param.role
+        else {
+            panic!("callback bridge param must be input");
+        };
+
+        if matches!(transport, Transport::Span(_)) {
+            let len_param = len_param
+                .as_ref()
+                .expect("encoded callback param must have len param");
+            let len_name: CSharpParamName = len_param.into();
+            let decode_ops = decode_ops
+                .as_ref()
+                .expect("encoded callback param must have decode ops");
+            let reader_name = format!("__boltffi{}Reader", name.as_str().trim_start_matches('@'));
+            let decode_expr = self.decode_expr_from_reader(
+                &self.normalize_custom_read_seq(decode_ops),
+                CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(
+                    reader_name.clone(),
+                ))),
+            );
+            let encode_ops = self.normalize_custom_write_seq(
+                encode_ops
+                    .as_ref()
+                    .expect("encoded callback param must have encode ops"),
+            );
+            let bytes_name = format!("_{}Bytes", name.as_str().trim_start_matches('@'));
+            let pin_name = format!("_{}Pin", name.as_str().trim_start_matches('@'));
+            let ptr_name = format!("_{}Ptr", name.as_str().trim_start_matches('@'));
+            let mut setup = self
+                .render_encode_to_bytes(
+                    &encode_ops,
+                    &format!("_{}Wire", name.as_str().trim_start_matches('@')),
+                    &bytes_name,
+                    "                ",
+                )
+                .lines()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            setup.push(format!("GCHandle {pin_name} = default;"));
+            setup.push(format!("IntPtr {ptr_name} = IntPtr.Zero;"));
+            BridgeParam {
+                public_decl,
+                native_decls: vec![format!("IntPtr {name}"), format!("UIntPtr {len_name}")],
+                decode_setup: vec![format!(
+                    "var {reader_name} = new WireReader({name}, {len_name});"
+                )],
+                decode_expr,
+                proxy_arg_exprs: vec![ptr_name.clone(), format!("(UIntPtr){bytes_name}.Length")],
+                proxy_setup: setup,
+                proxy_pin: vec![
+                    format!("if ({bytes_name}.Length != 0)"),
+                    "{".to_string(),
+                    format!("    {pin_name} = GCHandle.Alloc({bytes_name}, GCHandleType.Pinned);"),
+                    format!("    {ptr_name} = {pin_name}.AddrOfPinnedObject();"),
+                    "}".to_string(),
+                ],
+                proxy_cleanup: vec![format!("if ({pin_name}.IsAllocated) {pin_name}.Free();")],
+                needs_wire_reader: true,
+                needs_wire_writer: true,
+            }
+        } else {
+            let native_decl = self.native_param_decl(&abi_param.abi_type, &name);
+            let decode_expr = self.direct_decode_expr(&param.type_expr, &name);
+            let proxy_expr =
+                self.direct_proxy_arg_expr(&param.type_expr, &abi_param.abi_type, &name);
+            BridgeParam {
+                public_decl,
+                native_decls: vec![native_decl],
+                decode_setup: vec![],
+                decode_expr,
+                proxy_arg_exprs: vec![proxy_expr],
+                proxy_setup: vec![],
+                proxy_pin: vec![],
+                proxy_cleanup: vec![],
+                needs_wire_reader: false,
+                needs_wire_writer: false,
+            }
+        }
+    }
+
+    fn callback_return(
+        &self,
+        returns: &ReturnDef,
+        ret_shape: &ReturnShape,
+        mode: CallbackReturnMode,
+    ) -> CallbackReturn {
+        match returns {
+            ReturnDef::Void => CallbackReturn::Void,
+            ReturnDef::Value(ty) => self.callback_value_return(ty, ret_shape, mode),
+            ReturnDef::Result { ok, err: _ } => {
+                let public_type = if matches!(ok, TypeExpr::Void) {
+                    "void".to_string()
+                } else {
+                    self.lower_type(ok).expect("result ok type").to_string()
+                };
+                CallbackReturn::Encoded {
+                    public_type,
+                    decode_expr: None,
+                    encode_ops: self.normalize_custom_write_seq(
+                        ret_shape.encode_ops.as_ref().expect("result encode ops"),
+                    ),
+                    decode_ops: ret_shape
+                        .decode_ops
+                        .as_ref()
+                        .map(|ops| self.normalize_custom_read_seq(ops)),
+                    is_result: true,
+                }
+            }
+        }
+    }
+
+    fn callback_public_return_type(&self, returns: &ReturnDef) -> CSharpType {
+        match returns {
+            ReturnDef::Void => CSharpType::Void,
+            ReturnDef::Value(ty) => self.lower_type(ty).expect("callback return type"),
+            ReturnDef::Result { ok, .. } if matches!(ok, TypeExpr::Void) => CSharpType::Void,
+            ReturnDef::Result { ok, .. } => self.lower_type(ok).expect("result ok type"),
+        }
+    }
+
+    fn callback_value_return(
+        &self,
+        ty: &TypeExpr,
+        ret_shape: &ReturnShape,
+        mode: CallbackReturnMode,
+    ) -> CallbackReturn {
+        let public_type = self
+            .lower_type(ty)
+            .expect("callback return type")
+            .to_string();
+        match &ret_shape.transport {
+            None => CallbackReturn::Void,
+            Some(Transport::Scalar(origin)) => {
+                let primitive = origin.primitive();
+                let native_type = self.native_type_for_primitive(primitive).to_string();
+                let marshals_bool = primitive == PrimitiveType::Bool;
+                let native_out_type = if marshals_bool {
+                    "byte".to_string()
+                } else {
+                    native_type.clone()
+                };
+                let native_expr = self.direct_return_native_expr(ty, primitive, "value");
+                let public_expr = self.direct_return_public_expr(ty, primitive, OUT_PTR);
+                CallbackReturn::Direct {
+                    public_type,
+                    native_type,
+                    native_out_type,
+                    default_value: if marshals_bool {
+                        "0".to_string()
+                    } else {
+                        "default".to_string()
+                    },
+                    native_expr,
+                    public_expr,
+                    marshals_bool,
+                }
+            }
+            Some(Transport::Composite(layout)) if mode == CallbackReturnMode::InlineClosure => {
+                let native_type = CSharpClassName::from(&layout.record_id).to_string();
+                CallbackReturn::Direct {
+                    public_type,
+                    native_type: native_type.clone(),
+                    native_out_type: native_type,
+                    default_value: "default".to_string(),
+                    native_expr: "value".to_string(),
+                    public_expr: OUT_PTR.to_string(),
+                    marshals_bool: false,
+                }
+            }
+            Some(Transport::Composite(_)) => {
+                let decode_ops = ret_shape
+                    .decode_ops
+                    .as_ref()
+                    .map(|ops| self.normalize_custom_read_seq(ops));
+                let decode_expr = decode_ops.as_ref().map(|ops| {
+                    self.decode_expr_from_reader(
+                        ops,
+                        CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(
+                            RETURN_READER,
+                        ))),
+                    )
+                });
+                CallbackReturn::Encoded {
+                    public_type,
+                    decode_expr,
+                    encode_ops: self.normalize_custom_write_seq(
+                        ret_shape.encode_ops.as_ref().expect("encoded return ops"),
+                    ),
+                    decode_ops,
+                    is_result: false,
+                }
+            }
+            Some(Transport::Callback { callback_id, .. }) => {
+                let bridge = self.callback_bridge_class_name(callback_id);
+                CallbackReturn::Direct {
+                    public_type,
+                    native_type: "BoltFFICallbackHandle".to_string(),
+                    native_out_type: "BoltFFICallbackHandle".to_string(),
+                    default_value: "BoltFFICallbackHandle.Null".to_string(),
+                    native_expr: format!("{bridge}.Create(value)"),
+                    public_expr: format!("{bridge}.Wrap({OUT_PTR})"),
+                    marshals_bool: false,
+                }
+            }
+            Some(Transport::Handle { .. }) => CallbackReturn::Direct {
+                public_type,
+                native_type: "IntPtr".to_string(),
+                native_out_type: "IntPtr".to_string(),
+                default_value: "IntPtr.Zero".to_string(),
+                native_expr: "value.Handle".to_string(),
+                public_expr: OUT_PTR.to_string(),
+                marshals_bool: false,
+            },
+            Some(Transport::Span(_)) => {
+                let decode_ops = ret_shape
+                    .decode_ops
+                    .as_ref()
+                    .map(|ops| self.normalize_custom_read_seq(ops));
+                let decode_expr = decode_ops.as_ref().map(|ops| {
+                    self.decode_expr_from_reader(
+                        ops,
+                        CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(
+                            RETURN_READER,
+                        ))),
+                    )
+                });
+                CallbackReturn::Encoded {
+                    public_type,
+                    decode_expr,
+                    encode_ops: self.normalize_custom_write_seq(
+                        ret_shape.encode_ops.as_ref().expect("encoded return ops"),
+                    ),
+                    decode_ops,
+                    is_result: false,
+                }
+            }
+        }
+    }
+
+    fn public_param_plans(
+        &self,
+        params: &[crate::ir::definitions::ParamDef],
+    ) -> Vec<CSharpCallbackParamPlan> {
+        params
+            .iter()
+            .map(|param| CSharpCallbackParamPlan {
+                csharp_type: self
+                    .lower_type(&param.type_expr)
+                    .expect("callback param type"),
+                name: (&param.name).into(),
+            })
+            .collect()
+    }
+
+    fn render_result_assignment(
+        &self,
+        receiver: &str,
+        method_name: &str,
+        decoded_args: &str,
+        encode_ops: &WriteSeq,
+    ) -> String {
+        let mut out = String::new();
+        let result_ty = self.result_type_for_encode_ops(encode_ops);
+        out.push_str(&format!("            {result_ty} {RESULT_VALUE};\n"));
+        out.push_str("            try\n            {\n");
+        if result_ty.starts_with("BoltFFIResult<BoltFFIUnit,") {
+            out.push_str(&format!(
+                "                {receiver}.{method_name}({decoded_args});\n"
+            ));
+            out.push_str(&format!(
+                "                {RESULT_VALUE} = BoltFFIResult<BoltFFIUnit, "
+            ));
+            out.push_str(
+                result_ty
+                    .split_once(", ")
+                    .map(|(_, tail)| tail.trim_end_matches('>'))
+                    .unwrap_or("object"),
+            );
+            out.push_str(">.Ok(default);\n");
+        } else {
+            out.push_str(&format!(
+                "                {RESULT_VALUE} = {result_ty}.Ok({receiver}.{method_name}({decoded_args}));\n"
+            ));
+        }
+        out.push_str("            }\n");
+        out.push_str(&self.result_expected_catches_from_encode_ops(
+            encode_ops,
+            RESULT_VALUE,
+            "            ",
+        ));
+        out
+    }
+
+    fn result_type_for_encode_ops(&self, encode_ops: &WriteSeq) -> String {
+        let Some(crate::ir::ops::WriteOp::Result { ok, err, .. }) = encode_ops.ops.first() else {
+            return "BoltFFIResult<object, object>".to_string();
+        };
+        let ok_type = self
+            .result_branch_type(ok)
+            .unwrap_or_else(|| "BoltFFIUnit".to_string());
+        let err_type = self
+            .result_branch_type(err)
+            .unwrap_or_else(|| "object".to_string());
+        format!("BoltFFIResult<{ok_type}, {err_type}>")
+    }
+
+    fn result_branch_type(&self, seq: &WriteSeq) -> Option<String> {
+        let op = seq.ops.first()?;
+        match op {
+            crate::ir::ops::WriteOp::Primitive { primitive, .. } => {
+                Some(CSharpType::from(*primitive).to_string())
+            }
+            crate::ir::ops::WriteOp::String { .. } => Some("string".to_string()),
+            crate::ir::ops::WriteOp::Bytes { .. } => Some("byte[]".to_string()),
+            crate::ir::ops::WriteOp::Record { id, .. } => {
+                Some(CSharpClassName::from(id).to_string())
+            }
+            crate::ir::ops::WriteOp::Enum { id, .. } => Some(CSharpClassName::from(id).to_string()),
+            crate::ir::ops::WriteOp::Option { some, .. } => self
+                .result_branch_type(some)
+                .map(|inner| format!("{inner}?")),
+            crate::ir::ops::WriteOp::Vec { element_type, .. } => {
+                let inner = self.lower_type(element_type)?.to_string();
+                Some(format!("{inner}[]"))
+            }
+            crate::ir::ops::WriteOp::Custom { underlying, .. } => {
+                self.result_branch_type(underlying)
+            }
+            _ => None,
+        }
+    }
+
+    fn result_expected_catches_from_encode_ops(
+        &self,
+        encode_ops: &WriteSeq,
+        result_name: &str,
+        indent: &str,
+    ) -> String {
+        let Some(crate::ir::ops::WriteOp::Result { err, .. }) = encode_ops.ops.first() else {
+            return String::new();
+        };
+        let err_type = self
+            .result_branch_type(err)
+            .unwrap_or_else(|| "object".to_string());
+        let mut out = String::new();
+        if let Some(exception) = self.error_exception_for_write_seq(err) {
+            out.push_str(&format!(
+                "{indent}catch ({exception} {ASYNC_EXCEPTION})\n{indent}{{\n"
+            ));
+            out.push_str(&format!(
+                "{indent}    {result_name} = BoltFFIResult<{}, {err_type}>.Err({ASYNC_EXCEPTION}.Error);\n",
+                self.result_type_for_encode_ops(encode_ops)
+                    .trim_start_matches("BoltFFIResult<")
+                    .split_once(", ")
+                    .map(|(ok, _)| ok)
+                    .unwrap_or("object")
+            ));
+            out.push_str(&format!("{indent}}}\n"));
+        } else if err_type == "string" {
+            out.push_str(&format!(
+                "{indent}catch (Exception {ASYNC_EXCEPTION})\n{indent}{{\n"
+            ));
+            out.push_str(&format!(
+                "{indent}    {result_name} = BoltFFIResult<{}, string>.Err({ASYNC_EXCEPTION}.Message);\n",
+                self.result_type_for_encode_ops(encode_ops)
+                    .trim_start_matches("BoltFFIResult<")
+                    .split_once(", ")
+                    .map(|(ok, _)| ok)
+                    .unwrap_or("object")
+            ));
+            out.push_str(&format!("{indent}}}\n"));
+        }
+        out
+    }
+
+    fn error_exception_for_write_seq(&self, seq: &WriteSeq) -> Option<String> {
+        match seq.ops.first()? {
+            crate::ir::ops::WriteOp::Record { id, .. }
+                if self
+                    .ffi
+                    .catalog
+                    .resolve_record(id)
+                    .is_some_and(|record| record.is_error) =>
+            {
+                Some(format!("{}Exception", CSharpClassName::from(id)))
+            }
+            crate::ir::ops::WriteOp::Enum { id, .. }
+                if self
+                    .ffi
+                    .catalog
+                    .resolve_enum(id)
+                    .is_some_and(|enumeration| enumeration.is_error) =>
+            {
+                Some(format!("{}Exception", CSharpClassName::from(id)))
+            }
+            crate::ir::ops::WriteOp::Custom { underlying, .. } => {
+                self.error_exception_for_write_seq(underlying)
+            }
+            _ => None,
+        }
+    }
+
+    fn render_encode_to_bytes(
+        &self,
+        encode_ops: &WriteSeq,
+        writer_name: &str,
+        bytes_name: &str,
+        indent: &str,
+    ) -> String {
+        self.render_encode_to_bytes_with_renames(
+            encode_ops,
+            writer_name,
+            bytes_name,
+            indent,
+            &value::Renames::new(),
+        )
+    }
+
+    fn render_encode_to_bytes_with_renames(
+        &self,
+        encode_ops: &WriteSeq,
+        writer_name: &str,
+        bytes_name: &str,
+        indent: &str,
+        renames: &value::Renames,
+    ) -> String {
+        let mut size_locals = size::SizeLocalCounters::default();
+        let mut encode_locals = encode::EncodeLocalCounters::default();
+        let writer =
+            CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(writer_name)));
+        let size_expr = size::lower_size_expr(&encode_ops.size, renames, &mut size_locals);
+        let stmts = encode::lower_encode_expr(encode_ops, &writer, renames, &mut encode_locals);
+        let mut out = String::new();
+        out.push_str(&format!("{indent}byte[] {bytes_name};\n"));
+        out.push_str(&format!(
+            "{indent}using (var {writer_name} = new WireWriter({size_expr}))\n"
+        ));
+        out.push_str(&format!("{indent}{{\n"));
+        for stmt in stmts {
+            out.push_str(&format!("{indent}    {stmt};\n"));
+        }
+        out.push_str(&format!(
+            "{indent}    {bytes_name} = {writer_name}.ToArray();\n"
+        ));
+        out.push_str(&format!("{indent}}}\n"));
+        out
+    }
+
+    fn render_result_decode_from_ops(
+        &self,
+        decode_ops: &ReadSeq,
+        reader_name: &str,
+        indent: &str,
+    ) -> String {
+        let Some(crate::ir::ops::ReadOp::Result { ok, err, .. }) = decode_ops.ops.first() else {
+            return String::new();
+        };
+        let reader =
+            CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(reader_name)));
+        let mut locals = decode::DecodeLocalCounters::default();
+        let err_expr =
+            decode::lower_decode_expr(err, &reader, None, &self.namespace, &mut locals).to_string();
+        let ok_expr = if matches!(ok.ops.first(), None) {
+            None
+        } else {
+            Some(
+                decode::lower_decode_expr(ok, &reader, None, &self.namespace, &mut locals)
+                    .to_string(),
+            )
+        };
+        let mut out = String::new();
+        out.push_str(&format!(
+            "{indent}if ({reader_name}.ReadU8() != 0)\n{indent}{{\n"
+        ));
+        out.push_str(&format!(
+            "{indent}    throw new InvalidOperationException({err_expr}.ToString());\n"
+        ));
+        out.push_str(&format!("{indent}}}\n"));
+        if let Some(ok_expr) = ok_expr {
+            out.push_str(&format!("{indent}return {ok_expr};\n"));
+        }
+        out
+    }
+
+    fn decode_expr_from_reader(&self, decode_ops: &ReadSeq, reader: CSharpExpression) -> String {
+        let mut locals = decode::DecodeLocalCounters::default();
+        decode::lower_decode_expr(decode_ops, &reader, None, &self.namespace, &mut locals)
+            .to_string()
+    }
+
+    fn sync_callback_native_decls(&self, params: &[BridgeParam], ret: &CallbackReturn) -> String {
+        let mut decls = vec!["ulong handle".to_string()];
+        decls.extend(params.iter().flat_map(|p| p.native_decls.clone()));
+        match ret {
+            CallbackReturn::Void => {}
+            CallbackReturn::Direct {
+                native_out_type, ..
+            } => {
+                decls.push(format!("out {native_out_type} {OUT_PTR}"));
+            }
+            CallbackReturn::Encoded { .. } => {
+                decls.push(format!("out IntPtr {OUT_PTR}"));
+                decls.push(format!("out UIntPtr {OUT_LEN}"));
+            }
+        }
+        decls.push(format!("out FfiStatus {STATUS_OUT}"));
+        decls.join(", ")
+    }
+
+    fn sync_proxy_native_decls(&self, params: &[BridgeParam], ret: &CallbackReturn) -> String {
+        self.sync_callback_native_decls(params, ret)
+    }
+
+    fn sync_out_initializers(&self, ret: &CallbackReturn) -> Vec<String> {
+        match ret {
+            CallbackReturn::Void => vec![],
+            CallbackReturn::Direct { default_value, .. } => {
+                vec![format!("{OUT_PTR} = {default_value};")]
+            }
+            CallbackReturn::Encoded { .. } => vec![
+                format!("{OUT_PTR} = IntPtr.Zero;"),
+                format!("{OUT_LEN} = UIntPtr.Zero;"),
+            ],
+        }
+    }
+
+    fn async_completion_decls(&self, ret: &CallbackReturn) -> String {
+        let mut decls = vec!["ulong callbackData".to_string()];
+        match ret {
+            CallbackReturn::Void => {}
+            CallbackReturn::Direct {
+                native_type,
+                marshals_bool,
+                ..
+            } => {
+                if *marshals_bool {
+                    decls.push("[MarshalAs(UnmanagedType.I1)] bool value".to_string());
+                } else {
+                    decls.push(format!("{native_type} value"));
+                }
+            }
+            CallbackReturn::Encoded { .. } => {
+                decls.push("IntPtr valuePtr".to_string());
+                decls.push("UIntPtr valueLen".to_string());
+            }
+        }
+        decls.push(format!("FfiStatus {STATUS_OUT}"));
+        decls.join(", ")
+    }
+
+    fn async_complete_failure(
+        &self,
+        ret: &CallbackReturn,
+        callback_name: &str,
+        callback_data: &str,
+        indent: &str,
+    ) -> String {
+        match ret {
+            CallbackReturn::Void => {
+                format!("{indent}{callback_name}({callback_data}, {STATUS_INTERNAL_ERROR});\n")
+            }
+            CallbackReturn::Direct { default_value, .. } => format!(
+                "{indent}{callback_name}({callback_data}, {default_value}, {STATUS_INTERNAL_ERROR});\n"
+            ),
+            CallbackReturn::Encoded { .. } => format!(
+                "{indent}{callback_name}({callback_data}, IntPtr.Zero, UIntPtr.Zero, {STATUS_INTERNAL_ERROR});\n"
+            ),
+        }
+    }
+
+    fn async_complete_success(
+        &self,
+        ret: &CallbackReturn,
+        callback_name: &str,
+        callback_data: &str,
+        task_name: &str,
+        indent: &str,
+    ) -> String {
+        match ret {
+            CallbackReturn::Void => {
+                format!("{indent}{callback_name}({callback_data}, {STATUS_OK});\n")
+            }
+            CallbackReturn::Direct {
+                native_expr,
+                marshals_bool,
+                ..
+            } => {
+                let native_expr = if *marshals_bool {
+                    format!("{task_name}.Result")
+                } else {
+                    native_expr.replace("value", &format!("{task_name}.Result"))
+                };
+                format!("{indent}{callback_name}({callback_data}, {native_expr}, {STATUS_OK});\n")
+            }
+            CallbackReturn::Encoded {
+                encode_ops,
+                is_result,
+                ..
+            } => {
+                let mut out = String::new();
+                if *is_result {
+                    out.push_str(&format!(
+                        "{indent}var {RESULT_VALUE} = {}.Ok({task_name}.Result);\n",
+                        self.result_type_for_encode_ops(encode_ops)
+                    ));
+                } else {
+                    out.push_str(&format!(
+                        "{indent}var {RETURN_VALUE} = {task_name}.Result;\n"
+                    ));
+                }
+                out.push_str(&self.render_encode_to_bytes_with_renames(
+                    encode_ops,
+                    "_returnWire",
+                    "_returnBytes",
+                    indent,
+                    &root_local_rename(
+                        if *is_result { "result" } else { "value" },
+                        if *is_result {
+                            RESULT_VALUE
+                        } else {
+                            RETURN_VALUE
+                        },
+                    ),
+                ));
+                out.push_str(&format!(
+                    "{indent}BoltFFICallbackReturn.Store(_returnBytes, out var {OUT_PTR}, out var {OUT_LEN});\n"
+                ));
+                out.push_str(&format!("{indent}try\n{indent}{{\n"));
+                out.push_str(&format!(
+                    "{indent}    {callback_name}({callback_data}, {OUT_PTR}, {OUT_LEN}, {STATUS_OK});\n"
+                ));
+                out.push_str(&format!("{indent}}}\n{indent}finally\n{indent}{{\n"));
+                out.push_str(&format!(
+                    "{indent}    BoltFFICallbackReturn.Free({OUT_PTR});\n"
+                ));
+                out.push_str(&format!("{indent}}}\n"));
+                out
+            }
+        }
+    }
+
+    fn async_complete_exception(
+        &self,
+        ret: &CallbackReturn,
+        callback_name: &str,
+        callback_data: &str,
+        indent: &str,
+    ) -> String {
+        let CallbackReturn::Encoded {
+            encode_ops,
+            is_result: true,
+            ..
+        } = ret
+        else {
+            return self.async_complete_failure(ret, callback_name, callback_data, indent);
+        };
+        let mut out = String::new();
+        let result_ty = self.result_type_for_encode_ops(encode_ops);
+        let Some(crate::ir::ops::WriteOp::Result { err, .. }) = encode_ops.ops.first() else {
+            return self.async_complete_failure(ret, callback_name, callback_data, indent);
+        };
+        let err_type = self
+            .result_branch_type(err)
+            .unwrap_or_else(|| "object".to_string());
+        if let Some(exception_ty) = self.error_exception_for_write_seq(err) {
+            out.push_str(&format!(
+                "{indent}if ({ASYNC_EXCEPTION} is {exception_ty} __boltffiTypedException)\n{indent}{{\n"
+            ));
+            out.push_str(&format!(
+                "{indent}    var {ERROR_RESULT_VALUE} = {result_ty}.Err(__boltffiTypedException.Error);\n"
+            ));
+        } else if err_type == "string" {
+            out.push_str(&format!("{indent}{{\n"));
+            out.push_str(&format!(
+                "{indent}    var {ERROR_RESULT_VALUE} = {result_ty}.Err({ASYNC_EXCEPTION}.Message);\n"
+            ));
+        } else {
+            return self.async_complete_failure(ret, callback_name, callback_data, indent);
+        }
+        out.push_str(&self.render_encode_to_bytes_with_renames(
+            encode_ops,
+            "_returnErrorWire",
+            "_returnErrorBytes",
+            &(indent.to_string() + "    "),
+            &root_local_rename("result", ERROR_RESULT_VALUE),
+        ));
+        out.push_str(&format!(
+            "{indent}    BoltFFICallbackReturn.Store(_returnErrorBytes, out var {ERROR_OUT_PTR}, out var {ERROR_OUT_LEN});\n"
+        ));
+        out.push_str(&format!("{indent}    try\n{indent}    {{\n"));
+        out.push_str(&format!(
+            "{indent}        {callback_name}({callback_data}, {ERROR_OUT_PTR}, {ERROR_OUT_LEN}, {STATUS_OK});\n"
+        ));
+        out.push_str(&format!(
+            "{indent}    }}\n{indent}    finally\n{indent}    {{\n"
+        ));
+        out.push_str(&format!(
+            "{indent}        BoltFFICallbackReturn.Free({ERROR_OUT_PTR});\n"
+        ));
+        out.push_str(&format!("{indent}    }}\n"));
+        out.push_str(&format!("{indent}    return;\n"));
+        out.push_str(&format!("{indent}}}\n"));
+        if self.error_exception_for_write_seq(err).is_some() {
+            out.push_str(&self.async_complete_failure(ret, callback_name, callback_data, indent));
+        }
+        out
+    }
+
+    fn inline_callback_native_return_type(&self, ret: &CallbackReturn) -> String {
+        match ret {
+            CallbackReturn::Void => "void".to_string(),
+            CallbackReturn::Direct { native_type, .. } => native_type.clone(),
+            CallbackReturn::Encoded { .. } => "FfiBuf".to_string(),
+        }
+    }
+
+    fn native_param_decl(&self, abi_type: &AbiType, name: &CSharpParamName) -> String {
+        match abi_type {
+            AbiType::Bool => format!("[MarshalAs(UnmanagedType.I1)] bool {name}"),
+            _ => format!("{} {name}", self.native_type_for_abi_type(abi_type)),
+        }
+    }
+
+    fn native_type_for_abi_type(&self, abi_type: &AbiType) -> String {
+        match abi_type {
+            AbiType::Void => "void".to_string(),
+            AbiType::Bool => "bool".to_string(),
+            AbiType::I8 => "sbyte".to_string(),
+            AbiType::U8 => "byte".to_string(),
+            AbiType::I16 => "short".to_string(),
+            AbiType::U16 => "ushort".to_string(),
+            AbiType::I32 => "int".to_string(),
+            AbiType::U32 => "uint".to_string(),
+            AbiType::I64 => "long".to_string(),
+            AbiType::U64 => "ulong".to_string(),
+            AbiType::ISize => "nint".to_string(),
+            AbiType::USize => "nuint".to_string(),
+            AbiType::F32 => "float".to_string(),
+            AbiType::F64 => "double".to_string(),
+            AbiType::Pointer(_) => "IntPtr".to_string(),
+            AbiType::OwnedBuffer => "FfiBuf".to_string(),
+            AbiType::Handle(_) => "IntPtr".to_string(),
+            AbiType::CallbackHandle => "BoltFFICallbackHandle".to_string(),
+            AbiType::Struct(id) => CSharpClassName::from(id).to_string(),
+            AbiType::InlineCallbackFn { .. } => "IntPtr".to_string(),
+        }
+    }
+
+    fn native_type_for_primitive(&self, primitive: PrimitiveType) -> &'static str {
+        match primitive {
+            PrimitiveType::Bool => "bool",
+            PrimitiveType::I8 => "sbyte",
+            PrimitiveType::U8 => "byte",
+            PrimitiveType::I16 => "short",
+            PrimitiveType::U16 => "ushort",
+            PrimitiveType::I32 => "int",
+            PrimitiveType::U32 => "uint",
+            PrimitiveType::I64 => "long",
+            PrimitiveType::U64 => "ulong",
+            PrimitiveType::ISize => "nint",
+            PrimitiveType::USize => "nuint",
+            PrimitiveType::F32 => "float",
+            PrimitiveType::F64 => "double",
+        }
+    }
+
+    fn direct_decode_expr(&self, type_expr: &TypeExpr, name: &CSharpParamName) -> String {
+        if self.is_c_style_enum_type(type_expr) {
+            let ty = self.lower_type(type_expr).expect("enum type");
+            format!("({ty}){name}")
+        } else {
+            name.to_string()
+        }
+    }
+
+    fn direct_proxy_arg_expr(
+        &self,
+        type_expr: &TypeExpr,
+        abi_type: &AbiType,
+        name: &CSharpParamName,
+    ) -> String {
+        if self.is_c_style_enum_type(type_expr) {
+            format!("({}){name}", self.native_type_for_abi_type(abi_type))
+        } else {
+            name.to_string()
+        }
+    }
+
+    fn direct_return_native_expr(
+        &self,
+        type_expr: &TypeExpr,
+        primitive: PrimitiveType,
+        value_name: &str,
+    ) -> String {
+        if primitive == PrimitiveType::Bool {
+            format!("{value_name} ? (byte)1 : (byte)0")
+        } else if self.is_c_style_enum_type(type_expr) {
+            format!(
+                "({}){value_name}",
+                self.native_type_for_primitive(primitive)
+            )
+        } else {
+            value_name.to_string()
+        }
+    }
+
+    fn direct_return_public_expr(
+        &self,
+        type_expr: &TypeExpr,
+        primitive: PrimitiveType,
+        value_name: &str,
+    ) -> String {
+        if primitive == PrimitiveType::Bool {
+            format!("{value_name} != 0")
+        } else if self.is_c_style_enum_type(type_expr) {
+            let ty = self.lower_type(type_expr).expect("enum type");
+            format!("({ty}){value_name}")
+        } else {
+            value_name.to_string()
+        }
+    }
+
+    fn is_c_style_enum_type(&self, type_expr: &TypeExpr) -> bool {
+        matches!(
+            type_expr,
+            TypeExpr::Enum(id)
+                if self
+                    .ffi
+                    .catalog
+                    .resolve_enum(id)
+                    .is_some_and(|e| matches!(e.repr, crate::ir::definitions::EnumRepr::CStyle { .. }))
+        )
+    }
+
+    fn abi_callback_for(&self, callback_id: &CallbackId) -> Option<&AbiCallbackInvocation> {
+        self.abi
+            .callbacks
+            .iter()
+            .find(|callback| callback.callback_id == *callback_id)
+    }
+
+    fn abi_method_for<'b>(
+        &self,
+        abi_callback: &'b AbiCallbackInvocation,
+        method: &CallbackMethodDef,
+    ) -> Option<&'b AbiCallbackMethod> {
+        abi_callback
+            .methods
+            .iter()
+            .find(|candidate| candidate.id == method.id)
+    }
+
+    fn callback_method_needs_wire_reader(
+        &self,
+        method: &CallbackMethodDef,
+        abi_callback: &AbiCallbackInvocation,
+        mode: CallbackReturnMode,
+    ) -> bool {
+        let Some(abi_method) = self.abi_method_for(abi_callback, method) else {
+            return false;
+        };
+        let params = self.bridge_params(method, abi_method);
+        let ret = self.callback_return(&method.returns, &abi_method.returns, mode);
+        params.iter().any(|param| param.needs_wire_reader) || ret.needs_wire_reader()
+    }
+
+    fn callback_method_needs_wire_writer(
+        &self,
+        method: &CallbackMethodDef,
+        abi_callback: &AbiCallbackInvocation,
+        mode: CallbackReturnMode,
+    ) -> bool {
+        let Some(abi_method) = self.abi_method_for(abi_callback, method) else {
+            return false;
+        };
+        let params = self.bridge_params(method, abi_method);
+        let ret = self.callback_return(&method.returns, &abi_method.returns, mode);
+        params.iter().any(|param| param.needs_wire_writer) || ret.needs_wire_writer()
+    }
+
+    fn callback_method_needs_ffi_buf(
+        &self,
+        method: &CallbackMethodDef,
+        abi_callback: &AbiCallbackInvocation,
+        mode: CallbackReturnMode,
+    ) -> bool {
+        let Some(abi_method) = self.abi_method_for(abi_callback, method) else {
+            return false;
+        };
+        matches!(
+            self.callback_return(&method.returns, &abi_method.returns, mode),
+            CallbackReturn::Encoded { .. }
+        )
+    }
+}
+
+fn indent_block(text: &str, prefix: &str) -> String {
+    text.lines()
+        .map(|line| format!("{prefix}{line}\n"))
+        .collect::<String>()
+}
+
+fn root_local_rename(ir_name: &str, csharp_name: &str) -> value::Renames {
+    let mut renames = value::Renames::new();
+    renames.insert(
+        ir_name.to_string(),
+        CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(csharp_name))),
+    );
+    renames
+}

--- a/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
@@ -24,8 +24,6 @@ use super::super::plan::{
 use super::lowerer::CSharpLowerer;
 use super::{decode, encode, size, value};
 
-const STATUS_OK: &str = "new FfiStatus { code = 0 }";
-const STATUS_INTERNAL_ERROR: &str = "new FfiStatus { code = 100 }";
 const STATUS_OUT: &str = "__boltffiStatus";
 const OUT_PTR: &str = "__boltffiOutPtr";
 const OUT_LEN: &str = "__boltffiOutLen";
@@ -46,9 +44,10 @@ enum CallbackReturn {
         public_type: CSharpType,
         native_type: CSharpType,
         native_out_type: CSharpType,
-        default_value: String,
-        native_expr: String,
-        public_expr: String,
+        sync_default_value: CSharpExpression,
+        async_default_value: CSharpExpression,
+        native_value: CallbackNativeValuePlan,
+        public_value: CallbackPublicValuePlan,
         marshals_bool: bool,
     },
     Encoded {
@@ -64,6 +63,23 @@ enum CallbackReturn {
 enum CallbackReturnMode {
     CallbackVtable,
     InlineClosure,
+}
+
+#[derive(Debug, Clone)]
+enum CallbackNativeValuePlan {
+    Identity,
+    BoolToByte,
+    Cast(CSharpType),
+    CallbackHandleCreate { bridge: CSharpClassName },
+    HandleField,
+}
+
+#[derive(Debug, Clone)]
+enum CallbackPublicValuePlan {
+    Identity,
+    ByteToBool,
+    Cast(CSharpType),
+    CallbackHandleWrap { bridge: CSharpClassName },
 }
 
 impl CallbackReturn {
@@ -89,7 +105,6 @@ impl CallbackReturn {
             }
         }
     }
-
 }
 
 impl<'a> CSharpLowerer<'a> {
@@ -312,9 +327,6 @@ impl<'a> CSharpLowerer<'a> {
                 } else {
                     Some(self.callback_public_return_type(&method.returns))
                 },
-                not_supported_expr:
-                    "new NotSupportedException(\"async callback proxies are not implemented for C# yet\")"
-                        .to_string(),
             };
         }
 
@@ -366,14 +378,15 @@ impl<'a> CSharpLowerer<'a> {
         match ret {
             CallbackReturn::Void => CSharpClosureInvokePlan::Void { decoded_args },
             CallbackReturn::Direct {
-                native_expr,
+                native_value,
                 marshals_bool,
                 ..
             } => {
+                let value_expr = local_expr(RETURN_VALUE);
                 let native_value_expr = if *marshals_bool {
-                    RETURN_VALUE.to_string()
+                    value_expr
                 } else {
-                    native_expr.replace("value", RETURN_VALUE)
+                    self.native_value_expr(native_value, value_expr)
                 };
                 CSharpClosureInvokePlan::Direct {
                     decoded_args,
@@ -566,31 +579,36 @@ impl<'a> CSharpLowerer<'a> {
                 } else {
                     native_type.clone()
                 };
-                let native_expr = self.direct_return_native_expr(ty, primitive, "value");
-                let public_expr = self.direct_return_public_expr(ty, primitive, OUT_PTR);
                 CallbackReturn::Direct {
                     public_type,
                     native_type,
                     native_out_type,
-                    default_value: if marshals_bool {
-                        "0".to_string()
+                    sync_default_value: if marshals_bool {
+                        CSharpExpression::Literal(CSharpLiteral::Int(0))
                     } else {
-                        "default".to_string()
+                        CSharpExpression::Literal(CSharpLiteral::Default)
                     },
-                    native_expr,
-                    public_expr,
+                    async_default_value: if marshals_bool {
+                        CSharpExpression::Literal(CSharpLiteral::Bool(false))
+                    } else {
+                        CSharpExpression::Literal(CSharpLiteral::Default)
+                    },
+                    native_value: self.direct_return_native_value_plan(ty, primitive),
+                    public_value: self.direct_return_public_value_plan(ty, primitive),
                     marshals_bool,
                 }
             }
             Some(Transport::Composite(layout)) if mode == CallbackReturnMode::InlineClosure => {
-                let native_type = CSharpClassName::from(&layout.record_id).to_string();
+                let native_type =
+                    CSharpType::Record(CSharpClassName::from(&layout.record_id).into());
                 CallbackReturn::Direct {
                     public_type,
-                    native_type: named_type(&native_type),
-                    native_out_type: named_type(&native_type),
-                    default_value: "default".to_string(),
-                    native_expr: "value".to_string(),
-                    public_expr: OUT_PTR.to_string(),
+                    native_type: native_type.clone(),
+                    native_out_type: native_type,
+                    sync_default_value: CSharpExpression::Literal(CSharpLiteral::Default),
+                    async_default_value: CSharpExpression::Literal(CSharpLiteral::Default),
+                    native_value: CallbackNativeValuePlan::Identity,
+                    public_value: CallbackPublicValuePlan::Identity,
                     marshals_bool: false,
                 }
             }
@@ -623,9 +641,12 @@ impl<'a> CSharpLowerer<'a> {
                     public_type,
                     native_type: named_type("BoltFFICallbackHandle"),
                     native_out_type: named_type("BoltFFICallbackHandle"),
-                    default_value: "BoltFFICallbackHandle.Null".to_string(),
-                    native_expr: format!("{bridge}.Create(value)"),
-                    public_expr: format!("{bridge}.Wrap({OUT_PTR})"),
+                    sync_default_value: type_member_expr("BoltFFICallbackHandle", "Null"),
+                    async_default_value: type_member_expr("BoltFFICallbackHandle", "Null"),
+                    native_value: CallbackNativeValuePlan::CallbackHandleCreate {
+                        bridge: bridge.clone(),
+                    },
+                    public_value: CallbackPublicValuePlan::CallbackHandleWrap { bridge },
                     marshals_bool: false,
                 }
             }
@@ -633,9 +654,10 @@ impl<'a> CSharpLowerer<'a> {
                 public_type,
                 native_type: CSharpType::IntPtr,
                 native_out_type: CSharpType::IntPtr,
-                default_value: "IntPtr.Zero".to_string(),
-                native_expr: "value.Handle".to_string(),
-                public_expr: OUT_PTR.to_string(),
+                sync_default_value: type_member_expr("IntPtr", "Zero"),
+                async_default_value: type_member_expr("IntPtr", "Zero"),
+                native_value: CallbackNativeValuePlan::HandleField,
+                public_value: CallbackPublicValuePlan::Identity,
                 marshals_bool: false,
             },
             Some(Transport::Span(_)) => {
@@ -912,9 +934,9 @@ impl<'a> CSharpLowerer<'a> {
         let decoded_args = decoded_arg_list(params);
         match ret {
             CallbackReturn::Void => CSharpSyncCallbackSuccessPlan::Void { decoded_args },
-            CallbackReturn::Direct { native_expr, .. } => CSharpSyncCallbackSuccessPlan::Direct {
+            CallbackReturn::Direct { native_value, .. } => CSharpSyncCallbackSuccessPlan::Direct {
                 decoded_args,
-                native_value_expr: native_expr.replace("value", RETURN_VALUE),
+                native_value_expr: self.native_value_expr(native_value, local_expr(RETURN_VALUE)),
             },
             CallbackReturn::Encoded {
                 encode_ops,
@@ -975,12 +997,12 @@ impl<'a> CSharpLowerer<'a> {
             CallbackReturn::Void => CSharpCallbackProxyCallPlan::Void { args },
             CallbackReturn::Direct {
                 native_out_type,
-                public_expr,
+                public_value,
                 ..
             } => CSharpCallbackProxyCallPlan::Direct {
                 args,
                 native_out_type: native_out_type.clone(),
-                public_expr: public_expr.clone(),
+                public_expr: self.public_value_expr(public_value, local_expr(OUT_PTR)),
             },
             CallbackReturn::Encoded {
                 decode_expr,
@@ -1122,11 +1144,11 @@ impl<'a> CSharpLowerer<'a> {
     fn sync_out_initializer(&self, ret: &CallbackReturn) -> CSharpSyncCallbackOutInitializerPlan {
         match ret {
             CallbackReturn::Void => CSharpSyncCallbackOutInitializerPlan::Void,
-            CallbackReturn::Direct { default_value, .. } => {
-                CSharpSyncCallbackOutInitializerPlan::Direct {
-                    default_value: default_value.clone(),
-                }
-            }
+            CallbackReturn::Direct {
+                sync_default_value, ..
+            } => CSharpSyncCallbackOutInitializerPlan::Direct {
+                default_value: sync_default_value.clone(),
+            },
             CallbackReturn::Encoded { .. } => CSharpSyncCallbackOutInitializerPlan::Encoded,
         }
     }
@@ -1134,11 +1156,12 @@ impl<'a> CSharpLowerer<'a> {
     fn async_failure_completion(&self, ret: &CallbackReturn) -> CSharpAsyncCallbackFailurePlan {
         match ret {
             CallbackReturn::Void => CSharpAsyncCallbackFailurePlan::Void,
-            CallbackReturn::Direct { default_value, .. } => {
-                CSharpAsyncCallbackFailurePlan::Direct {
-                    default_value: default_value.clone(),
-                }
-            }
+            CallbackReturn::Direct {
+                async_default_value,
+                ..
+            } => CSharpAsyncCallbackFailurePlan::Direct {
+                default_value: async_default_value.clone(),
+            },
             CallbackReturn::Encoded { .. } => CSharpAsyncCallbackFailurePlan::Encoded,
         }
     }
@@ -1147,18 +1170,20 @@ impl<'a> CSharpLowerer<'a> {
         match ret {
             CallbackReturn::Void => CSharpAsyncCallbackSuccessPlan::Void,
             CallbackReturn::Direct {
-                native_expr,
+                native_value,
                 marshals_bool,
                 ..
             } => {
-                let native_expr = if *marshals_bool {
-                    format!("{ASYNC_COMPLETED}.Result")
-                } else {
-                    native_expr.replace("value", &format!("{ASYNC_COMPLETED}.Result"))
+                let task_result = CSharpExpression::MemberAccess {
+                    receiver: Box::new(local_expr(ASYNC_COMPLETED)),
+                    name: CSharpPropertyName::from_source("result"),
                 };
-                CSharpAsyncCallbackSuccessPlan::Direct {
-                    native_value_expr: native_expr,
-                }
+                let native_value_expr = if *marshals_bool {
+                    task_result
+                } else {
+                    self.native_value_expr(native_value, task_result)
+                };
+                CSharpAsyncCallbackSuccessPlan::Direct { native_value_expr }
             }
             CallbackReturn::Encoded {
                 encode_ops,
@@ -1291,24 +1316,6 @@ impl<'a> CSharpLowerer<'a> {
         }
     }
 
-    fn native_type_for_primitive(&self, primitive: PrimitiveType) -> &'static str {
-        match primitive {
-            PrimitiveType::Bool => "bool",
-            PrimitiveType::I8 => "sbyte",
-            PrimitiveType::U8 => "byte",
-            PrimitiveType::I16 => "short",
-            PrimitiveType::U16 => "ushort",
-            PrimitiveType::I32 => "int",
-            PrimitiveType::U32 => "uint",
-            PrimitiveType::I64 => "long",
-            PrimitiveType::U64 => "ulong",
-            PrimitiveType::ISize => "nint",
-            PrimitiveType::USize => "nuint",
-            PrimitiveType::F32 => "float",
-            PrimitiveType::F64 => "double",
-        }
-    }
-
     fn direct_decode_expr(&self, type_expr: &TypeExpr, name: &CSharpParamName) -> CSharpExpression {
         let param = CSharpExpression::Identity(CSharpIdentity::Param(name.clone()));
         if self.is_c_style_enum_type(type_expr) {
@@ -1339,37 +1346,96 @@ impl<'a> CSharpLowerer<'a> {
         }
     }
 
-    fn direct_return_native_expr(
+    fn direct_return_native_value_plan(
         &self,
         type_expr: &TypeExpr,
         primitive: PrimitiveType,
-        value_name: &str,
-    ) -> String {
+    ) -> CallbackNativeValuePlan {
         if primitive == PrimitiveType::Bool {
-            format!("{value_name} ? (byte)1 : (byte)0")
+            CallbackNativeValuePlan::BoolToByte
         } else if self.is_c_style_enum_type(type_expr) {
-            format!(
-                "({}){value_name}",
-                self.native_type_for_primitive(primitive)
-            )
+            CallbackNativeValuePlan::Cast(CSharpType::from(primitive))
         } else {
-            value_name.to_string()
+            CallbackNativeValuePlan::Identity
         }
     }
 
-    fn direct_return_public_expr(
+    fn direct_return_public_value_plan(
         &self,
         type_expr: &TypeExpr,
         primitive: PrimitiveType,
-        value_name: &str,
-    ) -> String {
+    ) -> CallbackPublicValuePlan {
         if primitive == PrimitiveType::Bool {
-            format!("{value_name} != 0")
+            CallbackPublicValuePlan::ByteToBool
         } else if self.is_c_style_enum_type(type_expr) {
             let ty = self.lower_type(type_expr).expect("enum type");
-            format!("({ty}){value_name}")
+            CallbackPublicValuePlan::Cast(ty)
         } else {
-            value_name.to_string()
+            CallbackPublicValuePlan::Identity
+        }
+    }
+
+    fn native_value_expr(
+        &self,
+        plan: &CallbackNativeValuePlan,
+        value: CSharpExpression,
+    ) -> CSharpExpression {
+        match plan {
+            CallbackNativeValuePlan::Identity => value,
+            CallbackNativeValuePlan::BoolToByte => CSharpExpression::Ternary {
+                cond: Box::new(value),
+                then: Box::new(CSharpExpression::Cast {
+                    target: CSharpType::Byte,
+                    inner: Box::new(CSharpExpression::Literal(CSharpLiteral::Int(1))),
+                }),
+                otherwise: Box::new(CSharpExpression::Cast {
+                    target: CSharpType::Byte,
+                    inner: Box::new(CSharpExpression::Literal(CSharpLiteral::Int(0))),
+                }),
+            },
+            CallbackNativeValuePlan::Cast(target) => CSharpExpression::Cast {
+                target: target.clone(),
+                inner: Box::new(value),
+            },
+            CallbackNativeValuePlan::CallbackHandleCreate { bridge } => {
+                CSharpExpression::MethodCall {
+                    receiver: Box::new(type_ref_expr(bridge.clone())),
+                    method: CSharpMethodName::new("Create"),
+                    type_args: vec![],
+                    args: vec![value].into(),
+                }
+            }
+            CallbackNativeValuePlan::HandleField => CSharpExpression::MemberAccess {
+                receiver: Box::new(value),
+                name: CSharpPropertyName::from_source("handle"),
+            },
+        }
+    }
+
+    fn public_value_expr(
+        &self,
+        plan: &CallbackPublicValuePlan,
+        value: CSharpExpression,
+    ) -> CSharpExpression {
+        match plan {
+            CallbackPublicValuePlan::Identity => value,
+            CallbackPublicValuePlan::ByteToBool => CSharpExpression::Binary {
+                op: super::super::ast::CSharpBinaryOp::Ne,
+                left: Box::new(value),
+                right: Box::new(CSharpExpression::Literal(CSharpLiteral::Int(0))),
+            },
+            CallbackPublicValuePlan::Cast(target) => CSharpExpression::Cast {
+                target: target.clone(),
+                inner: Box::new(value),
+            },
+            CallbackPublicValuePlan::CallbackHandleWrap { bridge } => {
+                CSharpExpression::MethodCall {
+                    receiver: Box::new(type_ref_expr(bridge.clone())),
+                    method: CSharpMethodName::new("Wrap"),
+                    type_args: vec![],
+                    args: vec![value].into(),
+                }
+            }
         }
     }
 
@@ -1467,6 +1533,21 @@ fn callback_public_param_list(params: &[CSharpCallbackBridgeParamPlan]) -> CShar
         .map(|param| param.public_param().clone())
         .collect::<Vec<_>>()
         .into()
+}
+
+fn local_expr(name: &str) -> CSharpExpression {
+    CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(name)))
+}
+
+fn type_ref_expr(name: CSharpClassName) -> CSharpExpression {
+    CSharpExpression::TypeRef(CSharpTypeReference::Plain(name))
+}
+
+fn type_member_expr(type_name: &str, member_name: &str) -> CSharpExpression {
+    CSharpExpression::MemberAccess {
+        receiver: Box::new(type_ref_expr(CSharpClassName::new(type_name))),
+        name: CSharpPropertyName::new(member_name),
+    }
 }
 
 fn stripped_name(name: &CSharpParamName) -> &str {

--- a/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
@@ -6,12 +6,14 @@ use crate::ir::plan::{AbiType, Transport};
 use crate::ir::types::{PrimitiveType, TypeExpr};
 
 use super::super::ast::{
-    CSharpClassName, CSharpExpression, CSharpIdentity, CSharpLocalName, CSharpMethodName,
-    CSharpParamName, CSharpType,
+    CSharpArgumentList, CSharpAttribute, CSharpAttributeArg, CSharpClassName, CSharpExpression,
+    CSharpIdentity, CSharpLocalName, CSharpMethodName, CSharpParamName, CSharpParameter,
+    CSharpPropertyName, CSharpType, CSharpTypeReference,
 };
 use super::super::plan::{
-    CFunctionName, CSharpCallbackMethodPlan, CSharpCallbackParamPlan, CSharpCallbackPlan,
-    CSharpClosureMethodPlan, CSharpClosurePlan,
+    CFunctionName, CSharpCallbackBridgeParamPlan, CSharpCallbackMethodPlan,
+    CSharpCallbackParamPlan, CSharpCallbackPlan, CSharpClosureMethodPlan, CSharpClosurePlan,
+    CSharpWireWriterPlan,
 };
 use super::lowerer::CSharpLowerer;
 use super::{decode, encode, size, value};
@@ -33,20 +35,6 @@ const ERROR_OUT_PTR: &str = "__boltffiErrorOutPtr";
 const ERROR_OUT_LEN: &str = "__boltffiErrorOutLen";
 
 #[derive(Debug, Clone)]
-struct BridgeParam {
-    public_decl: String,
-    native_decls: Vec<String>,
-    decode_setup: Vec<String>,
-    decode_expr: String,
-    proxy_arg_exprs: Vec<String>,
-    proxy_setup: Vec<String>,
-    proxy_pin: Vec<String>,
-    proxy_cleanup: Vec<String>,
-    needs_wire_reader: bool,
-    needs_wire_writer: bool,
-}
-
-#[derive(Debug, Clone)]
 enum CallbackReturn {
     Void,
     Direct {
@@ -60,7 +48,7 @@ enum CallbackReturn {
     },
     Encoded {
         public_type: String,
-        decode_expr: Option<String>,
+        decode_expr: Option<CSharpExpression>,
         encode_ops: WriteSeq,
         decode_ops: Option<ReadSeq>,
         is_result: bool,
@@ -224,13 +212,13 @@ impl<'a> CSharpLowerer<'a> {
         );
         let native_return_type = self.inline_callback_native_return_type(&ret);
         let native_decls = std::iter::once("IntPtr context".to_string())
-            .chain(params.iter().flat_map(|p| p.native_decls.clone()))
+            .chain(
+                params
+                    .iter()
+                    .flat_map(|p| p.native_params().into_iter().map(|param| param.to_string())),
+            )
             .collect::<Vec<_>>();
-        let decoded_args = params
-            .iter()
-            .map(|p| p.decode_expr.clone())
-            .collect::<Vec<_>>()
-            .join(", ");
+        let decoded_args = decoded_arg_list(&params).to_string();
         let marshals_return_bool = matches!(
             ret,
             CallbackReturn::Direct {
@@ -247,7 +235,7 @@ impl<'a> CSharpLowerer<'a> {
             marshals_return_bool,
             decode_setup: params
                 .iter()
-                .flat_map(|param| param.decode_setup.clone())
+                .flat_map(CSharpCallbackBridgeParamPlan::decode_setup_lines)
                 .collect(),
             invoke_body: self.render_closure_invoke_return(&ret, &decoded_args),
         }
@@ -358,11 +346,7 @@ impl<'a> CSharpLowerer<'a> {
             CallbackReturnMode::CallbackVtable,
         );
         let native_decls = self.sync_callback_native_decls(&params, &ret);
-        let decoded_args = params
-            .iter()
-            .map(|p| p.decode_expr.clone())
-            .collect::<Vec<_>>()
-            .join(", ");
+        let decoded_args = decoded_arg_list(&params).to_string();
         let mut out =
             format!("        private static void {method_name}({native_decls})\n        {{\n");
         for line in self.sync_out_initializers(&ret) {
@@ -374,7 +358,7 @@ impl<'a> CSharpLowerer<'a> {
         out.push_str("            try\n            {\n");
         out.push_str("                if (!Handles.TryGetValue(handle, out var impl_)) throw new InvalidOperationException(\"invalid callback handle\");\n");
         for param in &params {
-            for line in &param.decode_setup {
+            for line in param.decode_setup_lines() {
                 out.push_str(&format!("                {line}\n"));
             }
         }
@@ -465,14 +449,14 @@ impl<'a> CSharpLowerer<'a> {
             CallbackReturnMode::CallbackVtable,
         );
         let mut native_decls = vec!["ulong handle".to_string()];
-        native_decls.extend(params.iter().flat_map(|p| p.native_decls.clone()));
+        native_decls.extend(
+            params
+                .iter()
+                .flat_map(|p| p.native_params().into_iter().map(|param| param.to_string())),
+        );
         native_decls.push(format!("{method_name}Completion callback"));
         native_decls.push("ulong callbackData".to_string());
-        let decoded_args = params
-            .iter()
-            .map(|p| p.decode_expr.clone())
-            .collect::<Vec<_>>()
-            .join(", ");
+        let decoded_args = decoded_arg_list(&params).to_string();
         let mut out = format!(
             "        private static void {method_name}({})\n        {{\n",
             native_decls.join(", ")
@@ -489,7 +473,7 @@ impl<'a> CSharpLowerer<'a> {
         out.push_str("                return;\n            }\n");
         out.push_str("            try\n            {\n");
         for param in &params {
-            for line in &param.decode_setup {
+            for line in param.decode_setup_lines() {
                 out.push_str(&format!("                {line}\n"));
             }
         }
@@ -557,7 +541,7 @@ impl<'a> CSharpLowerer<'a> {
         );
         let public_params = params
             .iter()
-            .map(|p| p.public_decl.clone())
+            .map(|p| p.public_param().to_string())
             .collect::<Vec<_>>()
             .join(", ");
         if method.is_async() {
@@ -587,16 +571,18 @@ impl<'a> CSharpLowerer<'a> {
             abi_method.vtable_field.as_str()
         ));
         for param in &params {
-            for line in &param.proxy_setup {
+            for line in param.proxy_setup_lines() {
                 out.push_str(&format!("                {line}\n"));
             }
         }
-        let has_cleanup = params.iter().any(|p| !p.proxy_cleanup.is_empty());
+        let has_cleanup = params
+            .iter()
+            .any(|param| !param.proxy_cleanup_lines().is_empty());
         if has_cleanup {
             out.push_str("                try\n                {\n");
         }
         for param in &params {
-            for line in &param.proxy_pin {
+            for line in param.proxy_pin_lines() {
                 out.push_str(&format!(
                     "{}{line}\n",
                     if has_cleanup {
@@ -613,7 +599,11 @@ impl<'a> CSharpLowerer<'a> {
             "                "
         };
         let args = std::iter::once("_handle.handle".to_string())
-            .chain(params.iter().flat_map(|p| p.proxy_arg_exprs.clone()))
+            .chain(
+                params
+                    .iter()
+                    .flat_map(|p| p.proxy_args().into_iter().map(|expr| expr.to_string())),
+            )
             .collect::<Vec<_>>()
             .join(", ");
         match &ret {
@@ -683,7 +673,7 @@ impl<'a> CSharpLowerer<'a> {
         if has_cleanup {
             out.push_str("                }\n                finally\n                {\n");
             for param in &params {
-                for line in &param.proxy_cleanup {
+                for line in param.proxy_cleanup_lines() {
                     out.push_str(&format!("                    {line}\n"));
                 }
             }
@@ -711,7 +701,11 @@ impl<'a> CSharpLowerer<'a> {
             "        private delegate void {method_name}Fn({});\n",
             if method.is_async() {
                 let mut decls = vec!["ulong handle".to_string()];
-                decls.extend(params.iter().flat_map(|p| p.native_decls.clone()));
+                decls.extend(
+                    params
+                        .iter()
+                        .flat_map(|p| p.native_params().into_iter().map(|param| param.to_string())),
+                );
                 decls.push(format!("{method_name}Completion callback"));
                 decls.push("ulong callbackData".to_string());
                 decls.join(", ")
@@ -742,7 +736,7 @@ impl<'a> CSharpLowerer<'a> {
         &self,
         method: &CallbackMethodDef,
         abi_method: &AbiCallbackMethod,
-    ) -> Vec<BridgeParam> {
+    ) -> Vec<CSharpCallbackBridgeParamPlan> {
         method
             .params
             .iter()
@@ -760,13 +754,12 @@ impl<'a> CSharpLowerer<'a> {
         &self,
         param: &crate::ir::definitions::ParamDef,
         abi_param: &AbiParam,
-    ) -> BridgeParam {
+    ) -> CSharpCallbackBridgeParamPlan {
         let name: CSharpParamName = (&param.name).into();
         let public_type = self
             .lower_type(&param.type_expr)
-            .expect("callback param type")
-            .to_string();
-        let public_decl = format!("{public_type} {name}");
+            .expect("callback param type");
+        let public_param = CSharpParameter::bare(public_type, name.clone());
         let ParamRole::Input {
             transport,
             len_param,
@@ -786,69 +779,43 @@ impl<'a> CSharpLowerer<'a> {
             let decode_ops = decode_ops
                 .as_ref()
                 .expect("encoded callback param must have decode ops");
-            let reader_name = format!("__boltffi{}Reader", name.as_str().trim_start_matches('@'));
+            let reader_name =
+                CSharpLocalName::new(format!("__boltffi{}Reader", stripped_name(&name)));
             let decode_expr = self.decode_expr_from_reader(
                 &self.normalize_custom_read_seq(decode_ops),
-                CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(
-                    reader_name.clone(),
-                ))),
+                CSharpExpression::Identity(CSharpIdentity::Local(reader_name.clone())),
             );
             let encode_ops = self.normalize_custom_write_seq(
                 encode_ops
                     .as_ref()
                     .expect("encoded callback param must have encode ops"),
             );
-            let bytes_name = format!("_{}Bytes", name.as_str().trim_start_matches('@'));
-            let pin_name = format!("_{}Pin", name.as_str().trim_start_matches('@'));
-            let ptr_name = format!("_{}Ptr", name.as_str().trim_start_matches('@'));
-            let mut setup = self
-                .render_encode_to_bytes(
-                    &encode_ops,
-                    &format!("_{}Wire", name.as_str().trim_start_matches('@')),
-                    &bytes_name,
-                    "                ",
-                )
-                .lines()
-                .map(str::to_string)
-                .collect::<Vec<_>>();
-            setup.push(format!("GCHandle {pin_name} = default;"));
-            setup.push(format!("IntPtr {ptr_name} = IntPtr.Zero;"));
-            BridgeParam {
-                public_decl,
-                native_decls: vec![format!("IntPtr {name}"), format!("UIntPtr {len_name}")],
-                decode_setup: vec![format!(
-                    "var {reader_name} = new WireReader({name}, {len_name});"
-                )],
-                decode_expr,
-                proxy_arg_exprs: vec![ptr_name.clone(), format!("(UIntPtr){bytes_name}.Length")],
-                proxy_setup: setup,
-                proxy_pin: vec![
-                    format!("if ({bytes_name}.Length != 0)"),
-                    "{".to_string(),
-                    format!("    {pin_name} = GCHandle.Alloc({bytes_name}, GCHandleType.Pinned);"),
-                    format!("    {ptr_name} = {pin_name}.AddrOfPinnedObject();"),
-                    "}".to_string(),
-                ],
-                proxy_cleanup: vec![format!("if ({pin_name}.IsAllocated) {pin_name}.Free();")],
-                needs_wire_reader: true,
-                needs_wire_writer: true,
+            let writer = self.callback_param_wire_writer_plan(&encode_ops, &name);
+            CSharpCallbackBridgeParamPlan::WireEncoded {
+                public_param,
+                native_ptr_param: CSharpParameter::bare(CSharpType::IntPtr, name),
+                native_len_param: CSharpParameter::bare(CSharpType::UIntPtr, len_name),
+                reader_local: reader_name,
+                decoded_arg: decode_expr,
+                pin_local: CSharpLocalName::new(format!(
+                    "_{}Pin",
+                    stripped_name(&writer.param_name)
+                )),
+                ptr_local: CSharpLocalName::new(format!(
+                    "_{}Ptr",
+                    stripped_name(&writer.param_name)
+                )),
+                writer,
             }
         } else {
-            let native_decl = self.native_param_decl(&abi_param.abi_type, &name);
             let decode_expr = self.direct_decode_expr(&param.type_expr, &name);
             let proxy_expr =
                 self.direct_proxy_arg_expr(&param.type_expr, &abi_param.abi_type, &name);
-            BridgeParam {
-                public_decl,
-                native_decls: vec![native_decl],
-                decode_setup: vec![],
-                decode_expr,
-                proxy_arg_exprs: vec![proxy_expr],
-                proxy_setup: vec![],
-                proxy_pin: vec![],
-                proxy_cleanup: vec![],
-                needs_wire_reader: false,
-                needs_wire_writer: false,
+            CSharpCallbackBridgeParamPlan::Direct {
+                public_param,
+                native_param: self.native_param(&abi_param.abi_type, &name),
+                decoded_arg: decode_expr,
+                proxy_arg: proxy_expr,
             }
         }
     }
@@ -1175,20 +1142,32 @@ impl<'a> CSharpLowerer<'a> {
         }
     }
 
-    fn render_encode_to_bytes(
+    fn callback_param_wire_writer_plan(
         &self,
         encode_ops: &WriteSeq,
-        writer_name: &str,
-        bytes_name: &str,
-        indent: &str,
-    ) -> String {
-        self.render_encode_to_bytes_with_renames(
-            encode_ops,
-            writer_name,
-            bytes_name,
-            indent,
-            &value::Renames::new(),
-        )
+        name: &CSharpParamName,
+    ) -> CSharpWireWriterPlan {
+        let writer_name = CSharpLocalName::new(format!("_{}Wire", stripped_name(name)));
+        let bytes_name = CSharpLocalName::new(format!("_{}Bytes", stripped_name(name)));
+        let mut size_locals = size::SizeLocalCounters::default();
+        let mut encode_locals = encode::EncodeLocalCounters::default();
+        let writer = CSharpExpression::Identity(CSharpIdentity::Local(writer_name.clone()));
+        CSharpWireWriterPlan {
+            binding_name: writer_name,
+            bytes_binding_name: bytes_name,
+            param_name: name.clone(),
+            size_expr: size::lower_size_expr(
+                &encode_ops.size,
+                &value::Renames::new(),
+                &mut size_locals,
+            ),
+            encode_stmts: encode::lower_encode_expr(
+                encode_ops,
+                &writer,
+                &value::Renames::new(),
+                &mut encode_locals,
+            ),
+        }
     }
 
     fn render_encode_to_bytes_with_renames(
@@ -1257,15 +1236,26 @@ impl<'a> CSharpLowerer<'a> {
         out
     }
 
-    fn decode_expr_from_reader(&self, decode_ops: &ReadSeq, reader: CSharpExpression) -> String {
+    fn decode_expr_from_reader(
+        &self,
+        decode_ops: &ReadSeq,
+        reader: CSharpExpression,
+    ) -> CSharpExpression {
         let mut locals = decode::DecodeLocalCounters::default();
         decode::lower_decode_expr(decode_ops, &reader, None, &self.namespace, &mut locals)
-            .to_string()
     }
 
-    fn sync_callback_native_decls(&self, params: &[BridgeParam], ret: &CallbackReturn) -> String {
+    fn sync_callback_native_decls(
+        &self,
+        params: &[CSharpCallbackBridgeParamPlan],
+        ret: &CallbackReturn,
+    ) -> String {
         let mut decls = vec!["ulong handle".to_string()];
-        decls.extend(params.iter().flat_map(|p| p.native_decls.clone()));
+        decls.extend(
+            params
+                .iter()
+                .flat_map(|p| p.native_params().into_iter().map(|param| param.to_string())),
+        );
         match ret {
             CallbackReturn::Void => {}
             CallbackReturn::Direct {
@@ -1282,7 +1272,11 @@ impl<'a> CSharpLowerer<'a> {
         decls.join(", ")
     }
 
-    fn sync_proxy_native_decls(&self, params: &[BridgeParam], ret: &CallbackReturn) -> String {
+    fn sync_proxy_native_decls(
+        &self,
+        params: &[CSharpCallbackBridgeParamPlan],
+        ret: &CallbackReturn,
+    ) -> String {
         self.sync_callback_native_decls(params, ret)
     }
 
@@ -1489,35 +1483,45 @@ impl<'a> CSharpLowerer<'a> {
         }
     }
 
-    fn native_param_decl(&self, abi_type: &AbiType, name: &CSharpParamName) -> String {
+    fn native_param(&self, abi_type: &AbiType, name: &CSharpParamName) -> CSharpParameter {
         match abi_type {
-            AbiType::Bool => format!("[MarshalAs(UnmanagedType.I1)] bool {name}"),
-            _ => format!("{} {name}", self.native_type_for_abi_type(abi_type)),
+            AbiType::Bool => CSharpParameter {
+                attributes: vec![marshal_as_i1()],
+                csharp_type: CSharpType::Bool,
+                name: name.clone(),
+            },
+            _ => {
+                CSharpParameter::bare(self.native_csharp_type_for_abi_type(abi_type), name.clone())
+            }
         }
     }
 
     fn native_type_for_abi_type(&self, abi_type: &AbiType) -> String {
+        self.native_csharp_type_for_abi_type(abi_type).to_string()
+    }
+
+    fn native_csharp_type_for_abi_type(&self, abi_type: &AbiType) -> CSharpType {
         match abi_type {
-            AbiType::Void => "void".to_string(),
-            AbiType::Bool => "bool".to_string(),
-            AbiType::I8 => "sbyte".to_string(),
-            AbiType::U8 => "byte".to_string(),
-            AbiType::I16 => "short".to_string(),
-            AbiType::U16 => "ushort".to_string(),
-            AbiType::I32 => "int".to_string(),
-            AbiType::U32 => "uint".to_string(),
-            AbiType::I64 => "long".to_string(),
-            AbiType::U64 => "ulong".to_string(),
-            AbiType::ISize => "nint".to_string(),
-            AbiType::USize => "nuint".to_string(),
-            AbiType::F32 => "float".to_string(),
-            AbiType::F64 => "double".to_string(),
-            AbiType::Pointer(_) => "IntPtr".to_string(),
-            AbiType::OwnedBuffer => "FfiBuf".to_string(),
-            AbiType::Handle(_) => "IntPtr".to_string(),
-            AbiType::CallbackHandle => "BoltFFICallbackHandle".to_string(),
-            AbiType::Struct(id) => CSharpClassName::from(id).to_string(),
-            AbiType::InlineCallbackFn { .. } => "IntPtr".to_string(),
+            AbiType::Void => CSharpType::Void,
+            AbiType::Bool => CSharpType::Bool,
+            AbiType::I8 => CSharpType::SByte,
+            AbiType::U8 => CSharpType::Byte,
+            AbiType::I16 => CSharpType::Short,
+            AbiType::U16 => CSharpType::UShort,
+            AbiType::I32 => CSharpType::Int,
+            AbiType::U32 => CSharpType::UInt,
+            AbiType::I64 => CSharpType::Long,
+            AbiType::U64 => CSharpType::ULong,
+            AbiType::ISize => CSharpType::NInt,
+            AbiType::USize => CSharpType::NUInt,
+            AbiType::F32 => CSharpType::Float,
+            AbiType::F64 => CSharpType::Double,
+            AbiType::Pointer(_) => CSharpType::IntPtr,
+            AbiType::OwnedBuffer => named_type("FfiBuf"),
+            AbiType::Handle(_) => CSharpType::IntPtr,
+            AbiType::CallbackHandle => named_type("BoltFFICallbackHandle"),
+            AbiType::Struct(id) => CSharpType::Record(CSharpClassName::from(id).into()),
+            AbiType::InlineCallbackFn { .. } => CSharpType::IntPtr,
         }
     }
 
@@ -1539,12 +1543,16 @@ impl<'a> CSharpLowerer<'a> {
         }
     }
 
-    fn direct_decode_expr(&self, type_expr: &TypeExpr, name: &CSharpParamName) -> String {
+    fn direct_decode_expr(&self, type_expr: &TypeExpr, name: &CSharpParamName) -> CSharpExpression {
+        let param = CSharpExpression::Identity(CSharpIdentity::Param(name.clone()));
         if self.is_c_style_enum_type(type_expr) {
             let ty = self.lower_type(type_expr).expect("enum type");
-            format!("({ty}){name}")
+            CSharpExpression::Cast {
+                target: ty,
+                inner: Box::new(param),
+            }
         } else {
-            name.to_string()
+            param
         }
     }
 
@@ -1553,11 +1561,15 @@ impl<'a> CSharpLowerer<'a> {
         type_expr: &TypeExpr,
         abi_type: &AbiType,
         name: &CSharpParamName,
-    ) -> String {
+    ) -> CSharpExpression {
+        let param = CSharpExpression::Identity(CSharpIdentity::Param(name.clone()));
         if self.is_c_style_enum_type(type_expr) {
-            format!("({}){name}", self.native_type_for_abi_type(abi_type))
+            CSharpExpression::Cast {
+                target: self.native_csharp_type_for_abi_type(abi_type),
+                inner: Box::new(param),
+            }
         } else {
-            name.to_string()
+            param
         }
     }
 
@@ -1636,7 +1648,10 @@ impl<'a> CSharpLowerer<'a> {
         };
         let params = self.bridge_params(method, abi_method);
         let ret = self.callback_return(&method.returns, &abi_method.returns, mode);
-        params.iter().any(|param| param.needs_wire_reader) || ret.needs_wire_reader()
+        params
+            .iter()
+            .any(CSharpCallbackBridgeParamPlan::needs_wire_reader)
+            || ret.needs_wire_reader()
     }
 
     fn callback_method_needs_wire_writer(
@@ -1650,7 +1665,10 @@ impl<'a> CSharpLowerer<'a> {
         };
         let params = self.bridge_params(method, abi_method);
         let ret = self.callback_return(&method.returns, &abi_method.returns, mode);
-        params.iter().any(|param| param.needs_wire_writer) || ret.needs_wire_writer()
+        params
+            .iter()
+            .any(CSharpCallbackBridgeParamPlan::needs_wire_writer)
+            || ret.needs_wire_writer()
     }
 
     fn callback_method_needs_ffi_buf(
@@ -1673,6 +1691,36 @@ fn indent_block(text: &str, prefix: &str) -> String {
     text.lines()
         .map(|line| format!("{prefix}{line}\n"))
         .collect::<String>()
+}
+
+fn decoded_arg_list(params: &[CSharpCallbackBridgeParamPlan]) -> CSharpArgumentList {
+    params
+        .iter()
+        .map(|param| param.decoded_arg().clone())
+        .collect::<Vec<_>>()
+        .into()
+}
+
+fn stripped_name(name: &CSharpParamName) -> &str {
+    name.as_str().strip_prefix('@').unwrap_or(name.as_str())
+}
+
+fn named_type(name: &str) -> CSharpType {
+    CSharpType::Named(CSharpTypeReference::Plain(CSharpClassName::new(name)))
+}
+
+fn marshal_as_i1() -> CSharpAttribute {
+    CSharpAttribute {
+        name: CSharpClassName::new("MarshalAs"),
+        args: vec![CSharpAttributeArg::Positional(
+            CSharpExpression::MemberAccess {
+                receiver: Box::new(CSharpExpression::TypeRef(CSharpTypeReference::Plain(
+                    CSharpClassName::new("UnmanagedType"),
+                ))),
+                name: CSharpPropertyName::from_source("i1"),
+            },
+        )],
+    }
 }
 
 fn root_local_rename(ir_name: &str, csharp_name: &str) -> value::Renames {

--- a/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
@@ -8,12 +8,16 @@ use crate::ir::types::{PrimitiveType, TypeExpr};
 use super::super::ast::{
     CSharpArgumentList, CSharpAttribute, CSharpAttributeArg, CSharpClassName, CSharpExpression,
     CSharpIdentity, CSharpLocalName, CSharpMethodName, CSharpParamName, CSharpParameter,
-    CSharpPropertyName, CSharpType, CSharpTypeReference,
+    CSharpParameterList, CSharpPropertyName, CSharpType, CSharpTypeReference,
 };
 use super::super::plan::{
-    CFunctionName, CSharpCallbackBridgeParamPlan, CSharpCallbackMethodPlan,
-    CSharpCallbackParamPlan, CSharpCallbackPlan, CSharpClosureMethodPlan, CSharpClosurePlan,
-    CSharpWireWriterPlan,
+    CFunctionName, CSharpAsyncCallbackEntryPlan, CSharpAsyncCallbackFailurePlan,
+    CSharpAsyncCallbackFaultPlan, CSharpAsyncCallbackSuccessPlan, CSharpCallbackBridgeParamPlan,
+    CSharpCallbackDelegatePlan, CSharpCallbackEntryPlan, CSharpCallbackMethodPlan,
+    CSharpCallbackParamPlan, CSharpCallbackPlan, CSharpCallbackProxyCallPlan,
+    CSharpCallbackProxyPlan, CSharpClosureInvokePlan, CSharpClosureMethodPlan, CSharpClosurePlan,
+    CSharpSyncCallbackEntryPlan, CSharpSyncCallbackOutInitializerPlan, CSharpSyncCallbackProxyPlan,
+    CSharpSyncCallbackSuccessPlan, CSharpWireWriterPlan,
 };
 use super::lowerer::CSharpLowerer;
 use super::{decode, encode, size, value};
@@ -28,7 +32,6 @@ const RESULT_VALUE: &str = "__boltffiResult";
 const ERROR_RESULT_VALUE: &str = "__boltffiErrorResult";
 const RETURN_READER: &str = "__boltffiReader";
 const INVOKE_LOCAL: &str = "__boltffiInvoke";
-const ASYNC_TASK: &str = "__boltffiTask";
 const ASYNC_COMPLETED: &str = "__boltffiCompleted";
 const ASYNC_EXCEPTION: &str = "__boltffiException";
 const ERROR_OUT_PTR: &str = "__boltffiErrorOutPtr";
@@ -39,8 +42,8 @@ enum CallbackReturn {
     Void,
     Direct {
         public_type: String,
-        native_type: String,
-        native_out_type: String,
+        native_type: CSharpType,
+        native_out_type: CSharpType,
         default_value: String,
         native_expr: String,
         public_expr: String,
@@ -108,7 +111,7 @@ impl<'a> CSharpLowerer<'a> {
                 let abi_method = self
                     .abi_method_for(abi_callback, method)
                     .expect("callback abi method missing");
-                self.lower_callback_method(callback, method, abi_method)
+                self.lower_callback_method(method, abi_method)
             })
             .collect();
         CSharpCallbackPlan {
@@ -177,25 +180,18 @@ impl<'a> CSharpLowerer<'a> {
 
     fn lower_callback_method(
         &self,
-        callback: &CallbackTraitDef,
         method: &CallbackMethodDef,
         abi_method: &AbiCallbackMethod,
     ) -> CSharpCallbackMethodPlan {
-        let entry_source = if method.is_async() {
-            self.render_async_callback_entry(callback, method, abi_method)
-        } else {
-            self.render_sync_callback_entry(callback, method, abi_method)
-        };
-
         CSharpCallbackMethodPlan {
             name: (&method.id).into(),
             vtable_field: CSharpLocalName::new(abi_method.vtable_field.as_str()),
             return_type: self.callback_public_return_type(&method.returns),
             is_async: method.is_async(),
             public_params: self.public_param_plans(&method.params),
-            entry_source,
-            proxy_source: self.render_proxy_method(method, abi_method),
-            delegate_source: self.render_callback_delegate_types(method, abi_method),
+            entry: self.lower_callback_entry(method, abi_method),
+            proxy: self.lower_callback_proxy(method, abi_method),
+            delegates: self.lower_callback_delegates(method, abi_method),
         }
     }
 
@@ -211,14 +207,14 @@ impl<'a> CSharpLowerer<'a> {
             CallbackReturnMode::InlineClosure,
         );
         let native_return_type = self.inline_callback_native_return_type(&ret);
-        let native_decls = std::iter::once("IntPtr context".to_string())
-            .chain(
-                params
-                    .iter()
-                    .flat_map(|p| p.native_params().into_iter().map(|param| param.to_string())),
-            )
-            .collect::<Vec<_>>();
-        let decoded_args = decoded_arg_list(&params).to_string();
+        let mut native_params = CSharpParameterList::empty();
+        native_params.push(CSharpParameter::bare(
+            CSharpType::IntPtr,
+            CSharpParamName::new("context"),
+        ));
+        for param in &params {
+            native_params.extend(param.native_params());
+        }
         let marshals_return_bool = matches!(
             ret,
             CallbackReturn::Direct {
@@ -231,13 +227,10 @@ impl<'a> CSharpLowerer<'a> {
             return_type: self.callback_public_return_type(&method.returns),
             public_params: self.public_param_plans(&method.params),
             native_return_type,
-            native_decls,
+            native_params,
             marshals_return_bool,
-            decode_setup: params
-                .iter()
-                .flat_map(CSharpCallbackBridgeParamPlan::decode_setup_lines)
-                .collect(),
-            invoke_body: self.render_closure_invoke_return(&ret, &decoded_args),
+            bridge_params: params.clone(),
+            invoke: self.closure_invoke(&ret, &params),
         }
     }
 
@@ -272,464 +265,168 @@ impl<'a> CSharpLowerer<'a> {
         }
     }
 
-    fn render_closure_invoke_return(&self, ret: &CallbackReturn, decoded_args: &str) -> String {
+    fn lower_callback_entry(
+        &self,
+        method: &CallbackMethodDef,
+        abi_method: &AbiCallbackMethod,
+    ) -> CSharpCallbackEntryPlan {
+        let method_name: CSharpMethodName = (&method.id).into();
+        let params = self.bridge_params(method, abi_method);
+        let ret = self.callback_return(
+            &method.returns,
+            &abi_method.returns,
+            CallbackReturnMode::CallbackVtable,
+        );
+        if method.is_async() {
+            CSharpCallbackEntryPlan::Async(CSharpAsyncCallbackEntryPlan {
+                native_params: self.async_callback_native_params(&method_name, &params),
+                bridge_params: params.clone(),
+                decoded_args: decoded_arg_list(&params),
+                invalid_handle_completion: self.async_failure_completion(&ret),
+                canceled_completion: self.async_failure_completion(&ret),
+                faulted_completion: self.async_fault_completion(&ret),
+                success_completion: self.async_success_completion(&ret),
+                catch_completion: self.async_failure_completion(&ret),
+            })
+        } else {
+            let success = self.sync_callback_success(&method_name, &params, &ret);
+            CSharpCallbackEntryPlan::Sync(CSharpSyncCallbackEntryPlan {
+                native_params: self.sync_callback_native_params(&params, &ret),
+                out_initializer: self.sync_out_initializer(&ret),
+                bridge_params: params,
+                success,
+            })
+        }
+    }
+
+    fn lower_callback_proxy(
+        &self,
+        method: &CallbackMethodDef,
+        abi_method: &AbiCallbackMethod,
+    ) -> CSharpCallbackProxyPlan {
+        let params = self.bridge_params(method, abi_method);
+        let ret = self.callback_return(
+            &method.returns,
+            &abi_method.returns,
+            CallbackReturnMode::CallbackVtable,
+        );
+        let public_params = callback_public_param_list(&params);
+        if method.is_async() {
+            return CSharpCallbackProxyPlan::AsyncUnsupported {
+                public_params,
+                return_type: ret.async_task_type(),
+                result_type: if matches!(ret, CallbackReturn::Void) {
+                    None
+                } else {
+                    Some(self.callback_public_return_type(&method.returns))
+                },
+                not_supported_expr:
+                    "new NotSupportedException(\"async callback proxies are not implemented for C# yet\")"
+                        .to_string(),
+            };
+        }
+
+        let has_cleanup = params
+            .iter()
+            .any(CSharpCallbackBridgeParamPlan::needs_wire_writer);
+        let call = self.proxy_call(&params, &ret);
+        CSharpCallbackProxyPlan::Sync(CSharpSyncCallbackProxyPlan {
+            public_params,
+            return_type: ret.public_type(),
+            bridge_params: params,
+            has_cleanup,
+            call,
+        })
+    }
+
+    fn lower_callback_delegates(
+        &self,
+        method: &CallbackMethodDef,
+        abi_method: &AbiCallbackMethod,
+    ) -> CSharpCallbackDelegatePlan {
+        let method_name: CSharpMethodName = (&method.id).into();
+        let params = self.bridge_params(method, abi_method);
+        let ret = self.callback_return(
+            &method.returns,
+            &abi_method.returns,
+            CallbackReturnMode::CallbackVtable,
+        );
+        CSharpCallbackDelegatePlan {
+            entry_params: if method.is_async() {
+                self.async_callback_native_params(&method_name, &params)
+            } else {
+                self.sync_callback_native_params(&params, &ret)
+            },
+            completion_params: method
+                .is_async()
+                .then(|| self.async_completion_params(&ret)),
+            proxy_params: (!method.is_async())
+                .then(|| self.sync_callback_native_params(&params, &ret)),
+        }
+    }
+
+    fn closure_invoke(
+        &self,
+        ret: &CallbackReturn,
+        params: &[CSharpCallbackBridgeParamPlan],
+    ) -> CSharpClosureInvokePlan {
+        let decoded_args = decoded_arg_list(params);
         match ret {
-            CallbackReturn::Void => {
-                format!("            impl_({decoded_args});\n")
-            }
+            CallbackReturn::Void => CSharpClosureInvokePlan::Void { decoded_args },
             CallbackReturn::Direct {
                 native_expr,
                 marshals_bool,
                 ..
             } => {
-                let return_expr = if *marshals_bool {
+                let native_value_expr = if *marshals_bool {
                     RETURN_VALUE.to_string()
                 } else {
                     native_expr.replace("value", RETURN_VALUE)
                 };
-                format!(
-                    "            var {RETURN_VALUE} = impl_({decoded_args});\n            return {return_expr};\n"
-                )
-            }
-            CallbackReturn::Encoded {
-                encode_ops,
-                is_result,
-                ..
-            } => {
-                let mut out = String::new();
-                if *is_result {
-                    out.push_str(&self.render_result_assignment(
-                        "impl_",
-                        "Invoke",
-                        decoded_args,
-                        encode_ops,
-                    ));
-                } else {
-                    out.push_str(&format!(
-                        "            var {RETURN_VALUE} = impl_({decoded_args});\n"
-                    ));
+                CSharpClosureInvokePlan::Direct {
+                    decoded_args,
+                    native_value_expr,
                 }
-                out.push_str(&indent_block(
-                    &self.render_encode_to_bytes_with_renames(
-                        encode_ops,
-                        "_returnWire",
-                        "_returnBytes",
-                        "            ",
-                        &root_local_rename(
-                            if *is_result { "result" } else { "value" },
-                            if *is_result {
-                                RESULT_VALUE
-                            } else {
-                                RETURN_VALUE
-                            },
-                        ),
-                    ),
-                    "",
-                ));
-                out.push_str("            return FfiBuf.FromBytes(_returnBytes);\n");
-                out
-            }
-        }
-    }
-
-    fn render_sync_callback_entry(
-        &self,
-        _callback: &CallbackTraitDef,
-        method: &CallbackMethodDef,
-        abi_method: &AbiCallbackMethod,
-    ) -> String {
-        let method_name: CSharpMethodName = (&method.id).into();
-        let params = self.bridge_params(method, abi_method);
-        let ret = self.callback_return(
-            &method.returns,
-            &abi_method.returns,
-            CallbackReturnMode::CallbackVtable,
-        );
-        let native_decls = self.sync_callback_native_decls(&params, &ret);
-        let decoded_args = decoded_arg_list(&params).to_string();
-        let mut out =
-            format!("        private static void {method_name}({native_decls})\n        {{\n");
-        for line in self.sync_out_initializers(&ret) {
-            out.push_str(&format!("            {line}\n"));
-        }
-        out.push_str(&format!(
-            "            {STATUS_OUT} = {STATUS_INTERNAL_ERROR};\n"
-        ));
-        out.push_str("            try\n            {\n");
-        out.push_str("                if (!Handles.TryGetValue(handle, out var impl_)) throw new InvalidOperationException(\"invalid callback handle\");\n");
-        for param in &params {
-            for line in param.decode_setup_lines() {
-                out.push_str(&format!("                {line}\n"));
-            }
-        }
-        match &ret {
-            CallbackReturn::Void => {
-                out.push_str(&format!(
-                    "                impl_.{method_name}({decoded_args});\n"
-                ));
-                out.push_str(&format!("                {STATUS_OUT} = {STATUS_OK};\n"));
-            }
-            CallbackReturn::Direct { native_expr, .. } => {
-                out.push_str(&format!(
-                    "                var {RETURN_VALUE} = impl_.{method_name}({decoded_args});\n"
-                ));
-                out.push_str(&format!(
-                    "                {OUT_PTR} = {};\n",
-                    native_expr.replace("value", RETURN_VALUE)
-                ));
-                out.push_str(&format!("                {STATUS_OUT} = {STATUS_OK};\n"));
             }
             CallbackReturn::Encoded {
                 encode_ops,
                 is_result,
                 ..
             } => {
-                if *is_result {
-                    out.push_str(&indent_block(
+                let result_assignment_lines = if *is_result {
+                    unindented_lines(
                         &self.render_result_assignment(
                             "impl_",
-                            &method_name.to_string(),
-                            &decoded_args,
+                            "Invoke",
+                            &decoded_args.to_string(),
                             encode_ops,
                         ),
-                        "                ",
-                    ));
+                        "            ",
+                    )
                 } else {
-                    out.push_str(&format!(
-                        "                var {RETURN_VALUE} = impl_.{method_name}({decoded_args});\n"
-                    ));
-                }
-                out.push_str(&indent_block(
-                    &self.render_encode_to_bytes_with_renames(
-                        encode_ops,
-                        "_returnWire",
-                        "_returnBytes",
-                        "                ",
-                        &root_local_rename(
-                            if *is_result { "result" } else { "value" },
-                            if *is_result {
-                                RESULT_VALUE
-                            } else {
-                                RETURN_VALUE
-                            },
-                        ),
+                    vec![]
+                };
+                let writer = self.return_wire_writer_plan(
+                    encode_ops,
+                    "_returnWire",
+                    "_returnBytes",
+                    &root_local_rename(
+                        if *is_result { "result" } else { "value" },
+                        if *is_result {
+                            RESULT_VALUE
+                        } else {
+                            RETURN_VALUE
+                        },
                     ),
-                    "",
-                ));
-                out.push_str(&format!(
-                    "                BoltFFICallbackReturn.Store(_returnBytes, out {OUT_PTR}, out {OUT_LEN});\n"
-                ));
-                out.push_str(&format!("                {STATUS_OUT} = {STATUS_OK};\n"));
-            }
-        }
-        out.push_str("            }\n");
-        out.push_str("            catch\n            {\n");
-        for line in self.sync_out_initializers(&ret) {
-            out.push_str(&format!("                {line}\n"));
-        }
-        out.push_str(&format!(
-            "                {STATUS_OUT} = {STATUS_INTERNAL_ERROR};\n"
-        ));
-        out.push_str("            }\n");
-        out.push_str("        }\n");
-        out
-    }
-
-    fn render_async_callback_entry(
-        &self,
-        _callback: &CallbackTraitDef,
-        method: &CallbackMethodDef,
-        abi_method: &AbiCallbackMethod,
-    ) -> String {
-        let method_name: CSharpMethodName = (&method.id).into();
-        let params = self.bridge_params(method, abi_method);
-        let ret = self.callback_return(
-            &method.returns,
-            &abi_method.returns,
-            CallbackReturnMode::CallbackVtable,
-        );
-        let mut native_decls = vec!["ulong handle".to_string()];
-        native_decls.extend(
-            params
-                .iter()
-                .flat_map(|p| p.native_params().into_iter().map(|param| param.to_string())),
-        );
-        native_decls.push(format!("{method_name}Completion callback"));
-        native_decls.push("ulong callbackData".to_string());
-        let decoded_args = decoded_arg_list(&params).to_string();
-        let mut out = format!(
-            "        private static void {method_name}({})\n        {{\n",
-            native_decls.join(", ")
-        );
-        out.push_str(
-            "            if (!Handles.TryGetValue(handle, out var impl_))\n            {\n",
-        );
-        out.push_str(&self.async_complete_failure(
-            &ret,
-            "callback",
-            "callbackData",
-            "                ",
-        ));
-        out.push_str("                return;\n            }\n");
-        out.push_str("            try\n            {\n");
-        for param in &params {
-            for line in param.decode_setup_lines() {
-                out.push_str(&format!("                {line}\n"));
-            }
-        }
-        out.push_str(&format!(
-            "                var {ASYNC_TASK} = impl_.{method_name}({decoded_args});\n"
-        ));
-        out.push_str(&format!(
-            "                _ = {ASYNC_TASK}.ContinueWith({ASYNC_COMPLETED} =>\n                {{\n"
-        ));
-        out.push_str(&format!(
-            "                    if ({ASYNC_COMPLETED}.IsCanceled)\n                    {{\n"
-        ));
-        out.push_str(&self.async_complete_failure(
-            &ret,
-            "callback",
-            "callbackData",
-            "                        ",
-        ));
-        out.push_str("                        return;\n                    }\n");
-        out.push_str(&format!(
-            "                    if ({ASYNC_COMPLETED}.IsFaulted)\n                    {{\n"
-        ));
-        out.push_str(&format!(
-            "                        Exception {ASYNC_EXCEPTION} = UnwrapTaskException({ASYNC_COMPLETED}.Exception!);\n"
-        ));
-        out.push_str(&self.async_complete_exception(
-            &ret,
-            "callback",
-            "callbackData",
-            "                        ",
-        ));
-        out.push_str("                        return;\n                    }\n");
-        out.push_str(&self.async_complete_success(
-            &ret,
-            "callback",
-            "callbackData",
-            ASYNC_COMPLETED,
-            "                    ",
-        ));
-        out.push_str("                }, global::System.Threading.Tasks.TaskScheduler.Default);\n");
-        out.push_str("            }\n");
-        out.push_str("            catch\n            {\n");
-        out.push_str(&self.async_complete_failure(
-            &ret,
-            "callback",
-            "callbackData",
-            "                ",
-        ));
-        out.push_str("            }\n");
-        out.push_str("        }\n");
-        out
-    }
-
-    fn render_proxy_method(
-        &self,
-        method: &CallbackMethodDef,
-        abi_method: &AbiCallbackMethod,
-    ) -> String {
-        let method_name: CSharpMethodName = (&method.id).into();
-        let params = self.bridge_params(method, abi_method);
-        let ret = self.callback_return(
-            &method.returns,
-            &abi_method.returns,
-            CallbackReturnMode::CallbackVtable,
-        );
-        let public_params = params
-            .iter()
-            .map(|p| p.public_param().to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-        if method.is_async() {
-            let return_type = ret.async_task_type();
-            let not_supported = "new NotSupportedException(\"async callback proxies are not implemented for C# yet\")";
-            return match ret {
-                CallbackReturn::Void => format!(
-                    "            public {return_type} {method_name}({public_params}) => global::System.Threading.Tasks.Task.FromException({not_supported});\n"
-                ),
-                _ => format!(
-                    "            public {return_type} {method_name}({public_params}) => global::System.Threading.Tasks.Task.FromException<{}>({not_supported});\n",
-                    ret.public_type()
-                ),
-            };
-        }
-
-        let mut out = format!(
-            "            public {} {method_name}({public_params})\n            {{\n",
-            ret.public_type()
-        );
-        out.push_str("                if (_handle.IsNull) throw new ObjectDisposedException(nameof(Proxy));\n");
-        out.push_str(
-            "                VTable __boltffiTable = Marshal.PtrToStructure<VTable>(_handle.vtable);\n",
-        );
-        out.push_str(&format!(
-            "                var {INVOKE_LOCAL} = Marshal.GetDelegateForFunctionPointer<{method_name}ProxyFn>(__boltffiTable.{});\n",
-            abi_method.vtable_field.as_str()
-        ));
-        for param in &params {
-            for line in param.proxy_setup_lines() {
-                out.push_str(&format!("                {line}\n"));
-            }
-        }
-        let has_cleanup = params
-            .iter()
-            .any(|param| !param.proxy_cleanup_lines().is_empty());
-        if has_cleanup {
-            out.push_str("                try\n                {\n");
-        }
-        for param in &params {
-            for line in param.proxy_pin_lines() {
-                out.push_str(&format!(
-                    "{}{line}\n",
-                    if has_cleanup {
-                        "                    "
-                    } else {
-                        "                "
-                    }
-                ));
-            }
-        }
-        let call_indent = if has_cleanup {
-            "                    "
-        } else {
-            "                "
-        };
-        let args = std::iter::once("_handle.handle".to_string())
-            .chain(
-                params
-                    .iter()
-                    .flat_map(|p| p.proxy_args().into_iter().map(|expr| expr.to_string())),
-            )
-            .collect::<Vec<_>>()
-            .join(", ");
-        match &ret {
-            CallbackReturn::Void => {
-                out.push_str(&format!("{call_indent}FfiStatus {STATUS_OUT};\n"));
-                out.push_str(&format!(
-                    "{call_indent}{INVOKE_LOCAL}({args}, out {STATUS_OUT});\n"
-                ));
-                out.push_str(&format!(
-                    "{call_indent}ThrowIfCallbackStatus({STATUS_OUT});\n"
-                ));
-            }
-            CallbackReturn::Direct {
-                native_out_type,
-                public_expr,
-                ..
-            } => {
-                out.push_str(&format!("{call_indent}{native_out_type} {OUT_PTR};\n"));
-                out.push_str(&format!("{call_indent}FfiStatus {STATUS_OUT};\n"));
-                out.push_str(&format!(
-                    "{call_indent}{INVOKE_LOCAL}({args}, out {OUT_PTR}, out {STATUS_OUT});\n"
-                ));
-                out.push_str(&format!(
-                    "{call_indent}ThrowIfCallbackStatus({STATUS_OUT});\n"
-                ));
-                out.push_str(&format!("{call_indent}return {public_expr};\n"));
-            }
-            CallbackReturn::Encoded {
-                decode_expr,
-                decode_ops,
-                is_result,
-                ..
-            } => {
-                out.push_str(&format!("{call_indent}IntPtr {OUT_PTR};\n"));
-                out.push_str(&format!("{call_indent}UIntPtr {OUT_LEN};\n"));
-                out.push_str(&format!("{call_indent}FfiStatus {STATUS_OUT};\n"));
-                out.push_str(&format!(
-                    "{call_indent}{INVOKE_LOCAL}({args}, out {OUT_PTR}, out {OUT_LEN}, out {STATUS_OUT});\n"
-                ));
-                out.push_str(&format!("{call_indent}try\n{call_indent}{{\n"));
-                out.push_str(&format!(
-                    "{call_indent}    ThrowIfCallbackStatus({STATUS_OUT});\n"
-                ));
-                out.push_str(&format!(
-                    "{call_indent}    var {RETURN_READER} = new WireReader({OUT_PTR}, {OUT_LEN});\n"
-                ));
-                if *is_result {
-                    let result_body = self.render_result_decode_from_ops(
-                        decode_ops
-                            .as_ref()
-                            .expect("result callback return decode ops"),
-                        RETURN_READER,
-                        &(call_indent.to_string() + "    "),
-                    );
-                    out.push_str(&result_body);
-                } else if let Some(expr) = decode_expr {
-                    out.push_str(&format!("{call_indent}    return {expr};\n"));
-                }
-                out.push_str(&format!("{call_indent}}}\n"));
-                out.push_str(&format!("{call_indent}finally\n{call_indent}{{\n"));
-                out.push_str(&format!(
-                    "{call_indent}    BoltFFICallbackReturn.Free({OUT_PTR});\n"
-                ));
-                out.push_str(&format!("{call_indent}}}\n"));
-            }
-        }
-        if has_cleanup {
-            out.push_str("                }\n                finally\n                {\n");
-            for param in &params {
-                for line in param.proxy_cleanup_lines() {
-                    out.push_str(&format!("                    {line}\n"));
-                }
-            }
-            out.push_str("                }\n");
-        }
-        out.push_str("            }\n");
-        out
-    }
-
-    fn render_callback_delegate_types(
-        &self,
-        method: &CallbackMethodDef,
-        abi_method: &AbiCallbackMethod,
-    ) -> String {
-        let method_name: CSharpMethodName = (&method.id).into();
-        let params = self.bridge_params(method, abi_method);
-        let ret = self.callback_return(
-            &method.returns,
-            &abi_method.returns,
-            CallbackReturnMode::CallbackVtable,
-        );
-        let mut out = String::new();
-        out.push_str("        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]\n");
-        out.push_str(&format!(
-            "        private delegate void {method_name}Fn({});\n",
-            if method.is_async() {
-                let mut decls = vec!["ulong handle".to_string()];
-                decls.extend(
-                    params
-                        .iter()
-                        .flat_map(|p| p.native_params().into_iter().map(|param| param.to_string())),
                 );
-                decls.push(format!("{method_name}Completion callback"));
-                decls.push("ulong callbackData".to_string());
-                decls.join(", ")
-            } else {
-                self.sync_callback_native_decls(&params, &ret)
+                CSharpClosureInvokePlan::Encoded {
+                    is_result: *is_result,
+                    decoded_args,
+                    result_assignment_lines,
+                    writer,
+                }
             }
-        ));
-        out.push_str(&format!(
-            "        private static readonly {method_name}Fn {method_name}Delegate = {method_name};\n\n"
-        ));
-        if method.is_async() {
-            out.push_str("        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]\n");
-            out.push_str(&format!(
-                "        private delegate void {method_name}Completion({});\n\n",
-                self.async_completion_decls(&ret)
-            ));
-        } else {
-            out.push_str("        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]\n");
-            out.push_str(&format!(
-                "        private delegate void {method_name}ProxyFn({});\n\n",
-                self.sync_proxy_native_decls(&params, &ret)
-            ));
         }
-        out
     }
 
     fn bridge_params(
@@ -874,10 +571,10 @@ impl<'a> CSharpLowerer<'a> {
             None => CallbackReturn::Void,
             Some(Transport::Scalar(origin)) => {
                 let primitive = origin.primitive();
-                let native_type = self.native_type_for_primitive(primitive).to_string();
+                let native_type = CSharpType::from(primitive);
                 let marshals_bool = primitive == PrimitiveType::Bool;
                 let native_out_type = if marshals_bool {
-                    "byte".to_string()
+                    CSharpType::Byte
                 } else {
                     native_type.clone()
                 };
@@ -901,8 +598,8 @@ impl<'a> CSharpLowerer<'a> {
                 let native_type = CSharpClassName::from(&layout.record_id).to_string();
                 CallbackReturn::Direct {
                     public_type,
-                    native_type: native_type.clone(),
-                    native_out_type: native_type,
+                    native_type: named_type(&native_type),
+                    native_out_type: named_type(&native_type),
                     default_value: "default".to_string(),
                     native_expr: "value".to_string(),
                     public_expr: OUT_PTR.to_string(),
@@ -936,8 +633,8 @@ impl<'a> CSharpLowerer<'a> {
                 let bridge = self.callback_bridge_class_name(callback_id);
                 CallbackReturn::Direct {
                     public_type,
-                    native_type: "BoltFFICallbackHandle".to_string(),
-                    native_out_type: "BoltFFICallbackHandle".to_string(),
+                    native_type: named_type("BoltFFICallbackHandle"),
+                    native_out_type: named_type("BoltFFICallbackHandle"),
                     default_value: "BoltFFICallbackHandle.Null".to_string(),
                     native_expr: format!("{bridge}.Create(value)"),
                     public_expr: format!("{bridge}.Wrap({OUT_PTR})"),
@@ -946,8 +643,8 @@ impl<'a> CSharpLowerer<'a> {
             }
             Some(Transport::Handle { .. }) => CallbackReturn::Direct {
                 public_type,
-                native_type: "IntPtr".to_string(),
-                native_out_type: "IntPtr".to_string(),
+                native_type: CSharpType::IntPtr,
+                native_out_type: CSharpType::IntPtr,
                 default_value: "IntPtr.Zero".to_string(),
                 native_expr: "value.Handle".to_string(),
                 public_expr: OUT_PTR.to_string(),
@@ -1147,57 +844,56 @@ impl<'a> CSharpLowerer<'a> {
         encode_ops: &WriteSeq,
         name: &CSharpParamName,
     ) -> CSharpWireWriterPlan {
-        let writer_name = CSharpLocalName::new(format!("_{}Wire", stripped_name(name)));
-        let bytes_name = CSharpLocalName::new(format!("_{}Bytes", stripped_name(name)));
+        self.wire_writer_plan_with_renames(
+            encode_ops,
+            &format!("_{}Wire", stripped_name(name)),
+            &format!("_{}Bytes", stripped_name(name)),
+            name,
+            &value::Renames::new(),
+        )
+    }
+
+    fn return_wire_writer_plan(
+        &self,
+        encode_ops: &WriteSeq,
+        writer_name: &str,
+        bytes_name: &str,
+        renames: &value::Renames,
+    ) -> CSharpWireWriterPlan {
+        self.wire_writer_plan_with_renames(
+            encode_ops,
+            writer_name,
+            bytes_name,
+            &CSharpParamName::new(RETURN_VALUE),
+            renames,
+        )
+    }
+
+    fn wire_writer_plan_with_renames(
+        &self,
+        encode_ops: &WriteSeq,
+        writer_name: &str,
+        bytes_name: &str,
+        param_name: &CSharpParamName,
+        renames: &value::Renames,
+    ) -> CSharpWireWriterPlan {
+        let writer_name = CSharpLocalName::new(writer_name);
+        let bytes_name = CSharpLocalName::new(bytes_name);
         let mut size_locals = size::SizeLocalCounters::default();
         let mut encode_locals = encode::EncodeLocalCounters::default();
         let writer = CSharpExpression::Identity(CSharpIdentity::Local(writer_name.clone()));
         CSharpWireWriterPlan {
             binding_name: writer_name,
             bytes_binding_name: bytes_name,
-            param_name: name.clone(),
-            size_expr: size::lower_size_expr(
-                &encode_ops.size,
-                &value::Renames::new(),
-                &mut size_locals,
-            ),
+            param_name: param_name.clone(),
+            size_expr: size::lower_size_expr(&encode_ops.size, renames, &mut size_locals),
             encode_stmts: encode::lower_encode_expr(
                 encode_ops,
                 &writer,
-                &value::Renames::new(),
+                renames,
                 &mut encode_locals,
             ),
         }
-    }
-
-    fn render_encode_to_bytes_with_renames(
-        &self,
-        encode_ops: &WriteSeq,
-        writer_name: &str,
-        bytes_name: &str,
-        indent: &str,
-        renames: &value::Renames,
-    ) -> String {
-        let mut size_locals = size::SizeLocalCounters::default();
-        let mut encode_locals = encode::EncodeLocalCounters::default();
-        let writer =
-            CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new(writer_name)));
-        let size_expr = size::lower_size_expr(&encode_ops.size, renames, &mut size_locals);
-        let stmts = encode::lower_encode_expr(encode_ops, &writer, renames, &mut encode_locals);
-        let mut out = String::new();
-        out.push_str(&format!("{indent}byte[] {bytes_name};\n"));
-        out.push_str(&format!(
-            "{indent}using (var {writer_name} = new WireWriter({size_expr}))\n"
-        ));
-        out.push_str(&format!("{indent}{{\n"));
-        for stmt in stmts {
-            out.push_str(&format!("{indent}    {stmt};\n"));
-        }
-        out.push_str(&format!(
-            "{indent}    {bytes_name} = {writer_name}.ToArray();\n"
-        ));
-        out.push_str(&format!("{indent}}}\n"));
-        out
     }
 
     fn render_result_decode_from_ops(
@@ -1245,143 +941,41 @@ impl<'a> CSharpLowerer<'a> {
         decode::lower_decode_expr(decode_ops, &reader, None, &self.namespace, &mut locals)
     }
 
-    fn sync_callback_native_decls(
+    fn sync_callback_success(
         &self,
+        method_name: &CSharpMethodName,
         params: &[CSharpCallbackBridgeParamPlan],
         ret: &CallbackReturn,
-    ) -> String {
-        let mut decls = vec!["ulong handle".to_string()];
-        decls.extend(
-            params
-                .iter()
-                .flat_map(|p| p.native_params().into_iter().map(|param| param.to_string())),
-        );
+    ) -> CSharpSyncCallbackSuccessPlan {
+        let decoded_args = decoded_arg_list(params);
         match ret {
-            CallbackReturn::Void => {}
-            CallbackReturn::Direct {
-                native_out_type, ..
-            } => {
-                decls.push(format!("out {native_out_type} {OUT_PTR}"));
-            }
-            CallbackReturn::Encoded { .. } => {
-                decls.push(format!("out IntPtr {OUT_PTR}"));
-                decls.push(format!("out UIntPtr {OUT_LEN}"));
-            }
-        }
-        decls.push(format!("out FfiStatus {STATUS_OUT}"));
-        decls.join(", ")
-    }
-
-    fn sync_proxy_native_decls(
-        &self,
-        params: &[CSharpCallbackBridgeParamPlan],
-        ret: &CallbackReturn,
-    ) -> String {
-        self.sync_callback_native_decls(params, ret)
-    }
-
-    fn sync_out_initializers(&self, ret: &CallbackReturn) -> Vec<String> {
-        match ret {
-            CallbackReturn::Void => vec![],
-            CallbackReturn::Direct { default_value, .. } => {
-                vec![format!("{OUT_PTR} = {default_value};")]
-            }
-            CallbackReturn::Encoded { .. } => vec![
-                format!("{OUT_PTR} = IntPtr.Zero;"),
-                format!("{OUT_LEN} = UIntPtr.Zero;"),
-            ],
-        }
-    }
-
-    fn async_completion_decls(&self, ret: &CallbackReturn) -> String {
-        let mut decls = vec!["ulong callbackData".to_string()];
-        match ret {
-            CallbackReturn::Void => {}
-            CallbackReturn::Direct {
-                native_type,
-                marshals_bool,
-                ..
-            } => {
-                if *marshals_bool {
-                    decls.push("[MarshalAs(UnmanagedType.I1)] bool value".to_string());
-                } else {
-                    decls.push(format!("{native_type} value"));
-                }
-            }
-            CallbackReturn::Encoded { .. } => {
-                decls.push("IntPtr valuePtr".to_string());
-                decls.push("UIntPtr valueLen".to_string());
-            }
-        }
-        decls.push(format!("FfiStatus {STATUS_OUT}"));
-        decls.join(", ")
-    }
-
-    fn async_complete_failure(
-        &self,
-        ret: &CallbackReturn,
-        callback_name: &str,
-        callback_data: &str,
-        indent: &str,
-    ) -> String {
-        match ret {
-            CallbackReturn::Void => {
-                format!("{indent}{callback_name}({callback_data}, {STATUS_INTERNAL_ERROR});\n")
-            }
-            CallbackReturn::Direct { default_value, .. } => format!(
-                "{indent}{callback_name}({callback_data}, {default_value}, {STATUS_INTERNAL_ERROR});\n"
-            ),
-            CallbackReturn::Encoded { .. } => format!(
-                "{indent}{callback_name}({callback_data}, IntPtr.Zero, UIntPtr.Zero, {STATUS_INTERNAL_ERROR});\n"
-            ),
-        }
-    }
-
-    fn async_complete_success(
-        &self,
-        ret: &CallbackReturn,
-        callback_name: &str,
-        callback_data: &str,
-        task_name: &str,
-        indent: &str,
-    ) -> String {
-        match ret {
-            CallbackReturn::Void => {
-                format!("{indent}{callback_name}({callback_data}, {STATUS_OK});\n")
-            }
-            CallbackReturn::Direct {
-                native_expr,
-                marshals_bool,
-                ..
-            } => {
-                let native_expr = if *marshals_bool {
-                    format!("{task_name}.Result")
-                } else {
-                    native_expr.replace("value", &format!("{task_name}.Result"))
-                };
-                format!("{indent}{callback_name}({callback_data}, {native_expr}, {STATUS_OK});\n")
-            }
+            CallbackReturn::Void => CSharpSyncCallbackSuccessPlan::Void { decoded_args },
+            CallbackReturn::Direct { native_expr, .. } => CSharpSyncCallbackSuccessPlan::Direct {
+                decoded_args,
+                native_value_expr: native_expr.replace("value", RETURN_VALUE),
+            },
             CallbackReturn::Encoded {
                 encode_ops,
                 is_result,
                 ..
             } => {
-                let mut out = String::new();
-                if *is_result {
-                    out.push_str(&format!(
-                        "{indent}var {RESULT_VALUE} = {}.Ok({task_name}.Result);\n",
-                        self.result_type_for_encode_ops(encode_ops)
-                    ));
+                let result_assignment_lines = if *is_result {
+                    unindented_lines(
+                        &self.render_result_assignment(
+                            "impl_",
+                            &method_name.to_string(),
+                            &decoded_args.to_string(),
+                            encode_ops,
+                        ),
+                        "            ",
+                    )
                 } else {
-                    out.push_str(&format!(
-                        "{indent}var {RETURN_VALUE} = {task_name}.Result;\n"
-                    ));
-                }
-                out.push_str(&self.render_encode_to_bytes_with_renames(
+                    vec![]
+                };
+                let writer = self.return_wire_writer_plan(
                     encode_ops,
                     "_returnWire",
                     "_returnBytes",
-                    indent,
                     &root_local_rename(
                         if *is_result { "result" } else { "value" },
                         if *is_result {
@@ -1390,96 +984,311 @@ impl<'a> CSharpLowerer<'a> {
                             RETURN_VALUE
                         },
                     ),
-                ));
-                out.push_str(&format!(
-                    "{indent}BoltFFICallbackReturn.Store(_returnBytes, out var {OUT_PTR}, out var {OUT_LEN});\n"
-                ));
-                out.push_str(&format!("{indent}try\n{indent}{{\n"));
-                out.push_str(&format!(
-                    "{indent}    {callback_name}({callback_data}, {OUT_PTR}, {OUT_LEN}, {STATUS_OK});\n"
-                ));
-                out.push_str(&format!("{indent}}}\n{indent}finally\n{indent}{{\n"));
-                out.push_str(&format!(
-                    "{indent}    BoltFFICallbackReturn.Free({OUT_PTR});\n"
-                ));
-                out.push_str(&format!("{indent}}}\n"));
-                out
+                );
+                CSharpSyncCallbackSuccessPlan::Encoded {
+                    is_result: *is_result,
+                    decoded_args,
+                    result_assignment_lines,
+                    writer,
+                }
             }
         }
     }
 
-    fn async_complete_exception(
+    fn proxy_call(
         &self,
+        params: &[CSharpCallbackBridgeParamPlan],
         ret: &CallbackReturn,
-        callback_name: &str,
-        callback_data: &str,
-        indent: &str,
-    ) -> String {
+    ) -> CSharpCallbackProxyCallPlan {
+        let mut args = CSharpArgumentList::empty();
+        args.push(CSharpExpression::MemberAccess {
+            receiver: Box::new(CSharpExpression::Identity(CSharpIdentity::Local(
+                CSharpLocalName::new("_handle"),
+            ))),
+            name: CSharpPropertyName::new("handle"),
+        });
+        for expr in params.iter().flat_map(|p| p.proxy_args()) {
+            args.push(expr);
+        }
+        match ret {
+            CallbackReturn::Void => CSharpCallbackProxyCallPlan::Void { args },
+            CallbackReturn::Direct {
+                native_out_type,
+                public_expr,
+                ..
+            } => CSharpCallbackProxyCallPlan::Direct {
+                args,
+                native_out_type: native_out_type.clone(),
+                public_expr: public_expr.clone(),
+            },
+            CallbackReturn::Encoded {
+                decode_expr,
+                decode_ops,
+                is_result,
+                ..
+            } => {
+                let result_decode_lines = if *is_result {
+                    source_lines(
+                        &self.render_result_decode_from_ops(
+                            decode_ops
+                                .as_ref()
+                                .expect("result callback return decode ops"),
+                            RETURN_READER,
+                            "",
+                        ),
+                    )
+                } else {
+                    vec![]
+                };
+                CSharpCallbackProxyCallPlan::Encoded {
+                    args,
+                    decode_expr: decode_expr.clone(),
+                    result_decode_lines,
+                }
+            }
+        }
+    }
+
+    fn sync_callback_native_params(
+        &self,
+        params: &[CSharpCallbackBridgeParamPlan],
+        ret: &CallbackReturn,
+    ) -> CSharpParameterList {
+        let mut decls = CSharpParameterList::empty();
+        decls.push(CSharpParameter::bare(
+            CSharpType::ULong,
+            CSharpParamName::new("handle"),
+        ));
+        for param in params {
+            decls.extend(param.native_params());
+        }
+        match ret {
+            CallbackReturn::Void => {}
+            CallbackReturn::Direct {
+                native_out_type, ..
+            } => {
+                decls.push(CSharpParameter::out(
+                    native_out_type.clone(),
+                    CSharpParamName::new(OUT_PTR),
+                ));
+            }
+            CallbackReturn::Encoded { .. } => {
+                decls.push(CSharpParameter::out(
+                    CSharpType::IntPtr,
+                    CSharpParamName::new(OUT_PTR),
+                ));
+                decls.push(CSharpParameter::out(
+                    CSharpType::UIntPtr,
+                    CSharpParamName::new(OUT_LEN),
+                ));
+            }
+        }
+        decls.push(CSharpParameter::out(
+            named_type("FfiStatus"),
+            CSharpParamName::new(STATUS_OUT),
+        ));
+        decls
+    }
+
+    fn async_callback_native_params(
+        &self,
+        method_name: &CSharpMethodName,
+        params: &[CSharpCallbackBridgeParamPlan],
+    ) -> CSharpParameterList {
+        let mut decls = CSharpParameterList::empty();
+        decls.push(CSharpParameter::bare(
+            CSharpType::ULong,
+            CSharpParamName::new("handle"),
+        ));
+        for param in params {
+            decls.extend(param.native_params());
+        }
+        decls.push(CSharpParameter::bare(
+            named_type(&format!("{method_name}Completion")),
+            CSharpParamName::new("callback"),
+        ));
+        decls.push(CSharpParameter::bare(
+            CSharpType::ULong,
+            CSharpParamName::new("callbackData"),
+        ));
+        decls
+    }
+
+    fn async_completion_params(&self, ret: &CallbackReturn) -> CSharpParameterList {
+        let mut decls = CSharpParameterList::empty();
+        decls.push(CSharpParameter::bare(
+            CSharpType::ULong,
+            CSharpParamName::new("callbackData"),
+        ));
+        match ret {
+            CallbackReturn::Void => {}
+            CallbackReturn::Direct {
+                native_type,
+                marshals_bool,
+                ..
+            } => {
+                if *marshals_bool {
+                    decls.push(CSharpParameter {
+                        attributes: vec![marshal_as_i1()],
+                        modifier: None,
+                        csharp_type: CSharpType::Bool,
+                        name: CSharpParamName::new("value"),
+                    });
+                } else {
+                    decls.push(CSharpParameter::bare(
+                        native_type.clone(),
+                        CSharpParamName::new("value"),
+                    ));
+                }
+            }
+            CallbackReturn::Encoded { .. } => {
+                decls.push(CSharpParameter::bare(
+                    CSharpType::IntPtr,
+                    CSharpParamName::new("valuePtr"),
+                ));
+                decls.push(CSharpParameter::bare(
+                    CSharpType::UIntPtr,
+                    CSharpParamName::new("valueLen"),
+                ));
+            }
+        }
+        decls.push(CSharpParameter::bare(
+            named_type("FfiStatus"),
+            CSharpParamName::new(STATUS_OUT),
+        ));
+        decls
+    }
+
+    fn sync_out_initializer(&self, ret: &CallbackReturn) -> CSharpSyncCallbackOutInitializerPlan {
+        match ret {
+            CallbackReturn::Void => CSharpSyncCallbackOutInitializerPlan::Void,
+            CallbackReturn::Direct { default_value, .. } => {
+                CSharpSyncCallbackOutInitializerPlan::Direct {
+                    default_value: default_value.clone(),
+                }
+            }
+            CallbackReturn::Encoded { .. } => CSharpSyncCallbackOutInitializerPlan::Encoded,
+        }
+    }
+
+    fn async_failure_completion(&self, ret: &CallbackReturn) -> CSharpAsyncCallbackFailurePlan {
+        match ret {
+            CallbackReturn::Void => CSharpAsyncCallbackFailurePlan::Void,
+            CallbackReturn::Direct { default_value, .. } => {
+                CSharpAsyncCallbackFailurePlan::Direct {
+                    default_value: default_value.clone(),
+                }
+            }
+            CallbackReturn::Encoded { .. } => CSharpAsyncCallbackFailurePlan::Encoded,
+        }
+    }
+
+    fn async_success_completion(&self, ret: &CallbackReturn) -> CSharpAsyncCallbackSuccessPlan {
+        match ret {
+            CallbackReturn::Void => CSharpAsyncCallbackSuccessPlan::Void,
+            CallbackReturn::Direct {
+                native_expr,
+                marshals_bool,
+                ..
+            } => {
+                let native_expr = if *marshals_bool {
+                    format!("{ASYNC_COMPLETED}.Result")
+                } else {
+                    native_expr.replace("value", &format!("{ASYNC_COMPLETED}.Result"))
+                };
+                CSharpAsyncCallbackSuccessPlan::Direct {
+                    native_value_expr: native_expr,
+                }
+            }
+            CallbackReturn::Encoded {
+                encode_ops,
+                is_result,
+                ..
+            } => {
+                let writer = self.return_wire_writer_plan(
+                    encode_ops,
+                    "_returnWire",
+                    "_returnBytes",
+                    &root_local_rename(
+                        if *is_result { "result" } else { "value" },
+                        if *is_result {
+                            RESULT_VALUE
+                        } else {
+                            RETURN_VALUE
+                        },
+                    ),
+                );
+                CSharpAsyncCallbackSuccessPlan::Encoded {
+                    is_result: *is_result,
+                    result_type: self.result_type_for_encode_ops(encode_ops),
+                    writer,
+                }
+            }
+        }
+    }
+
+    fn async_fault_completion(&self, ret: &CallbackReturn) -> CSharpAsyncCallbackFaultPlan {
         let CallbackReturn::Encoded {
             encode_ops,
             is_result: true,
             ..
         } = ret
         else {
-            return self.async_complete_failure(ret, callback_name, callback_data, indent);
+            return CSharpAsyncCallbackFaultPlan::Failure(self.async_failure_completion(ret));
         };
-        let mut out = String::new();
         let result_ty = self.result_type_for_encode_ops(encode_ops);
         let Some(crate::ir::ops::WriteOp::Result { err, .. }) = encode_ops.ops.first() else {
-            return self.async_complete_failure(ret, callback_name, callback_data, indent);
+            return CSharpAsyncCallbackFaultPlan::Failure(self.async_failure_completion(ret));
         };
         let err_type = self
             .result_branch_type(err)
             .unwrap_or_else(|| "object".to_string());
-        if let Some(exception_ty) = self.error_exception_for_write_seq(err) {
-            out.push_str(&format!(
-                "{indent}if ({ASYNC_EXCEPTION} is {exception_ty} __boltffiTypedException)\n{indent}{{\n"
-            ));
-            out.push_str(&format!(
-                "{indent}    var {ERROR_RESULT_VALUE} = {result_ty}.Err(__boltffiTypedException.Error);\n"
-            ));
-        } else if err_type == "string" {
-            out.push_str(&format!("{indent}{{\n"));
-            out.push_str(&format!(
-                "{indent}    var {ERROR_RESULT_VALUE} = {result_ty}.Err({ASYNC_EXCEPTION}.Message);\n"
-            ));
-        } else {
-            return self.async_complete_failure(ret, callback_name, callback_data, indent);
-        }
-        out.push_str(&self.render_encode_to_bytes_with_renames(
+        let (exception_type, error_value_expr, fallback) =
+            if let Some(exception_ty) = self.error_exception_for_write_seq(err) {
+                (
+                    Some(exception_ty),
+                    CSharpExpression::MemberAccess {
+                        receiver: Box::new(CSharpExpression::Identity(CSharpIdentity::Local(
+                            CSharpLocalName::new("__boltffiTypedException"),
+                        ))),
+                        name: CSharpPropertyName::from_source("error"),
+                    },
+                    Some(self.async_failure_completion(ret)),
+                )
+            } else if err_type == "string" {
+                (
+                    None,
+                    CSharpExpression::MemberAccess {
+                        receiver: Box::new(CSharpExpression::Identity(CSharpIdentity::Local(
+                            CSharpLocalName::new(ASYNC_EXCEPTION),
+                        ))),
+                        name: CSharpPropertyName::from_source("message"),
+                    },
+                    None,
+                )
+            } else {
+                return CSharpAsyncCallbackFaultPlan::Failure(self.async_failure_completion(ret));
+            };
+        let writer = self.return_wire_writer_plan(
             encode_ops,
             "_returnErrorWire",
             "_returnErrorBytes",
-            &(indent.to_string() + "    "),
             &root_local_rename("result", ERROR_RESULT_VALUE),
-        ));
-        out.push_str(&format!(
-            "{indent}    BoltFFICallbackReturn.Store(_returnErrorBytes, out var {ERROR_OUT_PTR}, out var {ERROR_OUT_LEN});\n"
-        ));
-        out.push_str(&format!("{indent}    try\n{indent}    {{\n"));
-        out.push_str(&format!(
-            "{indent}        {callback_name}({callback_data}, {ERROR_OUT_PTR}, {ERROR_OUT_LEN}, {STATUS_OK});\n"
-        ));
-        out.push_str(&format!(
-            "{indent}    }}\n{indent}    finally\n{indent}    {{\n"
-        ));
-        out.push_str(&format!(
-            "{indent}        BoltFFICallbackReturn.Free({ERROR_OUT_PTR});\n"
-        ));
-        out.push_str(&format!("{indent}    }}\n"));
-        out.push_str(&format!("{indent}    return;\n"));
-        out.push_str(&format!("{indent}}}\n"));
-        if self.error_exception_for_write_seq(err).is_some() {
-            out.push_str(&self.async_complete_failure(ret, callback_name, callback_data, indent));
+        );
+        CSharpAsyncCallbackFaultPlan::EncodedResult {
+            exception_type,
+            error_value_expr,
+            result_type: result_ty,
+            writer,
+            fallback,
         }
-        out
     }
 
-    fn inline_callback_native_return_type(&self, ret: &CallbackReturn) -> String {
+    fn inline_callback_native_return_type(&self, ret: &CallbackReturn) -> CSharpType {
         match ret {
-            CallbackReturn::Void => "void".to_string(),
+            CallbackReturn::Void => CSharpType::Void,
             CallbackReturn::Direct { native_type, .. } => native_type.clone(),
-            CallbackReturn::Encoded { .. } => "FfiBuf".to_string(),
+            CallbackReturn::Encoded { .. } => named_type("FfiBuf"),
         }
     }
 
@@ -1487,6 +1296,7 @@ impl<'a> CSharpLowerer<'a> {
         match abi_type {
             AbiType::Bool => CSharpParameter {
                 attributes: vec![marshal_as_i1()],
+                modifier: None,
                 csharp_type: CSharpType::Bool,
                 name: name.clone(),
             },
@@ -1494,10 +1304,6 @@ impl<'a> CSharpLowerer<'a> {
                 CSharpParameter::bare(self.native_csharp_type_for_abi_type(abi_type), name.clone())
             }
         }
-    }
-
-    fn native_type_for_abi_type(&self, abi_type: &AbiType) -> String {
-        self.native_csharp_type_for_abi_type(abi_type).to_string()
     }
 
     fn native_csharp_type_for_abi_type(&self, abi_type: &AbiType) -> CSharpType {
@@ -1687,18 +1493,30 @@ impl<'a> CSharpLowerer<'a> {
     }
 }
 
-fn indent_block(text: &str, prefix: &str) -> String {
-    text.lines()
-        .map(|line| format!("{prefix}{line}\n"))
-        .collect::<String>()
-}
-
 fn decoded_arg_list(params: &[CSharpCallbackBridgeParamPlan]) -> CSharpArgumentList {
     params
         .iter()
         .map(|param| param.decoded_arg().clone())
         .collect::<Vec<_>>()
         .into()
+}
+
+fn callback_public_param_list(params: &[CSharpCallbackBridgeParamPlan]) -> CSharpParameterList {
+    params
+        .iter()
+        .map(|param| param.public_param().clone())
+        .collect::<Vec<_>>()
+        .into()
+}
+
+fn source_lines(text: &str) -> Vec<String> {
+    text.lines().map(str::to_string).collect()
+}
+
+fn unindented_lines(text: &str, prefix: &str) -> Vec<String> {
+    text.lines()
+        .map(|line| line.strip_prefix(prefix).unwrap_or(line).to_string())
+        .collect()
 }
 
 fn stripped_name(name: &CSharpParamName) -> &str {

--- a/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/callbacks.rs
@@ -66,6 +66,38 @@ enum CallbackReturnMode {
 }
 
 #[derive(Debug, Clone)]
+struct CallbackMethodShape {
+    name: CSharpMethodName,
+    vtable_field: CSharpLocalName,
+    is_async: bool,
+    bridge_params: Vec<CSharpCallbackBridgeParamPlan>,
+    ret: CallbackReturn,
+}
+
+impl CallbackMethodShape {
+    fn public_return_type(&self) -> CSharpType {
+        self.ret.public_type()
+    }
+
+    fn public_param_plans(&self) -> Vec<CSharpCallbackParamPlan> {
+        self.bridge_params
+            .iter()
+            .map(|param| {
+                let public_param = param.public_param();
+                CSharpCallbackParamPlan {
+                    csharp_type: public_param.csharp_type.clone(),
+                    name: public_param.name.clone(),
+                }
+            })
+            .collect()
+    }
+
+    fn public_param_list(&self) -> CSharpParameterList {
+        callback_public_param_list(&self.bridge_params)
+    }
+}
+
+#[derive(Debug, Clone)]
 enum CallbackNativeValuePlan {
     Identity,
     BoolToByte,
@@ -192,16 +224,12 @@ impl<'a> CSharpLowerer<'a> {
         method: &CallbackMethodDef,
         abi_method: &AbiCallbackMethod,
     ) -> CSharpCallbackMethodPlan {
-        CSharpCallbackMethodPlan {
-            name: (&method.id).into(),
-            vtable_field: CSharpLocalName::new(abi_method.vtable_field.as_str()),
-            return_type: self.callback_public_return_type(&method.returns),
-            is_async: method.is_async(),
-            public_params: self.public_param_plans(&method.params),
-            entry: self.lower_callback_entry(method, abi_method),
-            proxy: self.lower_callback_proxy(method, abi_method),
-            delegates: self.lower_callback_delegates(method, abi_method),
-        }
+        let shape = self.lower_callback_method_shape(
+            method,
+            abi_method,
+            CallbackReturnMode::CallbackVtable,
+        );
+        self.callback_method_plan_from_shape(&shape)
     }
 
     fn lower_closure_method(
@@ -209,29 +237,48 @@ impl<'a> CSharpLowerer<'a> {
         method: &CallbackMethodDef,
         abi_method: &AbiCallbackMethod,
     ) -> CSharpClosureMethodPlan {
-        let params = self.bridge_params(method, abi_method);
-        let ret = self.callback_return(
-            &method.returns,
-            &abi_method.returns,
-            CallbackReturnMode::InlineClosure,
-        );
-        let native_return_type = self.inline_callback_native_return_type(&ret);
+        let shape =
+            self.lower_callback_method_shape(method, abi_method, CallbackReturnMode::InlineClosure);
+        self.closure_method_plan_from_shape(&shape)
+    }
+
+    fn callback_method_plan_from_shape(
+        &self,
+        shape: &CallbackMethodShape,
+    ) -> CSharpCallbackMethodPlan {
+        CSharpCallbackMethodPlan {
+            name: shape.name.clone(),
+            vtable_field: shape.vtable_field.clone(),
+            return_type: shape.public_return_type(),
+            is_async: shape.is_async,
+            public_params: shape.public_param_plans(),
+            entry: self.lower_callback_entry(shape),
+            proxy: self.lower_callback_proxy(shape),
+            delegates: self.lower_callback_delegates(shape),
+        }
+    }
+
+    fn closure_method_plan_from_shape(
+        &self,
+        shape: &CallbackMethodShape,
+    ) -> CSharpClosureMethodPlan {
+        let native_return_type = self.inline_callback_native_return_type(&shape.ret);
         let mut native_params = CSharpParameterList::empty();
         native_params.push(CSharpParameter::bare(
             CSharpType::IntPtr,
             CSharpParamName::new("context"),
         ));
-        for param in &params {
+        for param in &shape.bridge_params {
             native_params.extend(param.native_params());
         }
 
         CSharpClosureMethodPlan {
-            return_type: self.callback_public_return_type(&method.returns),
-            public_params: self.public_param_plans(&method.params),
+            return_type: shape.public_return_type(),
+            public_params: shape.public_param_plans(),
             native_return_type,
             native_params,
-            bridge_params: params.clone(),
-            invoke: self.closure_invoke(&ret, &params),
+            bridge_params: shape.bridge_params.clone(),
+            invoke: self.closure_invoke(&shape.ret, &shape.bridge_params),
         }
     }
 
@@ -271,99 +318,83 @@ impl<'a> CSharpLowerer<'a> {
         CSharpClassName::new(format!("{}Proxy", public_name.as_str()))
     }
 
-    fn lower_callback_entry(
+    fn lower_callback_method_shape(
         &self,
         method: &CallbackMethodDef,
         abi_method: &AbiCallbackMethod,
-    ) -> CSharpCallbackEntryPlan {
-        let method_name: CSharpMethodName = (&method.id).into();
-        let params = self.bridge_params(method, abi_method);
-        let ret = self.callback_return(
-            &method.returns,
-            &abi_method.returns,
-            CallbackReturnMode::CallbackVtable,
-        );
-        if method.is_async() {
+        mode: CallbackReturnMode,
+    ) -> CallbackMethodShape {
+        CallbackMethodShape {
+            name: (&method.id).into(),
+            vtable_field: CSharpLocalName::new(abi_method.vtable_field.as_str()),
+            is_async: method.is_async(),
+            bridge_params: self.bridge_params(method, abi_method),
+            ret: self.callback_return(&method.returns, &abi_method.returns, mode),
+        }
+    }
+
+    fn lower_callback_entry(&self, shape: &CallbackMethodShape) -> CSharpCallbackEntryPlan {
+        if shape.is_async {
             CSharpCallbackEntryPlan::Async(Box::new(CSharpAsyncCallbackEntryPlan {
-                native_params: self.async_callback_native_params(&method_name, &params),
-                bridge_params: params.clone(),
-                decoded_args: decoded_arg_list(&params),
-                invalid_handle_completion: self.async_failure_completion(&ret),
-                canceled_completion: self.async_failure_completion(&ret),
-                faulted_completion: self.async_fault_completion(&ret),
-                success_completion: self.async_success_completion(&ret),
-                catch_completion: self.async_failure_completion(&ret),
+                native_params: self.async_callback_native_params(&shape.name, &shape.bridge_params),
+                bridge_params: shape.bridge_params.clone(),
+                decoded_args: decoded_arg_list(&shape.bridge_params),
+                invalid_handle_completion: self.async_failure_completion(&shape.ret),
+                canceled_completion: self.async_failure_completion(&shape.ret),
+                faulted_completion: self.async_fault_completion(&shape.ret),
+                success_completion: self.async_success_completion(&shape.ret),
+                catch_completion: self.async_failure_completion(&shape.ret),
             }))
         } else {
-            let success = self.sync_callback_success(&method_name, &params, &ret);
+            let success = self.sync_callback_success(&shape.name, &shape.bridge_params, &shape.ret);
             CSharpCallbackEntryPlan::Sync(Box::new(CSharpSyncCallbackEntryPlan {
-                native_params: self.sync_callback_native_params(&params, &ret),
-                out_initializer: self.sync_out_initializer(&ret),
-                bridge_params: params,
+                native_params: self.sync_callback_native_params(&shape.bridge_params, &shape.ret),
+                out_initializer: self.sync_out_initializer(&shape.ret),
+                bridge_params: shape.bridge_params.clone(),
                 success,
             }))
         }
     }
 
-    fn lower_callback_proxy(
-        &self,
-        method: &CallbackMethodDef,
-        abi_method: &AbiCallbackMethod,
-    ) -> CSharpCallbackProxyPlan {
-        let params = self.bridge_params(method, abi_method);
-        let ret = self.callback_return(
-            &method.returns,
-            &abi_method.returns,
-            CallbackReturnMode::CallbackVtable,
-        );
-        let public_params = callback_public_param_list(&params);
-        if method.is_async() {
+    fn lower_callback_proxy(&self, shape: &CallbackMethodShape) -> CSharpCallbackProxyPlan {
+        let public_params = shape.public_param_list();
+        if shape.is_async {
             return CSharpCallbackProxyPlan::AsyncUnsupported {
                 public_params,
-                result_type: if matches!(ret, CallbackReturn::Void) {
+                result_type: if matches!(shape.ret, CallbackReturn::Void) {
                     None
                 } else {
-                    Some(self.callback_public_return_type(&method.returns))
+                    Some(shape.public_return_type())
                 },
             };
         }
 
-        let has_cleanup = params
+        let has_cleanup = shape
+            .bridge_params
             .iter()
             .any(CSharpCallbackBridgeParamPlan::needs_wire_writer);
-        let call = self.proxy_call(&params, &ret);
+        let call = self.proxy_call(&shape.bridge_params, &shape.ret);
         CSharpCallbackProxyPlan::Sync(Box::new(CSharpSyncCallbackProxyPlan {
             public_params,
-            return_type: ret.public_type(),
-            bridge_params: params,
+            return_type: shape.ret.public_type(),
+            bridge_params: shape.bridge_params.clone(),
             has_cleanup,
             call,
         }))
     }
 
-    fn lower_callback_delegates(
-        &self,
-        method: &CallbackMethodDef,
-        abi_method: &AbiCallbackMethod,
-    ) -> CSharpCallbackDelegatePlan {
-        let method_name: CSharpMethodName = (&method.id).into();
-        let params = self.bridge_params(method, abi_method);
-        let ret = self.callback_return(
-            &method.returns,
-            &abi_method.returns,
-            CallbackReturnMode::CallbackVtable,
-        );
+    fn lower_callback_delegates(&self, shape: &CallbackMethodShape) -> CSharpCallbackDelegatePlan {
         CSharpCallbackDelegatePlan {
-            entry_params: if method.is_async() {
-                self.async_callback_native_params(&method_name, &params)
+            entry_params: if shape.is_async {
+                self.async_callback_native_params(&shape.name, &shape.bridge_params)
             } else {
-                self.sync_callback_native_params(&params, &ret)
+                self.sync_callback_native_params(&shape.bridge_params, &shape.ret)
             },
-            completion_params: method
-                .is_async()
-                .then(|| self.async_completion_params(&ret)),
-            proxy_params: (!method.is_async())
-                .then(|| self.sync_callback_native_params(&params, &ret)),
+            completion_params: shape
+                .is_async
+                .then(|| self.async_completion_params(&shape.ret)),
+            proxy_params: (!shape.is_async)
+                .then(|| self.sync_callback_native_params(&shape.bridge_params, &shape.ret)),
         }
     }
 
@@ -548,17 +579,6 @@ impl<'a> CSharpLowerer<'a> {
         }
     }
 
-    fn callback_public_return_type(&self, returns: &ReturnDef) -> CSharpType {
-        match returns {
-            ReturnDef::Void => CSharpType::Void,
-            ReturnDef::Value(ty) => self.lower_type(ty).expect("callback return type"),
-            ReturnDef::Result { ok, .. } => match ok {
-                TypeExpr::Void => CSharpType::Void,
-                ok => self.lower_type(ok).expect("result ok type"),
-            },
-        }
-    }
-
     fn callback_value_return(
         &self,
         ty: &TypeExpr,
@@ -682,21 +702,6 @@ impl<'a> CSharpLowerer<'a> {
                 }
             }
         }
-    }
-
-    fn public_param_plans(
-        &self,
-        params: &[crate::ir::definitions::ParamDef],
-    ) -> Vec<CSharpCallbackParamPlan> {
-        params
-            .iter()
-            .map(|param| CSharpCallbackParamPlan {
-                csharp_type: self
-                    .lower_type(&param.type_expr)
-                    .expect("callback param type"),
-                name: (&param.name).into(),
-            })
-            .collect()
     }
 
     fn result_assignment_plan(

--- a/boltffi_bindgen/src/render/csharp/lower/encode.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/encode.rs
@@ -135,6 +135,52 @@ pub(crate) fn lower_encode_expr(
                 otherwise: Some(vec![tag_byte(0)]),
             }]
         }
+        WriteOp::Result { value, ok, err } => {
+            let result_expr = render_value(value, renames);
+            let tag_byte = |byte: i64| {
+                CSharpStatement::Expression(CSharpExpression::MethodCall {
+                    receiver: Box::new(writer.clone()),
+                    method: CSharpMethodName::from_source("write_u8"),
+                    type_args: vec![],
+                    args: vec![CSharpExpression::Cast {
+                        target: CSharpType::Byte,
+                        inner: Box::new(CSharpExpression::Literal(CSharpLiteral::Int(byte))),
+                    }]
+                    .into(),
+                })
+            };
+
+            let mut ok_renames = renames.clone();
+            ok_renames.insert(
+                "okVal".to_string(),
+                CSharpExpression::MemberAccess {
+                    receiver: Box::new(result_expr.clone()),
+                    name: CSharpPropertyName::from_source("ok_value"),
+                },
+            );
+            let mut err_renames = renames.clone();
+            err_renames.insert(
+                "errVal".to_string(),
+                CSharpExpression::MemberAccess {
+                    receiver: Box::new(result_expr.clone()),
+                    name: CSharpPropertyName::from_source("err_value"),
+                },
+            );
+
+            let mut then = vec![tag_byte(0)];
+            then.extend(lower_encode_expr(ok, writer, &ok_renames, locals));
+            let mut otherwise = vec![tag_byte(1)];
+            otherwise.extend(lower_encode_expr(err, writer, &err_renames, locals));
+
+            vec![CSharpStatement::If {
+                cond: CSharpExpression::MemberAccess {
+                    receiver: Box::new(result_expr),
+                    name: CSharpPropertyName::from_source("is_ok"),
+                },
+                then,
+                otherwise: Some(otherwise),
+            }]
+        }
         WriteOp::Vec {
             value,
             element_type: TypeExpr::Primitive(p),

--- a/boltffi_bindgen/src/render/csharp/lower/functions.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/functions.rs
@@ -90,6 +90,12 @@ impl<'a> CSharpLowerer<'a> {
             ReturnDef::Value(t) => t,
             _ => return CSharpReturnKind::Direct,
         };
+        if let TypeExpr::Callback(id) = raw_type {
+            return CSharpReturnKind::CallbackHandle {
+                bridge_class: self.callback_bridge_class_name(id),
+                nullable: false,
+            };
+        }
         // Custom returns always cross as wire-encoded FfiBuf (the macro
         // wraps the underlying value uniformly). For repr shapes that
         // already have a wire-decode path (String, Record, Enum, Vec,

--- a/boltffi_bindgen/src/render/csharp/lower/lowerer.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/lowerer.rs
@@ -2,14 +2,15 @@ use std::collections::HashSet;
 
 use boltffi_ffi_rules::naming;
 
+use crate::ir::definitions::CallbackKind;
 use crate::ir::ids::{EnumId, RecordId};
 use crate::ir::{AbiContract, FfiContract};
 
 use super::super::CSharpOptions;
 use super::super::ast::{CSharpClassName, CSharpNamespace};
 use super::super::plan::{
-    CFunctionName, CSharpClassPlan, CSharpEnumPlan, CSharpFunctionPlan, CSharpModulePlan,
-    CSharpRecordPlan,
+    CFunctionName, CSharpCallbackPlan, CSharpClassPlan, CSharpClosurePlan, CSharpEnumPlan,
+    CSharpFunctionPlan, CSharpModulePlan, CSharpRecordPlan,
 };
 
 /// Produces a [`CSharpModulePlan`] from the IR contracts.
@@ -85,6 +86,22 @@ impl<'a> CSharpLowerer<'a> {
             .map(|c| self.lower_class(c))
             .collect();
 
+        let callbacks: Vec<CSharpCallbackPlan> = self
+            .ffi
+            .catalog
+            .all_callbacks()
+            .filter(|c| matches!(c.kind, CallbackKind::Trait))
+            .map(|c| self.lower_callback(c))
+            .collect();
+
+        let closures: Vec<CSharpClosurePlan> = self
+            .ffi
+            .catalog
+            .all_callbacks()
+            .filter(|c| matches!(c.kind, CallbackKind::Closure))
+            .map(|c| self.lower_closure(c))
+            .collect();
+
         CSharpModulePlan {
             namespace,
             class_name,
@@ -94,6 +111,8 @@ impl<'a> CSharpLowerer<'a> {
             enums,
             functions,
             classes,
+            callbacks,
+            closures,
         }
     }
 }

--- a/boltffi_bindgen/src/render/csharp/lower/mod.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/mod.rs
@@ -4,6 +4,7 @@
 
 mod abi;
 mod admission;
+mod callbacks;
 mod classes;
 mod custom;
 mod decode;

--- a/boltffi_bindgen/src/render/csharp/lower/predicates.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/predicates.rs
@@ -1,5 +1,5 @@
-use crate::ir::definitions::{EnumRepr, ParamDef, ParamPassing};
-use crate::ir::ids::{EnumId, RecordId};
+use crate::ir::definitions::{CallbackKind, EnumRepr, ParamDef, ParamPassing};
+use crate::ir::ids::{CallbackId, EnumId, RecordId};
 use crate::ir::types::TypeExpr;
 
 use super::lowerer::CSharpLowerer;
@@ -27,7 +27,18 @@ impl<'a> CSharpLowerer<'a> {
     /// Whether the param can be handled by the C# backend. Today only
     /// by-value passing is supported (no `&` / `&mut`).
     pub(super) fn is_supported_param(&self, param: &ParamDef) -> bool {
-        param.passing == ParamPassing::Value && self.is_supported_type(&param.type_expr)
+        match (&param.passing, &param.type_expr) {
+            (ParamPassing::Value, TypeExpr::Option(inner))
+                if matches!(inner.as_ref(), TypeExpr::Callback(_)) =>
+            {
+                self.is_supported_type(&param.type_expr)
+            }
+            (ParamPassing::ImplTrait | ParamPassing::BoxedDyn, TypeExpr::Callback(id)) => {
+                self.is_supported_callback(id)
+            }
+            (ParamPassing::Value, _) => self.is_supported_type(&param.type_expr),
+            _ => false,
+        }
     }
 
     /// Whether the type can appear as a function param or return today.
@@ -45,8 +56,18 @@ impl<'a> CSharpLowerer<'a> {
             TypeExpr::Option(inner) => {
                 !matches!(inner.as_ref(), TypeExpr::Option(_)) && self.is_supported_type(inner)
             }
+            TypeExpr::Callback(id) => self.is_supported_callback(id),
             _ => false,
         }
+    }
+
+    pub(super) fn is_supported_callback(&self, id: &CallbackId) -> bool {
+        self.ffi
+            .catalog
+            .resolve_callback(id)
+            .is_some_and(|callback| match callback.kind {
+                CallbackKind::Trait | CallbackKind::Closure => true,
+            })
     }
 
     /// Whether `ty` is admissible as the Ok or Err side of a

--- a/boltffi_bindgen/src/render/csharp/lower/size.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/size.rs
@@ -119,6 +119,38 @@ pub(crate) fn lower_size_expr(
                 right: Box::new(ternary),
             }))
         }
+        SizeExpr::ResultSize { value, ok, err } => {
+            let result_expr = render_value(value, renames);
+            let mut ok_renames = renames.clone();
+            ok_renames.insert(
+                "okVal".to_string(),
+                CSharpExpression::MemberAccess {
+                    receiver: Box::new(result_expr.clone()),
+                    name: CSharpPropertyName::from_source("ok_value"),
+                },
+            );
+            let mut err_renames = renames.clone();
+            err_renames.insert(
+                "errVal".to_string(),
+                CSharpExpression::MemberAccess {
+                    receiver: Box::new(result_expr.clone()),
+                    name: CSharpPropertyName::from_source("err_value"),
+                },
+            );
+            let branch_size = CSharpExpression::Paren(Box::new(CSharpExpression::Ternary {
+                cond: Box::new(CSharpExpression::MemberAccess {
+                    receiver: Box::new(result_expr),
+                    name: CSharpPropertyName::from_source("is_ok"),
+                }),
+                then: Box::new(lower_size_expr(ok, &ok_renames, locals)),
+                otherwise: Box::new(lower_size_expr(err, &err_renames, locals)),
+            }));
+            CSharpExpression::Paren(Box::new(CSharpExpression::Binary {
+                op: CSharpBinaryOp::Add,
+                left: Box::new(CSharpExpression::Literal(CSharpLiteral::Int(1))),
+                right: Box::new(branch_size),
+            }))
+        }
         SizeExpr::VecSize {
             value,
             layout: VecLayout::Blittable { element_size },

--- a/boltffi_bindgen/src/render/csharp/lower/types.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/types.rs
@@ -1,4 +1,4 @@
-use crate::ir::definitions::{ParamDef, ParamPassing, ReturnDef};
+use crate::ir::definitions::{CallbackKind, ParamDef, ParamPassing, ReturnDef};
 use crate::ir::types::TypeExpr;
 
 use super::super::ast::{
@@ -17,11 +17,28 @@ impl<'a> CSharpLowerer<'a> {
         wire_writers: &[CSharpWireWriterPlan],
     ) -> Option<CSharpParamPlan> {
         if param.passing != ParamPassing::Value {
+            if let TypeExpr::Callback(id) = &param.type_expr {
+                return Some(self.lower_callback_param(param, id)?);
+            }
             return None;
         }
 
         let csharp_type = self.lower_type(&param.type_expr)?;
         let csharp_param_name: CSharpParamName = (&param.name).into();
+        if let TypeExpr::Callback(id) = &param.type_expr {
+            return Some(self.lower_callback_param(param, id)?);
+        }
+        if let TypeExpr::Option(inner) = &param.type_expr
+            && let TypeExpr::Callback(id) = inner.as_ref()
+        {
+            return Some(CSharpParamPlan {
+                name: csharp_param_name,
+                csharp_type,
+                kind: CSharpParamKind::CallbackHandle {
+                    bridge_class: self.callback_bridge_class_name(id),
+                },
+            });
+        }
         // The macro exposes Custom-typed params (and Vec<Custom<_>>
         // params) as wire-buffer C ABIs regardless of repr — Custom is
         // treated as opaque on the boundary, so even Vec<Custom<i64>>
@@ -144,8 +161,38 @@ impl<'a> CSharpLowerer<'a> {
                 let inner_type = self.lower_type(inner)?;
                 Some(CSharpType::Nullable(Box::new(inner_type)))
             }
+            TypeExpr::Callback(id) => Some(CSharpType::Record(
+                self.callback_public_class_name(id).into(),
+            )),
             _ => None,
         }
+    }
+
+    fn lower_callback_param(
+        &self,
+        param: &ParamDef,
+        id: &crate::ir::ids::CallbackId,
+    ) -> Option<CSharpParamPlan> {
+        let callback = self.ffi.catalog.resolve_callback(id)?;
+        let name: CSharpParamName = (&param.name).into();
+        let csharp_type = CSharpType::Record(self.callback_public_class_name(id).into());
+        let kind = match callback.kind {
+            CallbackKind::Closure if param.passing == ParamPassing::ImplTrait => {
+                CSharpParamKind::InlineClosure {
+                    bridge_class: self.callback_bridge_class_name(id),
+                    scope_local: CSharpLocalName::for_inline_callback_scope(&name),
+                    context_param_name: CSharpParamName::new(format!("{}Ud", name.as_str())),
+                }
+            }
+            _ => CSharpParamKind::CallbackHandle {
+                bridge_class: self.callback_bridge_class_name(id),
+            },
+        };
+        Some(CSharpParamPlan {
+            name,
+            csharp_type,
+            kind,
+        })
     }
 }
 

--- a/boltffi_bindgen/src/render/csharp/lower/types.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/types.rs
@@ -122,7 +122,7 @@ impl<'a> CSharpLowerer<'a> {
     pub(super) fn lower_return(&self, return_def: &ReturnDef) -> Option<CSharpType> {
         match return_def {
             ReturnDef::Void => Some(CSharpType::Void),
-            ReturnDef::Value(type_expr) => self.lower_type(type_expr),
+            ReturnDef::Value(type_expr) => self.lower_return_value(type_expr),
             ReturnDef::Result { ok, err } => {
                 if !self.is_supported_result_type(ok) || !self.is_supported_result_type(err) {
                     return None;
@@ -132,6 +132,15 @@ impl<'a> CSharpLowerer<'a> {
                     other => self.lower_type(other),
                 }
             }
+        }
+    }
+
+    fn lower_return_value(&self, type_expr: &TypeExpr) -> Option<CSharpType> {
+        match type_expr {
+            TypeExpr::Callback(id) => Some(CSharpType::Record(
+                self.callback_proxy_class_name(id).into(),
+            )),
+            other => self.lower_type(other),
         }
     }
 

--- a/boltffi_bindgen/src/render/csharp/lower/types.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/types.rs
@@ -18,7 +18,7 @@ impl<'a> CSharpLowerer<'a> {
     ) -> Option<CSharpParamPlan> {
         if param.passing != ParamPassing::Value {
             if let TypeExpr::Callback(id) = &param.type_expr {
-                return Some(self.lower_callback_param(param, id)?);
+                return self.lower_callback_param(param, id);
             }
             return None;
         }
@@ -26,7 +26,7 @@ impl<'a> CSharpLowerer<'a> {
         let csharp_type = self.lower_type(&param.type_expr)?;
         let csharp_param_name: CSharpParamName = (&param.name).into();
         if let TypeExpr::Callback(id) = &param.type_expr {
-            return Some(self.lower_callback_param(param, id)?);
+            return self.lower_callback_param(param, id);
         }
         if let TypeExpr::Option(inner) = &param.type_expr
             && let TypeExpr::Callback(id) = inner.as_ref()

--- a/boltffi_bindgen/src/render/csharp/plan/callable/param.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callable/param.rs
@@ -42,6 +42,7 @@ impl CSharpParamPlan {
                 attributes: vec![marshal_as(CSharpAttributeArg::Positional(
                     unmanaged_type_member("I1"),
                 ))],
+                modifier: None,
                 csharp_type: CSharpType::Bool,
                 name: self.name.clone(),
             }],
@@ -66,6 +67,7 @@ impl CSharpParamPlan {
                     } else {
                         vec![]
                     },
+                    modifier: None,
                     csharp_type: CSharpType::Array(Box::new(element)),
                     name: self.name.clone(),
                 };
@@ -275,20 +277,6 @@ impl CSharpParamPlan {
                     .into(),
                 },
             }),
-            _ => None,
-        }
-    }
-
-    pub fn setup_statement(&self) -> Option<String> {
-        match &self.kind {
-            CSharpParamKind::InlineClosure {
-                bridge_class,
-                scope_local,
-                ..
-            } => Some(format!(
-                "using var {scope_local} = {bridge_class}.Pin({});",
-                self.name
-            )),
             _ => None,
         }
     }

--- a/boltffi_bindgen/src/render/csharp/plan/callable/param.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callable/param.rs
@@ -74,6 +74,27 @@ impl CSharpParamPlan {
             CSharpParamKind::PinnedArray { .. } => {
                 buffer_and_length(CSharpType::IntPtr, &self.name)
             }
+            CSharpParamKind::CallbackHandle { .. } => {
+                vec![CSharpParameter::bare(
+                    CSharpType::Record(CSharpTypeReference::Plain(CSharpClassName::new(
+                        "BoltFFICallbackHandle",
+                    ))),
+                    self.name.clone(),
+                )]
+            }
+            CSharpParamKind::InlineClosure {
+                bridge_class,
+                context_param_name,
+                ..
+            } => vec![
+                CSharpParameter::bare(
+                    CSharpType::Record(CSharpTypeReference::Plain(CSharpClassName::new(format!(
+                        "{bridge_class}.NativeInvoke"
+                    )))),
+                    self.name.clone(),
+                ),
+                CSharpParameter::bare(CSharpType::IntPtr, context_param_name.clone()),
+            ],
         }
     }
 }
@@ -173,6 +194,29 @@ impl CSharpParamPlan {
                 };
                 vec![ptr_arg, length_arg]
             }
+            CSharpParamKind::CallbackHandle { bridge_class } => {
+                vec![CSharpExpression::MethodCall {
+                    receiver: Box::new(CSharpExpression::TypeRef(CSharpTypeReference::Plain(
+                        bridge_class.clone(),
+                    ))),
+                    method: CSharpMethodName::from_source("create"),
+                    type_args: vec![],
+                    args: vec![param_ident(&self.name)].into(),
+                }]
+            }
+            CSharpParamKind::InlineClosure { scope_local, .. } => {
+                let scope = CSharpExpression::Identity(CSharpIdentity::Local(scope_local.clone()));
+                vec![
+                    CSharpExpression::MemberAccess {
+                        receiver: Box::new(scope.clone()),
+                        name: CSharpPropertyName::from_source("function"),
+                    },
+                    CSharpExpression::MemberAccess {
+                        receiver: Box::new(scope),
+                        name: CSharpPropertyName::from_source("context"),
+                    },
+                ]
+            }
         }
     }
 }
@@ -235,6 +279,20 @@ impl CSharpParamPlan {
         }
     }
 
+    pub fn setup_statement(&self) -> Option<String> {
+        match &self.kind {
+            CSharpParamKind::InlineClosure {
+                bridge_class,
+                scope_local,
+                ..
+            } => Some(format!(
+                "using var {scope_local} = {bridge_class}.Pin({});",
+                self.name
+            )),
+            _ => None,
+        }
+    }
+
     /// Whether this param needs a `fixed` statement around the native call.
     /// Drives the `unsafe { fixed (...) { ... } }` scaffolding in the
     /// wrapper templates.
@@ -270,6 +328,15 @@ pub enum CSharpParamKind {
     PinnedArray {
         element_type: CSharpType,
         ptr_local: CSharpLocalName,
+    },
+    /// A generated callback trait instance passed as `BoltFFICallbackHandle`.
+    CallbackHandle { bridge_class: CSharpClassName },
+    /// A generated closure delegate passed as an unmanaged function pointer
+    /// plus an opaque GCHandle user-data pointer.
+    InlineClosure {
+        bridge_class: CSharpClassName,
+        scope_local: CSharpLocalName,
+        context_param_name: CSharpParamName,
     },
 }
 

--- a/boltffi_bindgen/src/render/csharp/plan/callable/return_kind.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callable/return_kind.rs
@@ -11,6 +11,12 @@ pub enum CSharpReturnKind {
     /// Returned directly. Primitives, bools, and blittable records share
     /// this path.
     Direct,
+    /// Returned as a `BoltFFICallbackHandle` and wrapped into the generated
+    /// C# callback interface/delegate proxy.
+    CallbackHandle {
+        bridge_class: CSharpClassName,
+        nullable: bool,
+    },
     /// `FfiBuf` carrying a wire-encoded `string`.
     WireDecodeString,
     /// `FfiBuf` carrying a wire-encoded value with a static
@@ -75,6 +81,17 @@ impl CSharpReturnKind {
         matches!(self, Self::Direct)
     }
 
+    pub fn is_callback_handle(&self) -> bool {
+        matches!(self, Self::CallbackHandle { .. })
+    }
+
+    pub fn callback_bridge_class(&self) -> &CSharpClassName {
+        match self {
+            Self::CallbackHandle { bridge_class, .. } => bridge_class,
+            _ => panic!("callback_bridge_class called for non-callback return"),
+        }
+    }
+
     /// Whether the native (DllImport) signature returns an `FfiBuf`.
     pub fn native_returns_ffi_buf(&self) -> bool {
         matches!(
@@ -104,6 +121,8 @@ pub(crate) fn native_return_type(
 ) -> String {
     if return_kind.native_returns_ffi_buf() {
         "FfiBuf".to_string()
+    } else if return_kind.is_callback_handle() {
+        "BoltFFICallbackHandle".to_string()
     } else {
         return_type.to_string()
     }

--- a/boltffi_bindgen/src/render/csharp/plan/callable/return_kind.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callable/return_kind.rs
@@ -12,7 +12,7 @@ pub enum CSharpReturnKind {
     /// this path.
     Direct,
     /// Returned as a `BoltFFICallbackHandle` and wrapped into the generated
-    /// C# callback interface/delegate proxy.
+    /// C# callback proxy that owns the native handle.
     CallbackHandle {
         bridge_class: CSharpClassName,
         nullable: bool,

--- a/boltffi_bindgen/src/render/csharp/plan/callback.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callback.rs
@@ -47,7 +47,6 @@ pub struct CSharpClosureMethodPlan {
     pub public_params: Vec<CSharpCallbackParamPlan>,
     pub native_return_type: CSharpType,
     pub native_params: CSharpParameterList,
-    pub marshals_return_bool: bool,
     pub bridge_params: Vec<CSharpCallbackBridgeParamPlan>,
     pub invoke: CSharpClosureInvokePlan,
 }

--- a/boltffi_bindgen/src/render/csharp/plan/callback.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callback.rs
@@ -70,7 +70,7 @@ pub enum CSharpClosureInvokePlan {
     Encoded {
         is_result: bool,
         decoded_args: CSharpArgumentList,
-        result_assignment_lines: Vec<String>,
+        result_assignment: Option<CSharpCallbackResultAssignmentPlan>,
         writer: CSharpWireWriterPlan,
     },
 }
@@ -108,7 +108,7 @@ pub enum CSharpSyncCallbackSuccessPlan {
     Encoded {
         is_result: bool,
         decoded_args: CSharpArgumentList,
-        result_assignment_lines: Vec<String>,
+        result_assignment: Option<CSharpCallbackResultAssignmentPlan>,
         writer: CSharpWireWriterPlan,
     },
 }
@@ -140,7 +140,7 @@ pub enum CSharpAsyncCallbackSuccessPlan {
     },
     Encoded {
         is_result: bool,
-        result_type: String,
+        result_type: CSharpResultTypePlan,
         writer: CSharpWireWriterPlan,
     },
 }
@@ -149,9 +149,9 @@ pub enum CSharpAsyncCallbackSuccessPlan {
 pub enum CSharpAsyncCallbackFaultPlan {
     Failure(CSharpAsyncCallbackFailurePlan),
     EncodedResult {
-        exception_type: Option<String>,
+        exception_type: Option<CSharpType>,
         error_value_expr: CSharpExpression,
-        result_type: String,
+        result_type: CSharpResultTypePlan,
         writer: CSharpWireWriterPlan,
         fallback: Option<CSharpAsyncCallbackFailurePlan>,
     },
@@ -161,7 +161,6 @@ pub enum CSharpAsyncCallbackFaultPlan {
 pub enum CSharpCallbackProxyPlan {
     AsyncUnsupported {
         public_params: CSharpParameterList,
-        return_type: String,
         result_type: Option<CSharpType>,
         not_supported_expr: String,
     },
@@ -171,7 +170,7 @@ pub enum CSharpCallbackProxyPlan {
 #[derive(Debug, Clone)]
 pub struct CSharpSyncCallbackProxyPlan {
     pub public_params: CSharpParameterList,
-    pub return_type: String,
+    pub return_type: CSharpType,
     pub bridge_params: Vec<CSharpCallbackBridgeParamPlan>,
     pub has_cleanup: bool,
     pub call: CSharpCallbackProxyCallPlan,
@@ -190,7 +189,7 @@ pub enum CSharpCallbackProxyCallPlan {
     Encoded {
         args: CSharpArgumentList,
         decode_expr: Option<CSharpExpression>,
-        result_decode_lines: Vec<String>,
+        result_decode: Option<CSharpCallbackResultDecodePlan>,
     },
 }
 
@@ -199,6 +198,45 @@ pub struct CSharpCallbackDelegatePlan {
     pub entry_params: CSharpParameterList,
     pub completion_params: Option<CSharpParameterList>,
     pub proxy_params: Option<CSharpParameterList>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CSharpResultTypePlan {
+    pub ok_type: CSharpType,
+    pub err_type: CSharpType,
+}
+
+#[derive(Debug, Clone)]
+pub struct CSharpCallbackResultAssignmentPlan {
+    pub result_type: CSharpResultTypePlan,
+    pub ok: CSharpCallbackResultOkPlan,
+    pub catch: Option<CSharpCallbackResultCatchPlan>,
+}
+
+#[derive(Debug, Clone)]
+pub enum CSharpCallbackResultOkPlan {
+    Void {
+        receiver: CSharpExpression,
+        method_name: CSharpMethodName,
+        args: CSharpArgumentList,
+    },
+    Value {
+        receiver: CSharpExpression,
+        method_name: CSharpMethodName,
+        args: CSharpArgumentList,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum CSharpCallbackResultCatchPlan {
+    TypedException { exception_type: CSharpType },
+    ExceptionMessage,
+}
+
+#[derive(Debug, Clone)]
+pub struct CSharpCallbackResultDecodePlan {
+    pub err_expr: CSharpExpression,
+    pub ok_expr: Option<CSharpExpression>,
 }
 
 #[derive(Debug, Clone)]

--- a/boltffi_bindgen/src/render/csharp/plan/callback.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callback.rs
@@ -1,7 +1,7 @@
 use super::super::ast::{
-    CSharpArgumentList, CSharpBinaryOp, CSharpClassName, CSharpExpression, CSharpIdentity,
-    CSharpLiteral, CSharpLocalName, CSharpMethodName, CSharpParamName, CSharpParameter,
-    CSharpPropertyName, CSharpType, CSharpTypeReference,
+    CSharpArgumentList, CSharpClassName, CSharpExpression, CSharpIdentity, CSharpLocalName,
+    CSharpMethodName, CSharpParamName, CSharpParameter, CSharpParameterList, CSharpPropertyName,
+    CSharpType,
 };
 use super::CFunctionName;
 use super::callable::CSharpWireWriterPlan;
@@ -36,26 +36,169 @@ pub struct CSharpCallbackMethodPlan {
     pub return_type: CSharpType,
     pub is_async: bool,
     pub public_params: Vec<CSharpCallbackParamPlan>,
-    pub entry_source: String,
-    pub proxy_source: String,
-    pub delegate_source: String,
+    pub entry: CSharpCallbackEntryPlan,
+    pub proxy: CSharpCallbackProxyPlan,
+    pub delegates: CSharpCallbackDelegatePlan,
 }
 
 #[derive(Debug, Clone)]
 pub struct CSharpClosureMethodPlan {
     pub return_type: CSharpType,
     pub public_params: Vec<CSharpCallbackParamPlan>,
-    pub native_return_type: String,
-    pub native_decls: Vec<String>,
+    pub native_return_type: CSharpType,
+    pub native_params: CSharpParameterList,
     pub marshals_return_bool: bool,
-    pub decode_setup: Vec<String>,
-    pub invoke_body: String,
+    pub bridge_params: Vec<CSharpCallbackBridgeParamPlan>,
+    pub invoke: CSharpClosureInvokePlan,
 }
 
 #[derive(Debug, Clone)]
 pub struct CSharpCallbackParamPlan {
     pub csharp_type: CSharpType,
     pub name: CSharpParamName,
+}
+
+#[derive(Debug, Clone)]
+pub enum CSharpClosureInvokePlan {
+    Void {
+        decoded_args: CSharpArgumentList,
+    },
+    Direct {
+        decoded_args: CSharpArgumentList,
+        native_value_expr: String,
+    },
+    Encoded {
+        is_result: bool,
+        decoded_args: CSharpArgumentList,
+        result_assignment_lines: Vec<String>,
+        writer: CSharpWireWriterPlan,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum CSharpCallbackEntryPlan {
+    Sync(CSharpSyncCallbackEntryPlan),
+    Async(CSharpAsyncCallbackEntryPlan),
+}
+
+#[derive(Debug, Clone)]
+pub struct CSharpSyncCallbackEntryPlan {
+    pub native_params: CSharpParameterList,
+    pub out_initializer: CSharpSyncCallbackOutInitializerPlan,
+    pub bridge_params: Vec<CSharpCallbackBridgeParamPlan>,
+    pub success: CSharpSyncCallbackSuccessPlan,
+}
+
+#[derive(Debug, Clone)]
+pub enum CSharpSyncCallbackOutInitializerPlan {
+    Void,
+    Direct { default_value: String },
+    Encoded,
+}
+
+#[derive(Debug, Clone)]
+pub enum CSharpSyncCallbackSuccessPlan {
+    Void {
+        decoded_args: CSharpArgumentList,
+    },
+    Direct {
+        decoded_args: CSharpArgumentList,
+        native_value_expr: String,
+    },
+    Encoded {
+        is_result: bool,
+        decoded_args: CSharpArgumentList,
+        result_assignment_lines: Vec<String>,
+        writer: CSharpWireWriterPlan,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct CSharpAsyncCallbackEntryPlan {
+    pub native_params: CSharpParameterList,
+    pub bridge_params: Vec<CSharpCallbackBridgeParamPlan>,
+    pub decoded_args: CSharpArgumentList,
+    pub invalid_handle_completion: CSharpAsyncCallbackFailurePlan,
+    pub canceled_completion: CSharpAsyncCallbackFailurePlan,
+    pub faulted_completion: CSharpAsyncCallbackFaultPlan,
+    pub success_completion: CSharpAsyncCallbackSuccessPlan,
+    pub catch_completion: CSharpAsyncCallbackFailurePlan,
+}
+
+#[derive(Debug, Clone)]
+pub enum CSharpAsyncCallbackFailurePlan {
+    Void,
+    Direct { default_value: String },
+    Encoded,
+}
+
+#[derive(Debug, Clone)]
+pub enum CSharpAsyncCallbackSuccessPlan {
+    Void,
+    Direct {
+        native_value_expr: String,
+    },
+    Encoded {
+        is_result: bool,
+        result_type: String,
+        writer: CSharpWireWriterPlan,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum CSharpAsyncCallbackFaultPlan {
+    Failure(CSharpAsyncCallbackFailurePlan),
+    EncodedResult {
+        exception_type: Option<String>,
+        error_value_expr: CSharpExpression,
+        result_type: String,
+        writer: CSharpWireWriterPlan,
+        fallback: Option<CSharpAsyncCallbackFailurePlan>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum CSharpCallbackProxyPlan {
+    AsyncUnsupported {
+        public_params: CSharpParameterList,
+        return_type: String,
+        result_type: Option<CSharpType>,
+        not_supported_expr: String,
+    },
+    Sync(CSharpSyncCallbackProxyPlan),
+}
+
+#[derive(Debug, Clone)]
+pub struct CSharpSyncCallbackProxyPlan {
+    pub public_params: CSharpParameterList,
+    pub return_type: String,
+    pub bridge_params: Vec<CSharpCallbackBridgeParamPlan>,
+    pub has_cleanup: bool,
+    pub call: CSharpCallbackProxyCallPlan,
+}
+
+#[derive(Debug, Clone)]
+pub enum CSharpCallbackProxyCallPlan {
+    Void {
+        args: CSharpArgumentList,
+    },
+    Direct {
+        args: CSharpArgumentList,
+        native_out_type: CSharpType,
+        public_expr: String,
+    },
+    Encoded {
+        args: CSharpArgumentList,
+        decode_expr: Option<CSharpExpression>,
+        result_decode_lines: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct CSharpCallbackDelegatePlan {
+    pub entry_params: CSharpParameterList,
+    pub completion_params: Option<CSharpParameterList>,
+    pub proxy_params: Option<CSharpParameterList>,
 }
 
 #[derive(Debug, Clone)]
@@ -133,131 +276,6 @@ impl CSharpCallbackBridgeParamPlan {
         }
     }
 
-    pub fn decode_setup_lines(&self) -> Vec<String> {
-        match self {
-            Self::Direct { .. } => vec![],
-            Self::WireEncoded {
-                native_ptr_param,
-                native_len_param,
-                reader_local,
-                ..
-            } => vec![format!(
-                "var {reader_local} = new WireReader({}, {});",
-                native_ptr_param.name, native_len_param.name
-            )],
-        }
-    }
-
-    pub fn proxy_setup_lines(&self) -> Vec<String> {
-        match self {
-            Self::Direct { .. } => vec![],
-            Self::WireEncoded {
-                writer,
-                pin_local,
-                ptr_local,
-                ..
-            } => {
-                let mut lines = vec![
-                    format!("byte[] {};", writer.bytes_binding_name),
-                    format!(
-                        "using (var {} = new WireWriter({}))",
-                        writer.binding_name, writer.size_expr
-                    ),
-                    "{".to_string(),
-                ];
-                for stmt in &writer.encode_stmts {
-                    lines.push(format!("    {stmt};"));
-                }
-                lines.push(format!(
-                    "    {} = {};",
-                    writer.bytes_binding_name,
-                    CSharpExpression::MethodCall {
-                        receiver: Box::new(local_expr(&writer.binding_name)),
-                        method: CSharpMethodName::new("ToArray"),
-                        type_args: vec![],
-                        args: CSharpArgumentList::empty(),
-                    }
-                ));
-                lines.push("}".to_string());
-                lines.push(format!(
-                    "{} {pin_local} = {};",
-                    named_type("GCHandle"),
-                    CSharpExpression::Literal(CSharpLiteral::Default)
-                ));
-                lines.push(format!(
-                    "{} {ptr_local} = {};",
-                    CSharpType::IntPtr,
-                    int_ptr_zero()
-                ));
-                lines
-            }
-        }
-    }
-
-    pub fn proxy_pin_lines(&self) -> Vec<String> {
-        match self {
-            Self::Direct { .. } => vec![],
-            Self::WireEncoded {
-                writer,
-                pin_local,
-                ptr_local,
-                ..
-            } => {
-                let bytes = local_expr(&writer.bytes_binding_name);
-                let cond = CSharpExpression::Binary {
-                    op: CSharpBinaryOp::Ne,
-                    left: Box::new(bytes_length_expr(&writer.bytes_binding_name)),
-                    right: Box::new(CSharpExpression::Literal(CSharpLiteral::Int(0))),
-                };
-                let alloc = CSharpExpression::MethodCall {
-                    receiver: Box::new(type_expr("GCHandle")),
-                    method: CSharpMethodName::new("Alloc"),
-                    type_args: vec![],
-                    args: vec![
-                        bytes,
-                        CSharpExpression::MemberAccess {
-                            receiver: Box::new(type_expr("GCHandleType")),
-                            name: CSharpPropertyName::from_source("pinned"),
-                        },
-                    ]
-                    .into(),
-                };
-                let addr = CSharpExpression::MethodCall {
-                    receiver: Box::new(local_expr(pin_local)),
-                    method: CSharpMethodName::new("AddrOfPinnedObject"),
-                    type_args: vec![],
-                    args: CSharpArgumentList::empty(),
-                };
-                vec![
-                    format!("if ({cond})"),
-                    "{".to_string(),
-                    format!("    {pin_local} = {alloc};"),
-                    format!("    {ptr_local} = {addr};"),
-                    "}".to_string(),
-                ]
-            }
-        }
-    }
-
-    pub fn proxy_cleanup_lines(&self) -> Vec<String> {
-        match self {
-            Self::Direct { .. } => vec![],
-            Self::WireEncoded { pin_local, .. } => {
-                let cond = CSharpExpression::MemberAccess {
-                    receiver: Box::new(local_expr(pin_local)),
-                    name: CSharpPropertyName::from_source("is_allocated"),
-                };
-                let free = CSharpExpression::MethodCall {
-                    receiver: Box::new(local_expr(pin_local)),
-                    method: CSharpMethodName::new("Free"),
-                    type_args: vec![],
-                    args: CSharpArgumentList::empty(),
-                };
-                vec![format!("if ({cond}) {free};")]
-            }
-        }
-    }
-
     pub fn needs_wire_reader(&self) -> bool {
         matches!(self, Self::WireEncoded { .. })
     }
@@ -271,14 +289,6 @@ fn local_expr(name: &CSharpLocalName) -> CSharpExpression {
     CSharpExpression::Identity(CSharpIdentity::Local(name.clone()))
 }
 
-fn type_expr(name: &str) -> CSharpExpression {
-    CSharpExpression::TypeRef(CSharpTypeReference::Plain(CSharpClassName::new(name)))
-}
-
-fn named_type(name: &str) -> CSharpType {
-    CSharpType::Named(CSharpTypeReference::Plain(CSharpClassName::new(name)))
-}
-
 fn bytes_length_expr(bytes_local: &CSharpLocalName) -> CSharpExpression {
     CSharpExpression::MemberAccess {
         receiver: Box::new(local_expr(bytes_local)),
@@ -286,16 +296,9 @@ fn bytes_length_expr(bytes_local: &CSharpLocalName) -> CSharpExpression {
     }
 }
 
-fn int_ptr_zero() -> CSharpExpression {
-    CSharpExpression::MemberAccess {
-        receiver: Box::new(type_expr("IntPtr")),
-        name: CSharpPropertyName::from_source("zero"),
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::super::super::ast::CSharpStatement;
+    use super::super::super::ast::{CSharpLiteral, CSharpStatement};
     use super::*;
 
     fn param_expr(name: &CSharpParamName) -> CSharpExpression {
@@ -326,14 +329,12 @@ mod tests {
         );
         assert_eq!(plan.decoded_arg().to_string(), "value");
         assert_eq!(plan.proxy_args().to_string(), "value");
-        assert!(plan.decode_setup_lines().is_empty());
-        assert!(plan.proxy_setup_lines().is_empty());
         assert!(!plan.needs_wire_reader());
         assert!(!plan.needs_wire_writer());
     }
 
     #[test]
-    fn wire_encoded_bridge_param_derives_reader_writer_pin_and_cleanup_lines() {
+    fn wire_encoded_bridge_param_exposes_reader_writer_pin_and_cleanup_parts() {
         let value = CSharpParamName::from_source("value");
         let value_len = CSharpParamName::new("valueLen");
         let writer = CSharpWireWriterPlan {
@@ -368,40 +369,24 @@ mod tests {
             vec!["IntPtr value", "UIntPtr valueLen"]
         );
         assert_eq!(
-            plan.decode_setup_lines(),
-            vec!["var __boltffiValueReader = new WireReader(value, valueLen);"]
-        );
-        assert_eq!(
             plan.proxy_args().to_string(),
             "_valuePtr, (UIntPtr)_valueBytes.Length"
         );
-        assert_eq!(
-            plan.proxy_setup_lines(),
-            vec![
-                "byte[] _valueBytes;",
-                "using (var _valueWire = new WireWriter(4))",
-                "{",
-                "    _valueWire.WriteI32(value);",
-                "    _valueBytes = _valueWire.ToArray();",
-                "}",
-                "GCHandle _valuePin = default;",
-                "IntPtr _valuePtr = IntPtr.Zero;",
-            ]
-        );
-        assert_eq!(
-            plan.proxy_pin_lines(),
-            vec![
-                "if (_valueBytes.Length != 0)",
-                "{",
-                "    _valuePin = GCHandle.Alloc(_valueBytes, GCHandleType.Pinned);",
-                "    _valuePtr = _valuePin.AddrOfPinnedObject();",
-                "}",
-            ]
-        );
-        assert_eq!(
-            plan.proxy_cleanup_lines(),
-            vec!["if (_valuePin.IsAllocated) _valuePin.Free();"]
-        );
+        let CSharpCallbackBridgeParamPlan::WireEncoded {
+            reader_local,
+            writer,
+            pin_local,
+            ptr_local,
+            ..
+        } = &plan
+        else {
+            panic!("expected wire-encoded bridge param");
+        };
+        assert_eq!(reader_local.to_string(), "__boltffiValueReader");
+        assert_eq!(writer.binding_name.to_string(), "_valueWire");
+        assert_eq!(writer.bytes_binding_name.to_string(), "_valueBytes");
+        assert_eq!(pin_local.to_string(), "_valuePin");
+        assert_eq!(ptr_local.to_string(), "_valuePtr");
         assert!(plan.needs_wire_reader());
         assert!(plan.needs_wire_writer());
     }

--- a/boltffi_bindgen/src/render/csharp/plan/callback.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callback.rs
@@ -65,7 +65,7 @@ pub enum CSharpClosureInvokePlan {
     },
     Direct {
         decoded_args: CSharpArgumentList,
-        native_value_expr: String,
+        native_value_expr: CSharpExpression,
     },
     Encoded {
         is_result: bool,
@@ -92,7 +92,7 @@ pub struct CSharpSyncCallbackEntryPlan {
 #[derive(Debug, Clone)]
 pub enum CSharpSyncCallbackOutInitializerPlan {
     Void,
-    Direct { default_value: String },
+    Direct { default_value: CSharpExpression },
     Encoded,
 }
 
@@ -103,7 +103,7 @@ pub enum CSharpSyncCallbackSuccessPlan {
     },
     Direct {
         decoded_args: CSharpArgumentList,
-        native_value_expr: String,
+        native_value_expr: CSharpExpression,
     },
     Encoded {
         is_result: bool,
@@ -128,7 +128,7 @@ pub struct CSharpAsyncCallbackEntryPlan {
 #[derive(Debug, Clone)]
 pub enum CSharpAsyncCallbackFailurePlan {
     Void,
-    Direct { default_value: String },
+    Direct { default_value: CSharpExpression },
     Encoded,
 }
 
@@ -136,7 +136,7 @@ pub enum CSharpAsyncCallbackFailurePlan {
 pub enum CSharpAsyncCallbackSuccessPlan {
     Void,
     Direct {
-        native_value_expr: String,
+        native_value_expr: CSharpExpression,
     },
     Encoded {
         is_result: bool,
@@ -162,7 +162,6 @@ pub enum CSharpCallbackProxyPlan {
     AsyncUnsupported {
         public_params: CSharpParameterList,
         result_type: Option<CSharpType>,
-        not_supported_expr: String,
     },
     Sync(CSharpSyncCallbackProxyPlan),
 }
@@ -184,7 +183,7 @@ pub enum CSharpCallbackProxyCallPlan {
     Direct {
         args: CSharpArgumentList,
         native_out_type: CSharpType,
-        public_expr: String,
+        public_expr: CSharpExpression,
     },
     Encoded {
         args: CSharpArgumentList,
@@ -257,19 +256,6 @@ pub enum CSharpCallbackBridgeParamPlan {
         pin_local: CSharpLocalName,
         ptr_local: CSharpLocalName,
     },
-}
-
-impl CSharpCallbackMethodPlan {
-    pub fn public_return_type(&self) -> String {
-        if !self.is_async {
-            return self.return_type.to_string();
-        }
-        if self.return_type.is_void() {
-            "global::System.Threading.Tasks.Task".to_string()
-        } else {
-            format!("global::System.Threading.Tasks.Task<{}>", self.return_type)
-        }
-    }
 }
 
 impl CSharpCallbackBridgeParamPlan {

--- a/boltffi_bindgen/src/render/csharp/plan/callback.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callback.rs
@@ -1,0 +1,69 @@
+use super::super::ast::{
+    CSharpClassName, CSharpLocalName, CSharpMethodName, CSharpParamName, CSharpType,
+};
+use super::CFunctionName;
+
+#[derive(Debug, Clone)]
+pub struct CSharpCallbackPlan {
+    pub public_name: CSharpClassName,
+    pub bridge_name: CSharpClassName,
+    pub methods: Vec<CSharpCallbackMethodPlan>,
+    pub register_fn: CFunctionName,
+    pub create_fn: CFunctionName,
+    pub has_async_methods: bool,
+    pub needs_wire_reader: bool,
+    pub needs_wire_writer: bool,
+    pub needs_ffi_buf: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct CSharpClosurePlan {
+    pub public_name: CSharpClassName,
+    pub bridge_name: CSharpClassName,
+    pub method: CSharpClosureMethodPlan,
+    pub needs_wire_reader: bool,
+    pub needs_wire_writer: bool,
+    pub needs_ffi_buf: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct CSharpCallbackMethodPlan {
+    pub name: CSharpMethodName,
+    pub vtable_field: CSharpLocalName,
+    pub return_type: CSharpType,
+    pub is_async: bool,
+    pub public_params: Vec<CSharpCallbackParamPlan>,
+    pub entry_source: String,
+    pub proxy_source: String,
+    pub delegate_source: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CSharpClosureMethodPlan {
+    pub return_type: CSharpType,
+    pub public_params: Vec<CSharpCallbackParamPlan>,
+    pub native_return_type: String,
+    pub native_decls: Vec<String>,
+    pub marshals_return_bool: bool,
+    pub decode_setup: Vec<String>,
+    pub invoke_body: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CSharpCallbackParamPlan {
+    pub csharp_type: CSharpType,
+    pub name: CSharpParamName,
+}
+
+impl CSharpCallbackMethodPlan {
+    pub fn public_return_type(&self) -> String {
+        if !self.is_async {
+            return self.return_type.to_string();
+        }
+        if self.return_type.is_void() {
+            "global::System.Threading.Tasks.Task".to_string()
+        } else {
+            format!("global::System.Threading.Tasks.Task<{}>", self.return_type)
+        }
+    }
+}

--- a/boltffi_bindgen/src/render/csharp/plan/callback.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callback.rs
@@ -70,15 +70,15 @@ pub enum CSharpClosureInvokePlan {
     Encoded {
         is_result: bool,
         decoded_args: CSharpArgumentList,
-        result_assignment: Option<CSharpCallbackResultAssignmentPlan>,
-        writer: CSharpWireWriterPlan,
+        result_assignment: Option<Box<CSharpCallbackResultAssignmentPlan>>,
+        writer: Box<CSharpWireWriterPlan>,
     },
 }
 
 #[derive(Debug, Clone)]
 pub enum CSharpCallbackEntryPlan {
-    Sync(CSharpSyncCallbackEntryPlan),
-    Async(CSharpAsyncCallbackEntryPlan),
+    Sync(Box<CSharpSyncCallbackEntryPlan>),
+    Async(Box<CSharpAsyncCallbackEntryPlan>),
 }
 
 #[derive(Debug, Clone)]
@@ -108,8 +108,8 @@ pub enum CSharpSyncCallbackSuccessPlan {
     Encoded {
         is_result: bool,
         decoded_args: CSharpArgumentList,
-        result_assignment: Option<CSharpCallbackResultAssignmentPlan>,
-        writer: CSharpWireWriterPlan,
+        result_assignment: Option<Box<CSharpCallbackResultAssignmentPlan>>,
+        writer: Box<CSharpWireWriterPlan>,
     },
 }
 
@@ -141,7 +141,7 @@ pub enum CSharpAsyncCallbackSuccessPlan {
     Encoded {
         is_result: bool,
         result_type: CSharpResultTypePlan,
-        writer: CSharpWireWriterPlan,
+        writer: Box<CSharpWireWriterPlan>,
     },
 }
 
@@ -150,9 +150,9 @@ pub enum CSharpAsyncCallbackFaultPlan {
     Failure(CSharpAsyncCallbackFailurePlan),
     EncodedResult {
         exception_type: Option<CSharpType>,
-        error_value_expr: CSharpExpression,
-        result_type: CSharpResultTypePlan,
-        writer: CSharpWireWriterPlan,
+        error_value_expr: Box<CSharpExpression>,
+        result_type: Box<CSharpResultTypePlan>,
+        writer: Box<CSharpWireWriterPlan>,
         fallback: Option<CSharpAsyncCallbackFailurePlan>,
     },
 }
@@ -163,7 +163,7 @@ pub enum CSharpCallbackProxyPlan {
         public_params: CSharpParameterList,
         result_type: Option<CSharpType>,
     },
-    Sync(CSharpSyncCallbackProxyPlan),
+    Sync(Box<CSharpSyncCallbackProxyPlan>),
 }
 
 #[derive(Debug, Clone)]
@@ -252,7 +252,7 @@ pub enum CSharpCallbackBridgeParamPlan {
         native_len_param: CSharpParameter,
         reader_local: CSharpLocalName,
         decoded_arg: CSharpExpression,
-        writer: CSharpWireWriterPlan,
+        writer: Box<CSharpWireWriterPlan>,
         pin_local: CSharpLocalName,
         ptr_local: CSharpLocalName,
     },
@@ -379,7 +379,7 @@ mod tests {
             native_len_param: CSharpParameter::bare(CSharpType::UIntPtr, value_len),
             reader_local: local("__boltffiValueReader"),
             decoded_arg: local_expr(&local("__boltffiValueReader")),
-            writer,
+            writer: Box::new(writer),
             pin_local: local("_valuePin"),
             ptr_local: local("_valuePtr"),
         };

--- a/boltffi_bindgen/src/render/csharp/plan/callback.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callback.rs
@@ -1,7 +1,10 @@
 use super::super::ast::{
-    CSharpClassName, CSharpLocalName, CSharpMethodName, CSharpParamName, CSharpType,
+    CSharpArgumentList, CSharpBinaryOp, CSharpClassName, CSharpExpression, CSharpIdentity,
+    CSharpLiteral, CSharpLocalName, CSharpMethodName, CSharpParamName, CSharpParameter,
+    CSharpPropertyName, CSharpType, CSharpTypeReference,
 };
 use super::CFunctionName;
+use super::callable::CSharpWireWriterPlan;
 
 #[derive(Debug, Clone)]
 pub struct CSharpCallbackPlan {
@@ -55,6 +58,26 @@ pub struct CSharpCallbackParamPlan {
     pub name: CSharpParamName,
 }
 
+#[derive(Debug, Clone)]
+pub enum CSharpCallbackBridgeParamPlan {
+    Direct {
+        public_param: CSharpParameter,
+        native_param: CSharpParameter,
+        decoded_arg: CSharpExpression,
+        proxy_arg: CSharpExpression,
+    },
+    WireEncoded {
+        public_param: CSharpParameter,
+        native_ptr_param: CSharpParameter,
+        native_len_param: CSharpParameter,
+        reader_local: CSharpLocalName,
+        decoded_arg: CSharpExpression,
+        writer: CSharpWireWriterPlan,
+        pin_local: CSharpLocalName,
+        ptr_local: CSharpLocalName,
+    },
+}
+
 impl CSharpCallbackMethodPlan {
     pub fn public_return_type(&self) -> String {
         if !self.is_async {
@@ -65,5 +88,321 @@ impl CSharpCallbackMethodPlan {
         } else {
             format!("global::System.Threading.Tasks.Task<{}>", self.return_type)
         }
+    }
+}
+
+impl CSharpCallbackBridgeParamPlan {
+    pub fn public_param(&self) -> &CSharpParameter {
+        match self {
+            Self::Direct { public_param, .. } | Self::WireEncoded { public_param, .. } => {
+                public_param
+            }
+        }
+    }
+
+    pub fn native_params(&self) -> Vec<CSharpParameter> {
+        match self {
+            Self::Direct { native_param, .. } => vec![native_param.clone()],
+            Self::WireEncoded {
+                native_ptr_param,
+                native_len_param,
+                ..
+            } => vec![native_ptr_param.clone(), native_len_param.clone()],
+        }
+    }
+
+    pub fn decoded_arg(&self) -> &CSharpExpression {
+        match self {
+            Self::Direct { decoded_arg, .. } | Self::WireEncoded { decoded_arg, .. } => decoded_arg,
+        }
+    }
+
+    pub fn proxy_args(&self) -> CSharpArgumentList {
+        match self {
+            Self::Direct { proxy_arg, .. } => vec![proxy_arg.clone()].into(),
+            Self::WireEncoded {
+                writer, ptr_local, ..
+            } => vec![
+                local_expr(ptr_local),
+                CSharpExpression::Cast {
+                    target: CSharpType::UIntPtr,
+                    inner: Box::new(bytes_length_expr(&writer.bytes_binding_name)),
+                },
+            ]
+            .into(),
+        }
+    }
+
+    pub fn decode_setup_lines(&self) -> Vec<String> {
+        match self {
+            Self::Direct { .. } => vec![],
+            Self::WireEncoded {
+                native_ptr_param,
+                native_len_param,
+                reader_local,
+                ..
+            } => vec![format!(
+                "var {reader_local} = new WireReader({}, {});",
+                native_ptr_param.name, native_len_param.name
+            )],
+        }
+    }
+
+    pub fn proxy_setup_lines(&self) -> Vec<String> {
+        match self {
+            Self::Direct { .. } => vec![],
+            Self::WireEncoded {
+                writer,
+                pin_local,
+                ptr_local,
+                ..
+            } => {
+                let mut lines = vec![
+                    format!("byte[] {};", writer.bytes_binding_name),
+                    format!(
+                        "using (var {} = new WireWriter({}))",
+                        writer.binding_name, writer.size_expr
+                    ),
+                    "{".to_string(),
+                ];
+                for stmt in &writer.encode_stmts {
+                    lines.push(format!("    {stmt};"));
+                }
+                lines.push(format!(
+                    "    {} = {};",
+                    writer.bytes_binding_name,
+                    CSharpExpression::MethodCall {
+                        receiver: Box::new(local_expr(&writer.binding_name)),
+                        method: CSharpMethodName::new("ToArray"),
+                        type_args: vec![],
+                        args: CSharpArgumentList::empty(),
+                    }
+                ));
+                lines.push("}".to_string());
+                lines.push(format!(
+                    "{} {pin_local} = {};",
+                    named_type("GCHandle"),
+                    CSharpExpression::Literal(CSharpLiteral::Default)
+                ));
+                lines.push(format!(
+                    "{} {ptr_local} = {};",
+                    CSharpType::IntPtr,
+                    int_ptr_zero()
+                ));
+                lines
+            }
+        }
+    }
+
+    pub fn proxy_pin_lines(&self) -> Vec<String> {
+        match self {
+            Self::Direct { .. } => vec![],
+            Self::WireEncoded {
+                writer,
+                pin_local,
+                ptr_local,
+                ..
+            } => {
+                let bytes = local_expr(&writer.bytes_binding_name);
+                let cond = CSharpExpression::Binary {
+                    op: CSharpBinaryOp::Ne,
+                    left: Box::new(bytes_length_expr(&writer.bytes_binding_name)),
+                    right: Box::new(CSharpExpression::Literal(CSharpLiteral::Int(0))),
+                };
+                let alloc = CSharpExpression::MethodCall {
+                    receiver: Box::new(type_expr("GCHandle")),
+                    method: CSharpMethodName::new("Alloc"),
+                    type_args: vec![],
+                    args: vec![
+                        bytes,
+                        CSharpExpression::MemberAccess {
+                            receiver: Box::new(type_expr("GCHandleType")),
+                            name: CSharpPropertyName::from_source("pinned"),
+                        },
+                    ]
+                    .into(),
+                };
+                let addr = CSharpExpression::MethodCall {
+                    receiver: Box::new(local_expr(pin_local)),
+                    method: CSharpMethodName::new("AddrOfPinnedObject"),
+                    type_args: vec![],
+                    args: CSharpArgumentList::empty(),
+                };
+                vec![
+                    format!("if ({cond})"),
+                    "{".to_string(),
+                    format!("    {pin_local} = {alloc};"),
+                    format!("    {ptr_local} = {addr};"),
+                    "}".to_string(),
+                ]
+            }
+        }
+    }
+
+    pub fn proxy_cleanup_lines(&self) -> Vec<String> {
+        match self {
+            Self::Direct { .. } => vec![],
+            Self::WireEncoded { pin_local, .. } => {
+                let cond = CSharpExpression::MemberAccess {
+                    receiver: Box::new(local_expr(pin_local)),
+                    name: CSharpPropertyName::from_source("is_allocated"),
+                };
+                let free = CSharpExpression::MethodCall {
+                    receiver: Box::new(local_expr(pin_local)),
+                    method: CSharpMethodName::new("Free"),
+                    type_args: vec![],
+                    args: CSharpArgumentList::empty(),
+                };
+                vec![format!("if ({cond}) {free};")]
+            }
+        }
+    }
+
+    pub fn needs_wire_reader(&self) -> bool {
+        matches!(self, Self::WireEncoded { .. })
+    }
+
+    pub fn needs_wire_writer(&self) -> bool {
+        matches!(self, Self::WireEncoded { .. })
+    }
+}
+
+fn local_expr(name: &CSharpLocalName) -> CSharpExpression {
+    CSharpExpression::Identity(CSharpIdentity::Local(name.clone()))
+}
+
+fn type_expr(name: &str) -> CSharpExpression {
+    CSharpExpression::TypeRef(CSharpTypeReference::Plain(CSharpClassName::new(name)))
+}
+
+fn named_type(name: &str) -> CSharpType {
+    CSharpType::Named(CSharpTypeReference::Plain(CSharpClassName::new(name)))
+}
+
+fn bytes_length_expr(bytes_local: &CSharpLocalName) -> CSharpExpression {
+    CSharpExpression::MemberAccess {
+        receiver: Box::new(local_expr(bytes_local)),
+        name: CSharpPropertyName::from_source("length"),
+    }
+}
+
+fn int_ptr_zero() -> CSharpExpression {
+    CSharpExpression::MemberAccess {
+        receiver: Box::new(type_expr("IntPtr")),
+        name: CSharpPropertyName::from_source("zero"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::ast::CSharpStatement;
+    use super::*;
+
+    fn param_expr(name: &CSharpParamName) -> CSharpExpression {
+        CSharpExpression::Identity(CSharpIdentity::Param(name.clone()))
+    }
+
+    fn local(name: &str) -> CSharpLocalName {
+        CSharpLocalName::new(name)
+    }
+
+    #[test]
+    fn direct_bridge_param_exposes_typed_signature_and_args() {
+        let name = CSharpParamName::from_source("value");
+        let plan = CSharpCallbackBridgeParamPlan::Direct {
+            public_param: CSharpParameter::bare(CSharpType::Int, name.clone()),
+            native_param: CSharpParameter::bare(CSharpType::Int, name.clone()),
+            decoded_arg: param_expr(&name),
+            proxy_arg: param_expr(&name),
+        };
+
+        assert_eq!(plan.public_param().to_string(), "int value");
+        assert_eq!(
+            plan.native_params()
+                .into_iter()
+                .map(|param| param.to_string())
+                .collect::<Vec<_>>(),
+            vec!["int value"]
+        );
+        assert_eq!(plan.decoded_arg().to_string(), "value");
+        assert_eq!(plan.proxy_args().to_string(), "value");
+        assert!(plan.decode_setup_lines().is_empty());
+        assert!(plan.proxy_setup_lines().is_empty());
+        assert!(!plan.needs_wire_reader());
+        assert!(!plan.needs_wire_writer());
+    }
+
+    #[test]
+    fn wire_encoded_bridge_param_derives_reader_writer_pin_and_cleanup_lines() {
+        let value = CSharpParamName::from_source("value");
+        let value_len = CSharpParamName::new("valueLen");
+        let writer = CSharpWireWriterPlan {
+            binding_name: local("_valueWire"),
+            bytes_binding_name: local("_valueBytes"),
+            param_name: value.clone(),
+            size_expr: CSharpExpression::Literal(CSharpLiteral::Int(4)),
+            encode_stmts: vec![CSharpStatement::Expression(CSharpExpression::MethodCall {
+                receiver: Box::new(local_expr(&local("_valueWire"))),
+                method: CSharpMethodName::new("WriteI32"),
+                type_args: vec![],
+                args: vec![param_expr(&value)].into(),
+            })],
+        };
+        let plan = CSharpCallbackBridgeParamPlan::WireEncoded {
+            public_param: CSharpParameter::bare(CSharpType::String, value.clone()),
+            native_ptr_param: CSharpParameter::bare(CSharpType::IntPtr, value.clone()),
+            native_len_param: CSharpParameter::bare(CSharpType::UIntPtr, value_len),
+            reader_local: local("__boltffiValueReader"),
+            decoded_arg: local_expr(&local("__boltffiValueReader")),
+            writer,
+            pin_local: local("_valuePin"),
+            ptr_local: local("_valuePtr"),
+        };
+
+        assert_eq!(plan.public_param().to_string(), "string value");
+        assert_eq!(
+            plan.native_params()
+                .into_iter()
+                .map(|param| param.to_string())
+                .collect::<Vec<_>>(),
+            vec!["IntPtr value", "UIntPtr valueLen"]
+        );
+        assert_eq!(
+            plan.decode_setup_lines(),
+            vec!["var __boltffiValueReader = new WireReader(value, valueLen);"]
+        );
+        assert_eq!(
+            plan.proxy_args().to_string(),
+            "_valuePtr, (UIntPtr)_valueBytes.Length"
+        );
+        assert_eq!(
+            plan.proxy_setup_lines(),
+            vec![
+                "byte[] _valueBytes;",
+                "using (var _valueWire = new WireWriter(4))",
+                "{",
+                "    _valueWire.WriteI32(value);",
+                "    _valueBytes = _valueWire.ToArray();",
+                "}",
+                "GCHandle _valuePin = default;",
+                "IntPtr _valuePtr = IntPtr.Zero;",
+            ]
+        );
+        assert_eq!(
+            plan.proxy_pin_lines(),
+            vec![
+                "if (_valueBytes.Length != 0)",
+                "{",
+                "    _valuePin = GCHandle.Alloc(_valueBytes, GCHandleType.Pinned);",
+                "    _valuePtr = _valuePin.AddrOfPinnedObject();",
+                "}",
+            ]
+        );
+        assert_eq!(
+            plan.proxy_cleanup_lines(),
+            vec!["if (_valuePin.IsAllocated) _valuePin.Free();"]
+        );
+        assert!(plan.needs_wire_reader());
+        assert!(plan.needs_wire_writer());
     }
 }

--- a/boltffi_bindgen/src/render/csharp/plan/callback.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/callback.rs
@@ -9,6 +9,7 @@ use super::callable::CSharpWireWriterPlan;
 #[derive(Debug, Clone)]
 pub struct CSharpCallbackPlan {
     pub public_name: CSharpClassName,
+    pub proxy_name: CSharpClassName,
     pub bridge_name: CSharpClassName,
     pub methods: Vec<CSharpCallbackMethodPlan>,
     pub register_fn: CFunctionName,

--- a/boltffi_bindgen/src/render/csharp/plan/mod.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/mod.rs
@@ -23,8 +23,13 @@ pub use callable::{
     CSharpParamPlan, CSharpReceiver, CSharpReturnKind, CSharpWireWriterPlan,
 };
 pub use callback::{
-    CSharpCallbackBridgeParamPlan, CSharpCallbackMethodPlan, CSharpCallbackParamPlan,
-    CSharpCallbackPlan, CSharpClosureMethodPlan, CSharpClosurePlan,
+    CSharpAsyncCallbackEntryPlan, CSharpAsyncCallbackFailurePlan, CSharpAsyncCallbackFaultPlan,
+    CSharpAsyncCallbackSuccessPlan, CSharpCallbackBridgeParamPlan, CSharpCallbackDelegatePlan,
+    CSharpCallbackEntryPlan, CSharpCallbackMethodPlan, CSharpCallbackParamPlan, CSharpCallbackPlan,
+    CSharpCallbackProxyCallPlan, CSharpCallbackProxyPlan, CSharpClosureInvokePlan,
+    CSharpClosureMethodPlan, CSharpClosurePlan, CSharpSyncCallbackEntryPlan,
+    CSharpSyncCallbackOutInitializerPlan, CSharpSyncCallbackProxyPlan,
+    CSharpSyncCallbackSuccessPlan,
 };
 pub use class::{CSharpClassPlan, CSharpConstructorKind, CSharpConstructorPlan};
 pub use enumeration::{CSharpEnumKind, CSharpEnumPlan, CSharpEnumVariantPlan};

--- a/boltffi_bindgen/src/render/csharp/plan/mod.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/mod.rs
@@ -26,9 +26,10 @@ pub use callback::{
     CSharpAsyncCallbackEntryPlan, CSharpAsyncCallbackFailurePlan, CSharpAsyncCallbackFaultPlan,
     CSharpAsyncCallbackSuccessPlan, CSharpCallbackBridgeParamPlan, CSharpCallbackDelegatePlan,
     CSharpCallbackEntryPlan, CSharpCallbackMethodPlan, CSharpCallbackParamPlan, CSharpCallbackPlan,
-    CSharpCallbackProxyCallPlan, CSharpCallbackProxyPlan, CSharpClosureInvokePlan,
-    CSharpClosureMethodPlan, CSharpClosurePlan, CSharpSyncCallbackEntryPlan,
-    CSharpSyncCallbackOutInitializerPlan, CSharpSyncCallbackProxyPlan,
+    CSharpCallbackProxyCallPlan, CSharpCallbackProxyPlan, CSharpCallbackResultAssignmentPlan,
+    CSharpCallbackResultCatchPlan, CSharpCallbackResultDecodePlan, CSharpCallbackResultOkPlan,
+    CSharpClosureInvokePlan, CSharpClosureMethodPlan, CSharpClosurePlan, CSharpResultTypePlan,
+    CSharpSyncCallbackEntryPlan, CSharpSyncCallbackOutInitializerPlan, CSharpSyncCallbackProxyPlan,
     CSharpSyncCallbackSuccessPlan,
 };
 pub use class::{CSharpClassPlan, CSharpConstructorKind, CSharpConstructorPlan};

--- a/boltffi_bindgen/src/render/csharp/plan/mod.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/mod.rs
@@ -10,6 +10,7 @@
 //! Plans are created by the `lower` module, and consumed by the `templates` module.
 
 mod callable;
+mod callback;
 mod class;
 mod enumeration;
 mod field;
@@ -20,6 +21,10 @@ mod record;
 pub use callable::{
     CSharpAsyncCallPlan, CSharpCallablePlan, CSharpFunctionPlan, CSharpMethodPlan, CSharpParamKind,
     CSharpParamPlan, CSharpReceiver, CSharpReturnKind, CSharpWireWriterPlan,
+};
+pub use callback::{
+    CSharpCallbackMethodPlan, CSharpCallbackParamPlan, CSharpCallbackPlan, CSharpClosureMethodPlan,
+    CSharpClosurePlan,
 };
 pub use class::{CSharpClassPlan, CSharpConstructorKind, CSharpConstructorPlan};
 pub use enumeration::{CSharpEnumKind, CSharpEnumPlan, CSharpEnumVariantPlan};

--- a/boltffi_bindgen/src/render/csharp/plan/mod.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/mod.rs
@@ -23,8 +23,8 @@ pub use callable::{
     CSharpParamPlan, CSharpReceiver, CSharpReturnKind, CSharpWireWriterPlan,
 };
 pub use callback::{
-    CSharpCallbackMethodPlan, CSharpCallbackParamPlan, CSharpCallbackPlan, CSharpClosureMethodPlan,
-    CSharpClosurePlan,
+    CSharpCallbackBridgeParamPlan, CSharpCallbackMethodPlan, CSharpCallbackParamPlan,
+    CSharpCallbackPlan, CSharpClosureMethodPlan, CSharpClosurePlan,
 };
 pub use class::{CSharpClassPlan, CSharpConstructorKind, CSharpConstructorPlan};
 pub use enumeration::{CSharpEnumKind, CSharpEnumPlan, CSharpEnumVariantPlan};

--- a/boltffi_bindgen/src/render/csharp/plan/module.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/module.rs
@@ -2,8 +2,8 @@ use boltffi_ffi_rules::naming::{LibraryName, Name};
 
 use super::super::ast::{CSharpClassName, CSharpNamespace};
 use super::{
-    CFunctionName, CSharpCallablePlan, CSharpClassPlan, CSharpEnumPlan, CSharpFunctionPlan,
-    CSharpRecordPlan,
+    CFunctionName, CSharpCallablePlan, CSharpCallbackPlan, CSharpClassPlan, CSharpClosurePlan,
+    CSharpEnumPlan, CSharpFunctionPlan, CSharpRecordPlan,
 };
 
 /// A whole C# module: namespace, library binding, and every record, enum,
@@ -36,6 +36,10 @@ pub struct CSharpModulePlan {
     /// own `.cs` file as a `sealed class` implementing `IDisposable`
     /// around an opaque native handle.
     pub classes: Vec<CSharpClassPlan>,
+    /// Callback trait interfaces and bridges.
+    pub callbacks: Vec<CSharpCallbackPlan>,
+    /// Closure delegate types and bridges.
+    pub closures: Vec<CSharpClosurePlan>,
 }
 
 impl CSharpModulePlan {
@@ -56,6 +60,28 @@ impl CSharpModulePlan {
             || self.classes.iter().any(CSharpClassPlan::has_async_methods)
             || self.records.iter().any(CSharpRecordPlan::has_async_methods)
             || self.enums.iter().any(CSharpEnumPlan::has_async_methods)
+    }
+
+    pub fn has_callbacks(&self) -> bool {
+        !self.callbacks.is_empty()
+    }
+
+    pub fn has_closures(&self) -> bool {
+        !self.closures.is_empty()
+    }
+
+    pub fn has_async_callbacks(&self) -> bool {
+        self.callbacks
+            .iter()
+            .any(|callback| callback.has_async_methods)
+    }
+
+    pub fn needs_callback_runtime(&self) -> bool {
+        self.has_callbacks() || self.has_closures()
+    }
+
+    pub fn needs_ffi_status(&self) -> bool {
+        self.has_async() || self.needs_callback_runtime()
     }
 
     /// Whether the module needs `using System.Text;`. True when any function
@@ -111,21 +137,45 @@ impl CSharpModulePlan {
     /// Needed for wire-encoded returns, and pulled in whenever a record or
     /// enum exists so the `WireReader` (which takes `FfiBuf`) compiles.
     pub fn needs_ffi_buf(&self) -> bool {
-        self.has_ffi_buf_returns() || !self.records.is_empty() || !self.enums.is_empty()
+        self.has_ffi_buf_returns()
+            || !self.records.is_empty()
+            || !self.enums.is_empty()
+            || self.callbacks.iter().any(|callback| callback.needs_ffi_buf)
+            || self.closures.iter().any(|closure| closure.needs_ffi_buf)
     }
 
     /// Whether the stateful `WireReader` helper is emitted. Needed for
     /// wire-decoded returns, for any record's `Decode` method, and for the
     /// enum wire helpers (`StatusWire.Decode`, `Shape.Decode`).
     pub fn needs_wire_reader(&self) -> bool {
-        self.has_ffi_buf_returns() || !self.records.is_empty() || !self.enums.is_empty()
+        self.has_ffi_buf_returns()
+            || !self.records.is_empty()
+            || !self.enums.is_empty()
+            || self
+                .callbacks
+                .iter()
+                .any(|callback| callback.needs_wire_reader)
+            || self
+                .closures
+                .iter()
+                .any(|closure| closure.needs_wire_reader)
     }
 
     /// Whether the `WireWriter` helper is emitted. Needed for wire-encoded
     /// params, for any record's `WireEncodeTo` method, and for the enum
     /// encode helpers.
     pub fn needs_wire_writer(&self) -> bool {
-        self.has_wire_params() || !self.records.is_empty() || !self.enums.is_empty()
+        self.has_wire_params()
+            || !self.records.is_empty()
+            || !self.enums.is_empty()
+            || self
+                .callbacks
+                .iter()
+                .any(|callback| callback.needs_wire_writer)
+            || self
+                .closures
+                .iter()
+                .any(|closure| closure.needs_wire_writer)
     }
 
     /// Whether the runtime `BoltException` class is emitted. True when
@@ -174,6 +224,8 @@ mod tests {
             enums: vec![],
             functions: vec![],
             classes: vec![],
+            callbacks: vec![],
+            closures: vec![],
         }
     }
 

--- a/boltffi_bindgen/src/render/csharp/snapshots/boltffi_bindgen__render__csharp__templates__tests__snapshot_async_native_runtime_and_pinvoke_declarations.snap
+++ b/boltffi_bindgen/src/render/csharp/snapshots/boltffi_bindgen__render__csharp__templates__tests__snapshot_async_native_runtime_and_pinvoke_declarations.snap
@@ -1,5 +1,6 @@
 ---
 source: boltffi_bindgen/src/render/csharp/templates.rs
+assertion_line: 901
 expression: template.render().unwrap()
 ---
 
@@ -255,7 +256,7 @@ expression: template.render().unwrap()
 
     internal static class NativeMethods
     {
-        private const string LibName = "demo";
+        internal const string LibName = "demo";
         [DllImport(LibName, EntryPoint = "boltffi_async_add")]
         internal static extern IntPtr AsyncAdd(int a, int b);
 

--- a/boltffi_bindgen/src/render/csharp/templates.rs
+++ b/boltffi_bindgen/src/render/csharp/templates.rs
@@ -15,9 +15,12 @@ use askama::Template;
 
 use super::ast::{CSharpComment, CSharpNamespace};
 use super::plan::{
-    CSharpCallablePlan, CSharpCallbackPlan, CSharpClassPlan, CSharpClosurePlan,
-    CSharpConstructorKind, CSharpEnumPlan, CSharpFieldPlan, CSharpModulePlan, CSharpParamKind,
-    CSharpRecordPlan, CSharpReturnKind,
+    CSharpAsyncCallbackFailurePlan, CSharpAsyncCallbackFaultPlan, CSharpAsyncCallbackSuccessPlan,
+    CSharpCallablePlan, CSharpCallbackBridgeParamPlan, CSharpCallbackEntryPlan, CSharpCallbackPlan,
+    CSharpCallbackProxyCallPlan, CSharpCallbackProxyPlan, CSharpClassPlan, CSharpClosureInvokePlan,
+    CSharpClosurePlan, CSharpConstructorKind, CSharpEnumPlan, CSharpFieldPlan, CSharpModulePlan,
+    CSharpParamKind, CSharpRecordPlan, CSharpReturnKind, CSharpSyncCallbackOutInitializerPlan,
+    CSharpSyncCallbackSuccessPlan,
 };
 
 /// Renders a `<summary>` doc block at `indent`, ending with a

--- a/boltffi_bindgen/src/render/csharp/templates.rs
+++ b/boltffi_bindgen/src/render/csharp/templates.rs
@@ -17,9 +17,10 @@ use super::ast::{CSharpComment, CSharpNamespace};
 use super::plan::{
     CSharpAsyncCallbackFailurePlan, CSharpAsyncCallbackFaultPlan, CSharpAsyncCallbackSuccessPlan,
     CSharpCallablePlan, CSharpCallbackBridgeParamPlan, CSharpCallbackEntryPlan, CSharpCallbackPlan,
-    CSharpCallbackProxyCallPlan, CSharpCallbackProxyPlan, CSharpClassPlan, CSharpClosureInvokePlan,
-    CSharpClosurePlan, CSharpConstructorKind, CSharpEnumPlan, CSharpFieldPlan, CSharpModulePlan,
-    CSharpParamKind, CSharpRecordPlan, CSharpReturnKind, CSharpSyncCallbackOutInitializerPlan,
+    CSharpCallbackProxyCallPlan, CSharpCallbackProxyPlan, CSharpCallbackResultCatchPlan,
+    CSharpCallbackResultOkPlan, CSharpClassPlan, CSharpClosureInvokePlan, CSharpClosurePlan,
+    CSharpConstructorKind, CSharpEnumPlan, CSharpFieldPlan, CSharpModulePlan, CSharpParamKind,
+    CSharpRecordPlan, CSharpReturnKind, CSharpSyncCallbackOutInitializerPlan,
     CSharpSyncCallbackSuccessPlan,
 };
 

--- a/boltffi_bindgen/src/render/csharp/templates.rs
+++ b/boltffi_bindgen/src/render/csharp/templates.rs
@@ -114,6 +114,13 @@ pub struct CallbackInterfaceTemplate<'a> {
     pub callback: &'a CSharpCallbackPlan,
 }
 
+/// Renders the public owning proxy for callback handles returned from Rust.
+#[derive(Template)]
+#[template(path = "render_csharp/callback_proxy.txt", escape = "none")]
+pub struct CallbackProxyTemplate<'a> {
+    pub callback: &'a CSharpCallbackPlan,
+}
+
 /// Renders the managed vtable bridge for a callback interface.
 #[derive(Template)]
 #[template(path = "render_csharp/callback_bridge.txt", escape = "none")]

--- a/boltffi_bindgen/src/render/csharp/templates.rs
+++ b/boltffi_bindgen/src/render/csharp/templates.rs
@@ -15,8 +15,9 @@ use askama::Template;
 
 use super::ast::{CSharpComment, CSharpNamespace};
 use super::plan::{
-    CSharpCallablePlan, CSharpClassPlan, CSharpConstructorKind, CSharpEnumPlan, CSharpFieldPlan,
-    CSharpModulePlan, CSharpParamKind, CSharpRecordPlan, CSharpReturnKind,
+    CSharpCallablePlan, CSharpCallbackPlan, CSharpClassPlan, CSharpClosurePlan,
+    CSharpConstructorKind, CSharpEnumPlan, CSharpFieldPlan, CSharpModulePlan, CSharpParamKind,
+    CSharpRecordPlan, CSharpReturnKind,
 };
 
 /// Renders a `<summary>` doc block at `indent`, ending with a
@@ -100,6 +101,34 @@ fn push_text_line(out: &mut String, indent: &str, line: &str) {
 #[template(path = "render_csharp/preamble.txt", escape = "none")]
 pub struct PreambleTemplate<'a> {
     pub module: &'a CSharpModulePlan,
+}
+
+/// Renders a public callback interface.
+#[derive(Template)]
+#[template(path = "render_csharp/callback_interface.txt", escape = "none")]
+pub struct CallbackInterfaceTemplate<'a> {
+    pub callback: &'a CSharpCallbackPlan,
+}
+
+/// Renders the managed vtable bridge for a callback interface.
+#[derive(Template)]
+#[template(path = "render_csharp/callback_bridge.txt", escape = "none")]
+pub struct CallbackBridgeTemplate<'a> {
+    pub callback: &'a CSharpCallbackPlan,
+}
+
+/// Renders a public closure delegate.
+#[derive(Template)]
+#[template(path = "render_csharp/closure_delegate.txt", escape = "none")]
+pub struct ClosureDelegateTemplate<'a> {
+    pub closure: &'a CSharpClosurePlan,
+}
+
+/// Renders the managed bridge used to pin and invoke a closure delegate.
+#[derive(Template)]
+#[template(path = "render_csharp/closure_bridge.txt", escape = "none")]
+pub struct ClosureBridgeTemplate<'a> {
+    pub closure: &'a CSharpClosurePlan,
 }
 
 /// Renders the public static wrapper class with methods that delegate
@@ -786,6 +815,8 @@ mod tests {
             enums: vec![],
             functions,
             classes: vec![],
+            callbacks: vec![],
+            closures: vec![],
         }
     }
 

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callable_async_return.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callable_async_return.txt
@@ -20,6 +20,14 @@
                     BoltFFIAsync.ThrowIfStatus(status, cancellationToken);
                     return result;
                 },
+{%- else if callable.return_kind.is_callback_handle() %}
+                future =>
+                {
+                    FfiStatus status;
+                    BoltFFICallbackHandle handle = NativeMethods.{{ ac.complete_method_name }}(future, out status);
+                    BoltFFIAsync.ThrowIfStatus(status, cancellationToken);
+                    return {{ callable.return_kind.callback_bridge_class() }}.Wrap(handle);
+                },
 {%- else %}
                 future =>
                 {

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callable_setup.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callable_setup.txt
@@ -2,6 +2,9 @@
 {%- if let Some(decl) = param.setup_declaration() %}
             {{ decl }}
 {%- endif %}
+{%- if let Some(stmt) = param.setup_statement() %}
+            {{ stmt }}
+{%- endif %}
 {%- endfor %}
 {%- for writer in callable.wire_writers %}
             using var {{ writer.binding_name }} = new WireWriter({{ writer.size_expr }});

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callable_setup.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callable_setup.txt
@@ -2,9 +2,11 @@
 {%- if let Some(decl) = param.setup_declaration() %}
             {{ decl }}
 {%- endif %}
-{%- if let Some(stmt) = param.setup_statement() %}
-            {{ stmt }}
-{%- endif %}
+{%- match param.kind %}
+{%- when CSharpParamKind::InlineClosure with { bridge_class, scope_local, context_param_name } %}
+            using var {{ scope_local }} = {{ bridge_class }}.Pin({{ param.name }});
+{%- when _ %}
+{%- endmatch %}
 {%- endfor %}
 {%- for writer in callable.wire_writers %}
             using var {{ writer.binding_name }} = new WireWriter({{ writer.size_expr }});

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callable_sync_return.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callable_sync_return.txt
@@ -2,6 +2,8 @@
             NativeMethods.{{ native_method_name }}({{ native_call_args }});
 {%- else if callable.return_kind.is_direct() %}
             return NativeMethods.{{ native_method_name }}({{ native_call_args }});
+{%- else if callable.return_kind.is_callback_handle() %}
+            return {{ callable.return_kind.callback_bridge_class() }}.Wrap(NativeMethods.{{ native_method_name }}({{ native_call_args }}));
 {%- else %}
             FfiBuf _buf = NativeMethods.{{ native_method_name }}({{ native_call_args }});
             try

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callable_wire_decode_return.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callable_wire_decode_return.txt
@@ -27,4 +27,5 @@
 {%- endif %}
 {%- when CSharpReturnKind::Void %}
 {%- when CSharpReturnKind::Direct %}
+{%- when CSharpReturnKind::CallbackHandle with { .. } %}
 {%- endmatch %}

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_async_failure_completion.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_async_failure_completion.txt
@@ -1,0 +1,8 @@
+{%- match completion %}
+{%- when CSharpAsyncCallbackFailurePlan::Void %}
+{{ completion_indent }}callback(callbackData, new FfiStatus { code = 100 });
+{%- when CSharpAsyncCallbackFailurePlan::Direct with { default_value } %}
+{{ completion_indent }}callback(callbackData, {{ default_value }}, new FfiStatus { code = 100 });
+{%- when CSharpAsyncCallbackFailurePlan::Encoded %}
+{{ completion_indent }}callback(callbackData, IntPtr.Zero, UIntPtr.Zero, new FfiStatus { code = 100 });
+{%- endmatch %}

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_bridge.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_bridge.txt
@@ -21,15 +21,14 @@
         {
             _ = VTablePtr;
             if (impl_ is null) return BoltFFICallbackHandle.Null;
-            if (impl_ is Proxy proxy) return proxy.CloneHandle();
+            if (impl_ is {{ callback.proxy_name }} proxy) return proxy.CloneHandle();
             return CreateNative(Insert(impl_));
         }
 
-        internal static {{ callback.public_name }} Wrap(BoltFFICallbackHandle handle)
+        internal static {{ callback.proxy_name }} Wrap(BoltFFICallbackHandle handle)
         {
             if (handle.IsNull) throw new InvalidOperationException("callback handle is null");
-            if (Handles.TryGetValue(handle.handle, out var existing)) return existing;
-            return new Proxy(handle);
+            return new {{ callback.proxy_name }}(handle);
         }
 
         private static ulong Insert({{ callback.public_name }} impl_)
@@ -46,7 +45,7 @@
             return Handles.TryGetValue(handle, out {{ callback.public_name }}? impl_) ? Insert(impl_) : 0;
         }
 
-        private static void ThrowIfCallbackStatus(FfiStatus status)
+        internal static void ThrowIfCallbackStatus(FfiStatus status)
         {
             if (status.code != 0) throw new InvalidOperationException($"callback failed with status code {status.code}");
         }
@@ -281,188 +280,6 @@
         }
 {%- endmatch %}
 {% endfor %}
-        private sealed class Proxy : {{ callback.public_name }}
-        {
-            private BoltFFICallbackHandle _handle;
-
-            internal Proxy(BoltFFICallbackHandle handle)
-            {
-                _handle = handle;
-            }
-
-            ~Proxy()
-            {
-                Release();
-            }
-
-            internal BoltFFICallbackHandle CloneHandle()
-            {
-                if (_handle.IsNull) return BoltFFICallbackHandle.Null;
-                VTable table = Marshal.PtrToStructure<VTable>(_handle.vtable);
-                var clone = Marshal.GetDelegateForFunctionPointer<CloneFn>(table.clone);
-                ulong cloned = clone(_handle.handle);
-                return cloned == 0 ? BoltFFICallbackHandle.Null : new BoltFFICallbackHandle { handle = cloned, vtable = _handle.vtable };
-            }
-
-            private void Release()
-            {
-                if (_handle.IsNull) return;
-                VTable table = Marshal.PtrToStructure<VTable>(_handle.vtable);
-                var free = Marshal.GetDelegateForFunctionPointer<FreeFn>(table.free);
-                ulong handle = _handle.handle;
-                _handle = BoltFFICallbackHandle.Null;
-                free(handle);
-            }
-
-{% for method in callback.methods %}
-{%- match method.proxy %}
-{%- when CSharpCallbackProxyPlan::AsyncUnsupported with { public_params, result_type } %}
-{%- match result_type %}
-{%- when Some with (ty) %}
-            public global::System.Threading.Tasks.Task<{{ method.return_type }}> {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException<{{ ty }}>(new NotSupportedException("async callback proxies are not implemented for C# yet"));
-{%- when None %}
-            public global::System.Threading.Tasks.Task {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException(new NotSupportedException("async callback proxies are not implemented for C# yet"));
-{%- endmatch %}
-{%- when CSharpCallbackProxyPlan::Sync with (proxy) %}
-            public {{ proxy.return_type }} {{ method.name }}({{ proxy.public_params }})
-            {
-                if (_handle.IsNull) throw new ObjectDisposedException(nameof(Proxy));
-                VTable __boltffiTable = Marshal.PtrToStructure<VTable>(_handle.vtable);
-                var __boltffiInvoke = Marshal.GetDelegateForFunctionPointer<{{ method.name }}ProxyFn>(__boltffiTable.{{ method.vtable_field }});
-{%- for param in proxy.bridge_params %}
-{%- match param %}
-{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
-{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
-                byte[] {{ writer.bytes_binding_name }};
-                using (var {{ writer.binding_name }} = new WireWriter({{ writer.size_expr }}))
-                {
-{%- for stmt in writer.encode_stmts %}
-                    {{ stmt }};
-{%- endfor %}
-                    {{ writer.bytes_binding_name }} = {{ writer.binding_name }}.ToArray();
-                }
-                GCHandle {{ pin_local }} = default;
-                IntPtr {{ ptr_local }} = IntPtr.Zero;
-{%- endmatch %}
-{%- endfor %}
-{%- if proxy.has_cleanup %}
-                try
-                {
-{%- for param in proxy.bridge_params %}
-{%- match param %}
-{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
-{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
-                    if ({{ writer.bytes_binding_name }}.Length != 0)
-                    {
-                        {{ pin_local }} = GCHandle.Alloc({{ writer.bytes_binding_name }}, GCHandleType.Pinned);
-                        {{ ptr_local }} = {{ pin_local }}.AddrOfPinnedObject();
-                    }
-{%- endmatch %}
-{%- endfor %}
-{%- match proxy.call %}
-{%- when CSharpCallbackProxyCallPlan::Void with { args } %}
-                    FfiStatus __boltffiStatus;
-                    __boltffiInvoke({{ args }}, out __boltffiStatus);
-                    ThrowIfCallbackStatus(__boltffiStatus);
-{%- when CSharpCallbackProxyCallPlan::Direct with { args, native_out_type, public_expr } %}
-                    {{ native_out_type }} __boltffiOutPtr;
-                    FfiStatus __boltffiStatus;
-                    __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiStatus);
-                    ThrowIfCallbackStatus(__boltffiStatus);
-                    return {{ public_expr }};
-{%- when CSharpCallbackProxyCallPlan::Encoded with { args, decode_expr, result_decode } %}
-                    IntPtr __boltffiOutPtr;
-                    UIntPtr __boltffiOutLen;
-                    FfiStatus __boltffiStatus;
-                    __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiOutLen, out __boltffiStatus);
-                    try
-                    {
-                        ThrowIfCallbackStatus(__boltffiStatus);
-                        var __boltffiReader = new WireReader(__boltffiOutPtr, __boltffiOutLen);
-{%- if let Some(result_decode) = result_decode %}
-                        if (__boltffiReader.ReadU8() != 0)
-                        {
-                            throw new InvalidOperationException({{ result_decode.err_expr }}.ToString());
-                        }
-{%- if let Some(ok_expr) = result_decode.ok_expr %}
-                        return {{ ok_expr }};
-{%- endif %}
-{%- endif %}
-{%- if let Some(expr) = decode_expr %}
-                        return {{ expr }};
-{%- endif %}
-                    }
-                    finally
-                    {
-                        BoltFFICallbackReturn.Free(__boltffiOutPtr);
-                    }
-{%- endmatch %}
-                }
-                finally
-                {
-{%- for param in proxy.bridge_params %}
-{%- match param %}
-{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
-{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
-                    if ({{ pin_local }}.IsAllocated) {{ pin_local }}.Free();
-{%- endmatch %}
-{%- endfor %}
-                }
-{%- else %}
-{%- for param in proxy.bridge_params %}
-{%- match param %}
-{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
-{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
-                if ({{ writer.bytes_binding_name }}.Length != 0)
-                {
-                    {{ pin_local }} = GCHandle.Alloc({{ writer.bytes_binding_name }}, GCHandleType.Pinned);
-                    {{ ptr_local }} = {{ pin_local }}.AddrOfPinnedObject();
-                }
-{%- endmatch %}
-{%- endfor %}
-{%- match proxy.call %}
-{%- when CSharpCallbackProxyCallPlan::Void with { args } %}
-                FfiStatus __boltffiStatus;
-                __boltffiInvoke({{ args }}, out __boltffiStatus);
-                ThrowIfCallbackStatus(__boltffiStatus);
-{%- when CSharpCallbackProxyCallPlan::Direct with { args, native_out_type, public_expr } %}
-                {{ native_out_type }} __boltffiOutPtr;
-                FfiStatus __boltffiStatus;
-                __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiStatus);
-                ThrowIfCallbackStatus(__boltffiStatus);
-                return {{ public_expr }};
-{%- when CSharpCallbackProxyCallPlan::Encoded with { args, decode_expr, result_decode } %}
-                IntPtr __boltffiOutPtr;
-                UIntPtr __boltffiOutLen;
-                FfiStatus __boltffiStatus;
-                __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiOutLen, out __boltffiStatus);
-                try
-                {
-                    ThrowIfCallbackStatus(__boltffiStatus);
-                    var __boltffiReader = new WireReader(__boltffiOutPtr, __boltffiOutLen);
-{%- if let Some(result_decode) = result_decode %}
-                    if (__boltffiReader.ReadU8() != 0)
-                    {
-                        throw new InvalidOperationException({{ result_decode.err_expr }}.ToString());
-                    }
-{%- if let Some(ok_expr) = result_decode.ok_expr %}
-                    return {{ ok_expr }};
-{%- endif %}
-{%- endif %}
-{%- if let Some(expr) = decode_expr %}
-                    return {{ expr }};
-{%- endif %}
-                }
-                finally
-                {
-                    BoltFFICallbackReturn.Free(__boltffiOutPtr);
-                }
-{%- endmatch %}
-{%- endif %}
-            }
-{%- endmatch %}
-{% endfor %}
-        }
 
 {% if callback.has_async_methods %}
         private static Exception UnwrapTaskException(Exception exception)
@@ -476,7 +293,7 @@
 
 {% endif %}
         [StructLayout(LayoutKind.Sequential)]
-        private struct VTable
+        internal struct VTable
         {
             public IntPtr free;
             public IntPtr clone;
@@ -486,11 +303,11 @@
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate void FreeFn(ulong handle);
+        internal delegate void FreeFn(ulong handle);
         private static readonly FreeFn FreeDelegate = Free;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate ulong CloneFn(ulong handle);
+        internal delegate ulong CloneFn(ulong handle);
         private static readonly CloneFn CloneDelegate = Clone;
 
 {% for method in callback.methods %}
@@ -505,7 +322,7 @@
 {%- endif %}
 {%- if let Some(proxy_params) = method.delegates.proxy_params %}
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate void {{ method.name }}ProxyFn({{ proxy_params }});
+        internal delegate void {{ method.name }}ProxyFn({{ proxy_params }});
 
 {%- endif %}
 {% endfor %}

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_bridge.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_bridge.txt
@@ -316,12 +316,12 @@
 
 {% for method in callback.methods %}
 {%- match method.proxy %}
-{%- when CSharpCallbackProxyPlan::AsyncUnsupported with { public_params, result_type, not_supported_expr } %}
+{%- when CSharpCallbackProxyPlan::AsyncUnsupported with { public_params, result_type } %}
 {%- match result_type %}
 {%- when Some with (ty) %}
-            public {{ method.public_return_type() }} {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException<{{ ty }}>({{ not_supported_expr }});
+            public global::System.Threading.Tasks.Task<{{ method.return_type }}> {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException<{{ ty }}>(new NotSupportedException("async callback proxies are not implemented for C# yet"));
 {%- when None %}
-            public {{ method.public_return_type() }} {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException({{ not_supported_expr }});
+            public global::System.Threading.Tasks.Task {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException(new NotSupportedException("async callback proxies are not implemented for C# yet"));
 {%- endmatch %}
 {%- when CSharpCallbackProxyPlan::Sync with (proxy) %}
             public {{ proxy.return_type }} {{ method.name }}({{ proxy.public_params }})

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_bridge.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_bridge.txt
@@ -148,14 +148,9 @@
         {
             if (!Handles.TryGetValue(handle, out var impl_))
             {
-{%- match entry.invalid_handle_completion %}
-{%- when CSharpAsyncCallbackFailurePlan::Void %}
-                callback(callbackData, new FfiStatus { code = 100 });
-{%- when CSharpAsyncCallbackFailurePlan::Direct with { default_value } %}
-                callback(callbackData, {{ default_value }}, new FfiStatus { code = 100 });
-{%- when CSharpAsyncCallbackFailurePlan::Encoded %}
-                callback(callbackData, IntPtr.Zero, UIntPtr.Zero, new FfiStatus { code = 100 });
-{%- endmatch %}
+{%- let completion = entry.invalid_handle_completion %}
+{%- let completion_indent = "                " %}
+{%- include "render_csharp/callback_async_failure_completion.txt" %}
                 return;
             }
             try
@@ -172,14 +167,9 @@
                 {
                     if (__boltffiCompleted.IsCanceled)
                     {
-{%- match entry.canceled_completion %}
-{%- when CSharpAsyncCallbackFailurePlan::Void %}
-                        callback(callbackData, new FfiStatus { code = 100 });
-{%- when CSharpAsyncCallbackFailurePlan::Direct with { default_value } %}
-                        callback(callbackData, {{ default_value }}, new FfiStatus { code = 100 });
-{%- when CSharpAsyncCallbackFailurePlan::Encoded %}
-                        callback(callbackData, IntPtr.Zero, UIntPtr.Zero, new FfiStatus { code = 100 });
-{%- endmatch %}
+{%- let completion = entry.canceled_completion %}
+{%- let completion_indent = "                        " %}
+{%- include "render_csharp/callback_async_failure_completion.txt" %}
                         return;
                     }
                     if (__boltffiCompleted.IsFaulted)
@@ -187,14 +177,9 @@
                         Exception __boltffiException = UnwrapTaskException(__boltffiCompleted.Exception!);
 {%- match entry.faulted_completion %}
 {%- when CSharpAsyncCallbackFaultPlan::Failure with (failure) %}
-{%- match failure %}
-{%- when CSharpAsyncCallbackFailurePlan::Void %}
-                        callback(callbackData, new FfiStatus { code = 100 });
-{%- when CSharpAsyncCallbackFailurePlan::Direct with { default_value } %}
-                        callback(callbackData, {{ default_value }}, new FfiStatus { code = 100 });
-{%- when CSharpAsyncCallbackFailurePlan::Encoded %}
-                        callback(callbackData, IntPtr.Zero, UIntPtr.Zero, new FfiStatus { code = 100 });
-{%- endmatch %}
+{%- let completion = failure %}
+{%- let completion_indent = "                        " %}
+{%- include "render_csharp/callback_async_failure_completion.txt" %}
 {%- when CSharpAsyncCallbackFaultPlan::EncodedResult with { exception_type, error_value_expr, result_type, writer, fallback } %}
 {%- if let Some(exception_type) = exception_type %}
                         if (__boltffiException is {{ exception_type }} __boltffiTypedException)
@@ -223,14 +208,9 @@
                             return;
                         }
 {%- if let Some(fallback) = fallback %}
-{%- match fallback %}
-{%- when CSharpAsyncCallbackFailurePlan::Void %}
-                        callback(callbackData, new FfiStatus { code = 100 });
-{%- when CSharpAsyncCallbackFailurePlan::Direct with { default_value } %}
-                        callback(callbackData, {{ default_value }}, new FfiStatus { code = 100 });
-{%- when CSharpAsyncCallbackFailurePlan::Encoded %}
-                        callback(callbackData, IntPtr.Zero, UIntPtr.Zero, new FfiStatus { code = 100 });
-{%- endmatch %}
+{%- let completion = fallback %}
+{%- let completion_indent = "                        " %}
+{%- include "render_csharp/callback_async_failure_completion.txt" %}
 {%- endif %}
 {%- endmatch %}
                         return;
@@ -268,14 +248,9 @@
             }
             catch
             {
-{%- match entry.catch_completion %}
-{%- when CSharpAsyncCallbackFailurePlan::Void %}
-                callback(callbackData, new FfiStatus { code = 100 });
-{%- when CSharpAsyncCallbackFailurePlan::Direct with { default_value } %}
-                callback(callbackData, {{ default_value }}, new FfiStatus { code = 100 });
-{%- when CSharpAsyncCallbackFailurePlan::Encoded %}
-                callback(callbackData, IntPtr.Zero, UIntPtr.Zero, new FfiStatus { code = 100 });
-{%- endmatch %}
+{%- let completion = entry.catch_completion %}
+{%- let completion_indent = "                " %}
+{%- include "render_csharp/callback_async_failure_completion.txt" %}
             }
         }
 {%- endmatch %}

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_bridge.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_bridge.txt
@@ -1,0 +1,132 @@
+    internal static unsafe class {{ callback.bridge_name }}
+    {
+        private static readonly global::System.Collections.Concurrent.ConcurrentDictionary<ulong, {{ callback.public_name }}> Handles = new();
+        private static long _nextHandle = -1;
+        private static readonly IntPtr VTablePtr;
+
+        static {{ callback.bridge_name }}()
+        {
+            VTable table = new VTable
+            {
+                free = Marshal.GetFunctionPointerForDelegate(FreeDelegate),
+                clone = Marshal.GetFunctionPointerForDelegate(CloneDelegate){% for method in callback.methods %},
+                {{ method.vtable_field }} = Marshal.GetFunctionPointerForDelegate({{ method.name }}Delegate){% endfor %}
+            };
+            VTablePtr = (IntPtr)NativeMemory.Alloc((nuint)Marshal.SizeOf<VTable>());
+            Marshal.StructureToPtr(table, VTablePtr, false);
+            RegisterNative(VTablePtr);
+        }
+
+        internal static BoltFFICallbackHandle Create({{ callback.public_name }}? impl_)
+        {
+            _ = VTablePtr;
+            if (impl_ is null) return BoltFFICallbackHandle.Null;
+            if (impl_ is Proxy proxy) return proxy.CloneHandle();
+            return CreateNative(Insert(impl_));
+        }
+
+        internal static {{ callback.public_name }} Wrap(BoltFFICallbackHandle handle)
+        {
+            if (handle.IsNull) throw new InvalidOperationException("callback handle is null");
+            if (Handles.TryGetValue(handle.handle, out var existing)) return existing;
+            return new Proxy(handle);
+        }
+
+        private static ulong Insert({{ callback.public_name }} impl_)
+        {
+            ulong handle = unchecked((ulong)global::System.Threading.Interlocked.Add(ref _nextHandle, 2));
+            Handles[handle] = impl_;
+            return handle;
+        }
+
+        private static void Free(ulong handle) => Handles.TryRemove(handle, out _);
+
+        private static ulong Clone(ulong handle)
+        {
+            return Handles.TryGetValue(handle, out {{ callback.public_name }}? impl_) ? Insert(impl_) : 0;
+        }
+
+        private static void ThrowIfCallbackStatus(FfiStatus status)
+        {
+            if (status.code != 0) throw new InvalidOperationException($"callback failed with status code {status.code}");
+        }
+
+{% for method in callback.methods %}
+{{ method.entry_source }}
+{% endfor %}
+        private sealed class Proxy : {{ callback.public_name }}
+        {
+            private BoltFFICallbackHandle _handle;
+
+            internal Proxy(BoltFFICallbackHandle handle)
+            {
+                _handle = handle;
+            }
+
+            ~Proxy()
+            {
+                Release();
+            }
+
+            internal BoltFFICallbackHandle CloneHandle()
+            {
+                if (_handle.IsNull) return BoltFFICallbackHandle.Null;
+                VTable table = Marshal.PtrToStructure<VTable>(_handle.vtable);
+                var clone = Marshal.GetDelegateForFunctionPointer<CloneFn>(table.clone);
+                ulong cloned = clone(_handle.handle);
+                return cloned == 0 ? BoltFFICallbackHandle.Null : new BoltFFICallbackHandle { handle = cloned, vtable = _handle.vtable };
+            }
+
+            private void Release()
+            {
+                if (_handle.IsNull) return;
+                VTable table = Marshal.PtrToStructure<VTable>(_handle.vtable);
+                var free = Marshal.GetDelegateForFunctionPointer<FreeFn>(table.free);
+                ulong handle = _handle.handle;
+                _handle = BoltFFICallbackHandle.Null;
+                free(handle);
+            }
+
+{% for method in callback.methods %}
+{{ method.proxy_source }}
+{% endfor %}
+        }
+
+{% if callback.has_async_methods %}
+        private static Exception UnwrapTaskException(Exception exception)
+        {
+            while (exception is AggregateException aggregate && aggregate.InnerException is { } inner)
+            {
+                exception = inner;
+            }
+            return exception;
+        }
+
+{% endif %}
+        [StructLayout(LayoutKind.Sequential)]
+        private struct VTable
+        {
+            public IntPtr free;
+            public IntPtr clone;
+{% for method in callback.methods %}
+            public IntPtr {{ method.vtable_field }};
+{% endfor %}
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void FreeFn(ulong handle);
+        private static readonly FreeFn FreeDelegate = Free;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate ulong CloneFn(ulong handle);
+        private static readonly CloneFn CloneDelegate = Clone;
+
+{% for method in callback.methods %}
+{{ method.delegate_source }}
+{% endfor %}
+        [DllImport(NativeMethods.LibName, EntryPoint = "{{ callback.register_fn }}")]
+        private static extern void RegisterNative(IntPtr vtable);
+
+        [DllImport(NativeMethods.LibName, EntryPoint = "{{ callback.create_fn }}")]
+        private static extern BoltFFICallbackHandle CreateNative(ulong handle);
+    }

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_bridge.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_bridge.txt
@@ -52,7 +52,206 @@
         }
 
 {% for method in callback.methods %}
-{{ method.entry_source }}
+{%- match method.entry %}
+{%- when CSharpCallbackEntryPlan::Sync with (entry) %}
+        private static void {{ method.name }}({{ entry.native_params }})
+        {
+{%- match entry.out_initializer %}
+{%- when CSharpSyncCallbackOutInitializerPlan::Void %}
+{%- when CSharpSyncCallbackOutInitializerPlan::Direct with { default_value } %}
+            __boltffiOutPtr = {{ default_value }};
+{%- when CSharpSyncCallbackOutInitializerPlan::Encoded %}
+            __boltffiOutPtr = IntPtr.Zero;
+            __boltffiOutLen = UIntPtr.Zero;
+{%- endmatch %}
+            __boltffiStatus = new FfiStatus { code = 100 };
+            try
+            {
+                if (!Handles.TryGetValue(handle, out var impl_)) throw new InvalidOperationException("invalid callback handle");
+{%- for param in entry.bridge_params %}
+{%- match param %}
+{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
+{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
+                var {{ reader_local }} = new WireReader({{ native_ptr_param.name }}, {{ native_len_param.name }});
+{%- endmatch %}
+{%- endfor %}
+{%- match entry.success %}
+{%- when CSharpSyncCallbackSuccessPlan::Void with { decoded_args } %}
+                impl_.{{ method.name }}({{ decoded_args }});
+                __boltffiStatus = new FfiStatus { code = 0 };
+{%- when CSharpSyncCallbackSuccessPlan::Direct with { decoded_args, native_value_expr } %}
+                var __boltffiValue = impl_.{{ method.name }}({{ decoded_args }});
+                __boltffiOutPtr = {{ native_value_expr }};
+                __boltffiStatus = new FfiStatus { code = 0 };
+{%- when CSharpSyncCallbackSuccessPlan::Encoded with { is_result, decoded_args, result_assignment_lines, writer } %}
+{%- if is_result %}
+{%- for line in result_assignment_lines %}
+                {{ line }}
+{%- endfor %}
+{%- else %}
+                var __boltffiValue = impl_.{{ method.name }}({{ decoded_args }});
+{%- endif %}
+                byte[] {{ writer.bytes_binding_name }};
+                using (var {{ writer.binding_name }} = new WireWriter({{ writer.size_expr }}))
+                {
+{%- for stmt in writer.encode_stmts %}
+                    {{ stmt }};
+{%- endfor %}
+                    {{ writer.bytes_binding_name }} = {{ writer.binding_name }}.ToArray();
+                }
+                BoltFFICallbackReturn.Store({{ writer.bytes_binding_name }}, out __boltffiOutPtr, out __boltffiOutLen);
+                __boltffiStatus = new FfiStatus { code = 0 };
+{%- endmatch %}
+            }
+            catch
+            {
+{%- match entry.out_initializer %}
+{%- when CSharpSyncCallbackOutInitializerPlan::Void %}
+{%- when CSharpSyncCallbackOutInitializerPlan::Direct with { default_value } %}
+                __boltffiOutPtr = {{ default_value }};
+{%- when CSharpSyncCallbackOutInitializerPlan::Encoded %}
+                __boltffiOutPtr = IntPtr.Zero;
+                __boltffiOutLen = UIntPtr.Zero;
+{%- endmatch %}
+                __boltffiStatus = new FfiStatus { code = 100 };
+            }
+        }
+{%- when CSharpCallbackEntryPlan::Async with (entry) %}
+        private static void {{ method.name }}({{ entry.native_params }})
+        {
+            if (!Handles.TryGetValue(handle, out var impl_))
+            {
+{%- match entry.invalid_handle_completion %}
+{%- when CSharpAsyncCallbackFailurePlan::Void %}
+                callback(callbackData, new FfiStatus { code = 100 });
+{%- when CSharpAsyncCallbackFailurePlan::Direct with { default_value } %}
+                callback(callbackData, {{ default_value }}, new FfiStatus { code = 100 });
+{%- when CSharpAsyncCallbackFailurePlan::Encoded %}
+                callback(callbackData, IntPtr.Zero, UIntPtr.Zero, new FfiStatus { code = 100 });
+{%- endmatch %}
+                return;
+            }
+            try
+            {
+{%- for param in entry.bridge_params %}
+{%- match param %}
+{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
+{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
+                var {{ reader_local }} = new WireReader({{ native_ptr_param.name }}, {{ native_len_param.name }});
+{%- endmatch %}
+{%- endfor %}
+                var __boltffiTask = impl_.{{ method.name }}({{ entry.decoded_args }});
+                _ = __boltffiTask.ContinueWith(__boltffiCompleted =>
+                {
+                    if (__boltffiCompleted.IsCanceled)
+                    {
+{%- match entry.canceled_completion %}
+{%- when CSharpAsyncCallbackFailurePlan::Void %}
+                        callback(callbackData, new FfiStatus { code = 100 });
+{%- when CSharpAsyncCallbackFailurePlan::Direct with { default_value } %}
+                        callback(callbackData, {{ default_value }}, new FfiStatus { code = 100 });
+{%- when CSharpAsyncCallbackFailurePlan::Encoded %}
+                        callback(callbackData, IntPtr.Zero, UIntPtr.Zero, new FfiStatus { code = 100 });
+{%- endmatch %}
+                        return;
+                    }
+                    if (__boltffiCompleted.IsFaulted)
+                    {
+                        Exception __boltffiException = UnwrapTaskException(__boltffiCompleted.Exception!);
+{%- match entry.faulted_completion %}
+{%- when CSharpAsyncCallbackFaultPlan::Failure with (failure) %}
+{%- match failure %}
+{%- when CSharpAsyncCallbackFailurePlan::Void %}
+                        callback(callbackData, new FfiStatus { code = 100 });
+{%- when CSharpAsyncCallbackFailurePlan::Direct with { default_value } %}
+                        callback(callbackData, {{ default_value }}, new FfiStatus { code = 100 });
+{%- when CSharpAsyncCallbackFailurePlan::Encoded %}
+                        callback(callbackData, IntPtr.Zero, UIntPtr.Zero, new FfiStatus { code = 100 });
+{%- endmatch %}
+{%- when CSharpAsyncCallbackFaultPlan::EncodedResult with { exception_type, error_value_expr, result_type, writer, fallback } %}
+{%- if let Some(exception_type) = exception_type %}
+                        if (__boltffiException is {{ exception_type }} __boltffiTypedException)
+                        {
+{%- else %}
+                        {
+{%- endif %}
+                            var __boltffiErrorResult = {{ result_type }}.Err({{ error_value_expr }});
+                            byte[] {{ writer.bytes_binding_name }};
+                            using (var {{ writer.binding_name }} = new WireWriter({{ writer.size_expr }}))
+                            {
+{%- for stmt in writer.encode_stmts %}
+                                {{ stmt }};
+{%- endfor %}
+                                {{ writer.bytes_binding_name }} = {{ writer.binding_name }}.ToArray();
+                            }
+                            BoltFFICallbackReturn.Store({{ writer.bytes_binding_name }}, out var __boltffiErrorOutPtr, out var __boltffiErrorOutLen);
+                            try
+                            {
+                                callback(callbackData, __boltffiErrorOutPtr, __boltffiErrorOutLen, new FfiStatus { code = 0 });
+                            }
+                            finally
+                            {
+                                BoltFFICallbackReturn.Free(__boltffiErrorOutPtr);
+                            }
+                            return;
+                        }
+{%- if let Some(fallback) = fallback %}
+{%- match fallback %}
+{%- when CSharpAsyncCallbackFailurePlan::Void %}
+                        callback(callbackData, new FfiStatus { code = 100 });
+{%- when CSharpAsyncCallbackFailurePlan::Direct with { default_value } %}
+                        callback(callbackData, {{ default_value }}, new FfiStatus { code = 100 });
+{%- when CSharpAsyncCallbackFailurePlan::Encoded %}
+                        callback(callbackData, IntPtr.Zero, UIntPtr.Zero, new FfiStatus { code = 100 });
+{%- endmatch %}
+{%- endif %}
+{%- endmatch %}
+                        return;
+                    }
+{%- match entry.success_completion %}
+{%- when CSharpAsyncCallbackSuccessPlan::Void %}
+                    callback(callbackData, new FfiStatus { code = 0 });
+{%- when CSharpAsyncCallbackSuccessPlan::Direct with { native_value_expr } %}
+                    callback(callbackData, {{ native_value_expr }}, new FfiStatus { code = 0 });
+{%- when CSharpAsyncCallbackSuccessPlan::Encoded with { is_result, result_type, writer } %}
+{%- if is_result %}
+                    var __boltffiResult = {{ result_type }}.Ok(__boltffiCompleted.Result);
+{%- else %}
+                    var __boltffiValue = __boltffiCompleted.Result;
+{%- endif %}
+                    byte[] {{ writer.bytes_binding_name }};
+                    using (var {{ writer.binding_name }} = new WireWriter({{ writer.size_expr }}))
+                    {
+{%- for stmt in writer.encode_stmts %}
+                        {{ stmt }};
+{%- endfor %}
+                        {{ writer.bytes_binding_name }} = {{ writer.binding_name }}.ToArray();
+                    }
+                    BoltFFICallbackReturn.Store({{ writer.bytes_binding_name }}, out var __boltffiOutPtr, out var __boltffiOutLen);
+                    try
+                    {
+                        callback(callbackData, __boltffiOutPtr, __boltffiOutLen, new FfiStatus { code = 0 });
+                    }
+                    finally
+                    {
+                        BoltFFICallbackReturn.Free(__boltffiOutPtr);
+                    }
+{%- endmatch %}
+                }, global::System.Threading.Tasks.TaskScheduler.Default);
+            }
+            catch
+            {
+{%- match entry.catch_completion %}
+{%- when CSharpAsyncCallbackFailurePlan::Void %}
+                callback(callbackData, new FfiStatus { code = 100 });
+{%- when CSharpAsyncCallbackFailurePlan::Direct with { default_value } %}
+                callback(callbackData, {{ default_value }}, new FfiStatus { code = 100 });
+{%- when CSharpAsyncCallbackFailurePlan::Encoded %}
+                callback(callbackData, IntPtr.Zero, UIntPtr.Zero, new FfiStatus { code = 100 });
+{%- endmatch %}
+            }
+        }
+{%- endmatch %}
 {% endfor %}
         private sealed class Proxy : {{ callback.public_name }}
         {
@@ -88,7 +287,140 @@
             }
 
 {% for method in callback.methods %}
-{{ method.proxy_source }}
+{%- match method.proxy %}
+{%- when CSharpCallbackProxyPlan::AsyncUnsupported with { public_params, return_type, result_type, not_supported_expr } %}
+{%- match result_type %}
+{%- when Some with (ty) %}
+            public {{ return_type }} {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException<{{ ty }}>({{ not_supported_expr }});
+{%- when None %}
+            public {{ return_type }} {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException({{ not_supported_expr }});
+{%- endmatch %}
+{%- when CSharpCallbackProxyPlan::Sync with (proxy) %}
+            public {{ proxy.return_type }} {{ method.name }}({{ proxy.public_params }})
+            {
+                if (_handle.IsNull) throw new ObjectDisposedException(nameof(Proxy));
+                VTable __boltffiTable = Marshal.PtrToStructure<VTable>(_handle.vtable);
+                var __boltffiInvoke = Marshal.GetDelegateForFunctionPointer<{{ method.name }}ProxyFn>(__boltffiTable.{{ method.vtable_field }});
+{%- for param in proxy.bridge_params %}
+{%- match param %}
+{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
+{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
+                byte[] {{ writer.bytes_binding_name }};
+                using (var {{ writer.binding_name }} = new WireWriter({{ writer.size_expr }}))
+                {
+{%- for stmt in writer.encode_stmts %}
+                    {{ stmt }};
+{%- endfor %}
+                    {{ writer.bytes_binding_name }} = {{ writer.binding_name }}.ToArray();
+                }
+                GCHandle {{ pin_local }} = default;
+                IntPtr {{ ptr_local }} = IntPtr.Zero;
+{%- endmatch %}
+{%- endfor %}
+{%- if proxy.has_cleanup %}
+                try
+                {
+{%- for param in proxy.bridge_params %}
+{%- match param %}
+{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
+{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
+                    if ({{ writer.bytes_binding_name }}.Length != 0)
+                    {
+                        {{ pin_local }} = GCHandle.Alloc({{ writer.bytes_binding_name }}, GCHandleType.Pinned);
+                        {{ ptr_local }} = {{ pin_local }}.AddrOfPinnedObject();
+                    }
+{%- endmatch %}
+{%- endfor %}
+{%- match proxy.call %}
+{%- when CSharpCallbackProxyCallPlan::Void with { args } %}
+                    FfiStatus __boltffiStatus;
+                    __boltffiInvoke({{ args }}, out __boltffiStatus);
+                    ThrowIfCallbackStatus(__boltffiStatus);
+{%- when CSharpCallbackProxyCallPlan::Direct with { args, native_out_type, public_expr } %}
+                    {{ native_out_type }} __boltffiOutPtr;
+                    FfiStatus __boltffiStatus;
+                    __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiStatus);
+                    ThrowIfCallbackStatus(__boltffiStatus);
+                    return {{ public_expr }};
+{%- when CSharpCallbackProxyCallPlan::Encoded with { args, decode_expr, result_decode_lines } %}
+                    IntPtr __boltffiOutPtr;
+                    UIntPtr __boltffiOutLen;
+                    FfiStatus __boltffiStatus;
+                    __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiOutLen, out __boltffiStatus);
+                    try
+                    {
+                        ThrowIfCallbackStatus(__boltffiStatus);
+                        var __boltffiReader = new WireReader(__boltffiOutPtr, __boltffiOutLen);
+{%- for line in result_decode_lines %}
+                        {{ line }}
+{%- endfor %}
+{%- if let Some(expr) = decode_expr %}
+                        return {{ expr }};
+{%- endif %}
+                    }
+                    finally
+                    {
+                        BoltFFICallbackReturn.Free(__boltffiOutPtr);
+                    }
+{%- endmatch %}
+                }
+                finally
+                {
+{%- for param in proxy.bridge_params %}
+{%- match param %}
+{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
+{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
+                    if ({{ pin_local }}.IsAllocated) {{ pin_local }}.Free();
+{%- endmatch %}
+{%- endfor %}
+                }
+{%- else %}
+{%- for param in proxy.bridge_params %}
+{%- match param %}
+{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
+{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
+                if ({{ writer.bytes_binding_name }}.Length != 0)
+                {
+                    {{ pin_local }} = GCHandle.Alloc({{ writer.bytes_binding_name }}, GCHandleType.Pinned);
+                    {{ ptr_local }} = {{ pin_local }}.AddrOfPinnedObject();
+                }
+{%- endmatch %}
+{%- endfor %}
+{%- match proxy.call %}
+{%- when CSharpCallbackProxyCallPlan::Void with { args } %}
+                FfiStatus __boltffiStatus;
+                __boltffiInvoke({{ args }}, out __boltffiStatus);
+                ThrowIfCallbackStatus(__boltffiStatus);
+{%- when CSharpCallbackProxyCallPlan::Direct with { args, native_out_type, public_expr } %}
+                {{ native_out_type }} __boltffiOutPtr;
+                FfiStatus __boltffiStatus;
+                __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiStatus);
+                ThrowIfCallbackStatus(__boltffiStatus);
+                return {{ public_expr }};
+{%- when CSharpCallbackProxyCallPlan::Encoded with { args, decode_expr, result_decode_lines } %}
+                IntPtr __boltffiOutPtr;
+                UIntPtr __boltffiOutLen;
+                FfiStatus __boltffiStatus;
+                __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiOutLen, out __boltffiStatus);
+                try
+                {
+                    ThrowIfCallbackStatus(__boltffiStatus);
+                    var __boltffiReader = new WireReader(__boltffiOutPtr, __boltffiOutLen);
+{%- for line in result_decode_lines %}
+                    {{ line }}
+{%- endfor %}
+{%- if let Some(expr) = decode_expr %}
+                    return {{ expr }};
+{%- endif %}
+                }
+                finally
+                {
+                    BoltFFICallbackReturn.Free(__boltffiOutPtr);
+                }
+{%- endmatch %}
+{%- endif %}
+            }
+{%- endmatch %}
 {% endfor %}
         }
 
@@ -122,7 +454,20 @@
         private static readonly CloneFn CloneDelegate = Clone;
 
 {% for method in callback.methods %}
-{{ method.delegate_source }}
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void {{ method.name }}Fn({{ method.delegates.entry_params }});
+        private static readonly {{ method.name }}Fn {{ method.name }}Delegate = {{ method.name }};
+
+{%- if let Some(completion_params) = method.delegates.completion_params %}
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void {{ method.name }}Completion({{ completion_params }});
+
+{%- endif %}
+{%- if let Some(proxy_params) = method.delegates.proxy_params %}
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void {{ method.name }}ProxyFn({{ proxy_params }});
+
+{%- endif %}
 {% endfor %}
         [DllImport(NativeMethods.LibName, EntryPoint = "{{ callback.register_fn }}")]
         private static extern void RegisterNative(IntPtr vtable);

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_bridge.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_bridge.txt
@@ -83,11 +83,39 @@
                 var __boltffiValue = impl_.{{ method.name }}({{ decoded_args }});
                 __boltffiOutPtr = {{ native_value_expr }};
                 __boltffiStatus = new FfiStatus { code = 0 };
-{%- when CSharpSyncCallbackSuccessPlan::Encoded with { is_result, decoded_args, result_assignment_lines, writer } %}
-{%- if is_result %}
-{%- for line in result_assignment_lines %}
-                {{ line }}
-{%- endfor %}
+{%- when CSharpSyncCallbackSuccessPlan::Encoded with { is_result, decoded_args, result_assignment, writer } %}
+{%- if let Some(result_assignment) = result_assignment %}
+                BoltFFIResult<{{ result_assignment.result_type.ok_type }}, {{ result_assignment.result_type.err_type }}> __boltffiResult;
+                try
+                {
+{%- match result_assignment.ok %}
+{%- when CSharpCallbackResultOkPlan::Void with { receiver, method_name, args } %}
+                    {{ receiver }}.{{ method_name }}({{ args }});
+                    __boltffiResult = BoltFFIResult<{{ result_assignment.result_type.ok_type }}, {{ result_assignment.result_type.err_type }}>.Ok(default);
+{%- when CSharpCallbackResultOkPlan::Value with { receiver, method_name, args } %}
+                    __boltffiResult = BoltFFIResult<{{ result_assignment.result_type.ok_type }}, {{ result_assignment.result_type.err_type }}>.Ok({{ receiver }}.{{ method_name }}({{ args }}));
+{%- endmatch %}
+                }
+{%- match result_assignment.catch %}
+{%- when Some with (catch_plan) %}
+{%- match catch_plan %}
+{%- when CSharpCallbackResultCatchPlan::TypedException with { exception_type } %}
+                catch ({{ exception_type }} __boltffiException)
+                {
+                    __boltffiResult = BoltFFIResult<{{ result_assignment.result_type.ok_type }}, {{ result_assignment.result_type.err_type }}>.Err(__boltffiException.Error);
+                }
+{%- when CSharpCallbackResultCatchPlan::ExceptionMessage %}
+                catch (Exception __boltffiException)
+                {
+                    __boltffiResult = BoltFFIResult<{{ result_assignment.result_type.ok_type }}, {{ result_assignment.result_type.err_type }}>.Err(__boltffiException.Message);
+                }
+{%- endmatch %}
+{%- when None %}
+                catch
+                {
+                    throw;
+                }
+{%- endmatch %}
 {%- else %}
                 var __boltffiValue = impl_.{{ method.name }}({{ decoded_args }});
 {%- endif %}
@@ -175,7 +203,7 @@
 {%- else %}
                         {
 {%- endif %}
-                            var __boltffiErrorResult = {{ result_type }}.Err({{ error_value_expr }});
+                            var __boltffiErrorResult = BoltFFIResult<{{ result_type.ok_type }}, {{ result_type.err_type }}>.Err({{ error_value_expr }});
                             byte[] {{ writer.bytes_binding_name }};
                             using (var {{ writer.binding_name }} = new WireWriter({{ writer.size_expr }}))
                             {
@@ -215,7 +243,7 @@
                     callback(callbackData, {{ native_value_expr }}, new FfiStatus { code = 0 });
 {%- when CSharpAsyncCallbackSuccessPlan::Encoded with { is_result, result_type, writer } %}
 {%- if is_result %}
-                    var __boltffiResult = {{ result_type }}.Ok(__boltffiCompleted.Result);
+                    var __boltffiResult = BoltFFIResult<{{ result_type.ok_type }}, {{ result_type.err_type }}>.Ok(__boltffiCompleted.Result);
 {%- else %}
                     var __boltffiValue = __boltffiCompleted.Result;
 {%- endif %}
@@ -288,12 +316,12 @@
 
 {% for method in callback.methods %}
 {%- match method.proxy %}
-{%- when CSharpCallbackProxyPlan::AsyncUnsupported with { public_params, return_type, result_type, not_supported_expr } %}
+{%- when CSharpCallbackProxyPlan::AsyncUnsupported with { public_params, result_type, not_supported_expr } %}
 {%- match result_type %}
 {%- when Some with (ty) %}
-            public {{ return_type }} {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException<{{ ty }}>({{ not_supported_expr }});
+            public {{ method.public_return_type() }} {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException<{{ ty }}>({{ not_supported_expr }});
 {%- when None %}
-            public {{ return_type }} {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException({{ not_supported_expr }});
+            public {{ method.public_return_type() }} {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException({{ not_supported_expr }});
 {%- endmatch %}
 {%- when CSharpCallbackProxyPlan::Sync with (proxy) %}
             public {{ proxy.return_type }} {{ method.name }}({{ proxy.public_params }})
@@ -342,7 +370,7 @@
                     __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiStatus);
                     ThrowIfCallbackStatus(__boltffiStatus);
                     return {{ public_expr }};
-{%- when CSharpCallbackProxyCallPlan::Encoded with { args, decode_expr, result_decode_lines } %}
+{%- when CSharpCallbackProxyCallPlan::Encoded with { args, decode_expr, result_decode } %}
                     IntPtr __boltffiOutPtr;
                     UIntPtr __boltffiOutLen;
                     FfiStatus __boltffiStatus;
@@ -351,9 +379,15 @@
                     {
                         ThrowIfCallbackStatus(__boltffiStatus);
                         var __boltffiReader = new WireReader(__boltffiOutPtr, __boltffiOutLen);
-{%- for line in result_decode_lines %}
-                        {{ line }}
-{%- endfor %}
+{%- if let Some(result_decode) = result_decode %}
+                        if (__boltffiReader.ReadU8() != 0)
+                        {
+                            throw new InvalidOperationException({{ result_decode.err_expr }}.ToString());
+                        }
+{%- if let Some(ok_expr) = result_decode.ok_expr %}
+                        return {{ ok_expr }};
+{%- endif %}
+{%- endif %}
 {%- if let Some(expr) = decode_expr %}
                         return {{ expr }};
 {%- endif %}
@@ -397,7 +431,7 @@
                 __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiStatus);
                 ThrowIfCallbackStatus(__boltffiStatus);
                 return {{ public_expr }};
-{%- when CSharpCallbackProxyCallPlan::Encoded with { args, decode_expr, result_decode_lines } %}
+{%- when CSharpCallbackProxyCallPlan::Encoded with { args, decode_expr, result_decode } %}
                 IntPtr __boltffiOutPtr;
                 UIntPtr __boltffiOutLen;
                 FfiStatus __boltffiStatus;
@@ -406,9 +440,15 @@
                 {
                     ThrowIfCallbackStatus(__boltffiStatus);
                     var __boltffiReader = new WireReader(__boltffiOutPtr, __boltffiOutLen);
-{%- for line in result_decode_lines %}
-                    {{ line }}
-{%- endfor %}
+{%- if let Some(result_decode) = result_decode %}
+                    if (__boltffiReader.ReadU8() != 0)
+                    {
+                        throw new InvalidOperationException({{ result_decode.err_expr }}.ToString());
+                    }
+{%- if let Some(ok_expr) = result_decode.ok_expr %}
+                    return {{ ok_expr }};
+{%- endif %}
+{%- endif %}
 {%- if let Some(expr) = decode_expr %}
                     return {{ expr }};
 {%- endif %}

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_interface.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_interface.txt
@@ -1,6 +1,6 @@
     public interface {{ callback.public_name }}
     {
 {% for method in callback.methods %}
-        {{ method.public_return_type() }} {{ method.name }}({% for param in method.public_params %}{{ param.csharp_type }} {{ param.name }}{% if !loop.last %}, {% endif %}{% endfor %});
+        {% if method.is_async %}{% if method.return_type.is_void() %}global::System.Threading.Tasks.Task{% else %}global::System.Threading.Tasks.Task<{{ method.return_type }}>{% endif %}{% else %}{{ method.return_type }}{% endif %} {{ method.name }}({% for param in method.public_params %}{{ param.csharp_type }} {{ param.name }}{% if !loop.last %}, {% endif %}{% endfor %});
 {% endfor %}
     }

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_interface.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_interface.txt
@@ -1,0 +1,6 @@
+    public interface {{ callback.public_name }}
+    {
+{% for method in callback.methods %}
+        {{ method.public_return_type() }} {{ method.name }}({% for param in method.public_params %}{{ param.csharp_type }} {{ param.name }}{% if !loop.last %}, {% endif %}{% endfor %});
+{% endfor %}
+    }

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_proxy.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/callback_proxy.txt
@@ -1,0 +1,188 @@
+    public sealed class {{ callback.proxy_name }} : {{ callback.public_name }}, global::System.IDisposable
+    {
+        private BoltFFICallbackHandle _handle;
+
+        internal {{ callback.proxy_name }}(BoltFFICallbackHandle handle)
+        {
+            _handle = handle;
+        }
+
+        ~{{ callback.proxy_name }}()
+        {
+            Release();
+        }
+
+        public void Dispose()
+        {
+            Release();
+            global::System.GC.SuppressFinalize(this);
+        }
+
+        internal BoltFFICallbackHandle CloneHandle()
+        {
+            if (_handle.IsNull) return BoltFFICallbackHandle.Null;
+            {{ callback.bridge_name }}.VTable table = Marshal.PtrToStructure<{{ callback.bridge_name }}.VTable>(_handle.vtable);
+            var clone = Marshal.GetDelegateForFunctionPointer<{{ callback.bridge_name }}.CloneFn>(table.clone);
+            ulong cloned = clone(_handle.handle);
+            return cloned == 0 ? BoltFFICallbackHandle.Null : new BoltFFICallbackHandle { handle = cloned, vtable = _handle.vtable };
+        }
+
+        private void Release()
+        {
+            if (_handle.IsNull) return;
+            {{ callback.bridge_name }}.VTable table = Marshal.PtrToStructure<{{ callback.bridge_name }}.VTable>(_handle.vtable);
+            var free = Marshal.GetDelegateForFunctionPointer<{{ callback.bridge_name }}.FreeFn>(table.free);
+            ulong handle = _handle.handle;
+            _handle = BoltFFICallbackHandle.Null;
+            free(handle);
+        }
+
+{% for method in callback.methods %}
+{%- match method.proxy %}
+{%- when CSharpCallbackProxyPlan::AsyncUnsupported with { public_params, result_type } %}
+{%- match result_type %}
+{%- when Some with (ty) %}
+        public global::System.Threading.Tasks.Task<{{ method.return_type }}> {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException<{{ ty }}>(new NotSupportedException("async callback proxies are not implemented for C# yet"));
+{%- when None %}
+        public global::System.Threading.Tasks.Task {{ method.name }}({{ public_params }}) => global::System.Threading.Tasks.Task.FromException(new NotSupportedException("async callback proxies are not implemented for C# yet"));
+{%- endmatch %}
+{%- when CSharpCallbackProxyPlan::Sync with (proxy) %}
+        public {{ proxy.return_type }} {{ method.name }}({{ proxy.public_params }})
+        {
+            if (_handle.IsNull) throw new ObjectDisposedException(nameof({{ callback.proxy_name }}));
+            {{ callback.bridge_name }}.VTable __boltffiTable = Marshal.PtrToStructure<{{ callback.bridge_name }}.VTable>(_handle.vtable);
+            var __boltffiInvoke = Marshal.GetDelegateForFunctionPointer<{{ callback.bridge_name }}.{{ method.name }}ProxyFn>(__boltffiTable.{{ method.vtable_field }});
+{%- for param in proxy.bridge_params %}
+{%- match param %}
+{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
+{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
+            byte[] {{ writer.bytes_binding_name }};
+            using (var {{ writer.binding_name }} = new WireWriter({{ writer.size_expr }}))
+            {
+{%- for stmt in writer.encode_stmts %}
+                {{ stmt }};
+{%- endfor %}
+                {{ writer.bytes_binding_name }} = {{ writer.binding_name }}.ToArray();
+            }
+            GCHandle {{ pin_local }} = default;
+            IntPtr {{ ptr_local }} = IntPtr.Zero;
+{%- endmatch %}
+{%- endfor %}
+{%- if proxy.has_cleanup %}
+            try
+            {
+{%- for param in proxy.bridge_params %}
+{%- match param %}
+{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
+{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
+                if ({{ writer.bytes_binding_name }}.Length != 0)
+                {
+                    {{ pin_local }} = GCHandle.Alloc({{ writer.bytes_binding_name }}, GCHandleType.Pinned);
+                    {{ ptr_local }} = {{ pin_local }}.AddrOfPinnedObject();
+                }
+{%- endmatch %}
+{%- endfor %}
+{%- match proxy.call %}
+{%- when CSharpCallbackProxyCallPlan::Void with { args } %}
+                FfiStatus __boltffiStatus;
+                __boltffiInvoke({{ args }}, out __boltffiStatus);
+                {{ callback.bridge_name }}.ThrowIfCallbackStatus(__boltffiStatus);
+{%- when CSharpCallbackProxyCallPlan::Direct with { args, native_out_type, public_expr } %}
+                {{ native_out_type }} __boltffiOutPtr;
+                FfiStatus __boltffiStatus;
+                __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiStatus);
+                {{ callback.bridge_name }}.ThrowIfCallbackStatus(__boltffiStatus);
+                return {{ public_expr }};
+{%- when CSharpCallbackProxyCallPlan::Encoded with { args, decode_expr, result_decode } %}
+                IntPtr __boltffiOutPtr;
+                UIntPtr __boltffiOutLen;
+                FfiStatus __boltffiStatus;
+                __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiOutLen, out __boltffiStatus);
+                try
+                {
+                    {{ callback.bridge_name }}.ThrowIfCallbackStatus(__boltffiStatus);
+                    var __boltffiReader = new WireReader(__boltffiOutPtr, __boltffiOutLen);
+{%- if let Some(result_decode) = result_decode %}
+                    if (__boltffiReader.ReadU8() != 0)
+                    {
+                        throw new InvalidOperationException({{ result_decode.err_expr }}.ToString());
+                    }
+{%- if let Some(ok_expr) = result_decode.ok_expr %}
+                    return {{ ok_expr }};
+{%- endif %}
+{%- endif %}
+{%- if let Some(expr) = decode_expr %}
+                    return {{ expr }};
+{%- endif %}
+                }
+                finally
+                {
+                    BoltFFICallbackReturn.Free(__boltffiOutPtr);
+                }
+{%- endmatch %}
+            }
+            finally
+            {
+{%- for param in proxy.bridge_params %}
+{%- match param %}
+{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
+{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
+                if ({{ pin_local }}.IsAllocated) {{ pin_local }}.Free();
+{%- endmatch %}
+{%- endfor %}
+            }
+{%- else %}
+{%- for param in proxy.bridge_params %}
+{%- match param %}
+{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
+{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
+            if ({{ writer.bytes_binding_name }}.Length != 0)
+            {
+                {{ pin_local }} = GCHandle.Alloc({{ writer.bytes_binding_name }}, GCHandleType.Pinned);
+                {{ ptr_local }} = {{ pin_local }}.AddrOfPinnedObject();
+            }
+{%- endmatch %}
+{%- endfor %}
+{%- match proxy.call %}
+{%- when CSharpCallbackProxyCallPlan::Void with { args } %}
+            FfiStatus __boltffiStatus;
+            __boltffiInvoke({{ args }}, out __boltffiStatus);
+            {{ callback.bridge_name }}.ThrowIfCallbackStatus(__boltffiStatus);
+{%- when CSharpCallbackProxyCallPlan::Direct with { args, native_out_type, public_expr } %}
+            {{ native_out_type }} __boltffiOutPtr;
+            FfiStatus __boltffiStatus;
+            __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiStatus);
+            {{ callback.bridge_name }}.ThrowIfCallbackStatus(__boltffiStatus);
+            return {{ public_expr }};
+{%- when CSharpCallbackProxyCallPlan::Encoded with { args, decode_expr, result_decode } %}
+            IntPtr __boltffiOutPtr;
+            UIntPtr __boltffiOutLen;
+            FfiStatus __boltffiStatus;
+            __boltffiInvoke({{ args }}, out __boltffiOutPtr, out __boltffiOutLen, out __boltffiStatus);
+            try
+            {
+                {{ callback.bridge_name }}.ThrowIfCallbackStatus(__boltffiStatus);
+                var __boltffiReader = new WireReader(__boltffiOutPtr, __boltffiOutLen);
+{%- if let Some(result_decode) = result_decode %}
+                if (__boltffiReader.ReadU8() != 0)
+                {
+                    throw new InvalidOperationException({{ result_decode.err_expr }}.ToString());
+                }
+{%- if let Some(ok_expr) = result_decode.ok_expr %}
+                return {{ ok_expr }};
+{%- endif %}
+{%- endif %}
+{%- if let Some(expr) = decode_expr %}
+                return {{ expr }};
+{%- endif %}
+            }
+            finally
+            {
+                BoltFFICallbackReturn.Free(__boltffiOutPtr);
+            }
+{%- endmatch %}
+{%- endif %}
+        }
+{%- endmatch %}
+{% endfor %}
+    }

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/closure_bridge.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/closure_bridge.txt
@@ -1,0 +1,43 @@
+    internal static unsafe class {{ closure.bridge_name }}
+    {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+{% if closure.method.marshals_return_bool %}
+        [return: MarshalAs(UnmanagedType.I1)]
+{% endif %}
+        internal delegate {{ closure.method.native_return_type }} NativeInvoke({% for decl in closure.method.native_decls %}{{ decl }}{% if !loop.last %}, {% endif %}{% endfor %});
+
+        private static readonly NativeInvoke InvokeDelegate = Invoke;
+
+        internal static Scope Pin({{ closure.public_name }} impl_) => new(impl_);
+
+        internal sealed class Scope : IDisposable
+        {
+            private GCHandle _handle;
+            private bool _disposed;
+
+            internal Scope({{ closure.public_name }} impl_)
+            {
+                _handle = GCHandle.Alloc(impl_);
+                Function = InvokeDelegate;
+                Context = GCHandle.ToIntPtr(_handle);
+            }
+
+            internal NativeInvoke Function { get; }
+            internal IntPtr Context { get; }
+
+            public void Dispose()
+            {
+                if (_disposed) return;
+                _disposed = true;
+                if (_handle.IsAllocated) _handle.Free();
+            }
+        }
+
+        private static {{ closure.method.native_return_type }} Invoke({% for decl in closure.method.native_decls %}{{ decl }}{% if !loop.last %}, {% endif %}{% endfor %})
+        {
+            var impl_ = ({{ closure.public_name }})((GCHandle)context).Target!;
+{% for line in closure.method.decode_setup %}
+            {{ line }}
+{% endfor %}
+{{ closure.method.invoke_body }}        }
+    }

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/closure_bridge.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/closure_bridge.txt
@@ -4,7 +4,7 @@
 {% if closure.method.marshals_return_bool %}
         [return: MarshalAs(UnmanagedType.I1)]
 {% endif %}
-        internal delegate {{ closure.method.native_return_type }} NativeInvoke({% for decl in closure.method.native_decls %}{{ decl }}{% if !loop.last %}, {% endif %}{% endfor %});
+        internal delegate {{ closure.method.native_return_type }} NativeInvoke({{ closure.method.native_params }});
 
         private static readonly NativeInvoke InvokeDelegate = Invoke;
 
@@ -33,11 +33,39 @@
             }
         }
 
-        private static {{ closure.method.native_return_type }} Invoke({% for decl in closure.method.native_decls %}{{ decl }}{% if !loop.last %}, {% endif %}{% endfor %})
+        private static {{ closure.method.native_return_type }} Invoke({{ closure.method.native_params }})
         {
             var impl_ = ({{ closure.public_name }})((GCHandle)context).Target!;
-{% for line in closure.method.decode_setup %}
+{%- for param in closure.method.bridge_params %}
+{%- match param %}
+{%- when CSharpCallbackBridgeParamPlan::Direct with { public_param, native_param, decoded_arg, proxy_arg } %}
+{%- when CSharpCallbackBridgeParamPlan::WireEncoded with { public_param, native_ptr_param, native_len_param, reader_local, decoded_arg, writer, pin_local, ptr_local } %}
+            var {{ reader_local }} = new WireReader({{ native_ptr_param.name }}, {{ native_len_param.name }});
+{%- endmatch %}
+{%- endfor %}
+{%- match closure.method.invoke %}
+{%- when CSharpClosureInvokePlan::Void with { decoded_args } %}
+            impl_({{ decoded_args }});
+{%- when CSharpClosureInvokePlan::Direct with { decoded_args, native_value_expr } %}
+            var __boltffiValue = impl_({{ decoded_args }});
+            return {{ native_value_expr }};
+{%- when CSharpClosureInvokePlan::Encoded with { is_result, decoded_args, result_assignment_lines, writer } %}
+{%- if is_result %}
+{%- for line in result_assignment_lines %}
             {{ line }}
-{% endfor %}
-{{ closure.method.invoke_body }}        }
+{%- endfor %}
+{%- else %}
+            var __boltffiValue = impl_({{ decoded_args }});
+{%- endif %}
+            byte[] {{ writer.bytes_binding_name }};
+            using (var {{ writer.binding_name }} = new WireWriter({{ writer.size_expr }}))
+            {
+{%- for stmt in writer.encode_stmts %}
+                {{ stmt }};
+{%- endfor %}
+                {{ writer.bytes_binding_name }} = {{ writer.binding_name }}.ToArray();
+            }
+            return FfiBuf.FromBytes({{ writer.bytes_binding_name }});
+{%- endmatch %}
+        }
     }

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/closure_bridge.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/closure_bridge.txt
@@ -49,11 +49,39 @@
 {%- when CSharpClosureInvokePlan::Direct with { decoded_args, native_value_expr } %}
             var __boltffiValue = impl_({{ decoded_args }});
             return {{ native_value_expr }};
-{%- when CSharpClosureInvokePlan::Encoded with { is_result, decoded_args, result_assignment_lines, writer } %}
-{%- if is_result %}
-{%- for line in result_assignment_lines %}
-            {{ line }}
-{%- endfor %}
+{%- when CSharpClosureInvokePlan::Encoded with { is_result, decoded_args, result_assignment, writer } %}
+{%- if let Some(result_assignment) = result_assignment %}
+            BoltFFIResult<{{ result_assignment.result_type.ok_type }}, {{ result_assignment.result_type.err_type }}> __boltffiResult;
+            try
+            {
+{%- match result_assignment.ok %}
+{%- when CSharpCallbackResultOkPlan::Void with { receiver, method_name, args } %}
+                {{ receiver }}.{{ method_name }}({{ args }});
+                __boltffiResult = BoltFFIResult<{{ result_assignment.result_type.ok_type }}, {{ result_assignment.result_type.err_type }}>.Ok(default);
+{%- when CSharpCallbackResultOkPlan::Value with { receiver, method_name, args } %}
+                __boltffiResult = BoltFFIResult<{{ result_assignment.result_type.ok_type }}, {{ result_assignment.result_type.err_type }}>.Ok({{ receiver }}.{{ method_name }}({{ args }}));
+{%- endmatch %}
+            }
+{%- match result_assignment.catch %}
+{%- when Some with (catch_plan) %}
+{%- match catch_plan %}
+{%- when CSharpCallbackResultCatchPlan::TypedException with { exception_type } %}
+            catch ({{ exception_type }} __boltffiException)
+            {
+                __boltffiResult = BoltFFIResult<{{ result_assignment.result_type.ok_type }}, {{ result_assignment.result_type.err_type }}>.Err(__boltffiException.Error);
+            }
+{%- when CSharpCallbackResultCatchPlan::ExceptionMessage %}
+            catch (Exception __boltffiException)
+            {
+                __boltffiResult = BoltFFIResult<{{ result_assignment.result_type.ok_type }}, {{ result_assignment.result_type.err_type }}>.Err(__boltffiException.Message);
+            }
+{%- endmatch %}
+{%- when None %}
+            catch
+            {
+                throw;
+            }
+{%- endmatch %}
 {%- else %}
             var __boltffiValue = impl_({{ decoded_args }});
 {%- endif %}

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/closure_bridge.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/closure_bridge.txt
@@ -1,9 +1,9 @@
     internal static unsafe class {{ closure.bridge_name }}
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-{% if closure.method.marshals_return_bool %}
+{%- if closure.method.native_return_type.is_bool() %}
         [return: MarshalAs(UnmanagedType.I1)]
-{% endif %}
+{%- endif %}
         internal delegate {{ closure.method.native_return_type }} NativeInvoke({{ closure.method.native_params }});
 
         private static readonly NativeInvoke InvokeDelegate = Invoke;

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/closure_delegate.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/closure_delegate.txt
@@ -1,0 +1,1 @@
+    public delegate {{ closure.method.return_type }} {{ closure.public_name }}({% for param in closure.method.public_params %}{{ param.csharp_type }} {{ param.name }}{% if !loop.last %}, {% endif %}{% endfor %});

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
@@ -1,4 +1,4 @@
-{%- if module.has_async() %}
+{%- if module.needs_ffi_status() %}
     [StructLayout(LayoutKind.Sequential)]
     internal struct FfiStatus
     {
@@ -14,6 +14,24 @@
         public UIntPtr len;
         public UIntPtr cap;
         public UIntPtr align;
+
+        internal static unsafe FfiBuf FromBytes(byte[] bytes)
+        {
+            if (bytes.Length == 0)
+            {
+                return default;
+            }
+
+            void* allocated = NativeMemory.Alloc((nuint)bytes.Length);
+            Marshal.Copy(bytes, 0, (IntPtr)allocated, bytes.Length);
+            return new FfiBuf
+            {
+                ptr = (IntPtr)allocated,
+                len = (UIntPtr)bytes.Length,
+                cap = (UIntPtr)bytes.Length,
+                align = (UIntPtr)1,
+            };
+        }
     }
 
 {% endif %}
@@ -34,6 +52,13 @@
         {
             _ptr = buf.ptr;
             _length = buf.ptr == IntPtr.Zero ? 0 : checked((int)(nuint)buf.len);
+            _pos = 0;
+        }
+
+        internal WireReader(IntPtr ptr, UIntPtr len)
+        {
+            _ptr = ptr;
+            _length = ptr == IntPtr.Zero ? 0 : checked((int)(nuint)len);
             _pos = 0;
         }
 
@@ -477,6 +502,68 @@
     }
 
 {% endif %}
+{%- if module.needs_callback_runtime() %}
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct BoltFFICallbackHandle
+    {
+        public ulong handle;
+        public IntPtr vtable;
+
+        internal static BoltFFICallbackHandle Null => default;
+        internal bool IsNull => handle == 0 || vtable == IntPtr.Zero;
+    }
+
+    internal readonly struct BoltFFIUnit
+    {
+    }
+
+    internal readonly struct BoltFFIResult<TOk, TErr>
+    {
+        private readonly TOk _okValue;
+        private readonly TErr _errValue;
+
+        private BoltFFIResult(TOk okValue, TErr errValue, bool isOk)
+        {
+            _okValue = okValue;
+            _errValue = errValue;
+            IsOk = isOk;
+        }
+
+        internal bool IsOk { get; }
+        internal TOk OkValue => _okValue;
+        internal TErr ErrValue => _errValue;
+
+        internal static BoltFFIResult<TOk, TErr> Ok(TOk value) => new(value, default!, true);
+        internal static BoltFFIResult<TOk, TErr> Err(TErr value) => new(default!, value, false);
+    }
+
+    internal static class BoltFFICallbackReturn
+    {
+        internal static unsafe void Store(byte[] bytes, out IntPtr outPtr, out UIntPtr outLen)
+        {
+            if (bytes.Length == 0)
+            {
+                outPtr = IntPtr.Zero;
+                outLen = UIntPtr.Zero;
+                return;
+            }
+
+            void* allocated = NativeMemory.Alloc((nuint)bytes.Length);
+            Marshal.Copy(bytes, 0, (IntPtr)allocated, bytes.Length);
+            outPtr = (IntPtr)allocated;
+            outLen = (UIntPtr)bytes.Length;
+        }
+
+        internal static unsafe void Free(IntPtr ptr)
+        {
+            if (ptr != IntPtr.Zero)
+            {
+                NativeMemory.Free((void*)ptr);
+            }
+        }
+    }
+
+{% endif %}
 {%- if module.has_async() %}
     internal static class BoltFFIAsync
     {
@@ -723,7 +810,7 @@
 {% endif %}
     internal static class NativeMethods
     {
-        private const string LibName = "{{ module.lib_name }}";
+        internal const string LibName = "{{ module.lib_name }}";
 {%- if module.needs_ffi_buf() %}
 
         [DllImport(LibName, EntryPoint = "{{ module.free_buf_ffi_name }}")]

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -2056,7 +2056,9 @@ public static class DemoTest
             "InvokeTwoCallbacks local");
         Require(InvokeOptionalValueCallback(null, 4) == 4, "InvokeOptionalValueCallback null");
 
-        ValueCallback incrementer = MakeIncrementingCallback(5);
+        // Returned callbacks are owning proxies; `using` releases the native
+        // callback handle deterministically instead of waiting for finalization.
+        using ValueCallbackProxy incrementer = MakeIncrementingCallback(5);
         Require(InvokeValueCallback(incrementer, 4) == 9, "returned ValueCallback proxy");
 
         MessageFormatter formatter = new MessageFormatterImpl();
@@ -2064,7 +2066,8 @@ public static class DemoTest
             "FormatMessageWithCallback local");
         Require(FormatMessageWithOptionalCallback(null, "fallback", "message") == "fallback::message",
             "FormatMessageWithOptionalCallback null");
-        MessageFormatter prefixer = MakeMessagePrefixer("prefix");
+        // Same ownership contract for returned multi-method callback proxies.
+        using MessageFormatterProxy prefixer = MakeMessagePrefixer("prefix");
         Require(FormatMessageWithCallback(prefixer, "sync", "formatter") == "prefix::sync::formatter",
             "returned MessageFormatter proxy");
 

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -10,50 +10,58 @@ public static class DemoTest
 {
     public static async System.Threading.Tasks.Task<int> Main()
     {
-        Console.WriteLine("Testing C# bindings...\n");
-        TestBool();
-        TestI8();
-        TestU8();
-        TestI16();
-        TestU16();
-        TestI32();
-        TestU32();
-        TestI64();
-        TestU64();
-        TestF32();
-        TestF64();
-        TestUsize();
-        TestIsize();
-        TestStrings();
-        TestCustomTypes();
-        TestBlittableRecords();
-        TestRecordsWithStrings();
-        TestRecordsWithDefaults();
-        TestNestedRecords();
-        TestCStyleEnums();
-        TestDataEnums();
-        TestRecordsWithEnumFields();
-        TestPrimitiveVecs();
-        TestStringAndNestedVecs();
-        TestBlittableRecordVecs();
-        TestEnumVecs();
-        TestVecFields();
-        TestOptions();
-        TestOptionsInRecords();
-        TestOptionsWithVec();
-        TestClasses();
-        TestResultFunctions();
-        TestResultClassMethods();
-        TestResultEnumErrors();
-        await TestAsyncFunctions();
-        await TestAsyncResults();
-        await TestAsyncClassMethods();
-        await TestAsyncCancellation();
-        TestCallbackTraits();
-        TestClosures();
-        await TestAsyncCallbackTraits();
-        Console.WriteLine("All tests passed!");
-        return 0;
+        try
+        {
+            Console.WriteLine("Testing C# bindings...\n");
+            TestBool();
+            TestI8();
+            TestU8();
+            TestI16();
+            TestU16();
+            TestI32();
+            TestU32();
+            TestI64();
+            TestU64();
+            TestF32();
+            TestF64();
+            TestUsize();
+            TestIsize();
+            TestStrings();
+            TestCustomTypes();
+            TestBlittableRecords();
+            TestRecordsWithStrings();
+            TestRecordsWithDefaults();
+            TestNestedRecords();
+            TestCStyleEnums();
+            TestDataEnums();
+            TestRecordsWithEnumFields();
+            TestPrimitiveVecs();
+            TestStringAndNestedVecs();
+            TestBlittableRecordVecs();
+            TestEnumVecs();
+            TestVecFields();
+            TestOptions();
+            TestOptionsInRecords();
+            TestOptionsWithVec();
+            TestClasses();
+            TestResultFunctions();
+            TestResultClassMethods();
+            TestResultEnumErrors();
+            await TestAsyncFunctions();
+            await TestAsyncResults();
+            await TestAsyncClassMethods();
+            await TestAsyncCancellation();
+            TestCallbackTraits();
+            TestClosures();
+            await TestAsyncCallbackTraits();
+            Console.WriteLine("All tests passed!");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"FAIL: {ex}");
+            return 1;
+        }
     }
 
     private static void TestBool()

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -49,6 +49,9 @@ public static class DemoTest
         await TestAsyncResults();
         await TestAsyncClassMethods();
         await TestAsyncCancellation();
+        TestCallbackTraits();
+        TestClosures();
+        await TestAsyncCallbackTraits();
         Console.WriteLine("All tests passed!");
         return 0;
     }
@@ -2031,6 +2034,236 @@ public static class DemoTest
         catch (OperationCanceledException) { }
 
         Console.WriteLine("  PASS\n");
+    }
+
+    private static void TestCallbackTraits()
+    {
+        Console.WriteLine("Testing callback traits...");
+
+        ValueCallback doubler = new ValueCallbackImpl(v => v * 2);
+        Require(InvokeValueCallback(doubler, 4) == 8, "InvokeValueCallback local");
+        Require(InvokeValueCallbackTwice(doubler, 3, 4) == 14, "InvokeValueCallbackTwice local");
+        Require(InvokeBoxedValueCallback(doubler, 5) == 10, "InvokeBoxedValueCallback local");
+        Require(InvokeTwoCallbacks(doubler, new ValueCallbackImpl(v => v * 3), 5) == 25,
+            "InvokeTwoCallbacks local");
+        Require(InvokeOptionalValueCallback(null, 4) == 4, "InvokeOptionalValueCallback null");
+
+        ValueCallback incrementer = MakeIncrementingCallback(5);
+        Require(InvokeValueCallback(incrementer, 4) == 9, "returned ValueCallback proxy");
+
+        MessageFormatter formatter = new MessageFormatterImpl();
+        Require(FormatMessageWithCallback(formatter, "sync", "formatter") == "sync::formatter",
+            "FormatMessageWithCallback local");
+        Require(FormatMessageWithOptionalCallback(null, "fallback", "message") == "fallback::message",
+            "FormatMessageWithOptionalCallback null");
+        MessageFormatter prefixer = MakeMessagePrefixer("prefix");
+        Require(FormatMessageWithCallback(prefixer, "sync", "formatter") == "prefix::sync::formatter",
+            "returned MessageFormatter proxy");
+
+        Require(ProcessVec(new VecProcessorImpl(), new[] { 1, 2, 3 }).SequenceEqual(new[] { 2, 4, 6 }),
+            "ProcessVec callback");
+        Require(InvokeOptionCallback(new OptionCallbackImpl(), 7) == 70, "InvokeOptionCallback Some");
+        Require(InvokeOptionCallback(new OptionCallbackImpl(), 0) == null, "InvokeOptionCallback None");
+        Require(InvokeResultCallback(new ResultCallbackImpl(), 7) == 70, "InvokeResultCallback Ok");
+        try
+        {
+            InvokeResultCallback(new ResultCallbackImpl(), -1);
+            Require(false, "InvokeResultCallback Err should throw");
+        }
+        catch (MathErrorException e)
+        {
+            Require(e.Error == MathError.NegativeInput, "InvokeResultCallback Err type");
+        }
+
+        Require(InvokeOffsetCallback(new OffsetCallbackImpl(), (nint)(-5), (nuint)8) == (nint)3,
+            "InvokeOffsetCallback pointer-sized params");
+
+        using (var consumer = new DataConsumer())
+        {
+            consumer.SetProvider(new DataProviderImpl());
+            Require(consumer.ComputeSum() == 10UL, "stored DataProvider callback");
+        }
+
+        Console.WriteLine("  PASS\n");
+    }
+
+    private static void TestClosures()
+    {
+        Console.WriteLine("Testing closures...");
+
+        Require(ApplyClosure(v => v * 3, 4) == 12, "ApplyClosure");
+        Require(ApplyBinaryClosure((a, b) => a + b, 3, 4) == 7, "ApplyBinaryClosure");
+        int observed = 0;
+        ApplyVoidClosure(v => observed = v, 42);
+        Require(observed == 42, "ApplyVoidClosure");
+        Require(ApplyNullaryClosure(() => 7) == 7, "ApplyNullaryClosure");
+        Require(ApplyPointClosure(p => new Point(p.X + 1.0, p.Y + 2.0), new Point(3.0, 4.0))
+                == new Point(4.0, 6.0),
+            "ApplyPointClosure");
+        Require(ApplyStringClosure(s => s + "!", "hello") == "hello!", "ApplyStringClosure");
+        Require(!ApplyBoolClosure(v => !v, true), "ApplyBoolClosure");
+        Require(Math.Abs(ApplyF64Closure(v => v + 0.5, 1.25) - 1.75) < 1e-9, "ApplyF64Closure");
+        Require(MapVecWithClosure(v => v * 2, new[] { 1, 2, 3 }).SequenceEqual(new[] { 2, 4, 6 }),
+            "MapVecWithClosure");
+        Require(FilterVecWithClosure(v => v > 1, new[] { 0, 1, 2, 3 }).SequenceEqual(new[] { 2, 3 }),
+            "FilterVecWithClosure");
+        Require(ApplyOffsetClosure((value, delta) => value + (nint)delta, (nint)10, (nuint)4) == (nint)14,
+            "ApplyOffsetClosure");
+        Require(ApplyStatusClosure(status => status == Status.Active ? Status.Inactive : Status.Active,
+                Status.Active) == Status.Inactive,
+            "ApplyStatusClosure");
+        Require(ApplyOptionalPointClosure(point => point is null ? null : new Point(point.Value.X + 1.0, point.Value.Y),
+                new Point(1.0, 2.0)) == new Point(2.0, 2.0),
+            "ApplyOptionalPointClosure Some");
+        Require(ApplyOptionalPointClosure(point => point, null) == null, "ApplyOptionalPointClosure None");
+        Require(ApplyResultClosure(v => v * 2, 6) == 12, "ApplyResultClosure Ok");
+        try
+        {
+            ApplyResultClosure(_ => throw new MathErrorException(MathError.NegativeInput), 6);
+            Require(false, "ApplyResultClosure Err should throw");
+        }
+        catch (MathErrorException e)
+        {
+            Require(e.Error == MathError.NegativeInput, "ApplyResultClosure Err type");
+        }
+
+        Console.WriteLine("  PASS\n");
+    }
+
+    private static async System.Threading.Tasks.Task TestAsyncCallbackTraits()
+    {
+        Console.WriteLine("Testing async callback traits...");
+
+        AsyncFetcher fetcher = new AsyncFetcherImpl();
+        Require(await FetchWithAsyncCallback(fetcher, 5) == 15, "FetchWithAsyncCallback");
+        Require(await FetchStringWithAsyncCallback(fetcher, "hello") == "HELLO", "FetchStringWithAsyncCallback");
+        Require(await FetchJoinedMessageWithAsyncCallback(fetcher, "async", "callback") == "async::callback",
+            "FetchJoinedMessageWithAsyncCallback");
+
+        Require(await TransformPointWithAsyncCallback(new AsyncPointTransformerImpl(), new Point(1.0, 2.0))
+                == new Point(2.0, 4.0),
+            "TransformPointWithAsyncCallback");
+
+        AsyncResultFormatter resultFormatter = new AsyncResultFormatterImpl();
+        Require(await RenderMessageWithAsyncResultCallback(resultFormatter, "async", "result") == "async::result",
+            "RenderMessageWithAsyncResultCallback Ok");
+        Require(await TransformPointWithAsyncResultCallback(resultFormatter, new Point(3.0, 4.0), Status.Active)
+                == new Point(4.0, 5.0),
+            "TransformPointWithAsyncResultCallback Ok");
+        try
+        {
+            await RenderMessageWithAsyncResultCallback(resultFormatter, "", "result");
+            Require(false, "RenderMessageWithAsyncResultCallback Err should throw");
+        }
+        catch (MathErrorException e)
+        {
+            Require(e.Error == MathError.NegativeInput, "RenderMessageWithAsyncResultCallback Err type");
+        }
+
+        Console.WriteLine("  PASS\n");
+    }
+
+    private sealed class ValueCallbackImpl : ValueCallback
+    {
+        private readonly Func<int, int> _onValue;
+
+        internal ValueCallbackImpl(Func<int, int> onValue)
+        {
+            _onValue = onValue;
+        }
+
+        public int OnValue(int value) => _onValue(value);
+    }
+
+    private sealed class MessageFormatterImpl : MessageFormatter
+    {
+        public string FormatMessage(string scope, string message) => $"{scope}::{message}";
+    }
+
+    private sealed class VecProcessorImpl : VecProcessor
+    {
+        public int[] Process(int[] values) => values.Select(v => v * 2).ToArray();
+    }
+
+    private sealed class OptionCallbackImpl : OptionCallback
+    {
+        public int? FindValue(int key) => key == 0 ? null : key * 10;
+    }
+
+    private sealed class ResultCallbackImpl : ResultCallback
+    {
+        public int Compute(int value)
+        {
+            if (value < 0) throw new MathErrorException(MathError.NegativeInput);
+            return value * 10;
+        }
+    }
+
+    private sealed class OffsetCallbackImpl : OffsetCallback
+    {
+        public nint Offset(nint value, nuint delta) => value + (nint)delta;
+    }
+
+    private sealed class DataProviderImpl : DataProvider
+    {
+        public uint GetCount() => 2u;
+
+        public DataPoint GetItem(uint index)
+        {
+            return index switch
+            {
+                0u => new DataPoint(1.0, 2.0, 100L),
+                1u => new DataPoint(3.0, 4.0, 200L),
+                _ => new DataPoint(0.0, 0.0, 0L),
+            };
+        }
+    }
+
+    private sealed class AsyncFetcherImpl : AsyncFetcher
+    {
+        public async global::System.Threading.Tasks.Task<int> FetchValue(int key)
+        {
+            await global::System.Threading.Tasks.Task.Yield();
+            return key + 10;
+        }
+
+        public async global::System.Threading.Tasks.Task<string> FetchString(string input)
+        {
+            await global::System.Threading.Tasks.Task.Yield();
+            return input.ToUpperInvariant();
+        }
+
+        public async global::System.Threading.Tasks.Task<string> FetchJoinedMessage(string scope, string message)
+        {
+            await global::System.Threading.Tasks.Task.Yield();
+            return $"{scope}::{message}";
+        }
+    }
+
+    private sealed class AsyncPointTransformerImpl : AsyncPointTransformer
+    {
+        public async global::System.Threading.Tasks.Task<Point> TransformPoint(Point point)
+        {
+            await global::System.Threading.Tasks.Task.Yield();
+            return new Point(point.X + 1.0, point.Y + 2.0);
+        }
+    }
+
+    private sealed class AsyncResultFormatterImpl : AsyncResultFormatter
+    {
+        public async global::System.Threading.Tasks.Task<string> RenderMessage(string scope, string message)
+        {
+            await global::System.Threading.Tasks.Task.Yield();
+            if (scope.Length == 0) throw new MathErrorException(MathError.NegativeInput);
+            return $"{scope}::{message}";
+        }
+
+        public async global::System.Threading.Tasks.Task<Point> TransformPoint(Point point, Status status)
+        {
+            await global::System.Threading.Tasks.Task.Yield();
+            if (status == Status.Inactive) throw new MathErrorException(MathError.NegativeInput);
+            return new Point(point.X + 1.0, point.Y + 1.0);
+        }
     }
 
     private static void Require(bool condition, string label)


### PR DESCRIPTION
This PR adds C# callback support as a part of #146.

It covers callback traits, closures, and async callback traits in the generator and demo tests. I also did quite a bit of work keeping with the design to have lower only know about AST (not Strings) and ensuring String-based stuff is only in the AST or the Template layers