### PR TITLE
chore: fill java coverage gaps

### DIFF
--- a/examples/demo/src/async_fns/mod.rs
+++ b/examples/demo/src/async_fns/mod.rs
@@ -100,11 +100,6 @@ pub async fn async_concat(strings: Vec<String>) -> String {
     justification = "Ensure an async Result function resolves with a doubled value for valid input.",
     directions = "Call `async_fns::try_compute_async` through the generated binding and assert an async Result function resolves with a doubled value for valid input.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async Result helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently omits async functions. Include this case when async Python bindings are implemented."
@@ -120,11 +115,6 @@ pub async fn async_concat(strings: Vec<String>) -> String {
         details = "C# covers the zero-input invalid case for that branch today; add a separate assertion for the negative overflow case."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async Result helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently omits async functions. Include this case when async Python bindings are implemented."
@@ -134,11 +124,6 @@ pub async fn async_concat(strings: Vec<String>) -> String {
     "async_fns.results.try_compute.should_return_invalid_input_for_zero",
     justification = "Ensure an async Result function rejects zero input with the typed invalid-input error.",
     directions = "Call `async_fns::try_compute_async` through the generated binding and assert an async Result function rejects zero input with the typed invalid-input error.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async Result helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,
@@ -160,11 +145,6 @@ pub async fn try_compute_async(value: i32) -> Result<i32, ComputeError> {
     justification = "Ensure an async string-error Result function resolves with a scaled positive id.",
     directions = "Call `async_fns::fetch_data` through the generated binding and assert an async string-error Result function resolves with a scaled positive id.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async Result helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently omits async functions. Include this case when async Python bindings are implemented."
@@ -174,11 +154,6 @@ pub async fn try_compute_async(value: i32) -> Result<i32, ComputeError> {
     "async_fns.results.fetch_data.should_reject_non_positive_id",
     justification = "Ensure an async string-error Result function rejects a non-positive id.",
     directions = "Call `async_fns::fetch_data` through the generated binding and assert an async string-error Result function rejects a non-positive id.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async Result helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -198,11 +173,6 @@ pub async fn fetch_data(id: i32) -> Result<i32, String> {
     "async_fns.basic.get_numbers.should_return_counting_sequence",
     justification = "Ensure an async vector producer resolves with a zero-based counting sequence.",
     directions = "Call `async_fns::async_get_numbers` through the generated binding and assert an async vector producer resolves with a zero-based counting sequence.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async_get_numbers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,

--- a/examples/demo/src/builtins/mod.rs
+++ b/examples/demo/src/builtins/mod.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
+        details = "#320: Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -42,7 +42,7 @@ pub fn echo_duration(d: Duration) -> Duration {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
+        details = "#320: Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -67,7 +67,7 @@ pub fn make_duration(secs: u64, nanos: u32) -> Duration {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
+        details = "#320: Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -92,7 +92,7 @@ pub fn duration_as_millis(d: Duration) -> u64 {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
+        details = "#320: Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -117,7 +117,7 @@ pub fn echo_system_time(t: SystemTime) -> SystemTime {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
+        details = "#320: Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -142,7 +142,7 @@ pub fn system_time_to_millis(t: SystemTime) -> u64 {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
+        details = "#320: Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -168,7 +168,7 @@ pub fn millis_to_system_time(millis: u64) -> SystemTime {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
+        details = "#320: Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -193,7 +193,7 @@ pub fn echo_uuid(id: Uuid) -> Uuid {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
+        details = "#320: Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -218,7 +218,7 @@ pub fn uuid_to_string(id: Uuid) -> String {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
+        details = "#320: Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -243,7 +243,7 @@ pub fn echo_url(url: Url) -> Url {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
+        details = "#320: Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,

--- a/examples/demo/src/builtins/mod.rs
+++ b/examples/demo/src/builtins/mod.rs
@@ -16,8 +16,8 @@ use uuid::Uuid;
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for built-in Duration values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -41,8 +41,8 @@ pub fn echo_duration(d: Duration) -> Duration {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for built-in Duration values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -66,8 +66,8 @@ pub fn make_duration(secs: u64, nanos: u32) -> Duration {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for built-in Duration values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -91,8 +91,8 @@ pub fn duration_as_millis(d: Duration) -> u64 {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for built-in SystemTime values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -116,8 +116,8 @@ pub fn echo_system_time(t: SystemTime) -> SystemTime {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for built-in SystemTime values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -141,8 +141,8 @@ pub fn system_time_to_millis(t: SystemTime) -> u64 {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for built-in SystemTime values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -167,8 +167,8 @@ pub fn millis_to_system_time(millis: u64) -> SystemTime {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for built-in UUID values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -192,8 +192,8 @@ pub fn echo_uuid(id: Uuid) -> Uuid {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for built-in UUID values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -217,8 +217,8 @@ pub fn uuid_to_string(id: Uuid) -> String {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for built-in URL values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,
@@ -242,8 +242,8 @@ pub fn echo_url(url: Url) -> Url {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for built-in URL values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320 - Java bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant Java built-in binding is implemented."
     ),
     exclude(
         python,

--- a/examples/demo/src/enums/c_style.rs
+++ b/examples/demo/src/enums/c_style.rs
@@ -71,12 +71,7 @@ impl Direction {
     #[demo_bench_macros::demo_case(
         "enums.c_style.direction.should_construct_from_raw_value",
         justification = "Ensure Direction::new maps raw integer values to Direction variants.",
-        directions = "Call `enums::c_style::Direction::new` through the generated binding and assert Direction::new maps raw integer values to Direction variants.",
-        exclude(
-            java,
-            reason = ExclusionReason::CoverageGap,
-            details = "Java has no assertion for Direction::new in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-        )
+        directions = "Call `enums::c_style::Direction::new` through the generated binding and assert Direction::new maps raw integer values to Direction variants."
     )]
     pub fn new(raw: i32) -> Self {
         match raw {
@@ -199,11 +194,6 @@ pub fn opposite_direction(d: Direction) -> Direction {
         details = "C# has no assertion for direction_to_degrees in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for direction_to_degrees in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports C-style enum parameters and primitive returns, but the demo suite has no assertion for direction_to_degrees yet."
@@ -229,11 +219,6 @@ pub fn direction_to_degrees(direction: Direction) -> i32 {
     "enums.c_style.direction.should_generate_sequence",
     justification = "Ensure generate_directions returns a cyclic sequence of Direction values.",
     directions = "Call `enums::c_style::generate_directions` through the generated binding and assert generate_directions returns a cyclic sequence of Direction values.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for direction sequence helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::CoverageGap,
@@ -264,11 +249,6 @@ pub fn generate_directions(count: i32) -> Vec<Direction> {
     justification = "Ensure count_north returns the number of North variants in a Direction vector.",
     directions = "Call `enums::c_style::count_north` through the generated binding and assert count_north returns the number of North variants in a Direction vector.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for direction sequence helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports C-style enum vectors, but the demo suite has no assertion for direction sequence helpers yet."
@@ -298,11 +278,6 @@ pub fn count_north(directions: Vec<Direction>) -> i32 {
         details = "C# has no assertion for find_direction in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_direction in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; C-style enums are emitted, but Option<Direction> returns are not. Include this case when optional enum returns are implemented for Python."
@@ -321,11 +296,6 @@ pub fn count_north(directions: Vec<Direction>) -> i32 {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for find_direction in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_direction in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,
@@ -360,11 +330,6 @@ pub fn find_direction(id: i32) -> Option<Direction> {
         details = "C# has no assertion for find_directions in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_directions in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; C-style enum vectors are emitted, but Option<Vec<Direction>> returns are not. Include this case when optional enum-vector returns are implemented for Python."
@@ -383,11 +348,6 @@ pub fn find_direction(id: i32) -> Option<Direction> {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for find_directions in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_directions in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,

--- a/examples/demo/src/enums/complex_variants.rs
+++ b/examples/demo/src/enums/complex_variants.rs
@@ -23,11 +23,6 @@ pub enum Filter {
         details = "C# reaches the surrounding surface but still needs a round-trip assertion for the Filter::None variant."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the surrounding surface but still needs a round-trip assertion for the Filter::None variant."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -43,11 +38,6 @@ pub enum Filter {
         details = "C# reaches the surrounding surface but still needs a round-trip assertion for the Filter::ByName variant."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the surrounding surface but still needs a round-trip assertion for the Filter::ByName variant."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -57,11 +47,6 @@ pub enum Filter {
     "enums.complex_variants.filter.by_tags.should_roundtrip_string_vector_payload",
     justification = "Ensure the Filter::ByTags variant preserves a vector of UTF-8 strings when round-tripped.",
     directions = "Call `enums::complex_variants::echo_filter` through the generated binding and assert the Filter::ByTags variant preserves a vector of UTF-8 strings when round-tripped.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the surrounding surface but still needs a round-trip assertion for the Filter::ByTags variant."
-    ),
     exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,
@@ -88,11 +73,6 @@ pub enum Filter {
     justification = "Ensure the Filter::ByPoints variant preserves a vector of Point records when round-tripped.",
     directions = "Call `enums::complex_variants::echo_filter` through the generated binding and assert the Filter::ByPoints variant preserves a vector of Point records when round-tripped.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the surrounding surface but still needs a round-trip assertion for the Filter::ByPoints variant."
-    ),
-    exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,
         details = "TypeScript reaches the surrounding surface but still needs a round-trip assertion for the Filter::ByPoints variant."
@@ -118,11 +98,6 @@ pub fn echo_filter(f: Filter) -> Filter {
         details = "C# reaches the complex enum helpers but still needs an assertion for describing the Filter::ByName variant."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the complex enum helpers but still needs an assertion for describing the Filter::ByName variant."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -138,11 +113,6 @@ pub fn echo_filter(f: Filter) -> Filter {
         details = "C# reaches the complex enum helpers but still needs an assertion for describing the Filter::ByRange variant."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the complex enum helpers but still needs an assertion for describing the Filter::ByRange variant."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -152,11 +122,6 @@ pub fn echo_filter(f: Filter) -> Filter {
     "enums.complex_variants.filter.by_tags.should_describe_string_vector_payload",
     justification = "Ensure describe_filter counts the UTF-8 strings in a ByTags vector payload.",
     directions = "Call `enums::complex_variants::describe_filter` through the generated binding and assert describe_filter counts the UTF-8 strings in a ByTags vector payload.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the complex enum helpers but still needs an assertion for describing the Filter::ByTags variant."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -177,11 +142,6 @@ pub fn echo_filter(f: Filter) -> Filter {
     "enums.complex_variants.filter.by_points.should_describe_record_vector_payload",
     justification = "Ensure describe_filter counts Point records in a ByPoints vector payload.",
     directions = "Call `enums::complex_variants::describe_filter` through the generated binding and assert describe_filter counts Point records in a ByPoints vector payload.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the complex enum helpers but still needs an assertion for describing the Filter::ByPoints variant."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -232,11 +192,6 @@ pub enum ApiResponse {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# already exercises Filter complex variants; this case is still waiting on a focused assertion for ApiResponse helpers."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the surrounding surface but still needs a round-trip assertion for the ApiResponse::Redirect variant."
     ),
     exclude(
         python,

--- a/examples/demo/src/enums/data_enum.rs
+++ b/examples/demo/src/enums/data_enum.rs
@@ -44,7 +44,7 @@ impl Shape {
         exclude(
             java,
             reason = ExclusionReason::ImplementationGap,
-            details = "#323 - Java bindgen drops static methods whose Rust name collides with a Java keyword. Java cannot expose Shape::new because new is a Java keyword. Include this case when Java keyword-safe renaming lands."
+            details = "#323: Java bindgen drops static methods whose Rust name collides with a Java keyword. Java cannot expose Shape::new because new is a Java keyword. Include this case when Java keyword-safe renaming lands."
         ),
         exclude(
             python,

--- a/examples/demo/src/enums/data_enum.rs
+++ b/examples/demo/src/enums/data_enum.rs
@@ -44,7 +44,7 @@ impl Shape {
         exclude(
             java,
             reason = ExclusionReason::ImplementationGap,
-            details = "Java cannot expose Shape::new on the generated surface because new is a Java keyword."
+            details = "#323 - Java bindgen drops static methods whose Rust name collides with a Java keyword. Java cannot expose Shape::new because new is a Java keyword. Include this case when Java keyword-safe renaming lands."
         ),
         exclude(
             python,
@@ -330,11 +330,6 @@ pub enum Message {
     justification = "Ensure the Message::Image variant preserves its URL and dimension payload fields when round-tripped.",
     directions = "Call `enums::data_enum::echo_message` through the generated binding and assert the Message::Image variant preserves its URL and dimension payload fields when round-tripped.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the surrounding surface but still needs a round-trip assertion for the Message::Image variant."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -344,11 +339,6 @@ pub enum Message {
     "enums.data_enum.message.ping.should_roundtrip_unit_variant",
     justification = "Ensure the Message::Ping unit variant crosses the FFI boundary unchanged.",
     directions = "Call `enums::data_enum::echo_message` through the generated binding and assert the Message::Ping unit variant crosses the FFI boundary unchanged.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the surrounding surface but still needs a round-trip assertion for the Message::Ping variant."
-    ),
     exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,
@@ -383,11 +373,6 @@ pub fn echo_message(m: Message) -> Message {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# round-trips the value but still needs an assertion for the the Message::Image variant summary."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java round-trips the value but still needs an assertion for the the Message::Image variant summary."
     ),
     exclude(
         python,
@@ -437,11 +422,6 @@ pub enum Animal {
     justification = "Ensure the Animal::Cat variant preserves its name string and indoor boolean payloads when round-tripped.",
     directions = "Call `enums::data_enum::echo_animal` through the generated binding and assert the Animal::Cat variant preserves its name string and indoor boolean payloads when round-tripped.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the surrounding surface but still needs a round-trip assertion for the Animal::Cat variant."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -451,11 +431,6 @@ pub enum Animal {
     "enums.data_enum.animal.fish.should_roundtrip_count_payload",
     justification = "Ensure the Animal::Fish variant preserves its count payload when round-tripped.",
     directions = "Call `enums::data_enum::echo_animal` through the generated binding and assert the Animal::Fish variant preserves its count payload when round-tripped.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the surrounding surface but still needs a round-trip assertion for the Animal::Fish variant."
-    ),
     exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,
@@ -477,11 +452,6 @@ pub fn echo_animal(a: Animal) -> Animal {
     justification = "Ensure animal_name derives the dog name from an Animal::Dog payload.",
     directions = "Call `enums::data_enum::animal_name` through the generated binding and assert animal_name derives the dog name from an Animal::Dog payload.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java round-trips the enum family but still needs an assertion for the derived a name from Animal::Dog behavior."
-    ),
-    exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,
         details = "TypeScript round-trips the enum family but still needs an assertion for the derived a name from Animal::Dog behavior."
@@ -500,11 +470,6 @@ pub fn echo_animal(a: Animal) -> Animal {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# round-trips the enum family but still needs an assertion for the derived a name from Animal::Cat behavior."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java round-trips the enum family but still needs an assertion for the derived a name from Animal::Cat behavior."
     ),
     exclude(
         python,

--- a/examples/demo/src/options/complex.rs
+++ b/examples/demo/src/options/complex.rs
@@ -161,11 +161,6 @@ pub fn echo_optional_status(v: Option<Status>) -> Option<Status> {
     justification = "Ensure an Option<Vec<i32>> carrying Some(empty vector) remains distinct from None.",
     directions = "Call `options::complex::echo_optional_vec` through the generated binding and assert an Option<Vec<i32>> carrying Some(empty vector) remains distinct from None.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Some(empty Vec) for echo_optional_vec in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
@@ -212,11 +207,6 @@ pub fn optional_vec_length(v: Option<Vec<i32>>) -> Option<u32> {
     justification = "Ensure find_name returns Some generated string when the id is positive.",
     directions = "Call `options::complex::find_name` through the generated binding and assert find_name returns Some generated string when the id is positive.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_name in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
@@ -226,11 +216,6 @@ pub fn optional_vec_length(v: Option<Vec<i32>>) -> Option<u32> {
     "options.complex.string.should_return_none_for_non_positive_id",
     justification = "Ensure find_name returns None when the id is not positive.",
     directions = "Call `options::complex::find_name` through the generated binding and assert find_name returns None when the id is not positive.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_name in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -252,11 +237,6 @@ pub fn find_name(id: i32) -> Option<String> {
     justification = "Ensure find_numbers returns Some vector of i32 values when count is positive.",
     directions = "Call `options::complex::find_numbers` through the generated binding and assert find_numbers returns Some vector of i32 values when count is positive.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_numbers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
@@ -266,11 +246,6 @@ pub fn find_name(id: i32) -> Option<String> {
     "options.complex.vec.should_return_none_for_non_positive_number_count",
     justification = "Ensure find_numbers returns None when count is not positive.",
     directions = "Call `options::complex::find_numbers` through the generated binding and assert find_numbers returns None when count is not positive.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_numbers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -292,11 +267,6 @@ pub fn find_numbers(count: i32) -> Option<Vec<i32>> {
     justification = "Ensure find_names returns Some vector of generated strings when count is positive.",
     directions = "Call `options::complex::find_names` through the generated binding and assert find_names returns Some vector of generated strings when count is positive.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_names in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
@@ -306,11 +276,6 @@ pub fn find_numbers(count: i32) -> Option<Vec<i32>> {
     "options.complex.vec_string.should_return_none_for_non_positive_name_count",
     justification = "Ensure find_names returns None when count is not positive.",
     directions = "Call `options::complex::find_names` through the generated binding and assert find_names returns None when count is not positive.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_names in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -331,11 +296,6 @@ pub fn find_names(count: i32) -> Option<Vec<String>> {
     justification = "Ensure find_api_result returns Some(ApiResult::Success) for code 0.",
     directions = "Call `options::complex::find_api_result` through the generated binding and assert find_api_result returns Some(ApiResult::Success) for code 0.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_api_result in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
@@ -346,11 +306,6 @@ pub fn find_names(count: i32) -> Option<Vec<String>> {
     justification = "Ensure find_api_result returns Some(ApiResult::ErrorCode) for code 1.",
     directions = "Call `options::complex::find_api_result` through the generated binding and assert find_api_result returns Some(ApiResult::ErrorCode) for code 1.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_api_result in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
@@ -360,11 +315,6 @@ pub fn find_names(count: i32) -> Option<Vec<String>> {
     "options.complex.api_result.should_find_error_with_data_variant",
     justification = "Ensure find_api_result returns Some(ApiResult::ErrorWithData) for code 2.",
     directions = "Call `options::complex::find_api_result` through the generated binding and assert find_api_result returns Some(ApiResult::ErrorWithData) for code 2.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_api_result in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -380,11 +330,6 @@ pub fn find_names(count: i32) -> Option<Vec<String>> {
     "options.complex.api_result.should_return_none_for_unknown_code",
     justification = "Ensure find_api_result returns None when the code does not map to an ApiResult variant.",
     directions = "Call `options::complex::find_api_result` through the generated binding and assert find_api_result returns None when the code does not map to an ApiResult variant.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_api_result in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -433,11 +378,6 @@ pub fn find_api_result(code: i32) -> Option<ApiResult> {
     "options.complex.vec_optional_i32.should_roundtrip_all_none",
     justification = "Ensure a Vec<Option<i32>> carrying only None elements crosses the wire and preserves each absent slot.",
     directions = "Call `options::complex::echo_vec_optional_i32` through the generated binding and assert a Vec<Option<i32>> carrying only None elements crosses the wire and preserves each absent slot.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for all-None Vec<Option<i32>> in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/options/primitives.rs
+++ b/examples/demo/src/options/primitives.rs
@@ -32,11 +32,6 @@ pub fn echo_optional_i32(v: Option<i32>) -> Option<i32> {
     justification = "Ensure an Option<f64> carrying Some crosses the wire and returns the same value.",
     directions = "Call `options::primitives::echo_optional_f64` through the generated binding and assert an Option<f64> carrying Some crosses the wire and returns the same value.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Option<f64> in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
@@ -46,11 +41,6 @@ pub fn echo_optional_i32(v: Option<i32>) -> Option<i32> {
     "options.primitives.f64.should_roundtrip_none",
     justification = "Ensure an Option<f64> carrying None crosses the wire and returns None.",
     directions = "Call `options::primitives::echo_optional_f64` through the generated binding and assert an Option<f64> carrying None crosses the wire and returns None.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Option<f64> in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -67,11 +57,6 @@ pub fn echo_optional_f64(v: Option<f64>) -> Option<f64> {
     justification = "Ensure an Option<bool> carrying Some crosses the wire and returns the same value.",
     directions = "Call `options::primitives::echo_optional_bool` through the generated binding and assert an Option<bool> carrying Some crosses the wire and returns the same value.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Option<bool> in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
@@ -81,11 +66,6 @@ pub fn echo_optional_f64(v: Option<f64>) -> Option<f64> {
     "options.primitives.bool.should_roundtrip_none",
     justification = "Ensure an Option<bool> carrying None crosses the wire and returns None.",
     directions = "Call `options::primitives::echo_optional_bool` through the generated binding and assert an Option<bool> carrying None crosses the wire and returns None.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Option<bool> in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -183,11 +163,6 @@ pub fn double_if_some(v: Option<i32>) -> Option<i32> {
     justification = "Ensure find_even returns Some containing the input when the i32 value is even.",
     directions = "Call `options::primitives::find_even` through the generated binding and assert find_even returns Some containing the input when the i32 value is even.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_even in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
@@ -197,11 +172,6 @@ pub fn double_if_some(v: Option<i32>) -> Option<i32> {
     "options.primitives.i32.should_return_none_for_odd_value",
     justification = "Ensure find_even returns None when the i32 value is odd.",
     directions = "Call `options::primitives::find_even` through the generated binding and assert find_even returns None when the i32 value is odd.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_even in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -219,11 +189,6 @@ pub fn find_even(value: i32) -> Option<i32> {
     justification = "Ensure find_positive_i64 returns Some containing the input when the i64 value is positive.",
     directions = "Call `options::primitives::find_positive_i64` through the generated binding and assert find_positive_i64 returns Some containing the input when the i64 value is positive.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_positive_i64 in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
@@ -238,11 +203,6 @@ pub fn find_even(value: i32) -> Option<i32> {
     "options.primitives.i64.should_return_none_for_non_positive_value",
     justification = "Ensure find_positive_i64 returns None when the i64 value is zero or negative.",
     directions = "Call `options::primitives::find_positive_i64` through the generated binding and assert find_positive_i64 returns None when the i64 value is zero or negative.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_positive_i64 in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -265,11 +225,6 @@ pub fn find_positive_i64(value: i64) -> Option<i64> {
     justification = "Ensure find_positive_f64 returns Some containing the input when the f64 value is positive.",
     directions = "Call `options::primitives::find_positive_f64` through the generated binding and assert find_positive_f64 returns Some containing the input when the f64 value is positive.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_positive_f64 in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
@@ -279,11 +234,6 @@ pub fn find_positive_i64(value: i64) -> Option<i64> {
     "options.primitives.f64.should_return_none_for_non_positive_value",
     justification = "Ensure find_positive_f64 returns None when the f64 value is zero or negative.",
     directions = "Call `options::primitives::find_positive_f64` through the generated binding and assert find_positive_f64 returns None when the f64 value is zero or negative.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_positive_f64 in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/primitives/scalars.rs
+++ b/examples/demo/src/primitives/scalars.rs
@@ -26,12 +26,7 @@ pub fn negate_bool(v: bool) -> bool {
 #[demo_bench_macros::demo_case(
     "primitives.scalars.i8.should_roundtrip_negative_value",
     justification = "Ensure a negative i8 value crosses the wire and returns unchanged.",
-    directions = "Call `primitives::scalars::echo_i8` through the generated binding and assert a negative i8 value crosses the wire and returns unchanged.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for i8 scalar values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `primitives::scalars::echo_i8` through the generated binding and assert a negative i8 value crosses the wire and returns unchanged."
 )]
 #[export]
 pub fn echo_i8(v: i8) -> i8 {
@@ -41,12 +36,7 @@ pub fn echo_i8(v: i8) -> i8 {
 #[demo_bench_macros::demo_case(
     "primitives.scalars.u8.should_roundtrip_max_value",
     justification = "Ensure a maximum u8 value crosses the wire and returns unchanged.",
-    directions = "Call `primitives::scalars::echo_u8` through the generated binding and assert a maximum u8 value crosses the wire and returns unchanged.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for u8 scalar values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `primitives::scalars::echo_u8` through the generated binding and assert a maximum u8 value crosses the wire and returns unchanged."
 )]
 #[export]
 pub fn echo_u8(v: u8) -> u8 {
@@ -56,12 +46,7 @@ pub fn echo_u8(v: u8) -> u8 {
 #[demo_bench_macros::demo_case(
     "primitives.scalars.i16.should_roundtrip_negative_value",
     justification = "Ensure a negative i16 value crosses the wire and returns unchanged.",
-    directions = "Call `primitives::scalars::echo_i16` through the generated binding and assert a negative i16 value crosses the wire and returns unchanged.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for i16 scalar values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `primitives::scalars::echo_i16` through the generated binding and assert a negative i16 value crosses the wire and returns unchanged."
 )]
 #[export]
 pub fn echo_i16(v: i16) -> i16 {
@@ -71,12 +56,7 @@ pub fn echo_i16(v: i16) -> i16 {
 #[demo_bench_macros::demo_case(
     "primitives.scalars.u16.should_roundtrip_large_value",
     justification = "Ensure a large u16 value crosses the wire and returns unchanged.",
-    directions = "Call `primitives::scalars::echo_u16` through the generated binding and assert a large u16 value crosses the wire and returns unchanged.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for u16 scalar values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `primitives::scalars::echo_u16` through the generated binding and assert a large u16 value crosses the wire and returns unchanged."
 )]
 #[export]
 pub fn echo_u16(v: u16) -> u16 {
@@ -109,12 +89,7 @@ pub fn add_i32(a: i32, b: i32) -> i32 {
 #[demo_bench_macros::demo_case(
     "primitives.scalars.u32.should_roundtrip_large_value",
     justification = "Ensure a large u32 value crosses the wire and returns unchanged.",
-    directions = "Call `primitives::scalars::echo_u32` through the generated binding and assert a large u32 value crosses the wire and returns unchanged.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for u32 scalar values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `primitives::scalars::echo_u32` through the generated binding and assert a large u32 value crosses the wire and returns unchanged."
 )]
 #[export]
 pub fn echo_u32(v: u32) -> u32 {
@@ -134,12 +109,7 @@ pub fn echo_i64(v: i64) -> i64 {
 #[demo_bench_macros::demo_case(
     "primitives.scalars.u64.should_roundtrip_large_value",
     justification = "Ensure a large u64 value crosses the wire and returns unchanged.",
-    directions = "Call `primitives::scalars::echo_u64` through the generated binding and assert a large u64 value crosses the wire and returns unchanged.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for u64 scalar values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `primitives::scalars::echo_u64` through the generated binding and assert a large u64 value crosses the wire and returns unchanged."
 )]
 #[export]
 pub fn echo_u64(v: u64) -> u64 {
@@ -191,12 +161,7 @@ pub fn add_f64(a: f64, b: f64) -> f64 {
 #[demo_bench_macros::demo_case(
     "primitives.scalars.usize.should_roundtrip_value",
     justification = "Ensure a usize value crosses the wire and returns unchanged.",
-    directions = "Call `primitives::scalars::echo_usize` through the generated binding and assert a usize value crosses the wire and returns unchanged.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for usize scalar values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `primitives::scalars::echo_usize` through the generated binding and assert a usize value crosses the wire and returns unchanged."
 )]
 #[export]
 pub fn echo_usize(v: usize) -> usize {
@@ -206,12 +171,7 @@ pub fn echo_usize(v: usize) -> usize {
 #[demo_bench_macros::demo_case(
     "primitives.scalars.isize.should_roundtrip_negative_value",
     justification = "Ensure a negative isize value crosses the wire and returns unchanged.",
-    directions = "Call `primitives::scalars::echo_isize` through the generated binding and assert a negative isize value crosses the wire and returns unchanged.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for isize scalar values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `primitives::scalars::echo_isize` through the generated binding and assert a negative isize value crosses the wire and returns unchanged."
 )]
 #[export]
 pub fn echo_isize(v: isize) -> isize {
@@ -227,11 +187,6 @@ pub fn echo_isize(v: isize) -> isize {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for the scalar noop helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for the scalar noop helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,
@@ -258,11 +213,6 @@ pub fn noop() {}
         details = "C# has no assertion for the benchmark add alias in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for the benchmark add alias in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive scalar calls, but the demo suite has no assertion for the benchmark add alias yet."
@@ -287,11 +237,6 @@ pub fn add(a: i32, b: i32) -> i32 {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for the scalar multiply helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for the scalar multiply helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,

--- a/examples/demo/src/primitives/vecs.rs
+++ b/examples/demo/src/primitives/vecs.rs
@@ -205,11 +205,6 @@ pub fn reverse_vec_i32(v: Vec<i32>) -> Vec<i32> {
     justification = "Ensure an i32 count crosses the wire and returns a generated i32 sequence.",
     directions = "Call `primitives::vecs::generate_i32_vec` through the generated binding and assert an i32 count crosses the wire and returns a generated i32 sequence.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for benchmark vector generators in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive vector returns, but the demo suite has no assertion for this benchmark vector generator yet."
@@ -236,11 +231,6 @@ pub fn generate_i32_vec(count: i32) -> Vec<i32> {
         details = "C# has no assertion for the i32 benchmark sum helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for the i32 benchmark sum helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive vector parameters and primitive returns, but the demo suite has no assertion for this benchmark sum helper yet."
@@ -262,11 +252,6 @@ pub fn sum_i32_vec(values: Vec<i32>) -> i64 {
     justification = "Ensure an i32 count crosses the wire and returns a generated f64 sequence.",
     directions = "Call `primitives::vecs::generate_f64_vec` through the generated binding and assert an i32 count crosses the wire and returns a generated f64 sequence.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for benchmark vector generators in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive vector returns, but the demo suite has no assertion for this benchmark vector generator yet."
@@ -287,11 +272,6 @@ pub fn generate_f64_vec(count: i32) -> Vec<f64> {
     "primitives.vecs.f64.should_sum_values",
     justification = "Ensure a f64 vector crosses the wire and returns as a f64 sum.",
     directions = "Call `primitives::vecs::sum_f64_vec` through the generated binding and assert a f64 vector crosses the wire and returns as a f64 sum.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for f64 vector sums in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::CoverageGap,
@@ -320,11 +300,6 @@ pub fn sum_f64_vec(values: Vec<f64>) -> f64 {
         details = "C# has no assertion for the in-place u64 slice helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for the in-place u64 slice helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer only accepts value parameters today, so mutable slice parameters are omitted. Include this case when in-place sequence parameters are implemented for Python."
@@ -345,11 +320,6 @@ pub fn inc_u64(values: &mut [u64]) {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for the u64 value increment helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for the u64 value increment helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,
@@ -481,11 +451,6 @@ pub fn echo_vec_vec_string(v: Vec<Vec<String>>) -> Vec<Vec<String>> {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for flattening an empty nested vector in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for flattening an empty nested vector in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,

--- a/examples/demo/src/records/blittable.rs
+++ b/examples/demo/src/records/blittable.rs
@@ -26,7 +26,7 @@ impl Point {
         exclude(
             java,
             reason = ExclusionReason::ImplementationGap,
-            details = "#323 - Java bindgen drops static methods whose Rust name collides with a Java keyword. Java cannot expose Point::new because new is a Java keyword. Include this case when Java keyword-safe renaming lands."
+            details = "#323: Java bindgen drops static methods whose Rust name collides with a Java keyword. Java cannot expose Point::new because new is a Java keyword. Include this case when Java keyword-safe renaming lands."
         )
     )]
     pub fn new(x: f64, y: f64) -> Self {

--- a/examples/demo/src/records/blittable.rs
+++ b/examples/demo/src/records/blittable.rs
@@ -25,8 +25,8 @@ impl Point {
         ),
         exclude(
             java,
-            reason = ExclusionReason::CoverageGap,
-            details = "Java validates this area through the generated Point data constructor today; add a direct assertion for the Point::new method before marking this case covered."
+            reason = ExclusionReason::ImplementationGap,
+            details = "#323 - Java bindgen drops static methods whose Rust name collides with a Java keyword. Java cannot expose Point::new because new is a Java keyword. Include this case when Java keyword-safe renaming lands."
         )
     )]
     pub fn new(x: f64, y: f64) -> Self {
@@ -225,11 +225,6 @@ pub fn echo_point(p: Point) -> Point {
         details = "C# has no assertion for try_make_point in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for try_make_point in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T> around blittable records. Include this case when optional record returns are implemented for Python."
@@ -243,11 +238,6 @@ pub fn echo_point(p: Point) -> Point {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for try_make_point in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for try_make_point in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,
@@ -300,12 +290,7 @@ pub struct Color {
 #[demo_bench_macros::demo_case(
     "records.blittable.color.should_roundtrip_value",
     justification = "Ensure a blittable Color crosses the wire and returns unchanged.",
-    directions = "Call `records::blittable::echo_color` through the generated binding and assert a blittable Color crosses the wire and returns unchanged.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Color records in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `records::blittable::echo_color` through the generated binding and assert a blittable Color crosses the wire and returns unchanged."
 )]
 #[export]
 pub fn echo_color(c: Color) -> Color {
@@ -315,12 +300,7 @@ pub fn echo_color(c: Color) -> Color {
 #[demo_bench_macros::demo_case(
     "records.blittable.color.should_make_from_channels",
     justification = "Ensure make_color returns a Color containing the provided channel values.",
-    directions = "Call `records::blittable::make_color` through the generated binding and assert make_color returns a Color containing the provided channel values.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Color records in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `records::blittable::make_color` through the generated binding and assert make_color returns a Color containing the provided channel values."
 )]
 #[export]
 pub fn make_color(r: u8, g: u8, b: u8, a: u8) -> Color {
@@ -553,11 +533,6 @@ pub fn generate_locations(count: i32) -> Vec<Location> {
     justification = "Ensure process_locations treats an empty Location vector as count zero.",
     directions = "Call `records::blittable::process_locations` through the generated binding and assert process_locations treats an empty Location vector as count zero.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for the empty Location vector count in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,
         details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
@@ -572,11 +547,6 @@ pub fn generate_locations(count: i32) -> Vec<Location> {
     "records.blittable.locations.should_count_host_constructed_vector",
     justification = "Ensure process_locations receives host-constructed Location records and returns their item count.",
     directions = "Call `records::blittable::process_locations` through the generated binding and assert process_locations receives host-constructed Location records and returns their item count.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for host-constructed Location vectors in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,
@@ -613,11 +583,6 @@ pub fn process_locations(locations: Vec<Location>) -> i32 {
     "records.blittable.locations.should_sum_host_constructed_ratings",
     justification = "Ensure sum_ratings receives host-constructed Location records and sums their f64 rating fields.",
     directions = "Call `records::blittable::sum_ratings` through the generated binding and assert sum_ratings receives host-constructed Location records and sums their f64 rating fields.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for host-constructed Location vectors in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,
@@ -820,11 +785,6 @@ pub fn generate_sensor_readings(count: i32) -> Vec<SensorReading> {
     justification = "Ensure avg_sensor_temperature treats an empty SensorReading vector as average zero.",
     directions = "Call `records::blittable::avg_sensor_temperature` through the generated binding and assert avg_sensor_temperature treats an empty SensorReading vector as average zero.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for empty SensorReading vectors in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,
         details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
@@ -860,11 +820,6 @@ pub fn avg_sensor_temperature(readings: Vec<SensorReading>) -> f64 {
         details = "C# has no assertion for find_location in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_location in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,
         details = "TypeScript has no assertion for find_location in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
@@ -883,11 +838,6 @@ pub fn avg_sensor_temperature(readings: Vec<SensorReading>) -> f64 {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for find_location in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_location in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         typescript,
@@ -927,11 +877,6 @@ pub fn find_location(id: i32) -> Option<Location> {
         details = "C# has no assertion for find_locations in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_locations in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         typescript,
         reason = ExclusionReason::CoverageGap,
         details = "TypeScript has no assertion for find_locations in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
@@ -950,11 +895,6 @@ pub fn find_location(id: i32) -> Option<Location> {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for find_locations in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for find_locations in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         typescript,

--- a/examples/demo/src/records/nested.rs
+++ b/examples/demo/src/records/nested.rs
@@ -87,11 +87,6 @@ pub struct Rect {
     justification = "Ensure a Rect record containing Point and Dimensions records crosses the wire and returns unchanged.",
     directions = "Call `records::nested::echo_rect` through the generated binding and assert a Rect record containing Point and Dimensions records crosses the wire and returns unchanged.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Rect records in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when nested records are implemented for Python."
@@ -107,11 +102,6 @@ pub fn echo_rect(r: Rect) -> Rect {
     "records.nested.rect.should_compute_area",
     justification = "Ensure rect_area receives a Rect record and multiplies its nested width and height fields.",
     directions = "Call `records::nested::rect_area` through the generated binding and assert rect_area receives a Rect record and multiplies its nested width and height fields.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Rect records in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/records/with_collections.rs
+++ b/examples/demo/src/records/with_collections.rs
@@ -231,11 +231,6 @@ pub struct BenchmarkUserProfile {
     justification = "Ensure generate_user_profiles returns a vector of benchmark profile records with nested vectors.",
     directions = "Call `records::with_collections::generate_user_profiles` through the generated binding and assert generate_user_profiles returns a vector of benchmark profile records with nested vectors.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for benchmark user profile helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records and top-level primitive/C-style enum vectors. Include this case when records with collection fields are implemented for Python."
@@ -279,11 +274,6 @@ pub fn generate_user_profiles(count: i32) -> Vec<BenchmarkUserProfile> {
     justification = "Ensure sum_user_scores receives a vector of benchmark profile records and sums their score fields.",
     directions = "Call `records::with_collections::sum_user_scores` through the generated binding and assert sum_user_scores receives a vector of benchmark profile records and sums their score fields.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for benchmark user profile helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records and top-level primitive/C-style enum vectors. Include this case when records with collection fields are implemented for Python."
@@ -304,11 +294,6 @@ pub fn sum_user_scores(users: Vec<BenchmarkUserProfile>) -> f64 {
     "records.with_collections.user_profiles.should_count_active_users",
     justification = "Ensure count_active_users receives a vector of benchmark profile records and counts active users.",
     directions = "Call `records::with_collections::count_active_users` through the generated binding and assert count_active_users receives a vector of benchmark profile records and counts active users.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for benchmark user profile helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/records/with_enums.rs
+++ b/examples/demo/src/records/with_enums.rs
@@ -17,11 +17,6 @@ pub struct Task {
     justification = "Ensure a Task record with a Priority enum field crosses the wire and returns unchanged.",
     directions = "Call `records::with_enums::echo_task` through the generated binding and assert a Task record with a Priority enum field crosses the wire and returns unchanged.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java already exercises enum-bearing headers and holders; this case is still waiting on a focused assertion for Task helpers."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when records with enum fields are implemented for Python."
@@ -40,11 +35,6 @@ pub fn echo_task(task: Task) -> Task {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# already exercises Task round-trip; this case is still waiting on a focused assertion for make_task."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java already exercises enum-bearing headers and holders; this case is still waiting on a focused assertion for Task helpers."
     ),
     exclude(
         python,
@@ -71,11 +61,6 @@ pub fn make_task(title: String, priority: Priority) -> Task {
         details = "C# already exercises Task round-trip; this case is still waiting on a focused assertion for is_urgent."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java already exercises enum-bearing headers and holders; this case is still waiting on a focused assertion for Task helpers."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when records with enum fields are implemented for Python."
@@ -98,11 +83,6 @@ pub struct Notification {
     "records.with_enums.notification.should_roundtrip_priority_field",
     justification = "Ensure a Notification record with a Priority enum field crosses the wire and returns unchanged.",
     directions = "Call `records::with_enums::echo_notification` through the generated binding and assert a Notification record with a Priority enum field crosses the wire and returns unchanged.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java already exercises enum-bearing headers and holders; this case is still waiting on a focused assertion for Notification helpers."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/records/with_options.rs
+++ b/examples/demo/src/records/with_options.rs
@@ -28,11 +28,6 @@ pub struct UserProfile {
     justification = "Ensure a UserProfile record with absent optional fields crosses the wire and returns unchanged.",
     directions = "Call `records::with_options::echo_user_profile` through the generated binding and assert a UserProfile record with absent optional fields crosses the wire and returns unchanged.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the surrounding surface but still needs a round-trip assertion for UserProfile with absent options."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when records with optional fields are implemented for Python."
@@ -48,11 +43,6 @@ pub struct UserProfile {
     justification = "Ensure a UserProfile record with one present option and one absent option crosses the wire and returns unchanged.",
     directions = "Call `records::with_options::echo_user_profile` through the generated binding and assert a UserProfile record with one present option and one absent option crosses the wire and returns unchanged.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the surrounding surface but still needs a round-trip assertion for UserProfile with mixed option presence."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when records with optional fields are implemented for Python."
@@ -67,11 +57,6 @@ pub struct UserProfile {
     "records.with_options.user_profile.should_roundtrip_utf8_optional_string",
     justification = "Ensure a UserProfile record with UTF-8 text inside optional string fields crosses the wire and returns unchanged.",
     directions = "Call `records::with_options::echo_user_profile` through the generated binding and assert a UserProfile record with UTF-8 text inside optional string fields crosses the wire and returns unchanged.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java reaches the surrounding surface but still needs a round-trip assertion for UTF-8 inside UserProfile optional fields."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/records/with_strings.rs
+++ b/examples/demo/src/records/with_strings.rs
@@ -74,11 +74,6 @@ pub struct Address {
     justification = "Ensure an Address record with multiple string fields crosses the wire and returns unchanged.",
     directions = "Call `records::with_strings::echo_address` through the generated binding and assert an Address record with multiple string fields crosses the wire and returns unchanged.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Address records in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when records with string fields are implemented for Python."
@@ -94,11 +89,6 @@ pub fn echo_address(a: Address) -> Address {
     "records.with_strings.address.should_format_value",
     justification = "Ensure format_address receives an Address record and returns a formatted string.",
     directions = "Call `records::with_strings::format_address` through the generated binding and assert format_address receives an Address record and returns a formatted string.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Address records in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/results/async_results.rs
+++ b/examples/demo/src/results/async_results.rs
@@ -7,11 +7,6 @@ use super::error_enums::MathError;
     justification = "Ensure async_safe_divide resolves to the integer quotient when the divisor is non-zero.",
     directions = "Call `results::async_results::async_safe_divide` through the generated binding and assert async_safe_divide resolves to the integer quotient when the divisor is non-zero.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async result exports in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently omits async functions and Result returns. Include this case when async Result support is implemented for Python."
@@ -21,11 +16,6 @@ use super::error_enums::MathError;
     "results.async_results.safe_divide.should_reject_division_by_zero",
     justification = "Ensure async_safe_divide rejects with a typed MathError when the divisor is zero.",
     directions = "Call `results::async_results::async_safe_divide` through the generated binding and assert async_safe_divide rejects with a typed MathError when the divisor is zero.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async result exports in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -46,11 +36,6 @@ pub async fn async_safe_divide(a: i32, b: i32) -> Result<i32, MathError> {
     justification = "Ensure async_fallible_fetch resolves to a value string for a non-negative key.",
     directions = "Call `results::async_results::async_fallible_fetch` through the generated binding and assert async_fallible_fetch resolves to a value string for a non-negative key.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async result exports in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently omits async functions and Result returns. Include this case when async Result support is implemented for Python."
@@ -60,11 +45,6 @@ pub async fn async_safe_divide(a: i32, b: i32) -> Result<i32, MathError> {
     "results.async_results.fallible_fetch.should_reject_negative_key",
     justification = "Ensure async_fallible_fetch rejects with a string error for a negative key.",
     directions = "Call `results::async_results::async_fallible_fetch` through the generated binding and assert async_fallible_fetch rejects with a string error for a negative key.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async result exports in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -88,11 +68,6 @@ pub async fn async_fallible_fetch(key: i32) -> Result<String, String> {
     justification = "Ensure async_find_value resolves to Ok(Some) for a positive key.",
     directions = "Call `results::async_results::async_find_value` through the generated binding and assert async_find_value resolves to Ok(Some) for a positive key.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async result exports in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently omits async functions and Result returns. Include this case when async Result support is implemented for Python."
@@ -103,11 +78,6 @@ pub async fn async_fallible_fetch(key: i32) -> Result<String, String> {
     justification = "Ensure async_find_value resolves to Ok(None) for key zero.",
     directions = "Call `results::async_results::async_find_value` through the generated binding and assert async_find_value resolves to Ok(None) for key zero.",
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async result exports in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently omits async functions and Result returns. Include this case when async Result support is implemented for Python."
@@ -117,11 +87,6 @@ pub async fn async_fallible_fetch(key: i32) -> Result<String, String> {
     "results.async_results.find_value.should_reject_negative_key",
     justification = "Ensure async_find_value rejects with a string error for a negative key.",
     directions = "Call `results::async_results::async_find_value` through the generated binding and assert async_find_value rejects with a string error for a negative key.",
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for async result exports in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/results/basic.rs
+++ b/examples/demo/src/results/basic.rs
@@ -41,11 +41,6 @@ pub fn safe_divide(a: i32, b: i32) -> Result<i32, String> {
         details = "C# has no assertion for safe_sqrt in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for safe_sqrt in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result-returning functions. Include this case when Result returns are implemented for Python."
@@ -59,11 +54,6 @@ pub fn safe_divide(a: i32, b: i32) -> Result<i32, String> {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for safe_sqrt in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for safe_sqrt in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,
@@ -158,8 +148,8 @@ pub fn always_err(msg: String) -> Result<i32, String> {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Result parameters in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#321 - Java bindgen does not currently emit functions that take Result<T, E> as a parameter. Include this case when Java Result-parameter support lands."
     ),
     exclude(
         python,
@@ -178,8 +168,8 @@ pub fn always_err(msg: String) -> Result<i32, String> {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for Result parameters in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#321 - Java bindgen does not currently emit functions that take Result<T, E> as a parameter. Include this case when Java Result-parameter support lands."
     ),
     exclude(
         python,
@@ -205,11 +195,6 @@ pub fn result_to_string(v: Result<i32, String>) -> String {
         details = "C# has no assertion for the divide alias in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for the divide alias in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result-returning functions. Include this case when Result returns are implemented for Python."
@@ -223,11 +208,6 @@ pub fn result_to_string(v: Result<i32, String>) -> String {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for the divide alias in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for the divide alias in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,
@@ -250,11 +230,6 @@ pub fn divide(a: i32, b: i32) -> Result<i32, String> {
         details = "C# has no assertion for the top-level parse_int export in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for the top-level parse_int export in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result-returning functions. Include this case when Result returns are implemented for Python."
@@ -268,11 +243,6 @@ pub fn divide(a: i32, b: i32) -> Result<i32, String> {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for the top-level parse_int export in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for the top-level parse_int export in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,
@@ -297,11 +267,6 @@ pub fn parse_int(input: String) -> Result<i32, String> {
         details = "C# has no assertion for validate_name in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for validate_name in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result-returning functions. Include this case when Result returns are implemented for Python."
@@ -315,11 +280,6 @@ pub fn parse_int(input: String) -> Result<i32, String> {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for validate_name in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for validate_name in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,

--- a/examples/demo/src/results/basic.rs
+++ b/examples/demo/src/results/basic.rs
@@ -149,7 +149,7 @@ pub fn always_err(msg: String) -> Result<i32, String> {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#321 - Java bindgen does not currently emit functions that take Result<T, E> as a parameter. Include this case when Java Result-parameter support lands."
+        details = "#321: Java bindgen does not currently emit functions that take Result<T, E> as a parameter. Include this case when Java Result-parameter support lands."
     ),
     exclude(
         python,
@@ -169,7 +169,7 @@ pub fn always_err(msg: String) -> Result<i32, String> {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#321 - Java bindgen does not currently emit functions that take Result<T, E> as a parameter. Include this case when Java Result-parameter support lands."
+        details = "#321: Java bindgen does not currently emit functions that take Result<T, E> as a parameter. Include this case when Java Result-parameter support lands."
     ),
     exclude(
         python,

--- a/examples/demo/src/results/error_enums.rs
+++ b/examples/demo/src/results/error_enums.rs
@@ -321,11 +321,6 @@ pub struct BenchmarkResponse {
         details = "C# has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
@@ -341,11 +336,6 @@ pub struct BenchmarkResponse {
         details = "C# has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
@@ -359,11 +349,6 @@ pub struct BenchmarkResponse {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,
@@ -400,11 +385,6 @@ pub fn process_value(value: i32) -> ApiResult {
         details = "C# has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
@@ -418,11 +398,6 @@ pub fn process_value(value: i32) -> ApiResult {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,
@@ -445,11 +420,6 @@ pub fn api_result_is_success(result: ApiResult) -> bool {
         details = "C# has no assertion for ComputeError data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for ComputeError data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
@@ -463,11 +433,6 @@ pub fn api_result_is_success(result: ApiResult) -> bool {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for ComputeError data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for ComputeError data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,
@@ -497,8 +462,8 @@ pub fn try_compute(value: i32) -> Result<i32, ComputeError> {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for BenchmarkResponse result fields in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#322 - Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
     ),
     exclude(
         python,
@@ -525,8 +490,8 @@ pub fn create_success_response(request_id: i64, point: DataPoint) -> BenchmarkRe
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for BenchmarkResponse result fields in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#322 - Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
     ),
     exclude(
         python,
@@ -553,8 +518,8 @@ pub fn create_error_response(request_id: i64, error: ComputeError) -> BenchmarkR
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for BenchmarkResponse result fields in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#322 - Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
     ),
     exclude(
         python,
@@ -573,8 +538,8 @@ pub fn create_error_response(request_id: i64, error: ComputeError) -> BenchmarkR
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for BenchmarkResponse result fields in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#322 - Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
     ),
     exclude(
         python,
@@ -598,8 +563,8 @@ pub fn is_response_success(response: BenchmarkResponse) -> bool {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for BenchmarkResponse result fields in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#322 - Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
     ),
     exclude(
         python,
@@ -618,8 +583,8 @@ pub fn is_response_success(response: BenchmarkResponse) -> bool {
     ),
     exclude(
         java,
-        reason = ExclusionReason::CoverageGap,
-        details = "Java has no assertion for BenchmarkResponse result fields in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#322 - Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
     ),
     exclude(
         python,

--- a/examples/demo/src/results/error_enums.rs
+++ b/examples/demo/src/results/error_enums.rs
@@ -463,7 +463,7 @@ pub fn try_compute(value: i32) -> Result<i32, ComputeError> {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#322 - Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
+        details = "#322: Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
     ),
     exclude(
         python,
@@ -491,7 +491,7 @@ pub fn create_success_response(request_id: i64, point: DataPoint) -> BenchmarkRe
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#322 - Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
+        details = "#322: Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
     ),
     exclude(
         python,
@@ -519,7 +519,7 @@ pub fn create_error_response(request_id: i64, error: ComputeError) -> BenchmarkR
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#322 - Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
+        details = "#322: Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
     ),
     exclude(
         python,
@@ -539,7 +539,7 @@ pub fn create_error_response(request_id: i64, error: ComputeError) -> BenchmarkR
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#322 - Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
+        details = "#322: Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
     ),
     exclude(
         python,
@@ -564,7 +564,7 @@ pub fn is_response_success(response: BenchmarkResponse) -> bool {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#322 - Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
+        details = "#322: Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
     ),
     exclude(
         python,
@@ -584,7 +584,7 @@ pub fn is_response_success(response: BenchmarkResponse) -> bool {
     exclude(
         java,
         reason = ExclusionReason::ImplementationGap,
-        details = "#322 - Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
+        details = "#322: Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
     ),
     exclude(
         python,

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -13,15 +13,26 @@ public final class DemoTest {
         try {
             System.out.println("Testing Java bindings...\n");
             testBool();
+            testI8();
+            testU8();
+            testI16();
+            testU16();
             testI32();
+            testU32();
             testI64();
+            testU64();
+            testIsize();
+            testUsize();
             testF32();
             testF64();
+            testNoop();
             testStrings();
             testCustomTypes();
             testPointRecords();
             testLineRecords();
+            testAddressRecords();
             testPersonRecords();
+            testUserProfileVecs();
             testRecordDefaultValues();
             testCStyleEnums();
             testDataEnums();
@@ -80,6 +91,72 @@ public final class DemoTest {
         assert Demo.echoI32(42) == 42 : "echoI32(42)";
         assert Demo.echoI32(-100) == -100 : "case:primitives.scalars.i32.should_roundtrip_negative_value echoI32(-100)";
         assert Demo.addI32(10, 20) == 30 : "case:primitives.scalars.i32.should_add_two_values addI32(10, 20)";
+        assert Demo.add(7, 9) == 16 : "case:primitives.scalars.i32.should_add_with_benchmark_alias add(7, 9)";
+        System.out.println("  PASS\n");
+    }
+
+    private static void testI8() {
+        System.out.println("Testing i8...");
+        assert Demo.echoI8((byte) 0) == (byte) 0 : "echoI8(0)";
+        assert Demo.echoI8((byte) -7) == (byte) -7 : "case:primitives.scalars.i8.should_roundtrip_negative_value echoI8(-7)";
+        System.out.println("  PASS\n");
+    }
+
+    private static void testU8() {
+        System.out.println("Testing u8...");
+        assert Demo.echoU8((byte) 0) == (byte) 0 : "echoU8(0)";
+        assert Demo.echoU8((byte) 0xFF) == (byte) 0xFF : "case:primitives.scalars.u8.should_roundtrip_max_value echoU8(255)";
+        System.out.println("  PASS\n");
+    }
+
+    private static void testI16() {
+        System.out.println("Testing i16...");
+        assert Demo.echoI16((short) 0) == (short) 0 : "echoI16(0)";
+        assert Demo.echoI16((short) -1234) == (short) -1234 : "case:primitives.scalars.i16.should_roundtrip_negative_value echoI16(-1234)";
+        System.out.println("  PASS\n");
+    }
+
+    private static void testU16() {
+        System.out.println("Testing u16...");
+        assert Demo.echoU16((short) 0) == (short) 0 : "echoU16(0)";
+        // Round-trip a u16 value outside the signed short range (55000 -> (short) -10536 in two's complement).
+        assert Demo.echoU16((short) 55000) == (short) 55000 : "case:primitives.scalars.u16.should_roundtrip_large_value echoU16(55000)";
+        System.out.println("  PASS\n");
+    }
+
+    private static void testU32() {
+        System.out.println("Testing u32...");
+        assert Demo.echoU32(0) == 0 : "echoU32(0)";
+        // 4_000_000_000 is outside the signed int range; round-trip its two's-complement bit pattern.
+        assert Demo.echoU32((int) 4_000_000_000L) == (int) 4_000_000_000L : "case:primitives.scalars.u32.should_roundtrip_large_value echoU32(4e9)";
+        System.out.println("  PASS\n");
+    }
+
+    private static void testU64() {
+        System.out.println("Testing u64...");
+        assert Demo.echoU64(0L) == 0L : "echoU64(0)";
+        assert Demo.echoU64(9_999_999_999L) == 9_999_999_999L : "case:primitives.scalars.u64.should_roundtrip_large_value echoU64(1e10)";
+        System.out.println("  PASS\n");
+    }
+
+    private static void testIsize() {
+        System.out.println("Testing isize...");
+        assert Demo.echoIsize(0L) == 0L : "echoIsize(0)";
+        assert Demo.echoIsize(-123L) == -123L : "case:primitives.scalars.isize.should_roundtrip_negative_value echoIsize(-123)";
+        System.out.println("  PASS\n");
+    }
+
+    private static void testUsize() {
+        System.out.println("Testing usize...");
+        assert Demo.echoUsize(0L) == 0L : "echoUsize(0)";
+        assert Demo.echoUsize(123L) == 123L : "case:primitives.scalars.usize.should_roundtrip_value echoUsize(123)";
+        System.out.println("  PASS\n");
+    }
+
+    private static void testNoop() {
+        System.out.println("Testing noop...");
+        demoCase("case:primitives.scalars.noop.should_cross_without_values");
+        Demo.noop();
         System.out.println("  PASS\n");
     }
 
@@ -101,6 +178,7 @@ public final class DemoTest {
         System.out.println("Testing f64...");
         assert Math.abs(Demo.echoF64(3.14159265359) - 3.14159265359) < 0.0000001 : "case:primitives.scalars.f64.should_roundtrip_pi_with_tolerance echoF64(pi)";
         assert Math.abs(Demo.addF64(1.5, 2.5) - 4.0) < 0.0000001 : "case:primitives.scalars.f64.should_add_two_values_with_tolerance addF64(1.5, 2.5)";
+        assert Math.abs(Demo.multiply(1.5, 4.0) - 6.0) < 0.0000001 : "case:primitives.scalars.f64.should_multiply_two_values multiply(1.5, 4.0)";
         System.out.println("  PASS\n");
     }
 
@@ -225,6 +303,13 @@ public final class DemoTest {
         Point sumPoint = Demo.addPoints(new Point(3.0, 4.0), new Point(5.0, 6.0));
         assert sumPoint.x() == 8.0 : "addPoints.x";
         assert sumPoint.y() == 10.0 : "addPoints.y";
+
+        demoCase("case:records.blittable.point.should_return_some_for_nonzero_coordinates");
+        Optional<Point> tryNonzero = Demo.tryMakePoint(1.0, 2.0);
+        assert tryNonzero.isPresent() : "tryMakePoint non-zero present";
+        assert tryNonzero.get().x() == 1.0 && tryNonzero.get().y() == 2.0 : "tryMakePoint value";
+        demoCase("case:records.blittable.point.should_return_none_for_origin_coordinates");
+        assert !Demo.tryMakePoint(0.0, 0.0).isPresent() : "tryMakePoint origin none";
         assert Math.abs(MathUtils.distanceBetween(new Point(0.0, 0.0), new Point(3.0, 4.0)) - 5.0) < 0.0001 : "MathUtils.distanceBetween";
         Point midpoint = MathUtils.midpoint(new Point(0.0, 0.0), new Point(2.0, 4.0));
         assert midpoint.x() == 1.0 : "MathUtils.midpoint.x";
@@ -244,6 +329,54 @@ public final class DemoTest {
         assert echoedLine.end().x() == 3.0 : "echoLine.end.x";
         demoCase("case:records.nested.line.should_compute_length");
         assert Math.abs(Demo.lineLength(line) - 5.0) < 0.0001 : "lineLength";
+
+        Rect rect = new Rect(new Point(1.0, 2.0), new Dimensions(3.0, 4.0));
+        demoCase("case:records.nested.rect.should_compute_area");
+        assert Math.abs(Demo.rectArea(rect) - 12.0) < 0.0001 : "rectArea";
+        demoCase("case:records.nested.rect.should_roundtrip_nested_records");
+        Rect echoedRect = Demo.echoRect(rect);
+        assert echoedRect.origin().x() == 1.0 && echoedRect.origin().y() == 2.0 : "echoRect.origin";
+        assert echoedRect.dimensions().width() == 3.0 && echoedRect.dimensions().height() == 4.0 : "echoRect.dimensions";
+
+        System.out.println("  PASS\n");
+    }
+
+    private static void testUserProfileVecs() {
+        System.out.println("Testing records (user profiles)...");
+        demoCase("case:records.with_collections.user_profiles.should_generate_profiles");
+        List<BenchmarkUserProfile> profiles = Demo.generateUserProfiles(4);
+        assert profiles.size() == 4 : "generateUserProfiles size";
+        assert profiles.get(0).id == 0 && profiles.get(3).id == 3 : "generateUserProfiles ids";
+
+        demoCase("case:records.with_collections.user_profiles.should_sum_scores");
+        double scoreSum = Demo.sumUserScores(profiles);
+        double expectedScoreSum = 0.0;
+        for (BenchmarkUserProfile p : profiles) {
+            expectedScoreSum += p.score;
+        }
+        assert Math.abs(scoreSum - expectedScoreSum) < 0.0001 : "sumUserScores";
+
+        demoCase("case:records.with_collections.user_profiles.should_count_active_users");
+        int active = Demo.countActiveUsers(profiles);
+        int expectedActive = 0;
+        for (BenchmarkUserProfile p : profiles) {
+            if (p.isActive) {
+                expectedActive++;
+            }
+        }
+        assert active == expectedActive : "countActiveUsers";
+
+        System.out.println("  PASS\n");
+    }
+
+    private static void testAddressRecords() {
+        System.out.println("Testing records (Address)...");
+        Address address = new Address("123 Main St", "Springfield", "12345");
+        demoCase("case:records.with_strings.address.should_roundtrip_value");
+        Address echoedAddress = Demo.echoAddress(address);
+        assert echoedAddress.equals(address) : "echoAddress";
+        demoCase("case:records.with_strings.address.should_format_value");
+        assert Demo.formatAddress(address).equals("123 Main St, Springfield, 12345") : "formatAddress";
         System.out.println("  PASS\n");
     }
 
@@ -349,6 +482,41 @@ public final class DemoTest {
         demoCase("case:enums.c_style.direction.should_report_variant_count");
         assert Direction.count() == 4 : "Direction.count";
 
+        demoCase("case:enums.c_style.direction.should_construct_from_raw_value");
+        assert Direction.fromValue(0) == Direction.NORTH : "Direction.fromValue(0)";
+        assert Direction.fromValue(1) == Direction.SOUTH : "Direction.fromValue(1)";
+        assert Direction.fromValue(2) == Direction.EAST : "Direction.fromValue(2)";
+        assert Direction.fromValue(3) == Direction.WEST : "Direction.fromValue(3)";
+
+        demoCase("case:enums.c_style.direction.should_return_degrees");
+        assert Demo.directionToDegrees(Direction.NORTH) == 0 : "directionToDegrees(North)";
+        assert Demo.directionToDegrees(Direction.EAST) == 90 : "directionToDegrees(East)";
+        assert Demo.directionToDegrees(Direction.SOUTH) == 180 : "directionToDegrees(South)";
+        assert Demo.directionToDegrees(Direction.WEST) == 270 : "directionToDegrees(West)";
+
+        demoCase("case:enums.c_style.direction.should_generate_sequence");
+        List<Direction> generated = Demo.generateDirections(6);
+        assert generated.size() == 6 : "generateDirections size";
+        assert generated.get(0) == Direction.NORTH && generated.get(4) == Direction.NORTH : "generateDirections cycle";
+
+        demoCase("case:enums.c_style.direction.should_count_north_values");
+        assert Demo.countNorth(generated) == 2 : "countNorth";
+        assert Demo.countNorth(Arrays.asList(Direction.EAST, Direction.SOUTH)) == 0 : "countNorth zero";
+
+        demoCase("case:enums.c_style.direction.find_direction.should_return_some_for_known_id");
+        Optional<Direction> foundDir = Demo.findDirection(2);
+        assert foundDir.isPresent() && foundDir.get() == Direction.SOUTH : "findDirection known";
+        demoCase("case:enums.c_style.direction.find_direction.should_return_none_for_unknown_id");
+        assert !Demo.findDirection(99).isPresent() : "findDirection unknown";
+
+        demoCase("case:enums.c_style.direction.find_directions.should_return_sequence_for_positive_count");
+        Optional<List<Direction>> foundSeq = Demo.findDirections(3);
+        assert foundSeq.isPresent() : "findDirections positive present";
+        assert foundSeq.get().size() == 3 : "findDirections size";
+        assert foundSeq.get().get(0) == Direction.NORTH : "findDirections first";
+        demoCase("case:enums.c_style.direction.find_directions.should_return_none_for_non_positive_count");
+        assert !Demo.findDirections(0).isPresent() : "findDirections non-positive";
+
         demoCase("case:enums.repr_int.priority.should_roundtrip_value");
         assert Demo.echoPriority(Priority.HIGH) == Priority.HIGH : "echoPriority(High)";
         demoCase("case:enums.repr_int.priority.should_render_label");
@@ -395,6 +563,24 @@ public final class DemoTest {
         demoCase("case:records.with_enums.holder.should_roundtrip_data_enum_field");
         Holder echoedHolder = Demo.echoHolder(triangleHolder);
         assert echoedHolder.equals(triangleHolder) : "echoHolder round-trip";
+
+        demoCase("case:records.with_enums.task.should_make_incomplete_task");
+        Task task = Demo.makeTask("Ship Java coverage", Priority.HIGH);
+        assert task.title().equals("Ship Java coverage") : "makeTask.title";
+        assert task.priority() == Priority.HIGH : "makeTask.priority";
+        assert !task.completed() : "makeTask.completed";
+        demoCase("case:records.with_enums.task.should_roundtrip_priority_field");
+        Task echoedTask = Demo.echoTask(task);
+        assert echoedTask.equals(task) : "echoTask roundtrip";
+        demoCase("case:records.with_enums.task.should_detect_urgent_priority");
+        assert Demo.isUrgent(new Task("urgent", Priority.CRITICAL, false)) : "isUrgent(Critical)";
+        assert Demo.isUrgent(new Task("urgent", Priority.HIGH, false)) : "isUrgent(High)";
+        assert !Demo.isUrgent(new Task("calm", Priority.LOW, false)) : "isUrgent(Low)";
+
+        demoCase("case:records.with_enums.notification.should_roundtrip_priority_field");
+        Notification notification = new Notification("hello", Priority.MEDIUM, false);
+        Notification echoedNotification = Demo.echoNotification(notification);
+        assert echoedNotification.equals(notification) : "echoNotification roundtrip";
 
         demoCase("case:records.with_enums.task_header.should_make_critical_header");
         TaskHeader header = Demo.makeCriticalTaskHeader(42L);
@@ -527,8 +713,70 @@ public final class DemoTest {
         Animal dog = Demo.echoAnimal(new Animal.Dog("Rex", "Labrador"));
         assert dog instanceof Animal.Dog : "echoAnimal(Dog) type";
         assert ((Animal.Dog) dog).name.equals("Rex") : "echoAnimal(Dog).name";
+        demoCase("case:enums.data_enum.animal.dog.should_derive_name");
+        assert Demo.animalName(new Animal.Dog("Rex", "Labrador")).equals("Rex") : "animalName(Dog)";
+
+        demoCase("case:enums.data_enum.animal.cat.should_roundtrip_name_and_bool_payload");
+        Animal cat = Demo.echoAnimal(new Animal.Cat("Whiskers", true));
+        assert cat instanceof Animal.Cat : "echoAnimal(Cat) type";
+        assert ((Animal.Cat) cat).name.equals("Whiskers") : "echoAnimal(Cat).name";
+        assert ((Animal.Cat) cat).indoor : "echoAnimal(Cat).indoor";
+        demoCase("case:enums.data_enum.animal.cat.should_derive_name");
+        assert Demo.animalName(new Animal.Cat("Whiskers", true)).equals("Whiskers") : "animalName(Cat)";
+
         demoCase("case:enums.data_enum.animal.fish.should_derive_count_label");
         assert Demo.animalName(new Animal.Fish(5)).equals("5 fish") : "animalName(Fish)";
+        demoCase("case:enums.data_enum.animal.fish.should_roundtrip_count_payload");
+        Animal fish = Demo.echoAnimal(new Animal.Fish(7));
+        assert fish instanceof Animal.Fish : "echoAnimal(Fish) type";
+        assert ((Animal.Fish) fish).count == 7 : "echoAnimal(Fish).count";
+
+        demoCase("case:enums.data_enum.message.image.should_roundtrip_url_dimensions_payload");
+        Message image = Demo.echoMessage(new Message.Image("https://example.com/cat.png", 640, 480));
+        assert image instanceof Message.Image : "echoMessage(Image) type";
+        Message.Image img = (Message.Image) image;
+        assert img.url.equals("https://example.com/cat.png") && img.width == 640 && img.height == 480 : "echoMessage(Image) payload";
+        demoCase("case:enums.data_enum.message.image.should_render_image_summary");
+        assert Demo.messageSummary(new Message.Image("https://example.com/cat.png", 640, 480))
+            .equals("image: 640x480 at https://example.com/cat.png") : "messageSummary(Image)";
+
+        demoCase("case:enums.data_enum.message.ping.should_roundtrip_unit_variant");
+        Message ping = Demo.echoMessage(Message.Ping.INSTANCE);
+        assert ping instanceof Message.Ping : "echoMessage(Ping) type";
+
+        demoCase("case:enums.complex_variants.filter.none.should_roundtrip_unit_variant");
+        Filter noneFilter = Demo.echoFilter(Filter.None.INSTANCE);
+        assert noneFilter instanceof Filter.None : "echoFilter(None) type";
+
+        demoCase("case:enums.complex_variants.filter.by_name.should_roundtrip_string_payload");
+        Filter nameFilter = Demo.echoFilter(new Filter.ByName("alpha"));
+        assert nameFilter instanceof Filter.ByName : "echoFilter(ByName) type";
+        assert ((Filter.ByName) nameFilter).name.equals("alpha") : "echoFilter(ByName).name";
+        demoCase("case:enums.complex_variants.filter.by_name.should_describe_string_payload");
+        assert Demo.describeFilter(new Filter.ByName("alpha")).equals("filter by name: alpha") : "describeFilter(ByName)";
+
+        demoCase("case:enums.complex_variants.filter.by_range.should_describe_numeric_bounds");
+        assert Demo.describeFilter(new Filter.ByRange(1.0, 10.0)).equals("filter by range: 1..10") : "describeFilter(ByRange)";
+
+        demoCase("case:enums.complex_variants.filter.by_tags.should_roundtrip_string_vector_payload");
+        Filter tagsFilter = Demo.echoFilter(new Filter.ByTags(Arrays.asList("a", "b", "c")));
+        assert tagsFilter instanceof Filter.ByTags : "echoFilter(ByTags) type";
+        assert ((Filter.ByTags) tagsFilter).tags.equals(Arrays.asList("a", "b", "c")) : "echoFilter(ByTags) payload";
+        demoCase("case:enums.complex_variants.filter.by_tags.should_describe_string_vector_payload");
+        assert Demo.describeFilter(new Filter.ByTags(Arrays.asList("a", "b", "c"))).equals("filter by 3 tags") : "describeFilter(ByTags)";
+
+        demoCase("case:enums.complex_variants.filter.by_points.should_roundtrip_record_vector_payload");
+        List<Point> anchors = Arrays.asList(new Point(0.0, 0.0), new Point(1.0, 2.0));
+        Filter pointsFilter = Demo.echoFilter(new Filter.ByPoints(anchors));
+        assert pointsFilter instanceof Filter.ByPoints : "echoFilter(ByPoints) type";
+        assert ((Filter.ByPoints) pointsFilter).anchors.equals(anchors) : "echoFilter(ByPoints) payload";
+        demoCase("case:enums.complex_variants.filter.by_points.should_describe_record_vector_payload");
+        assert Demo.describeFilter(new Filter.ByPoints(anchors)).equals("filter by 2 anchor points") : "describeFilter(ByPoints)";
+
+        demoCase("case:enums.complex_variants.api_response.redirect.should_roundtrip_url_payload");
+        ApiResponse redirect = Demo.echoApiResponse(new ApiResponse.Redirect("https://example.com/new"));
+        assert redirect instanceof ApiResponse.Redirect : "echoApiResponse(Redirect) type";
+        assert ((ApiResponse.Redirect) redirect).url.equals("https://example.com/new") : "echoApiResponse(Redirect).url";
 
         demoCase("case:enums.complex_variants.api_response.success.should_roundtrip_string_payload");
         ApiResponse success = Demo.echoApiResponse(new ApiResponse.Success("ok"));
@@ -697,6 +945,32 @@ public final class DemoTest {
         int[] reversed = Demo.reverseVecI32(new int[]{1, 2, 3});
         assert reversed[0] == 3 && reversed[1] == 2 && reversed[2] == 1 : "reverseVecI32";
 
+        demoCase("case:primitives.vecs.i32.should_generate_sequence");
+        int[] genI32 = Demo.generateI32Vec(4);
+        assert genI32.length == 4 : "generateI32Vec length";
+        assert genI32[0] == 0 && genI32[1] == 1 && genI32[2] == 2 && genI32[3] == 3 : "generateI32Vec values";
+
+        demoCase("case:primitives.vecs.i32.should_sum_benchmark_values");
+        assert Demo.sumI32Vec(new int[]{4, 5, 6}) == 15L : "sumI32Vec";
+
+        demoCase("case:primitives.vecs.f64.should_generate_sequence");
+        double[] genF64 = Demo.generateF64Vec(3);
+        assert genF64.length == 3 : "generateF64Vec length";
+        assert Math.abs(genF64[0] - 0.0) < 0.0001
+            && Math.abs(genF64[1] - 0.1) < 0.0001
+            && Math.abs(genF64[2] - 0.2) < 0.0001 : "generateF64Vec values";
+
+        demoCase("case:primitives.vecs.f64.should_sum_values");
+        assert Math.abs(Demo.sumF64Vec(new double[]{1.5, 2.5, 4.0}) - 8.0) < 0.0001 : "sumF64Vec";
+
+        demoCase("case:primitives.vecs.u64.should_increment_first_value_in_place");
+        long[] u64Buf = new long[]{10L, 20L, 30L};
+        Demo.incU64(u64Buf);
+        assert u64Buf[0] == 11L && u64Buf[1] == 20L && u64Buf[2] == 30L : "incU64 first element";
+
+        demoCase("case:primitives.vecs.u64.should_increment_value");
+        assert Demo.incU64Value(41L) == 42L : "incU64Value";
+
         System.out.println("  PASS\n");
     }
 
@@ -780,6 +1054,7 @@ public final class DemoTest {
         assert flat.length == 5 : "flattenVecVecI32 length";
         assert flat[0] == 1 && flat[1] == 2 && flat[2] == 3 && flat[3] == 4 && flat[4] == 5 : "flattenVecVecI32 values";
 
+        demoCase("case:primitives.vecs.nested_i32.should_flatten_empty");
         assert Demo.flattenVecVecI32(Collections.emptyList()).length == 0 : "flattenVecVecI32 empty";
 
         System.out.println("  PASS\n");
@@ -815,6 +1090,41 @@ public final class DemoTest {
         assert readings.size() == 3 : "generateSensorReadings size";
         demoCase("case:records.blittable.sensor_readings.should_average_generated_temperatures");
         assert Math.abs(Demo.avgSensorTemperature(readings) - 21.0) < 0.0001 : "avgSensorTemperature";
+        demoCase("case:records.blittable.sensor_readings.should_average_empty_vector_as_zero");
+        assert Demo.avgSensorTemperature(Collections.emptyList()) == 0.0 : "avgSensorTemperature empty";
+
+        demoCase("case:records.blittable.color.should_roundtrip_value");
+        Color color = new Color((byte) 0xAA, (byte) 0xBB, (byte) 0xCC, (byte) 0xDD);
+        Color echoedColor = Demo.echoColor(color);
+        assert echoedColor.r() == color.r() && echoedColor.g() == color.g()
+            && echoedColor.b() == color.b() && echoedColor.a() == color.a() : "echoColor";
+        demoCase("case:records.blittable.color.should_make_from_channels");
+        Color madeColor = Demo.makeColor((byte) 1, (byte) 2, (byte) 3, (byte) 4);
+        assert madeColor.r() == 1 && madeColor.g() == 2 && madeColor.b() == 3 && madeColor.a() == 4 : "makeColor channels";
+
+        demoCase("case:records.blittable.locations.should_count_empty_vector");
+        assert Demo.processLocations(Collections.emptyList()) == 0 : "processLocations empty";
+        List<Location> hostLocations = Arrays.asList(
+            new Location(1L, 1.0, 2.0, 3.5, 4, true),
+            new Location(2L, 5.0, 6.0, 2.5, 8, false)
+        );
+        demoCase("case:records.blittable.locations.should_count_host_constructed_vector");
+        assert Demo.processLocations(hostLocations) == 2 : "processLocations host-constructed";
+        demoCase("case:records.blittable.locations.should_sum_host_constructed_ratings");
+        assert Math.abs(Demo.sumRatings(hostLocations) - 6.0) < 0.0001 : "sumRatings host-constructed";
+
+        demoCase("case:records.blittable.locations.find_location.should_return_some_for_positive_id");
+        Optional<Location> foundLoc = Demo.findLocation(7);
+        assert foundLoc.isPresent() && foundLoc.get().id() == 7L : "findLocation present";
+        demoCase("case:records.blittable.locations.find_location.should_return_none_for_non_positive_id");
+        assert !Demo.findLocation(0).isPresent() : "findLocation absent";
+
+        demoCase("case:records.blittable.locations.find_locations.should_return_some_vector_for_positive_count");
+        Optional<List<Location>> foundLocs = Demo.findLocations(3);
+        assert foundLocs.isPresent() : "findLocations present";
+        assert foundLocs.get().size() == 3 : "findLocations size";
+        demoCase("case:records.blittable.locations.find_locations.should_return_none_for_non_positive_count");
+        assert !Demo.findLocations(0).isPresent() : "findLocations non-positive";
 
         System.out.println("  PASS\n");
     }
@@ -912,6 +1222,24 @@ public final class DemoTest {
         assert echoedProfile.email().isPresent() : "echoUserProfile email";
         assert echoedProfile.email().get().equals("alice@example.com") : "echoUserProfile email value";
 
+        demoCase("case:records.with_options.user_profile.should_roundtrip_absent_options");
+        UserProfile echoedAbsent = Demo.echoUserProfile(noEmail);
+        assert !echoedAbsent.email().isPresent() : "echoUserProfile email absent";
+        assert !echoedAbsent.score().isPresent() : "echoUserProfile score absent";
+        assert echoedAbsent.name().equals("Bob") && echoedAbsent.age() == 22 : "echoUserProfile absent payload";
+
+        demoCase("case:records.with_options.user_profile.should_roundtrip_mixed_options");
+        UserProfile mixedProfile = new UserProfile("Cara", 27, Optional.of("cara@example.com"), Optional.empty());
+        UserProfile echoedMixedProfile = Demo.echoUserProfile(mixedProfile);
+        assert echoedMixedProfile.email().isPresent() && echoedMixedProfile.email().get().equals("cara@example.com") : "echoUserProfile mixed email";
+        assert !echoedMixedProfile.score().isPresent() : "echoUserProfile mixed score";
+
+        demoCase("case:records.with_options.user_profile.should_roundtrip_utf8_optional_string");
+        UserProfile utf8 = new UserProfile("Élodie", 34, Optional.of("élodie@café.example"), Optional.of(7.5));
+        UserProfile echoedUtf8 = Demo.echoUserProfile(utf8);
+        assert echoedUtf8.email().isPresent() && echoedUtf8.email().get().equals("élodie@café.example") : "echoUserProfile utf-8 string";
+        assert echoedUtf8.name().equals("Élodie") : "echoUserProfile utf-8 name";
+
         demoCase("case:records.with_options.search_result.should_roundtrip_present_options");
         SearchResult withCursor = Demo.echoSearchResult(
             new SearchResult("rust ffi", 12, Optional.of("cursor-1"), Optional.of(0.99))
@@ -943,6 +1271,84 @@ public final class DemoTest {
         demoCase("case:options.complex.vec_optional_i32.should_roundtrip_empty");
         assert Demo.echoVecOptionalI32(java.util.Collections.emptyList()).isEmpty()
             : "echoVecOptionalI32 empty";
+
+        demoCase("case:options.complex.vec_optional_i32.should_roundtrip_all_none");
+        java.util.List<Optional<Integer>> allNone = Arrays.asList(Optional.empty(), Optional.empty(), Optional.empty());
+        java.util.List<Optional<Integer>> echoedAllNone = Demo.echoVecOptionalI32(allNone);
+        assert echoedAllNone.size() == 3 : "echoVecOptionalI32 all-none size";
+        for (Optional<Integer> v : echoedAllNone) {
+            assert !v.isPresent() : "echoVecOptionalI32 all-none entry";
+        }
+
+        demoCase("case:options.primitives.bool.should_roundtrip_some");
+        Optional<Boolean> optBoolSome = Demo.echoOptionalBool(Optional.of(true));
+        assert optBoolSome.isPresent() && optBoolSome.get() : "echoOptionalBool some";
+        demoCase("case:options.primitives.bool.should_roundtrip_none");
+        assert !Demo.echoOptionalBool(Optional.empty()).isPresent() : "echoOptionalBool none";
+
+        demoCase("case:options.primitives.f64.should_roundtrip_some");
+        Optional<Double> optF64Some = Demo.echoOptionalF64(Optional.of(1.5));
+        assert optF64Some.isPresent() && Math.abs(optF64Some.get() - 1.5) < 0.0001 : "echoOptionalF64 some";
+        demoCase("case:options.primitives.f64.should_roundtrip_none");
+        assert !Demo.echoOptionalF64(Optional.empty()).isPresent() : "echoOptionalF64 none";
+
+        demoCase("case:options.primitives.f64.should_find_positive_value");
+        Optional<Double> posF64 = Demo.findPositiveF64(3.5);
+        assert posF64.isPresent() && Math.abs(posF64.get() - 3.5) < 0.0001 : "findPositiveF64 positive";
+        demoCase("case:options.primitives.f64.should_return_none_for_non_positive_value");
+        assert !Demo.findPositiveF64(-1.0).isPresent() : "findPositiveF64 non-positive";
+
+        demoCase("case:options.primitives.i32.should_find_even_value");
+        Optional<Integer> even = Demo.findEven(8);
+        assert even.isPresent() && even.get() == 8 : "findEven even";
+        demoCase("case:options.primitives.i32.should_return_none_for_odd_value");
+        assert !Demo.findEven(7).isPresent() : "findEven odd";
+
+        demoCase("case:options.primitives.i64.should_find_positive_value");
+        Optional<Long> posI64 = Demo.findPositiveI64(123L);
+        assert posI64.isPresent() && posI64.get() == 123L : "findPositiveI64 positive";
+        demoCase("case:options.primitives.i64.should_return_none_for_non_positive_value");
+        assert !Demo.findPositiveI64(-5L).isPresent() : "findPositiveI64 non-positive";
+
+        demoCase("case:options.complex.string.should_find_name_for_positive_id");
+        Optional<String> foundName = Demo.findName(3);
+        assert foundName.isPresent() && foundName.get().equals("Name_3") : "findName positive";
+        demoCase("case:options.complex.string.should_return_none_for_non_positive_id");
+        assert !Demo.findName(0).isPresent() : "findName non-positive";
+
+        demoCase("case:options.complex.vec.should_find_numbers_for_positive_count");
+        Optional<int[]> foundNumbers = Demo.findNumbers(4);
+        assert foundNumbers.isPresent() : "findNumbers positive present";
+        int[] foundArr = foundNumbers.get();
+        assert foundArr.length == 4 && foundArr[0] == 0 && foundArr[3] == 3 : "findNumbers values";
+        demoCase("case:options.complex.vec.should_return_none_for_non_positive_number_count");
+        assert !Demo.findNumbers(0).isPresent() : "findNumbers non-positive";
+
+        demoCase("case:options.complex.vec.should_roundtrip_empty_some");
+        Optional<int[]> emptySome = Demo.echoOptionalVec(Optional.of(new int[0]));
+        assert emptySome.isPresent() && emptySome.get().length == 0 : "echoOptionalVec empty-some";
+
+        demoCase("case:options.complex.vec_string.should_find_names_for_positive_count");
+        Optional<java.util.List<String>> foundNames = Demo.findNames(2);
+        assert foundNames.isPresent() : "findNames positive present";
+        assert foundNames.get().equals(Arrays.asList("Name_0", "Name_1")) : "findNames values";
+        demoCase("case:options.complex.vec_string.should_return_none_for_non_positive_name_count");
+        assert !Demo.findNames(-1).isPresent() : "findNames non-positive";
+
+        demoCase("case:options.complex.api_result.should_find_success_variant");
+        Optional<ApiResult> apiSuccess = Demo.findApiResult(0);
+        assert apiSuccess.isPresent() && apiSuccess.get() instanceof ApiResult.Success : "findApiResult success";
+        demoCase("case:options.complex.api_result.should_find_error_code_variant");
+        Optional<ApiResult> apiErrorCode = Demo.findApiResult(1);
+        assert apiErrorCode.isPresent() && apiErrorCode.get() instanceof ApiResult.ErrorCode : "findApiResult error code variant";
+        assert ((ApiResult.ErrorCode) apiErrorCode.get()).value0 == -1 : "findApiResult error code value";
+        demoCase("case:options.complex.api_result.should_find_error_with_data_variant");
+        Optional<ApiResult> apiErrorData = Demo.findApiResult(2);
+        assert apiErrorData.isPresent() && apiErrorData.get() instanceof ApiResult.ErrorWithData : "findApiResult error with data variant";
+        ApiResult.ErrorWithData err = (ApiResult.ErrorWithData) apiErrorData.get();
+        assert err.code == -1 && err.detail == -2 : "findApiResult error-with-data payload";
+        demoCase("case:options.complex.api_result.should_return_none_for_unknown_code");
+        assert !Demo.findApiResult(99).isPresent() : "findApiResult unknown";
 
         System.out.println("  PASS\n");
     }
@@ -1506,6 +1912,78 @@ public final class DemoTest {
                 record.shape(),
                 record.parameters()
             ).get().equals(record) : "asyncMakeMixedRecord";
+
+            demoCase("case:async_fns.basic.get_numbers.should_return_counting_sequence");
+            int[] counting = Demo.asyncGetNumbers(4).get();
+            assert counting.length == 4 : "asyncGetNumbers length";
+            assert counting[0] == 0 && counting[1] == 1 && counting[2] == 2 && counting[3] == 3 : "asyncGetNumbers values";
+
+            demoCase("case:async_fns.results.fetch_data.should_return_scaled_positive_id");
+            assert Demo.fetchData(7).get() == 70 : "fetchData scaled";
+
+            demoCase("case:async_fns.results.fetch_data.should_reject_non_positive_id");
+            try {
+                Demo.fetchData(0).get();
+                assert false : "fetchData should reject non-positive id";
+            } catch (java.util.concurrent.ExecutionException ee) {
+                assert ee.getCause().getMessage().contains("invalid id") : "fetchData error message";
+            }
+
+            demoCase("case:async_fns.results.try_compute.should_return_doubled_value");
+            assert Demo.tryComputeAsync(21).get() == 42 : "tryComputeAsync doubled";
+
+            demoCase("case:async_fns.results.try_compute.should_return_invalid_input_for_zero");
+            try {
+                Demo.tryComputeAsync(0).get();
+                assert false : "tryComputeAsync should reject zero";
+            } catch (java.util.concurrent.ExecutionException ee) {
+                assert ee.getCause() instanceof ComputeError.InvalidInput : "tryComputeAsync zero -> InvalidInput";
+                assert ((ComputeError.InvalidInput) ee.getCause()).value0 == -999 : "tryComputeAsync InvalidInput payload";
+            }
+
+            demoCase("case:async_fns.results.try_compute.should_return_overflow_for_negative_value");
+            try {
+                Demo.tryComputeAsync(-3).get();
+                assert false : "tryComputeAsync should reject negative";
+            } catch (java.util.concurrent.ExecutionException ee) {
+                assert ee.getCause() instanceof ComputeError.Overflow : "tryComputeAsync negative -> Overflow";
+                ComputeError.Overflow ovf = (ComputeError.Overflow) ee.getCause();
+                assert ovf.value == -3 && ovf.limit == 0 : "tryComputeAsync Overflow payload";
+            }
+
+            demoCase("case:results.async_results.safe_divide.should_return_quotient");
+            assert Demo.asyncSafeDivide(12, 3).get() == 4 : "asyncSafeDivide ok";
+            demoCase("case:results.async_results.safe_divide.should_reject_division_by_zero");
+            try {
+                Demo.asyncSafeDivide(12, 0).get();
+                assert false : "asyncSafeDivide should reject zero";
+            } catch (java.util.concurrent.ExecutionException ee) {
+                assert ee.getCause() instanceof MathError.Exception : "asyncSafeDivide -> MathError.Exception";
+                assert ((MathError.Exception) ee.getCause()).getError() == MathError.DIVISION_BY_ZERO : "asyncSafeDivide error variant";
+            }
+
+            demoCase("case:results.async_results.fallible_fetch.should_return_value_for_non_negative_key");
+            assert Demo.asyncFallibleFetch(7).get().equals("value_7") : "asyncFallibleFetch ok";
+            demoCase("case:results.async_results.fallible_fetch.should_reject_negative_key");
+            try {
+                Demo.asyncFallibleFetch(-1).get();
+                assert false : "asyncFallibleFetch should reject negative";
+            } catch (java.util.concurrent.ExecutionException ee) {
+                assert ee.getCause().getMessage().contains("invalid key") : "asyncFallibleFetch error";
+            }
+
+            demoCase("case:results.async_results.find_value.should_return_some_for_positive_key");
+            Optional<Integer> findSomeKey = Demo.asyncFindValue(4).get();
+            assert findSomeKey.isPresent() && findSomeKey.get() == 40 : "asyncFindValue positive";
+            demoCase("case:results.async_results.find_value.should_return_none_for_zero_key");
+            assert !Demo.asyncFindValue(0).get().isPresent() : "asyncFindValue zero";
+            demoCase("case:results.async_results.find_value.should_reject_negative_key");
+            try {
+                Demo.asyncFindValue(-1).get();
+                assert false : "asyncFindValue should reject negative";
+            } catch (java.util.concurrent.ExecutionException ee) {
+                assert ee.getCause().getMessage().contains("invalid key") : "asyncFindValue error";
+            }
         } catch (Exception e) {
             throw new RuntimeException("async function test failed", e);
         }
@@ -1647,6 +2125,46 @@ public final class DemoTest {
             assert false : "resultOfVec should throw on negative count";
         } catch (RuntimeException ignored) {}
 
+        demoCase("case:results.basic.divide.should_return_quotient");
+        assert Demo.divide(20, 4) == 5 : "divide ok";
+        demoCase("case:results.basic.divide.should_reject_division_by_zero");
+        try {
+            Demo.divide(20, 0);
+            assert false : "divide should throw on zero";
+        } catch (RuntimeException e) {
+            assert e.getMessage().contains("division by zero") : "divide error";
+        }
+
+        demoCase("case:results.basic.parse_int.should_parse_integer");
+        assert Demo.parseInt("42") == 42 : "parseInt ok";
+        demoCase("case:results.basic.parse_int.should_reject_invalid_integer");
+        try {
+            Demo.parseInt("not-a-number");
+            assert false : "parseInt should throw on invalid input";
+        } catch (RuntimeException e) {
+            assert e.getMessage().contains("invalid integer") : "parseInt error";
+        }
+
+        demoCase("case:results.basic.safe_sqrt.should_return_square_root");
+        assert Math.abs(Demo.safeSqrt(16.0) - 4.0) < 0.0001 : "safeSqrt ok";
+        demoCase("case:results.basic.safe_sqrt.should_reject_negative_input");
+        try {
+            Demo.safeSqrt(-4.0);
+            assert false : "safeSqrt should throw on negative";
+        } catch (RuntimeException e) {
+            assert e.getMessage().contains("negative input") : "safeSqrt error";
+        }
+
+        demoCase("case:results.basic.validate_name.should_greet_valid_name");
+        assert Demo.validateName("Java").equals("Hello, Java!") : "validateName ok";
+        demoCase("case:results.basic.validate_name.should_reject_empty_name");
+        try {
+            Demo.validateName("");
+            assert false : "validateName should reject empty";
+        } catch (RuntimeException e) {
+            assert e.getMessage().contains("name cannot be empty") : "validateName error";
+        }
+
         System.out.println("  PASS\n");
     }
 
@@ -1748,6 +2266,31 @@ public final class DemoTest {
             assert e.code() == 400 : "mayFail code";
             assert e.message().equals("Invalid input") : "mayFail message field";
             assert e.getMessage().equals("Invalid input") : "mayFail exception message";
+        }
+
+        demoCase("case:results.error_enums.api_result_is_success.should_report_success_variant");
+        assert Demo.apiResultIsSuccess(ApiResult.Success.INSTANCE) : "apiResultIsSuccess(Success)";
+        demoCase("case:results.error_enums.api_result_is_success.should_report_error_variant");
+        assert !Demo.apiResultIsSuccess(new ApiResult.ErrorCode(-1)) : "apiResultIsSuccess(ErrorCode)";
+
+        demoCase("case:results.error_enums.process_value.should_return_success_variant");
+        assert Demo.processValue(5) instanceof ApiResult.Success : "processValue(positive) -> Success";
+        demoCase("case:results.error_enums.process_value.should_return_error_code_variant");
+        ApiResult zeroResult = Demo.processValue(0);
+        assert zeroResult instanceof ApiResult.ErrorCode : "processValue(0) -> ErrorCode";
+        assert ((ApiResult.ErrorCode) zeroResult).value0 == -1 : "processValue(0) error code value";
+        demoCase("case:results.error_enums.process_value.should_return_error_with_data_variant");
+        ApiResult negResult = Demo.processValue(-3);
+        assert negResult instanceof ApiResult.ErrorWithData : "processValue(negative) -> ErrorWithData";
+
+        demoCase("case:results.error_enums.try_compute.should_return_doubled_value");
+        assert Demo.tryCompute(21) == 42 : "tryCompute doubled";
+        demoCase("case:results.error_enums.try_compute.should_return_overflow_error");
+        try {
+            Demo.tryCompute(-3);
+            assert false : "tryCompute should throw on negative";
+        } catch (ComputeError.Overflow ovf) {
+            assert ovf.value == -3 && ovf.limit == 0 : "tryCompute Overflow payload";
         }
 
         demoCase("case:results.error_enums.divide_app.should_return_quotient");


### PR DESCRIPTION
This closes the coverage gaps outlined in #309 for java. Also filed #320, #321, #322, #323 for implementation gaps surfaced while writing the assertions.