### PR TITLE
Support C# Pack

### DIFF
--- a/BOLTFFI_TOML_SPEC.md
+++ b/BOLTFFI_TOML_SPEC.md
@@ -357,6 +357,30 @@ Controls npm package generation in `boltffi pack wasm`.
 - `repository` (string, optional): Package repository URL.
   - Default: `{package.repository}`
 
+## C#
+
+### `[targets.csharp]` (optional)
+
+- `enabled` (bool): Whether C# generation and packaging are active.
+  - Default: `false`
+- `output` (path): C# artifact root directory.
+  - Default: `dist/csharp`
+  - `boltffi generate csharp` writes `.cs` files directly here.
+  - `boltffi pack csharp` writes generated sources under `{output}/src`, native assets under `{output}/runtimes/<rid>/native`, and a generated project file at `{output}/BoltFFI.CSharp.csproj`.
+- `package_id` (string, optional): NuGet package ID.
+  - Default: `{package.name}`
+- `target_framework` (string, optional): Target framework for the generated NuGet package project.
+  - Default: `net10.0`
+- `package_output` (path, optional): Directory where `boltffi pack csharp` writes `.nupkg` files.
+  - Default: `{targets.csharp.output}/packages`
+- `runtime_identifiers` (array of strings, optional): Desired .NET native runtime asset outputs.
+  - Supported canonical values: `current`, `osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`, `win-x64`
+  - Supported aliases: `darwin-arm64`, `darwin-x86_64`, `linux-x86_64`, `linux-aarch64`, `windows-x86_64`
+  - Default: `["current"]`
+  - Behavior: `current` resolves to the active host RID, repeated values are deduped after resolution, and native libraries are packaged under NuGet `runtimes/{rid}/native/`.
+
+`boltffi pack csharp` rejects explicit Cargo `--target` passthrough args because the native asset matrix is controlled by `targets.csharp.runtime_identifiers`. Current-host packaging works on `osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`, and `win-x64`. Cross-host support follows the shared desktop toolchain support used by JVM packaging; unsupported host/target pairs fail during preflight.
+
 ## Apple SwiftPM layouts
 
 `boltffi pack apple` always produces an xcframework (unless `--spm-only`) and can generate `Package.swift` (unless `--xcframework-only`).

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ boltffi pack android
 
 boltffi pack wasm
 # Produces: ./dist/wasm/pkg/*.wasm + TypeScript bindings + npm package
