### PR TITLE
Fix shared ref of class type incorrectly wire-encoded across FFI

### DIFF
--- a/boltffi_macros/src/data/expansion/record_impl.rs
+++ b/boltffi_macros/src/data/expansion/record_impl.rs
@@ -643,7 +643,7 @@ mod tests {
     use super::*;
     use crate::index::callback_traits::CallbackTraitRegistry;
     use crate::index::custom_types::CustomTypeRegistry;
-    use crate::index::data_types::DataTypeRegistry;
+    use crate::index::data_types::{DataTypeCategory, DataTypeRegistry};
     use crate::lowering::returns::model::ReturnLoweringContext;
 
     fn parse_impl(code: &str) -> syn::ItemImpl {
@@ -652,7 +652,10 @@ mod tests {
 
     fn return_lowering() -> ReturnLoweringContext<'static> {
         let custom_types = Box::leak(Box::new(CustomTypeRegistry::default()));
-        let data_types = Box::leak(Box::new(DataTypeRegistry::default()));
+        let data_types = Box::leak(Box::new(DataTypeRegistry::with_entries(&[
+            ("UserProfile", DataTypeCategory::WireEncoded),
+            ("Filter", DataTypeCategory::WireEncoded),
+        ])));
         ReturnLoweringContext::new(custom_types, data_types)
     }
 

--- a/boltffi_macros/src/exports/methods.rs
+++ b/boltffi_macros/src/exports/methods.rs
@@ -1453,7 +1453,7 @@ mod tests {
     use super::*;
     use crate::index::callback_traits::CallbackTraitRegistry;
     use crate::index::custom_types::CustomTypeRegistry;
-    use crate::index::data_types::DataTypeRegistry;
+    use crate::index::data_types::{DataTypeCategory, DataTypeRegistry};
     use crate::lowering::returns::model::ReturnLoweringContext;
 
     fn parse_impl(code: &str) -> syn::ItemImpl {
@@ -1462,7 +1462,10 @@ mod tests {
 
     fn return_lowering() -> ReturnLoweringContext<'static> {
         let custom_types = Box::leak(Box::new(CustomTypeRegistry::default()));
-        let data_types = Box::leak(Box::new(DataTypeRegistry::default()));
+        let data_types = Box::leak(Box::new(DataTypeRegistry::with_entries(&[
+            ("UserProfile", DataTypeCategory::WireEncoded),
+            ("Filter", DataTypeCategory::WireEncoded),
+        ])));
         ReturnLoweringContext::new(custom_types, data_types)
     }
 

--- a/boltffi_macros/src/index/data_types.rs
+++ b/boltffi_macros/src/index/data_types.rs
@@ -84,6 +84,18 @@ impl DataTypeRegistry {
     }
 }
 
+#[cfg(test)]
+impl DataTypeRegistry {
+    pub(crate) fn with_entries(entries: &[(&str, DataTypeCategory)]) -> Self {
+        let mut registry = DataTypeRegistry::default();
+        for (name, category) in entries {
+            registry.insert(vec![name.to_string()], *category);
+        }
+        registry.finalize_unique_names();
+        registry
+    }
+}
+
 pub fn registry_for_current_crate() -> syn::Result<DataTypeRegistry> {
     Ok(CrateIndex::for_current_crate()?.data_types().clone())
 }

--- a/boltffi_macros/src/lowering/params/transform.rs
+++ b/boltffi_macros/src/lowering/params/transform.rs
@@ -315,7 +315,12 @@ impl<'a> ParamTransformClassifier<'a> {
             };
         }
 
-        if matches!(ty, Type::Reference(_)) {
+        if let Type::Reference(type_ref) = ty
+            && self
+                .named_type_transport_classifier
+                .named_type_category(&type_ref.elem)
+                .is_some()
+        {
             return ClassifiedParamTransform {
                 contract: ParamContract::new(
                     ParamValueStrategy::WireEncoded(WireParamStrategy::SingleValue),

--- a/examples/demo/src/classes/borrowed.rs
+++ b/examples/demo/src/classes/borrowed.rs
@@ -1,0 +1,7 @@
+use boltffi::*;
+use crate::Counter;
+
+#[export]
+pub fn describe_counter(counter: &Counter) -> String {
+    format!("Counter(value={})", counter.get())
+}

--- a/examples/demo/src/classes/mod.rs
+++ b/examples/demo/src/classes/mod.rs
@@ -6,6 +6,7 @@ pub mod static_methods;
 pub mod streams;
 pub mod thread_safe;
 pub mod unsafe_single_threaded;
+pub mod borrowed;
 
 pub use async_methods::*;
 pub use constructor_matrix::*;
@@ -15,3 +16,4 @@ pub use static_methods::*;
 pub use streams::*;
 pub use thread_safe::*;
 pub use unsafe_single_threaded::*;
+pub use borrowed::*;

--- a/examples/platforms/apple/Tests/DemoConsumerTests/RustSwiftSurfaceContractTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/RustSwiftSurfaceContractTests.swift
@@ -547,6 +547,7 @@ private let rustToSwiftCoverageFile: [String: String] = [
     "callbacks/closures.rs": "callbacks/ClosuresTests.swift",
     "callbacks/sync_traits.rs": "callbacks/SyncTraitsTests.swift",
     "classes/async_methods.rs": "classes/AsyncMethodsTests.swift",
+    "classes/borrowed.rs": "classes/BorrowedTests.swift",
     "classes/constructor_matrix.rs": "classes/ConstructorCoverageMatrixTests.swift",
     "classes/constructors.rs": "classes/ConstructorsTests.swift",
     "classes/methods.rs": "classes/MethodsTests.swift",

--- a/examples/platforms/apple/Tests/DemoConsumerTests/classes/BorrowedTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/classes/BorrowedTests.swift
@@ -1,0 +1,9 @@
+import Demo
+import XCTest
+
+final class BorrowedTests: XCTestCase {
+    func testDescribeCounterWithBorrowedRef() {
+        let counter = Counter(initial: 42)
+        XCTAssertEqual(describeCounter(counter: counter), "Counter(value=42)")
+    }
+}

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -39,6 +39,7 @@ public final class DemoTest {
         testAsyncClassMethods();
         testSingleThreadedStateHolder();
         testResultFunctions();
+        testBorrowedClassRef();
         testResultClassMethods();
         testResultEnumErrors();
         testStreams();
@@ -1398,6 +1399,16 @@ public final class DemoTest {
             Demo.resultOfVec(-1);
             assert false : "resultOfVec should throw on negative count";
         } catch (RuntimeException ignored) {}
+
+        System.out.println("  PASS\n");
+    }
+
+    private static void testBorrowedClassRef() {
+        System.out.println("Testing borrowed class ref...");
+
+        try (Counter counter = new Counter(42)) {
+            assert Demo.describeCounter(counter).equals("Counter(value=42)") : "describeCounter";
+        }
 
         System.out.println("  PASS\n");
     }

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoClassesAndStreamsTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoClassesAndStreamsTest.kt
@@ -55,6 +55,10 @@ class DemoClassesAndStreamsTest {
             assertMessageContains(assertFailsWith<FfiException> { counter.tryGetPositive() }, "count is not positive")
         }
 
+        Counter(42).use { counter ->
+            assertEquals("Counter(value=42)", describeCounter(counter))
+        }
+
         MathUtils(2u).use { mathUtils ->
             assertDoubleEquals(3.14, mathUtils.round(3.14159), 1e-9)
         }

--- a/examples/platforms/wasm/tests/classes/borrowed.test.mjs
+++ b/examples/platforms/wasm/tests/classes/borrowed.test.mjs
@@ -1,0 +1,7 @@
+import { assert, demo } from "../support/index.mjs";
+
+export async function run() {
+  const counter = demo.Counter.new(42);
+  assert.equal(demo.describeCounter(counter), "Counter(value=42)");
+  counter.dispose();
+}

--- a/examples/platforms/wasm/tests/classes/methods.test.mjs
+++ b/examples/platforms/wasm/tests/classes/methods.test.mjs
@@ -16,6 +16,10 @@ export async function run() {
   assertThrowsWithMessage(() => counter.tryGetPositive(), "count is not positive");
   counter.dispose();
 
+  const borrowedCounter = demo.Counter.new(42);
+  assert.equal(demo.describeCounter(borrowedCounter), "Counter(value=42)");
+  borrowedCounter.dispose();
+
   const service = demo.MixedRecordService.new("records");
   const record = sampleMixedRecord();
   assert.equal(service.getLabel(), "records");

--- a/examples/platforms/wasm/tests/classes/methods.test.mjs
+++ b/examples/platforms/wasm/tests/classes/methods.test.mjs
@@ -16,10 +16,6 @@ export async function run() {
   assertThrowsWithMessage(() => counter.tryGetPositive(), "count is not positive");
   counter.dispose();
 
-  const borrowedCounter = demo.Counter.new(42);
-  assert.equal(demo.describeCounter(borrowedCounter), "Counter(value=42)");
-  borrowedCounter.dispose();
-
   const service = demo.MixedRecordService.new("records");
   const record = sampleMixedRecord();
   assert.equal(service.getLabel(), "records");


### PR DESCRIPTION
## Description

Fixes https://github.com/boltffi/boltffi/issues/299

Shared references of class types (e.g. `&Counter`) crossing FFI boundaries broke starting in `v0.23.0`.

## How to reproduce

```rust
pub struct User {
    name: String
}

#[export]
pub fn greet(user: &User) {
    println!("Hello {}", user.name);
}
```

This works fine in `v0.22.1` and before.

## Root cause

https://github.com/boltffi/boltffi/pull/131  introduced a catch-all [here](https://github.com/boltffi/boltffi/pull/131/changes#diff-b1e2892560c7b040550b0518b1a61cd653026b65447995fb02be41a0f5b54a4dR318-R329) to support borrowed wire-encoded data type params (e.g. `&UserProfile`). However, this was too broad, it also matched `&Counter` where Counter is a class type, routing it through wire-encoding instead of pass-through.

## What's changed

- Class types are neither data types nor custom types, so `named_type_category(&Counter)` should return `None`. The fix narrows the guard to only wire-encode references to known named data types. 
- Updated tests so it registers data types (e.g. `UserProfile`, `Filter`) in `ReturnLoweringContext`.