+
+boltffi pack csharp
+# Produces: ./dist/csharp/packages/*.nupkg with RID native assets
 ```
 
 Android ABI selection is configurable in `boltffi.toml`:
@@ -144,7 +147,7 @@ The generated bindings use each language's idioms. Swift gets async/await. Kotli
 | C        | Partial      |
 | Python   | In progress  |
 | C++      | Planned      |
-| C#       | In progress  |
+| C#       | Full support |
 | Ruby     | Planned      |
 | Dart     | Planned      |
 | Scala    | Planned      |

--- a/boltffi_cli/Cargo.toml
+++ b/boltffi_cli/Cargo.toml
@@ -16,6 +16,7 @@ name = "boltffi"
 path = "src/main.rs"
 
 [dependencies]
+askama = "0.15"
 boltffi_bindgen.workspace = true
 boltffi_verify.workspace = true
 clap = { version = "4.4", features = ["derive"] }

--- a/boltffi_cli/src/commands/generate/languages/csharp.rs
+++ b/boltffi_cli/src/commands/generate/languages/csharp.rs
@@ -1,10 +1,30 @@
+use std::path::{Path, PathBuf};
+
 use boltffi_bindgen::render::csharp::{CSharpEmitter, CSharpOptions};
 
 use crate::cli::{CliError, Result};
-use crate::commands::generate::generator::{GenerateRequest, LanguageGenerator, ScanPointerWidth};
-use crate::config::Target;
+use crate::commands::generate::generator::{
+    GenerateRequest, LanguageGenerator, ScanPointerWidth, SourceCrate,
+};
+use crate::config::{Config, Target};
 
 pub struct CSharpGenerator;
+
+impl CSharpGenerator {
+    pub fn generate_from_source_directory(
+        config: &Config,
+        output: Option<PathBuf>,
+        source_directory: &Path,
+        crate_name: &str,
+    ) -> Result<()> {
+        let request = GenerateRequest::new(
+            config,
+            output,
+            SourceCrate::new(source_directory, crate_name),
+        );
+        Self::generate(&request)
+    }
+}
 
 impl LanguageGenerator for CSharpGenerator {
     const TARGET: Target = Target::CSharp;

--- a/boltffi_cli/src/commands/generate/mod.rs
+++ b/boltffi_cli/src/commands/generate/mod.rs
@@ -102,6 +102,15 @@ pub fn run_generate_python_with_output_from_source_dir(
     PythonGenerator::generate_from_source_directory(config, output, source_directory, crate_name)
 }
 
+pub fn run_generate_csharp_with_output_from_source_dir(
+    config: &Config,
+    output: Option<PathBuf>,
+    source_directory: &Path,
+    crate_name: &str,
+) -> Result<()> {
+    CSharpGenerator::generate_from_source_directory(config, output, source_directory, crate_name)
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/boltffi_cli/src/commands/pack/all.rs
+++ b/boltffi_cli/src/commands/pack/all.rs
@@ -3,9 +3,9 @@ use crate::config::{Config, Target};
 use crate::reporter::Reporter;
 
 use super::{
-    PackAllOptions, PackAndroidOptions, PackAppleOptions, PackDartOptions, PackJavaOptions,
-    PackPythonOptions, PackWasmOptions, pack_android, pack_apple, pack_dart, pack_java,
-    pack_python, pack_wasm, prepare_java_packaging,
+    PackAllOptions, PackAndroidOptions, PackAppleOptions, PackCSharpOptions, PackDartOptions,
+    PackJavaOptions, PackPythonOptions, PackWasmOptions, pack_android, pack_apple, pack_csharp,
+    pack_dart, pack_java, pack_python, pack_wasm, prepare_java_packaging,
 };
 
 pub(super) fn pack_all(
@@ -99,8 +99,19 @@ pub(super) fn pack_all(
         pack_dart(
             config,
             PackDartOptions {
-                execution: options.execution,
+                execution: options.execution.clone(),
                 experimental: options.experimental,
+            },
+            reporter,
+        )?;
+        packed_any = true;
+    }
+
+    if config.is_csharp_enabled() {
+        pack_csharp(
+            config,
+            PackCSharpOptions {
+                execution: options.execution,
             },
             reporter,
         )?;

--- a/boltffi_cli/src/commands/pack/mod.rs
+++ b/boltffi_cli/src/commands/pack/mod.rs
@@ -6,11 +6,12 @@ use crate::config::Config;
 use crate::reporter::Reporter;
 
 pub use self::request::{
-    PackAllOptions, PackAndroidOptions, PackAppleOptions, PackCommand, PackDartOptions,
-    PackExecutionOptions, PackJavaOptions, PackPythonOptions, PackWasmOptions,
+    PackAllOptions, PackAndroidOptions, PackAppleOptions, PackCSharpOptions, PackCommand,
+    PackDartOptions, PackExecutionOptions, PackJavaOptions, PackPythonOptions, PackWasmOptions,
 };
 pub(crate) use crate::pack::android::pack_android;
 pub(crate) use crate::pack::apple::pack_apple;
+pub(crate) use crate::pack::csharp::pack_csharp;
 pub(crate) use crate::pack::dart::pack_dart;
 pub(crate) use crate::pack::java::{
     check_java_packaging_prereqs, ensure_java_no_build_supported, pack_java, prepare_java_packaging,
@@ -27,5 +28,6 @@ pub fn run_pack(config: &Config, command: PackCommand, reporter: &Reporter) -> R
         PackCommand::Java(options) => pack_java(config, options, None, reporter),
         PackCommand::Python(options) => pack_python(config, options, reporter),
         PackCommand::Dart(options) => pack_dart(config, options, reporter),
+        PackCommand::CSharp(options) => pack_csharp(config, options, reporter),
     }
 }

--- a/boltffi_cli/src/commands/pack/request.rs
+++ b/boltffi_cli/src/commands/pack/request.rs
@@ -8,6 +8,7 @@ pub enum PackCommand {
     Java(PackJavaOptions),
     Python(PackPythonOptions),
     Dart(PackDartOptions),
+    CSharp(PackCSharpOptions),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,4 +55,8 @@ pub struct PackPythonOptions {
 pub struct PackDartOptions {
     pub execution: PackExecutionOptions,
     pub experimental: bool,
+}
+
+pub struct PackCSharpOptions {
+    pub execution: PackExecutionOptions,
 }

--- a/boltffi_cli/src/config.rs
+++ b/boltffi_cli/src/config.rs
@@ -1,8 +1,8 @@
 use crate::target::{
-    AndroidArchitecture, AppleArchitecture, AppleIosArchitecture, DartNativeArchitecture,
-    JavaHostTarget, RustTarget, resolve_android_targets, resolve_apple_ios_targets,
-    resolve_apple_macos_targets, resolve_apple_simulator_targets, resolve_dart_native_targets,
-    resolve_java_host_targets,
+    AndroidArchitecture, AppleArchitecture, AppleIosArchitecture, CSharpRuntimeIdentifier,
+    DartNativeArchitecture, JavaHostTarget, RustTarget, resolve_android_targets,
+    resolve_apple_ios_targets, resolve_apple_macos_targets, resolve_apple_simulator_targets,
+    resolve_dart_native_targets, resolve_java_host_targets,
 };
 use boltffi_bindgen::render::python::NamingConvention;
 use serde::{Deserialize, Serialize};
@@ -50,7 +50,6 @@ impl Experimental {
         },
         Experimental::WholeTarget(Target::Dart),
         Experimental::WholeTarget(Target::Python),
-        Experimental::WholeTarget(Target::CSharp),
     ];
 
     pub fn is_target_experimental(target: Target) -> bool {
@@ -162,6 +161,10 @@ pub struct PythonWheelConfig {
 pub struct CSharpConfig {
     #[serde(default = "default_csharp_output")]
     pub output: PathBuf,
+    pub package_id: Option<String>,
+    pub target_framework: Option<String>,
+    pub package_output: Option<PathBuf>,
+    pub runtime_identifiers: Option<Vec<CSharpRuntimeIdentifier>>,
     #[serde(default)]
     pub enabled: bool,
 }
@@ -170,6 +173,10 @@ impl Default for CSharpConfig {
     fn default() -> Self {
         Self {
             output: default_csharp_output(),
+            package_id: None,
+            target_framework: None,
+            package_output: None,
+            runtime_identifiers: None,
             enabled: false,
         }
     }
@@ -820,6 +827,43 @@ impl Config {
             )));
         }
 
+        if self.is_csharp_enabled() {
+            if let Some(runtime_identifiers) = self.targets.csharp.runtime_identifiers.as_ref() {
+                if runtime_identifiers.is_empty() {
+                    return Err(ConfigError::Validation(
+                        "targets.csharp.runtime_identifiers must be non-empty when provided"
+                            .to_string(),
+                    ));
+                }
+
+                let mut seen = HashSet::new();
+                for runtime_identifier in runtime_identifiers {
+                    if !seen.insert(*runtime_identifier) {
+                        return Err(ConfigError::Validation(format!(
+                            "targets.csharp.runtime_identifiers contains duplicate runtime identifier '{}'",
+                            runtime_identifier.canonical_name()
+                        )));
+                    }
+                }
+            }
+
+            if let Some(package_id) = self.targets.csharp.package_id.as_deref()
+                && package_id.trim().is_empty()
+            {
+                return Err(ConfigError::Validation(
+                    "targets.csharp.package_id must not be empty".to_string(),
+                ));
+            }
+
+            if let Some(target_framework) = self.targets.csharp.target_framework.as_deref()
+                && target_framework.trim().is_empty()
+            {
+                return Err(ConfigError::Validation(
+                    "targets.csharp.target_framework must not be empty".to_string(),
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -1304,6 +1348,44 @@ impl Config {
 
     pub fn csharp_output(&self) -> PathBuf {
         self.targets.csharp.output.clone()
+    }
+
+    pub fn csharp_package_id(&self) -> String {
+        self.targets
+            .csharp
+            .package_id
+            .clone()
+            .unwrap_or_else(|| self.package.name.clone())
+    }
+
+    pub fn csharp_target_framework(&self) -> String {
+        self.targets
+            .csharp
+            .target_framework
+            .clone()
+            .unwrap_or_else(|| "net10.0".to_string())
+    }
+
+    pub fn csharp_package_output(&self) -> PathBuf {
+        self.targets
+            .csharp
+            .package_output
+            .clone()
+            .unwrap_or_else(|| self.csharp_output().join("packages"))
+    }
+
+    pub fn csharp_requested_runtime_identifiers(&self) -> &[CSharpRuntimeIdentifier] {
+        self.targets
+            .csharp
+            .runtime_identifiers
+            .as_deref()
+            .unwrap_or(CSharpRuntimeIdentifier::DEFAULTS)
+    }
+
+    pub fn csharp_runtime_identifiers(
+        &self,
+    ) -> std::result::Result<Vec<CSharpRuntimeIdentifier>, String> {
+        CSharpRuntimeIdentifier::resolve_requested(self.csharp_requested_runtime_identifiers())
     }
 
     pub fn wasm_triple(&self) -> &str {
@@ -2555,5 +2637,107 @@ interpreters = ["python3.11"]
             config.python_wheel_interpreters(),
             Some(["python3.11".to_string()].as_slice())
         );
+    }
+
+    #[test]
+    fn csharp_configuration_defaults_for_packaging() {
+        let config = parse_config(
+            r#"
+[package]
+name = "my-lib"
+
+[targets.csharp]
+enabled = true
+"#,
+        );
+
+        assert_eq!(config.csharp_output(), PathBuf::from("dist/csharp"));
+        assert_eq!(
+            config.csharp_package_output(),
+            PathBuf::from("dist/csharp/packages")
+        );
+        assert_eq!(config.csharp_package_id(), "my-lib");
+        assert_eq!(config.csharp_target_framework(), "net10.0");
+        assert_eq!(
+            config.csharp_requested_runtime_identifiers(),
+            crate::target::CSharpRuntimeIdentifier::DEFAULTS
+        );
+        assert!(config.should_process(Target::CSharp, false));
+    }
+
+    #[test]
+    fn csharp_configuration_supports_package_and_runtime_matrix() {
+        let config = parse_config(
+            r#"
+[package]
+name = "my-lib"
+
+[targets.csharp]
+enabled = true
+output = "artifacts/csharp"
+package_output = "artifacts/nuget"
+package_id = "Company.MyLib"
+target_framework = "net9.0"
+runtime_identifiers = ["current", "linux-x64"]
+"#,
+        );
+
+        assert_eq!(config.csharp_output(), PathBuf::from("artifacts/csharp"));
+        assert_eq!(
+            config.csharp_package_output(),
+            PathBuf::from("artifacts/nuget")
+        );
+        assert_eq!(config.csharp_package_id(), "Company.MyLib");
+        assert_eq!(config.csharp_target_framework(), "net9.0");
+        assert_eq!(
+            config.csharp_requested_runtime_identifiers(),
+            &[
+                crate::target::CSharpRuntimeIdentifier::Current,
+                crate::target::CSharpRuntimeIdentifier::LinuxX64
+            ]
+        );
+        assert!(config.should_process(Target::CSharp, false));
+    }
+
+    #[test]
+    fn rejects_empty_csharp_runtime_identifier_matrix() {
+        let parsed: Config = toml::from_str(
+            r#"
+[package]
+name = "my-lib"
+
+[targets.csharp]
+enabled = true
+runtime_identifiers = []
+"#,
+        )
+        .expect("toml parse failed");
+
+        assert!(matches!(
+            parsed.validate(),
+            Err(ConfigError::Validation(message))
+                if message.contains("targets.csharp.runtime_identifiers must be non-empty")
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_csharp_runtime_identifiers() {
+        let parsed: Config = toml::from_str(
+            r#"
+[package]
+name = "my-lib"
+
+[targets.csharp]
+enabled = true
+runtime_identifiers = ["linux-x64", "linux-x64"]
+"#,
+        )
+        .expect("toml parse failed");
+
+        assert!(matches!(
+            parsed.validate(),
+            Err(ConfigError::Validation(message))
+                if message.contains("targets.csharp.runtime_identifiers contains duplicate runtime identifier")
+        ));
     }
 }

--- a/boltffi_cli/src/main.rs
+++ b/boltffi_cli/src/main.rs
@@ -19,8 +19,8 @@ use commands::doctor::{ConfigSummary, DoctorOptions};
 use commands::generate::{GenerateOptions, GenerateTarget, run_generate_with_output};
 use commands::init::InitOptions;
 use commands::pack::{
-    PackAllOptions, PackAndroidOptions, PackAppleOptions, PackCommand, PackDartOptions,
-    PackExecutionOptions, PackJavaOptions, PackPythonOptions, PackWasmOptions,
+    PackAllOptions, PackAndroidOptions, PackAppleOptions, PackCSharpOptions, PackCommand,
+    PackDartOptions, PackExecutionOptions, PackJavaOptions, PackPythonOptions, PackWasmOptions,
     check_java_packaging_prereqs,
 };
 use commands::verify::VerifyOptions;
@@ -31,7 +31,7 @@ use config::{Config, Target};
 #[command(name = "boltffi")]
 #[command(about = "BoltFFI - Rust FFI toolchain (Apple + Android + WASM)")]
 #[command(
-    after_help = "Examples:\n  boltffi init\n  boltffi check --apple\n  boltffi generate swift\n  boltffi build apple --release\n  boltffi build wasm --release\n  boltffi pack apple --layout bundled\n  boltffi pack wasm --release\n  boltffi --overlay boltffi.ci.toml pack android\n\nConfig:\n  boltffi reads ./boltffi.toml\n  Use --overlay PATH to load a merged overlay config on top of it\n  Settings live under [targets.apple.*], [targets.android.*], [targets.wasm.*], [targets.java.*], [targets.dart.*], and [targets.python.*]\n"
+    after_help = "Examples:\n  boltffi init\n  boltffi check --apple\n  boltffi generate swift\n  boltffi build apple --release\n  boltffi build wasm --release\n  boltffi pack apple --layout bundled\n  boltffi pack wasm --release\n  boltffi pack csharp\n  boltffi --overlay boltffi.ci.toml pack android\n\nConfig:\n  boltffi reads ./boltffi.toml\n  Use --overlay PATH to load a merged overlay config on top of it\n  Settings live under [targets.apple.*], [targets.android.*], [targets.wasm.*], [targets.java.*], [targets.dart.*], [targets.python.*], and [targets.csharp.*]\n"
 )]
 #[command(version)]
 struct Cli {
@@ -136,8 +136,8 @@ enum Commands {
     },
 
     #[command(
-        about = "Package platform artifacts (xcframework/SPM/jniLibs/npm)",
-        long_about = "Package platform artifacts.\n\nExamples:\n  boltffi pack apple\n  boltffi pack apple --layout bundled\n  boltffi pack android --release\n  boltffi pack wasm --release\n  boltffi pack python --experimental\n"
+        about = "Package platform artifacts (xcframework/SPM/jniLibs/npm/NuGet)",
+        long_about = "Package platform artifacts.\n\nExamples:\n  boltffi pack apple\n  boltffi pack apple --layout bundled\n  boltffi pack android --release\n  boltffi pack wasm --release\n  boltffi pack python --experimental\n  boltffi pack csharp\n"
     )]
     Pack {
         #[command(subcommand)]
@@ -334,6 +334,21 @@ enum PackTargetArg {
 
         #[arg(long, help = "Enable experimental targets/features")]
         experimental: bool,
+    },
+
+    #[command(
+        about = "Build + package C# artifacts",
+        long_about = "Build + package C# artifacts.\n\nOutputs:\n  - C# package project: {targets.csharp.output}\n  - NuGet package:      {targets.csharp.package_output}\n  - Native assets:      runtimes/<rid>/native inside the .nupkg\n"
+    )]
+    Csharp {
+        #[arg(long)]
+        release: bool,
+
+        #[arg(long, default_value = "true")]
+        regenerate: bool,
+
+        #[arg(long)]
+        no_build: bool,
     },
 }
 
@@ -601,6 +616,13 @@ fn execute_command(
                 } => PackCommand::Dart(PackDartOptions {
                     execution: pack_execution_options(release, regenerate, no_build, cargo_args),
                     experimental,
+                }),
+                PackTargetArg::Csharp {
+                    release,
+                    regenerate,
+                    no_build,
+                } => PackCommand::CSharp(PackCSharpOptions {
+                    execution: pack_execution_options(release, regenerate, no_build, cargo_args),
                 }),
             };
             run_pack(&config, command, reporter)
@@ -917,6 +939,12 @@ fn release_pack_commands(
                     experimental: false,
                 }));
             }
+
+            if config.is_csharp_enabled() {
+                commands.push(PackCommand::CSharp(PackCSharpOptions {
+                    execution: pack_execution_options(true, true, false, cargo_args.to_vec()),
+                }));
+            }
         }
     }
 
@@ -1209,6 +1237,29 @@ enabled = true
     }
 
     #[test]
+    fn release_all_includes_csharp_packaging_when_enabled() {
+        let config = parse_config(
+            r#"
+[package]
+name = "mylib"
+
+[targets.csharp]
+enabled = true
+"#,
+        );
+
+        let commands = release_pack_commands(&config, Some(BuildPlatformArg::All), &[]);
+
+        assert!(commands.iter().any(|command| matches!(
+            command,
+            PackCommand::CSharp(options)
+                if options.execution.release
+                    && options.execution.regenerate
+                    && !options.execution.no_build
+        )));
+    }
+
+    #[test]
     fn cli_parses_generate_python_target() {
         let cli = Cli::try_parse_from(["boltffi", "generate", "python", "--experimental"])
             .expect("cli parse should succeed");
@@ -1235,6 +1286,19 @@ enabled = true
                     experimental: true,
                     ..
                 }
+            }
+        ));
+    }
+
+    #[test]
+    fn cli_parses_pack_csharp_target() {
+        let cli =
+            Cli::try_parse_from(["boltffi", "pack", "csharp"]).expect("cli parse should succeed");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Pack {
+                target: PackTargetArg::Csharp { .. }
             }
         ));
     }

--- a/boltffi_cli/src/pack/csharp/mod.rs
+++ b/boltffi_cli/src/pack/csharp/mod.rs
@@ -1,0 +1,619 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use askama::Template;
+
+use crate::build::{
+    CargoBuildProfile, OutputCallback, resolve_build_profile, run_command_streaming,
+};
+use crate::cargo::Cargo;
+use crate::cli::{CliError, Result};
+use crate::commands::generate::run_generate_csharp_with_output_from_source_dir;
+use crate::commands::pack::PackCSharpOptions;
+use crate::config::Config;
+use crate::pack::{PackError, format_command_for_log, print_cargo_line, resolve_build_cargo_args};
+use crate::reporter::{Reporter, Step};
+use crate::target::{CSharpRuntimeIdentifier, NativeHostPlatform};
+use crate::toolchain::NativeHostToolchain;
+
+pub(crate) fn pack_csharp(
+    config: &Config,
+    options: PackCSharpOptions,
+    reporter: &Reporter,
+) -> Result<()> {
+    if !config.is_csharp_enabled() {
+        return Err(CliError::CommandFailed {
+            command: "targets.csharp.enabled = false".to_string(),
+            status: None,
+        });
+    }
+
+    reporter.section("🔷", "Packing C#");
+
+    let step = reporter.step("Preparing C# packaging");
+    let plan = CSharpPackagingPlan::from_config(
+        config,
+        options.execution.release,
+        &options.execution.cargo_args,
+    )?;
+    step.finish_success();
+
+    sync_csharp_project(config, &plan)?;
+    remove_stale_csharp_runtime_assets(&plan)?;
+
+    if options.execution.regenerate {
+        let step = reporter.step("Generating C# bindings");
+        run_generate_csharp_with_output_from_source_dir(
+            config,
+            Some(plan.layout.source_directory.clone()),
+            &plan.source_directory,
+            &plan.artifact_name,
+        )?;
+        step.finish_success();
+    }
+
+    for packaging_target in &plan.packaging_targets {
+        let action = if options.execution.no_build {
+            "Reusing"
+        } else {
+            "Building"
+        };
+        let step = reporter.step(&format!(
+            "{action} Rust cdylib for {}",
+            packaging_target.runtime_identifier.canonical_name()
+        ));
+        let native_library = if options.execution.no_build {
+            existing_csharp_native_library(packaging_target)?
+        } else {
+            build_csharp_native_library(packaging_target, &step)?
+        };
+        copy_csharp_native_asset(&plan.layout, packaging_target, &native_library)?;
+        step.finish_success_with(&format!("{}", native_library.display()));
+    }
+
+    let step = reporter.step("Building NuGet package");
+    let package_path = dotnet_pack(&plan, &step)?;
+    step.finish_success_with(&format!("{}", package_path.display()));
+
+    reporter.finish();
+    Ok(())
+}
+
+#[derive(Debug)]
+struct CSharpPackageLayout {
+    root_directory: PathBuf,
+    source_directory: PathBuf,
+    package_output: PathBuf,
+    project_path: PathBuf,
+}
+
+#[derive(Debug)]
+struct CSharpCargoContext {
+    rust_target_triple: String,
+    release: bool,
+    build_profile: CargoBuildProfile,
+    artifact_name: String,
+    cargo_manifest_path: PathBuf,
+    package_selector: Option<String>,
+    target_directory: PathBuf,
+    cargo_command_args: Vec<String>,
+    toolchain_selector: Option<String>,
+}
+
+#[derive(Debug)]
+struct CSharpPackagingTarget {
+    runtime_identifier: CSharpRuntimeIdentifier,
+    host_target: NativeHostPlatform,
+    cargo_context: CSharpCargoContext,
+    toolchain: NativeHostToolchain,
+}
+
+#[derive(Debug)]
+struct CSharpPackagingPlan {
+    package_id: String,
+    package_version: String,
+    target_framework: String,
+    artifact_name: String,
+    source_directory: PathBuf,
+    layout: CSharpPackageLayout,
+    packaging_targets: Vec<CSharpPackagingTarget>,
+}
+
+impl CSharpCargoContext {
+    fn artifact_directory(&self) -> PathBuf {
+        self.target_directory
+            .join(&self.rust_target_triple)
+            .join(self.build_profile.output_directory_name())
+    }
+}
+
+impl CSharpPackagingPlan {
+    fn from_config(config: &Config, release: bool, cargo_args: &[String]) -> Result<Self> {
+        let build_cargo_args = resolve_build_cargo_args(config, cargo_args);
+        let cargo = Cargo::current(&build_cargo_args)?;
+        ensure_csharp_pack_cargo_args_supported(&cargo)?;
+        let metadata = cargo.metadata()?;
+        let cargo_manifest_path = cargo.manifest_path()?;
+        let package_selector =
+            cargo.effective_package_selector(config, &metadata, &cargo_manifest_path);
+        let package = metadata.find_package(&cargo_manifest_path, package_selector.as_deref())?;
+        let artifact_name = package
+            .resolve_library_artifact_name(&config.crate_artifact_name(), &cargo_manifest_path)?
+            .to_string();
+        let library_target =
+            package.resolve_library_target(&artifact_name, &cargo_manifest_path)?;
+        if !library_target.builds_cdylib() {
+            return Err(CliError::CommandFailed {
+                command: "pack csharp requires the selected Rust library target to build a cdylib"
+                    .to_string(),
+                status: None,
+            });
+        }
+
+        let source_directory = package
+            .manifest_path
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| CliError::CommandFailed {
+                command:
+                    "could not resolve selected Cargo package source directory for C# generation"
+                        .to_string(),
+                status: None,
+            })?;
+
+        let runtime_identifiers =
+            config
+                .csharp_runtime_identifiers()
+                .map_err(|message| CliError::CommandFailed {
+                    command: message,
+                    status: None,
+                })?;
+        let current_host = NativeHostPlatform::current().ok_or_else(|| CliError::CommandFailed {
+            command:
+                "C# packaging is only supported on osx-arm64, osx-x64, linux-x64, linux-arm64, and win-x64 hosts".to_string(),
+            status: None,
+        })?;
+        let build_profile = resolve_build_profile(release, &build_cargo_args);
+        let toolchain_selector = cargo.toolchain_selector().map(str::to_owned);
+        let cargo_command_args = cargo.probe_command_arguments();
+
+        let packaging_targets = runtime_identifiers
+            .iter()
+            .copied()
+            .map(|runtime_identifier| {
+                let host_target = runtime_identifier.native_host_platform();
+                let toolchain = NativeHostToolchain::discover_csharp(
+                    toolchain_selector.as_deref(),
+                    &cargo_command_args,
+                    host_target,
+                    current_host,
+                )?;
+                let cargo_context = CSharpCargoContext {
+                    rust_target_triple: toolchain.rust_target_triple().to_string(),
+                    release,
+                    build_profile: build_profile.clone(),
+                    artifact_name: artifact_name.clone(),
+                    cargo_manifest_path: cargo_manifest_path.clone(),
+                    package_selector: package_selector.clone(),
+                    target_directory: metadata.target_directory.clone(),
+                    cargo_command_args: cargo_command_args.clone(),
+                    toolchain_selector: toolchain_selector.clone(),
+                };
+                Ok(CSharpPackagingTarget {
+                    runtime_identifier,
+                    host_target,
+                    cargo_context,
+                    toolchain,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let root_directory = config.csharp_output();
+        let layout = CSharpPackageLayout {
+            source_directory: root_directory.join("src"),
+            package_output: config.csharp_package_output(),
+            project_path: root_directory.join("BoltFFI.CSharp.csproj"),
+            root_directory,
+        };
+
+        Ok(Self {
+            package_id: config.csharp_package_id(),
+            package_version: config
+                .package_version()
+                .unwrap_or_else(|| "0.1.0".to_string()),
+            target_framework: config.csharp_target_framework(),
+            artifact_name,
+            source_directory,
+            layout,
+            packaging_targets,
+        })
+    }
+}
+
+fn ensure_csharp_pack_cargo_args_supported(cargo: &Cargo) -> Result<()> {
+    if let Some(target_selector) = cargo.target_selector() {
+        return Err(CliError::CommandFailed {
+            command: format!(
+                "pack csharp resolves native assets from targets.csharp.runtime_identifiers; remove cargo --target '{}'",
+                target_selector
+            ),
+            status: None,
+        });
+    }
+
+    Ok(())
+}
+
+fn build_csharp_native_library(
+    packaging_target: &CSharpPackagingTarget,
+    step: &Step,
+) -> Result<PathBuf> {
+    let cargo_context = &packaging_target.cargo_context;
+    let verbose = step.is_verbose();
+    let on_output: Option<OutputCallback> = Some(Box::new(move |line: &str| {
+        if verbose {
+            print_cargo_line(line);
+        }
+    }));
+
+    let crate_directory = std::env::current_dir().map_err(|source| CliError::CommandFailed {
+        command: format!("current_dir: {source}"),
+        status: None,
+    })?;
+    let mut command = Command::new("cargo");
+    command.current_dir(crate_directory);
+
+    if let Some(toolchain_selector) = cargo_context.toolchain_selector.as_deref() {
+        command.arg(toolchain_selector);
+    }
+
+    command
+        .arg("build")
+        .arg("--target")
+        .arg(&cargo_context.rust_target_triple)
+        .arg("--manifest-path")
+        .arg(&cargo_context.cargo_manifest_path);
+    if let Some(package_selector) = cargo_context.package_selector.as_deref() {
+        command.arg("-p").arg(package_selector);
+    }
+    if cargo_context.release {
+        command.arg("--release");
+    }
+    command.args(&cargo_context.cargo_command_args);
+    packaging_target
+        .toolchain
+        .configure_cargo_build(&mut command);
+
+    if step.is_verbose() {
+        crate::pack::print_verbose_detail(&format!(
+            "Cargo build command: {}",
+            format_command_for_log(&command)
+        ));
+    }
+
+    if !run_command_streaming(&mut command, on_output.as_ref()) {
+        return Err(PackError::BuildFailed {
+            targets: vec![
+                packaging_target
+                    .runtime_identifier
+                    .canonical_name()
+                    .to_string(),
+            ],
+        }
+        .into());
+    }
+
+    existing_csharp_native_library(packaging_target)
+}
+
+fn existing_csharp_native_library(packaging_target: &CSharpPackagingTarget) -> Result<PathBuf> {
+    let cargo_context = &packaging_target.cargo_context;
+    let native_library = cargo_context.artifact_directory().join(
+        packaging_target
+            .host_target
+            .shared_library_filename(&cargo_context.artifact_name),
+    );
+
+    if native_library.exists() {
+        return Ok(native_library);
+    }
+
+    Err(CliError::FileNotFound(native_library))
+}
+
+fn copy_csharp_native_asset(
+    layout: &CSharpPackageLayout,
+    packaging_target: &CSharpPackagingTarget,
+    native_library: &Path,
+) -> Result<PathBuf> {
+    let output_directory = layout
+        .root_directory
+        .join("runtimes")
+        .join(packaging_target.runtime_identifier.canonical_name())
+        .join("native");
+    std::fs::create_dir_all(&output_directory).map_err(|source| {
+        CliError::CreateDirectoryFailed {
+            path: output_directory.clone(),
+            source,
+        }
+    })?;
+
+    let output_path = output_directory.join(
+        native_library
+            .file_name()
+            .expect("native library should have a filename"),
+    );
+    std::fs::copy(native_library, &output_path).map_err(|source| CliError::CopyFailed {
+        from: native_library.to_path_buf(),
+        to: output_path.clone(),
+        source,
+    })?;
+
+    Ok(output_path)
+}
+
+fn remove_stale_csharp_runtime_assets(plan: &CSharpPackagingPlan) -> Result<()> {
+    let requested = plan
+        .packaging_targets
+        .iter()
+        .map(|target| target.runtime_identifier)
+        .collect::<std::collections::HashSet<_>>();
+    let runtimes_root = plan.layout.root_directory.join("runtimes");
+
+    for runtime_identifier in CSharpRuntimeIdentifier::EXPLICIT_TARGETS {
+        if requested.contains(runtime_identifier) {
+            continue;
+        }
+
+        let runtime_dir = runtimes_root.join(runtime_identifier.canonical_name());
+        match std::fs::remove_dir_all(&runtime_dir) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(source) => {
+                return Err(CliError::WriteFailed {
+                    path: runtime_dir,
+                    source,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn sync_csharp_project(config: &Config, plan: &CSharpPackagingPlan) -> Result<()> {
+    std::fs::create_dir_all(&plan.layout.root_directory).map_err(|source| {
+        CliError::CreateDirectoryFailed {
+            path: plan.layout.root_directory.clone(),
+            source,
+        }
+    })?;
+    std::fs::create_dir_all(&plan.layout.source_directory).map_err(|source| {
+        CliError::CreateDirectoryFailed {
+            path: plan.layout.source_directory.clone(),
+            source,
+        }
+    })?;
+    std::fs::create_dir_all(&plan.layout.package_output).map_err(|source| {
+        CliError::CreateDirectoryFailed {
+            path: plan.layout.package_output.clone(),
+            source,
+        }
+    })?;
+
+    let project = render_csharp_project(config, plan)?;
+    std::fs::write(&plan.layout.project_path, project).map_err(|source| CliError::WriteFailed {
+        path: plan.layout.project_path.clone(),
+        source,
+    })
+}
+
+#[derive(Template)]
+#[template(path = "BoltFFI.CSharp.csproj.xml", escape = "html")]
+struct CSharpProjectTemplate<'a> {
+    target_framework: &'a str,
+    runtime_identifiers: &'a str,
+    package_id: &'a str,
+    package_version: &'a str,
+    has_description: bool,
+    description: &'a str,
+    has_license: bool,
+    license: &'a str,
+    has_repository: bool,
+    repository: &'a str,
+}
+
+fn render_csharp_project(config: &Config, plan: &CSharpPackagingPlan) -> Result<String> {
+    let runtime_identifiers = plan
+        .packaging_targets
+        .iter()
+        .map(|target| target.runtime_identifier.canonical_name())
+        .collect::<Vec<_>>()
+        .join(";");
+    let description = config.package.description.as_deref().unwrap_or_default();
+    let license = config.package_license();
+    let repository = config.package_repository();
+
+    CSharpProjectTemplate {
+        target_framework: &plan.target_framework,
+        runtime_identifiers: &runtime_identifiers,
+        package_id: &plan.package_id,
+        package_version: &plan.package_version,
+        has_description: config.package.description.is_some(),
+        description,
+        has_license: license.is_some(),
+        license: license.as_deref().unwrap_or_default(),
+        has_repository: repository.is_some(),
+        repository: repository.as_deref().unwrap_or_default(),
+    }
+    .render()
+    .map_err(|source| CliError::CommandFailed {
+        command: format!("render C# project template: {source}"),
+        status: None,
+    })
+}
+
+fn dotnet_pack(plan: &CSharpPackagingPlan, step: &Step) -> Result<PathBuf> {
+    let mut command = Command::new("dotnet");
+    command
+        .arg("pack")
+        .arg(&plan.layout.project_path)
+        .arg("--configuration")
+        .arg(
+            if plan
+                .packaging_targets
+                .iter()
+                .any(|target| target.cargo_context.build_profile.is_release_like())
+            {
+                "Release"
+            } else {
+                "Debug"
+            },
+        )
+        .arg("--output")
+        .arg(&plan.layout.package_output)
+        .arg("--ignore-failed-sources")
+        .arg("-p:NuGetAudit=false")
+        // Keep RuntimeIdentifiers in the generated project, but avoid restoring
+        // framework runtime packs while building this library-only package.
+        .arg("-p:RuntimeIdentifiers=")
+        .arg("-p:RuntimeIdentifier=")
+        .arg("--nologo");
+
+    if step.is_verbose() {
+        crate::pack::print_verbose_detail(&format!(
+            "dotnet pack command: {}",
+            format_command_for_log(&command)
+        ));
+    }
+
+    let status = command.status().map_err(|source| CliError::CommandFailed {
+        command: format!("dotnet pack: {source}"),
+        status: None,
+    })?;
+
+    if !status.success() {
+        return Err(CliError::CommandFailed {
+            command: "dotnet pack".to_string(),
+            status: status.code(),
+        });
+    }
+
+    Ok(plan.layout.package_output.join(format!(
+        "{}.{}.nupkg",
+        plan.package_id, plan.package_version
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CSharpPackageLayout, CSharpPackagingPlan, pack_csharp, render_csharp_project};
+    use crate::cli::CliError;
+    use crate::commands::pack::{PackCSharpOptions, PackExecutionOptions};
+    use crate::config::{CSharpConfig, CargoConfig, Config, PackageConfig, TargetsConfig};
+    use crate::reporter::{Reporter, Verbosity};
+    use crate::target::CSharpRuntimeIdentifier;
+    use std::path::PathBuf;
+
+    fn config() -> Config {
+        Config {
+            experimental: Vec::new(),
+            cargo: CargoConfig::default(),
+            package: PackageConfig {
+                name: "demo".to_string(),
+                crate_name: None,
+                version: Some("1.2.3".to_string()),
+                description: Some("Demo <runtime>".to_string()),
+                license: Some("MIT".to_string()),
+                repository: Some("https://example.com/demo".to_string()),
+            },
+            targets: TargetsConfig {
+                csharp: CSharpConfig {
+                    enabled: true,
+                    runtime_identifiers: Some(vec![
+                        CSharpRuntimeIdentifier::OsxArm64,
+                        CSharpRuntimeIdentifier::LinuxX64,
+                    ]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        }
+    }
+
+    fn options() -> PackCSharpOptions {
+        PackCSharpOptions {
+            execution: PackExecutionOptions {
+                release: false,
+                regenerate: true,
+                no_build: false,
+                cargo_args: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn csharp_runtime_identifier_maps_native_assets() {
+        assert_eq!(
+            CSharpRuntimeIdentifier::OsxArm64.native_library_filename("demo"),
+            "libdemo.dylib"
+        );
+        assert_eq!(
+            CSharpRuntimeIdentifier::LinuxX64.native_library_filename("demo"),
+            "libdemo.so"
+        );
+        assert_eq!(
+            CSharpRuntimeIdentifier::WinX64.native_library_filename("demo"),
+            "demo.dll"
+        );
+    }
+
+    #[test]
+    fn csharp_project_includes_packable_native_assets() {
+        let plan = CSharpPackagingPlan {
+            package_id: "Demo.Runtime".to_string(),
+            package_version: "1.2.3".to_string(),
+            target_framework: "net10.0".to_string(),
+            artifact_name: "demo".to_string(),
+            source_directory: PathBuf::from("/tmp/demo"),
+            layout: CSharpPackageLayout {
+                root_directory: PathBuf::from("/tmp/dist/csharp"),
+                source_directory: PathBuf::from("/tmp/dist/csharp/src"),
+                package_output: PathBuf::from("/tmp/dist/csharp/packages"),
+                project_path: PathBuf::from("/tmp/dist/csharp/BoltFFI.CSharp.csproj"),
+            },
+            packaging_targets: Vec::new(),
+        };
+
+        let project = render_csharp_project(&config(), &plan).expect("C# project should render");
+
+        assert!(project.contains("<TargetFramework>net10.0</TargetFramework>"));
+        assert!(project.contains("<RuntimeIdentifiers></RuntimeIdentifiers>"));
+        assert!(project.contains("<PackageId>Demo.Runtime</PackageId>"));
+        assert!(project.contains("<Version>1.2.3</Version>"));
+        assert!(project.contains("<AllowUnsafeBlocks>true</AllowUnsafeBlocks>"));
+        assert!(project.contains(r#"<Compile Include="src/**/*.cs" />"#));
+        assert!(
+            project.contains(
+                r#"<None Include="runtimes/**/*" Pack="true" PackagePath="%(Identity)" />"#
+            )
+        );
+        assert!(project.contains("<Description>Demo &#60;runtime&#62;</Description>"));
+        assert!(project.contains("<RepositoryUrl>https://example.com/demo</RepositoryUrl>"));
+    }
+
+    #[test]
+    fn rejects_pack_csharp_when_target_is_disabled() {
+        let mut config = config();
+        config.targets.csharp.enabled = false;
+
+        let error = pack_csharp(&config, options(), &Reporter::new(Verbosity::Quiet))
+            .expect_err("disabled csharp target should fail before packaging");
+
+        assert!(matches!(
+            error,
+            CliError::CommandFailed { command, .. }
+                if command.contains("targets.csharp.enabled = false")
+        ));
+    }
+}

--- a/boltffi_cli/src/pack/mod.rs
+++ b/boltffi_cli/src/pack/mod.rs
@@ -1,5 +1,6 @@
 pub mod android;
 pub mod apple;
+pub mod csharp;
 pub mod dart;
 pub mod java;
 pub mod python;

--- a/boltffi_cli/src/target.rs
+++ b/boltffi_cli/src/target.rs
@@ -364,6 +364,98 @@ impl From<NativeHostPlatform> for JavaHostTarget {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CSharpRuntimeIdentifier {
+    #[serde(rename = "current")]
+    Current,
+    #[serde(rename = "osx-arm64", alias = "darwin-arm64", alias = "osx-aarch64")]
+    OsxArm64,
+    #[serde(rename = "osx-x64", alias = "darwin-x86_64", alias = "osx-x86_64")]
+    OsxX64,
+    #[serde(rename = "linux-x64", alias = "linux-x86_64")]
+    LinuxX64,
+    #[serde(rename = "linux-arm64", alias = "linux-aarch64")]
+    LinuxArm64,
+    #[serde(rename = "win-x64", alias = "windows-x86_64", alias = "win-x86_64")]
+    WinX64,
+}
+
+impl CSharpRuntimeIdentifier {
+    pub const DEFAULTS: &'static [Self] = &[Self::Current];
+    pub const EXPLICIT_TARGETS: &'static [Self] = &[
+        Self::OsxArm64,
+        Self::OsxX64,
+        Self::LinuxX64,
+        Self::LinuxArm64,
+        Self::WinX64,
+    ];
+
+    pub fn canonical_name(self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::OsxArm64 => "osx-arm64",
+            Self::OsxX64 => "osx-x64",
+            Self::LinuxX64 => "linux-x64",
+            Self::LinuxArm64 => "linux-arm64",
+            Self::WinX64 => "win-x64",
+        }
+    }
+
+    pub fn current() -> Option<Self> {
+        NativeHostPlatform::current().map(Into::into)
+    }
+
+    pub fn resolve_requested(targets: &[Self]) -> Result<Vec<Self>, String> {
+        let current_host = Self::current().ok_or_else(Self::unsupported_host_message)?;
+        let mut resolved = Vec::new();
+
+        targets.iter().copied().for_each(|target| {
+            let target = match target {
+                Self::Current => current_host,
+                explicit => explicit,
+            };
+
+            if !resolved.contains(&target) {
+                resolved.push(target);
+            }
+        });
+
+        Ok(resolved)
+    }
+
+    pub fn native_host_platform(self) -> NativeHostPlatform {
+        match self {
+            Self::Current => unreachable!("resolved C# runtime identifier required"),
+            Self::OsxArm64 => NativeHostPlatform::DarwinArm64,
+            Self::OsxX64 => NativeHostPlatform::DarwinX86_64,
+            Self::LinuxX64 => NativeHostPlatform::LinuxX86_64,
+            Self::LinuxArm64 => NativeHostPlatform::LinuxAarch64,
+            Self::WinX64 => NativeHostPlatform::WindowsX86_64,
+        }
+    }
+
+    pub fn native_library_filename(self, artifact_name: &str) -> String {
+        self.native_host_platform()
+            .shared_library_filename(artifact_name)
+    }
+
+    fn unsupported_host_message() -> String {
+        "C# packaging is only supported on osx-arm64, osx-x64, linux-x64, linux-arm64, and win-x64 hosts".to_string()
+    }
+}
+
+impl From<NativeHostPlatform> for CSharpRuntimeIdentifier {
+    fn from(value: NativeHostPlatform) -> Self {
+        match value {
+            NativeHostPlatform::DarwinArm64 => Self::OsxArm64,
+            NativeHostPlatform::DarwinX86_64 => Self::OsxX64,
+            NativeHostPlatform::LinuxX86_64 => Self::LinuxX64,
+            NativeHostPlatform::LinuxAarch64 => Self::LinuxArm64,
+            NativeHostPlatform::WindowsX86_64 => Self::WinX64,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RustTarget {
     triple: &'static str,

--- a/boltffi_cli/src/toolchain/native_host.rs
+++ b/boltffi_cli/src/toolchain/native_host.rs
@@ -7,7 +7,7 @@ use crate::cargo::config::{
     extract_cargo_config_args, resolve_cargo_config_path,
 };
 use crate::cli::{CliError, Result};
-use crate::target::JavaHostTarget;
+use crate::target::{JavaHostTarget, NativeHostPlatform};
 
 #[cfg(test)]
 use crate::cargo::config::{
@@ -91,7 +91,32 @@ impl NativeHostToolchain {
         target: JavaHostTarget,
         current_host: JavaHostTarget,
     ) -> Result<Self> {
-        ensure_supported_jvm_host_pair(current_host, target)?;
+        Self::discover_for_platform(toolchain_selector, cargo_args, target, current_host, "JVM")
+    }
+
+    pub fn discover_csharp(
+        toolchain_selector: Option<&str>,
+        cargo_args: &[String],
+        target: NativeHostPlatform,
+        current_host: NativeHostPlatform,
+    ) -> Result<Self> {
+        Self::discover_for_platform(
+            toolchain_selector,
+            cargo_args,
+            target.into(),
+            current_host.into(),
+            "C#",
+        )
+    }
+
+    fn discover_for_platform(
+        toolchain_selector: Option<&str>,
+        cargo_args: &[String],
+        target: JavaHostTarget,
+        current_host: JavaHostTarget,
+        platform_name: &str,
+    ) -> Result<Self> {
+        ensure_supported_native_host_pair(current_host, target, platform_name)?;
         let rust_target_triple =
             resolve_rust_target_triple(target, current_host, toolchain_selector, cargo_args)?;
         ensure_rust_target_installed(
@@ -220,9 +245,10 @@ impl NativeHostToolchain {
     }
 }
 
-fn ensure_supported_jvm_host_pair(
+fn ensure_supported_native_host_pair(
     current_host: JavaHostTarget,
     target: JavaHostTarget,
+    platform_name: &str,
 ) -> Result<()> {
     let supported = matches!(
         (current_host, target),
@@ -246,7 +272,7 @@ fn ensure_supported_jvm_host_pair(
 
     Err(CliError::CommandFailed {
         command: format!(
-            "JVM host target '{}' is not supported from current host '{}' in Phase 4",
+            "{platform_name} host target '{}' is not supported from current host '{}' in Phase 4",
             target.canonical_name(),
             current_host.canonical_name()
         ),
@@ -1536,7 +1562,7 @@ mod tests {
         configured_linux_build_target, configured_linux_x86_64_cross_linker_values_with_sources,
         configured_target_linker_values, configured_target_rustflag_linker_args,
         configured_target_rustflag_linker_args_with_sources, configured_windows_build_target,
-        default_windows_jni_compiler_candidates, ensure_supported_jvm_host_pair,
+        default_windows_jni_compiler_candidates, ensure_supported_native_host_pair,
         extract_cargo_config_args, fallback_without_rustup, linux_cross_linker_args,
         linux_host_linker_args, parse_build_target_from_config_file,
         parse_build_target_from_inline_config, parse_rustc_host_triple,
@@ -2277,9 +2303,10 @@ unix
 
     #[test]
     fn rejects_unsupported_jvm_host_pairs_before_toolchain_probing() {
-        let error = ensure_supported_jvm_host_pair(
+        let error = ensure_supported_native_host_pair(
             JavaHostTarget::DarwinArm64,
             JavaHostTarget::WindowsX86_64,
+            "JVM",
         )
         .expect_err("unsupported host pair should fail");
 

--- a/boltffi_cli/templates/BoltFFI.CSharp.csproj.xml
+++ b/boltffi_cli/templates/BoltFFI.CSharp.csproj.xml
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>{{ target_framework }}</TargetFramework>
+    <RuntimeIdentifiers>{{ runtime_identifiers }}</RuntimeIdentifiers>
+    <PackageId>{{ package_id }}</PackageId>
+    <Version>{{ package_version }}</Version>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+{% if has_description %}    <Description>{{ description }}</Description>
+{% endif %}{% if has_license %}    <PackageLicenseExpression>{{ license }}</PackageLicenseExpression>
+{% endif %}{% if has_repository %}    <RepositoryUrl>{{ repository }}</RepositoryUrl>
+{% endif %}  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="src/**/*.cs" />
+    <None Include="runtimes/**/*" Pack="true" PackagePath="%(Identity)" />
+  </ItemGroup>
+
+</Project>

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -140,7 +140,7 @@ Per-platform entry points (all invoked for you by `verify-platform-demos.sh`):
 | Java     | `boltffi pack java && examples/platforms/java/test-demo.sh --auto`          |
 | WASM     | `boltffi pack wasm && examples/platforms/wasm/test-demo.sh`                 |
 | Python   | `boltffi pack python --release --experimental && examples/platforms/python/test-demo.sh` |
-| C#       | `examples/platforms/csharp/test-demo.sh`                                    |
+| C#       | `examples/platforms/csharp/test-demo.sh` (runs `boltffi pack csharp`) |
 
 Rust-side tests (the lib itself) still run via `cargo test -p demo` from this directory or `just test` from the repo root.
 

--- a/examples/platforms/csharp/DemoTest/DemoTest.csproj
+++ b/examples/platforms/csharp/DemoTest/DemoTest.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\dist\*.cs" Link="Generated\%(Filename)%(Extension)" />
+    <PackageReference Include="demo" Version="0.1.0" />
   </ItemGroup>
 
 </Project>

--- a/examples/platforms/csharp/test-demo.sh
+++ b/examples/platforms/csharp/test-demo.sh
@@ -25,39 +25,28 @@ while [[ $# -gt 0 ]]; do
 done
 
 cargo_profile="debug"
-cargo_flags=()
+pack_flags=()
 if [[ "$configuration" == "Release" ]]; then
   cargo_profile="release"
-  cargo_flags=(--release)
+  pack_flags=(--release)
 fi
 
-native_lib_dir="$demo_dir/target/$cargo_profile"
-case "$(uname -s)" in
-  Darwin)   native_lib_file="libdemo.dylib" ;;
-  Linux)    native_lib_file="libdemo.so" ;;
-  MINGW*|MSYS*|CYGWIN*) native_lib_file="demo.dll" ;;
-  *)
-    echo "Unsupported host for C# demo: $(uname -s)" >&2
-    exit 1
-    ;;
-esac
+package_dir="$script_dir/dist/packages"
+packages_cache="$script_dir/dist/.nuget/packages"
 
-echo "=== cargo build demo ($cargo_profile) ==="
-(cd "$demo_dir" && cargo build "${cargo_flags[@]}")
-
-if [[ ! -f "$native_lib_dir/$native_lib_file" ]]; then
-  echo "Expected native library not found: $native_lib_dir/$native_lib_file" >&2
-  exit 1
-fi
-
-echo "=== boltffi generate csharp ==="
-(cd "$demo_dir" && cargo run --quiet --manifest-path "$manifest_path" -p boltffi_cli -- generate csharp --experimental)
+echo "=== boltffi pack csharp ($cargo_profile) ==="
+(cd "$demo_dir" && cargo run --quiet --manifest-path "$manifest_path" -p boltffi_cli -- pack csharp "${pack_flags[@]}")
 
 echo "=== dotnet build DemoTest ==="
-dotnet build "$test_project" --configuration "$configuration" --nologo
+rm -rf "$packages_cache"
+dotnet build "$test_project" \
+  --configuration "$configuration" \
+  --source "$package_dir" \
+  --property:RestorePackagesPath="$packages_cache" \
+  --property:RestoreNoCache=true \
+  --nologo
 
 bin_dir="$test_project/bin/$configuration/$target_framework"
-cp "$native_lib_dir/$native_lib_file" "$bin_dir/$native_lib_file"
 
 echo "=== dotnet run DemoTest ==="
 dotnet "$bin_dir/DemoTest.dll"


### PR DESCRIPTION
This PR adds C# package support as a part of #146.

It adds `boltffi pack csharp`, which generates the C# bindings into a packable project layout, builds the Rust native library for the configured .NET runtime identifiers, places those native assets under `runtimes/<rid>/native/`, and emits a local NuGet package that consumers can restore from a local package source.

I also wired C# into `pack all` when `targets.csharp.enabled = true`, added the C# package config fields, and updated the C# demo to consume the generated NuGet package instead of compiling the generated `.cs` files directly.

One thing I kept explicit here is that this is normal C# support, not experimental support. This is the last C# release step, so I did not add an experimental flag or language around it.

I also kept the generated `.csproj` as a small Askama template to avoid explicit XML escape code. The pack layer is mixed today, but for this XML-shaped package manifest it made the final file easier to review and kept escaping centralized.