### PR TITLE
chore: fill typescript coverage gaps

### DIFF
--- a/examples/demo/src/async_fns/mod.rs
+++ b/examples/demo/src/async_fns/mod.rs
@@ -125,11 +125,6 @@ pub async fn async_concat(strings: Vec<String>) -> String {
     justification = "Ensure an async Result function rejects zero input with the typed invalid-input error.",
     directions = "Call `async_fns::try_compute_async` through the generated binding and assert an async Result function rejects zero input with the typed invalid-input error.",
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript covers the negative overflow case for that branch today; add a separate assertion for the zero-input invalid case."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently omits async functions. Include this case when async Python bindings are implemented."
@@ -173,11 +168,6 @@ pub async fn fetch_data(id: i32) -> Result<i32, String> {
     "async_fns.basic.get_numbers.should_return_counting_sequence",
     justification = "Ensure an async vector producer resolves with a zero-based counting sequence.",
     directions = "Call `async_fns::async_get_numbers` through the generated binding and assert an async vector producer resolves with a zero-based counting sequence.",
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for async_get_numbers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/custom_types/mod.rs
+++ b/examples/demo/src/custom_types/mod.rs
@@ -58,11 +58,6 @@ custom_type!(
         details = "C# constructs the surrounding value but still needs an assertion for Event fields before crossing FFI."
     ),
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript constructs the surrounding value but still needs an assertion for Event fields before crossing FFI."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently map custom FFI types or records containing custom fields. Include this case when custom-type Python bindings are implemented."

--- a/examples/demo/src/enums/c_style.rs
+++ b/examples/demo/src/enums/c_style.rs
@@ -197,11 +197,6 @@ pub fn opposite_direction(d: Direction) -> Direction {
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports C-style enum parameters and primitive returns, but the demo suite has no assertion for direction_to_degrees yet."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for direction_to_degrees in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]
@@ -223,11 +218,6 @@ pub fn direction_to_degrees(direction: Direction) -> i32 {
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports C-style enum vectors, but the demo suite has no assertion for direction sequence helpers yet."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for direction sequence helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]
@@ -252,11 +242,6 @@ pub fn generate_directions(count: i32) -> Vec<Direction> {
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports C-style enum vectors, but the demo suite has no assertion for direction sequence helpers yet."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for direction sequence helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]
@@ -281,11 +266,6 @@ pub fn count_north(directions: Vec<Direction>) -> i32 {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; C-style enums are emitted, but Option<Direction> returns are not. Include this case when optional enum returns are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for find_direction in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[demo_bench_macros::demo_case(
@@ -301,11 +281,6 @@ pub fn count_north(directions: Vec<Direction>) -> i32 {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; C-style enums are emitted, but Option<Direction> returns are not. Include this case when optional enum returns are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for find_direction in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]
@@ -333,11 +308,6 @@ pub fn find_direction(id: i32) -> Option<Direction> {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; C-style enum vectors are emitted, but Option<Vec<Direction>> returns are not. Include this case when optional enum-vector returns are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for find_directions in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[demo_bench_macros::demo_case(
@@ -353,11 +323,6 @@ pub fn find_direction(id: i32) -> Option<Direction> {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; C-style enum vectors are emitted, but Option<Vec<Direction>> returns are not. Include this case when optional enum-vector returns are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for find_directions in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]

--- a/examples/demo/src/enums/complex_variants.rs
+++ b/examples/demo/src/enums/complex_variants.rs
@@ -48,11 +48,6 @@ pub enum Filter {
     justification = "Ensure the Filter::ByTags variant preserves a vector of UTF-8 strings when round-tripped.",
     directions = "Call `enums::complex_variants::echo_filter` through the generated binding and assert the Filter::ByTags variant preserves a vector of UTF-8 strings when round-tripped.",
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript reaches the surrounding surface but still needs a round-trip assertion for the Filter::ByTags variant."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -72,11 +67,6 @@ pub enum Filter {
     "enums.complex_variants.filter.by_points.should_roundtrip_record_vector_payload",
     justification = "Ensure the Filter::ByPoints variant preserves a vector of Point records when round-tripped.",
     directions = "Call `enums::complex_variants::echo_filter` through the generated binding and assert the Filter::ByPoints variant preserves a vector of Point records when round-tripped.",
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript reaches the surrounding surface but still needs a round-trip assertion for the Filter::ByPoints variant."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/enums/data_enum.rs
+++ b/examples/demo/src/enums/data_enum.rs
@@ -340,11 +340,6 @@ pub enum Message {
     justification = "Ensure the Message::Ping unit variant crosses the FFI boundary unchanged.",
     directions = "Call `enums::data_enum::echo_message` through the generated binding and assert the Message::Ping unit variant crosses the FFI boundary unchanged.",
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript reaches the surrounding surface but still needs a round-trip assertion for the Message::Ping variant."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -432,11 +427,6 @@ pub enum Animal {
     justification = "Ensure the Animal::Fish variant preserves its count payload when round-tripped.",
     directions = "Call `enums::data_enum::echo_animal` through the generated binding and assert the Animal::Fish variant preserves its count payload when round-tripped.",
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript reaches the surrounding surface but still needs a round-trip assertion for the Animal::Fish variant."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -451,11 +441,6 @@ pub fn echo_animal(a: Animal) -> Animal {
     "enums.data_enum.animal.dog.should_derive_name",
     justification = "Ensure animal_name derives the dog name from an Animal::Dog payload.",
     directions = "Call `enums::data_enum::animal_name` through the generated binding and assert animal_name derives the dog name from an Animal::Dog payload.",
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript round-trips the enum family but still needs an assertion for the derived a name from Animal::Dog behavior."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/options/complex.rs
+++ b/examples/demo/src/options/complex.rs
@@ -164,11 +164,6 @@ pub fn echo_optional_status(v: Option<Status>) -> Option<Status> {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for Some(empty Vec) for echo_optional_vec in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]
@@ -319,11 +314,6 @@ pub fn find_names(count: i32) -> Option<Vec<String>> {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for the ErrorWithData find_api_result branch in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[demo_bench_macros::demo_case(
@@ -382,11 +372,6 @@ pub fn find_api_result(code: i32) -> Option<ApiResult> {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T>. Include this case when optional values are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for all-None Vec<Option<i32>> in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]

--- a/examples/demo/src/options/primitives.rs
+++ b/examples/demo/src/options/primitives.rs
@@ -196,7 +196,7 @@ pub fn find_even(value: i32) -> Option<i32> {
     exclude(
         typescript,
         reason = ExclusionReason::ImplementationGap,
-        details = "TypeScript wrapper for Option<i64> uses takePackedBuffer expecting a packed BigInt, but the wasm export returns a NaN-boxed f64. Include this case when the Option<i64> lowerer is aligned with the i64 NaN-boxed return convention."
+        details = "#326: TypeScript wraps Option<i64> with takePackedBuffer expecting a packed BigInt, but the wasm export returns a NaN-boxed f64 like Option<f64>. Include this case when the Option<i64> lowerer routes through the NaN-box helper."
     )
 )]
 #[demo_bench_macros::demo_case(
@@ -211,7 +211,7 @@ pub fn find_even(value: i32) -> Option<i32> {
     exclude(
         typescript,
         reason = ExclusionReason::ImplementationGap,
-        details = "TypeScript wrapper for Option<i64> uses takePackedBuffer expecting a packed BigInt, but the wasm export returns a NaN-boxed f64. Include this case when the Option<i64> lowerer is aligned with the i64 NaN-boxed return convention."
+        details = "#326: TypeScript wraps Option<i64> with takePackedBuffer expecting a packed BigInt, but the wasm export returns a NaN-boxed f64 like Option<f64>. Include this case when the Option<i64> lowerer routes through the NaN-box helper."
     )
 )]
 #[export]

--- a/examples/demo/src/primitives/scalars.rs
+++ b/examples/demo/src/primitives/scalars.rs
@@ -192,11 +192,6 @@ pub fn echo_isize(v: isize) -> isize {
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive scalar calls, but the demo suite has no assertion for the scalar noop benchmark helper yet."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for the scalar noop helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]
@@ -216,11 +211,6 @@ pub fn noop() {}
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive scalar calls, but the demo suite has no assertion for the benchmark add alias yet."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for the benchmark add alias in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]
@@ -242,11 +232,6 @@ pub fn add(a: i32, b: i32) -> i32 {
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive scalar calls, but the demo suite has no assertion for the scalar multiply helper yet."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for the scalar multiply helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]

--- a/examples/demo/src/primitives/vecs.rs
+++ b/examples/demo/src/primitives/vecs.rs
@@ -208,11 +208,6 @@ pub fn reverse_vec_i32(v: Vec<i32>) -> Vec<i32> {
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive vector returns, but the demo suite has no assertion for this benchmark vector generator yet."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for benchmark vector generators in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]
@@ -234,11 +229,6 @@ pub fn generate_i32_vec(count: i32) -> Vec<i32> {
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive vector parameters and primitive returns, but the demo suite has no assertion for this benchmark sum helper yet."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for the i32 benchmark sum helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]
@@ -255,11 +245,6 @@ pub fn sum_i32_vec(values: Vec<i32>) -> i64 {
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive vector returns, but the demo suite has no assertion for this benchmark vector generator yet."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for benchmark vector generators in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]
@@ -276,11 +261,6 @@ pub fn generate_f64_vec(count: i32) -> Vec<f64> {
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive vector parameters and f64 returns, but the demo suite has no assertion for this vector sum helper yet."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for f64 vector sums in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]
@@ -325,11 +305,6 @@ pub fn inc_u64(values: &mut [u64]) {
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive scalar calls, but the demo suite has no assertion for this benchmark increment helper yet."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for the u64 value increment helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]
@@ -390,7 +365,7 @@ pub fn echo_vec_vec_bool(v: Vec<Vec<bool>>) -> Vec<Vec<bool>> {
     exclude(
         typescript,
         reason = ExclusionReason::ImplementationGap,
-        details = "TypeScript nested Vec<Vec<isize>> lowering is blocked on #203: the generated writer passes plain Number values to BigInt setters."
+        details = "#203: TypeScript nested Vec<Vec<isize>> lowering passes plain Number values to BigInt setters in the generated writer. Include this case when the nested isize writer coerces elements to BigInt."
     )
 )]
 #[export]
@@ -410,7 +385,7 @@ pub fn echo_vec_vec_isize(v: Vec<Vec<isize>>) -> Vec<Vec<isize>> {
     exclude(
         typescript,
         reason = ExclusionReason::ImplementationGap,
-        details = "TypeScript nested Vec<Vec<usize>> lowering is blocked on #203: the generated writer passes plain Number values to BigInt setters."
+        details = "#203: TypeScript nested Vec<Vec<usize>> lowering passes plain Number values to BigInt setters in the generated writer. Include this case when the nested usize writer coerces elements to BigInt."
     )
 )]
 #[export]

--- a/examples/demo/src/records/blittable.rs
+++ b/examples/demo/src/records/blittable.rs
@@ -488,11 +488,6 @@ impl DataPoint {
     justification = "Ensure generate_locations returns the requested number of Location records.",
     directions = "Call `records::blittable::generate_locations` through the generated binding and assert generate_locations returns the requested number of Location records.",
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Vec<Record> parameters or returns, even for blittable records. Include this case when record-vector support is implemented for Python."
@@ -518,11 +513,6 @@ pub fn generate_locations(count: i32) -> Vec<Location> {
     justification = "Ensure process_locations receives a vector of Location records and returns its item count.",
     directions = "Call `records::blittable::process_locations` through the generated binding and assert process_locations receives a vector of Location records and returns its item count.",
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Vec<Record> parameters or returns, even for blittable records. Include this case when record-vector support is implemented for Python."
@@ -533,11 +523,6 @@ pub fn generate_locations(count: i32) -> Vec<Location> {
     justification = "Ensure process_locations treats an empty Location vector as count zero.",
     directions = "Call `records::blittable::process_locations` through the generated binding and assert process_locations treats an empty Location vector as count zero.",
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Vec<Record> parameters or returns, even for blittable records. Include this case when record-vector support is implemented for Python."
@@ -547,11 +532,6 @@ pub fn generate_locations(count: i32) -> Vec<Location> {
     "records.blittable.locations.should_count_host_constructed_vector",
     justification = "Ensure process_locations receives host-constructed Location records and returns their item count.",
     directions = "Call `records::blittable::process_locations` through the generated binding and assert process_locations receives host-constructed Location records and returns their item count.",
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -569,11 +549,6 @@ pub fn process_locations(locations: Vec<Location>) -> i32 {
     justification = "Ensure sum_ratings receives generated Location records and sums their f64 rating fields.",
     directions = "Call `records::blittable::sum_ratings` through the generated binding and assert sum_ratings receives generated Location records and sums their f64 rating fields.",
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Vec<Record> parameters or returns, even for blittable records. Include this case when record-vector support is implemented for Python."
@@ -583,11 +558,6 @@ pub fn process_locations(locations: Vec<Location>) -> i32 {
     "records.blittable.locations.should_sum_host_constructed_ratings",
     justification = "Ensure sum_ratings receives host-constructed Location records and sums their f64 rating fields.",
     directions = "Call `records::blittable::sum_ratings` through the generated binding and assert sum_ratings receives host-constructed Location records and sums their f64 rating fields.",
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -604,11 +574,6 @@ pub fn sum_ratings(locations: Vec<Location>) -> f64 {
     "records.blittable.trades.should_generate_sample_vector",
     justification = "Ensure generate_trades returns the requested number of Trade records.",
     directions = "Call `records::blittable::generate_trades` through the generated binding and assert generate_trades returns the requested number of Trade records.",
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -638,14 +603,14 @@ pub fn generate_trades(count: i32) -> Vec<Trade> {
     justification = "Ensure sum_trade_volumes receives Trade records and sums their i64 volume fields.",
     directions = "Call `records::blittable::sum_trade_volumes` through the generated binding and assert sum_trade_volumes receives Trade records and sums their i64 volume fields.",
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Vec<Record> parameters or returns, even for blittable records. Include this case when record-vector support is implemented for Python."
+    ),
+    exclude(
+        typescript,
+        reason = ExclusionReason::ImplementationGap,
+        details = "#202: TypeScript encodes Vec<Trade> parameters with packed field layout instead of repr(C), so the internal i32-then-f64 padding in Trade is lost and downstream sums are corrupted. Include this case when Vec<BlittableRecord> parameter encoding matches repr(C) padding."
     )
 )]
 #[export]
@@ -659,14 +624,14 @@ pub fn sum_trade_volumes(trades: Vec<Trade>) -> i64 {
     justification = "Ensure aggregate_location_trade_stats receives Location and Trade vectors together and combines open-location count with total trade volume.",
     directions = "Call `records::blittable::aggregate_location_trade_stats` through the generated binding and assert aggregate_location_trade_stats receives Location and Trade vectors together and combines open-location count with total trade volume.",
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Vec<Record> parameters or returns, even for blittable records. Include this case when record-vector support is implemented for Python."
+    ),
+    exclude(
+        typescript,
+        reason = ExclusionReason::ImplementationGap,
+        details = "#202: TypeScript encodes Vec<Trade> parameters with packed field layout instead of repr(C), so the internal i32-then-f64 padding in Trade is lost and downstream sums are corrupted. Include this case when Vec<BlittableRecord> parameter encoding matches repr(C) padding."
     )
 )]
 #[export]
@@ -681,11 +646,6 @@ pub fn aggregate_location_trade_stats(locations: Vec<Location>, trades: Vec<Trad
     "records.blittable.particles.should_generate_sample_vector",
     justification = "Ensure generate_particles returns the requested number of Particle records.",
     directions = "Call `records::blittable::generate_particles` through the generated binding and assert generate_particles returns the requested number of Particle records.",
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -716,11 +676,6 @@ pub fn generate_particles(count: i32) -> Vec<Particle> {
     justification = "Ensure sum_particle_masses receives Particle records and sums their f64 mass fields.",
     directions = "Call `records::blittable::sum_particle_masses` through the generated binding and assert sum_particle_masses receives Particle records and sums their f64 mass fields.",
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Vec<Record> parameters or returns, even for blittable records. Include this case when record-vector support is implemented for Python."
@@ -736,11 +691,6 @@ pub fn sum_particle_masses(particles: Vec<Particle>) -> f64 {
     "records.blittable.sensor_readings.should_generate_sample_vector",
     justification = "Ensure generate_sensor_readings returns the requested number of SensorReading records.",
     directions = "Call `records::blittable::generate_sensor_readings` through the generated binding and assert generate_sensor_readings returns the requested number of SensorReading records.",
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -770,11 +720,6 @@ pub fn generate_sensor_readings(count: i32) -> Vec<SensorReading> {
     justification = "Ensure avg_sensor_temperature receives SensorReading records and averages their f64 temperature fields.",
     directions = "Call `records::blittable::avg_sensor_temperature` through the generated binding and assert avg_sensor_temperature receives SensorReading records and averages their f64 temperature fields.",
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Vec<Record> parameters or returns, even for blittable records. Include this case when record-vector support is implemented for Python."
@@ -784,11 +729,6 @@ pub fn generate_sensor_readings(count: i32) -> Vec<SensorReading> {
     "records.blittable.sensor_readings.should_average_empty_vector_as_zero",
     justification = "Ensure avg_sensor_temperature treats an empty SensorReading vector as average zero.",
     directions = "Call `records::blittable::avg_sensor_temperature` through the generated binding and assert avg_sensor_temperature treats an empty SensorReading vector as average zero.",
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for blittable record vector helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -820,11 +760,6 @@ pub fn avg_sensor_temperature(readings: Vec<SensorReading>) -> f64 {
         details = "C# has no assertion for find_location in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for find_location in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Vec<Record> parameters or returns, even for blittable records. Include this case when record-vector support is implemented for Python."
@@ -838,11 +773,6 @@ pub fn avg_sensor_temperature(readings: Vec<SensorReading>) -> f64 {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for find_location in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for find_location in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,
@@ -877,11 +807,6 @@ pub fn find_location(id: i32) -> Option<Location> {
         details = "C# has no assertion for find_locations in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for find_locations in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Vec<Record> parameters or returns, even for blittable records. Include this case when record-vector support is implemented for Python."
@@ -895,11 +820,6 @@ pub fn find_location(id: i32) -> Option<Location> {
         csharp,
         reason = ExclusionReason::CoverageGap,
         details = "C# has no assertion for find_locations in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for find_locations in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     ),
     exclude(
         python,

--- a/examples/demo/src/records/with_collections.rs
+++ b/examples/demo/src/records/with_collections.rs
@@ -234,11 +234,6 @@ pub struct BenchmarkUserProfile {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records and top-level primitive/C-style enum vectors. Include this case when records with collection fields are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for benchmark user profile helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 pub fn generate_user_profiles(count: i32) -> Vec<BenchmarkUserProfile> {
@@ -277,11 +272,6 @@ pub fn generate_user_profiles(count: i32) -> Vec<BenchmarkUserProfile> {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records and top-level primitive/C-style enum vectors. Include this case when records with collection fields are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for benchmark user profile helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 pub fn sum_user_scores(users: Vec<BenchmarkUserProfile>) -> f64 {
@@ -298,11 +288,6 @@ pub fn sum_user_scores(users: Vec<BenchmarkUserProfile>) -> f64 {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records and top-level primitive/C-style enum vectors. Include this case when records with collection fields are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for benchmark user profile helpers in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 pub fn count_active_users(users: Vec<BenchmarkUserProfile>) -> i32 {

--- a/examples/demo/src/records/with_options.rs
+++ b/examples/demo/src/records/with_options.rs
@@ -31,11 +31,6 @@ pub struct UserProfile {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when records with optional fields are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript reaches the surrounding surface but still needs a round-trip assertion for UserProfile with absent options."
     )
 )]
 #[demo_bench_macros::demo_case(
@@ -46,11 +41,6 @@ pub struct UserProfile {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when records with optional fields are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript reaches the surrounding surface but still needs a round-trip assertion for UserProfile with mixed option presence."
     )
 )]
 #[demo_bench_macros::demo_case(
@@ -61,11 +51,6 @@ pub struct UserProfile {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when records with optional fields are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript reaches the surrounding surface but still needs a round-trip assertion for UTF-8 inside UserProfile optional fields."
     )
 )]
 pub fn echo_user_profile(profile: UserProfile) -> UserProfile {
@@ -163,11 +148,6 @@ pub struct SearchResult {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when records with optional fields are implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript reaches the surrounding surface but still needs a round-trip assertion for SearchResult with absent options."
     )
 )]
 pub fn echo_search_result(result: SearchResult) -> SearchResult {

--- a/examples/demo/src/results/error_enums.rs
+++ b/examples/demo/src/results/error_enums.rs
@@ -95,11 +95,6 @@ pub fn checked_sqrt(x: f64) -> Result<f64, MathError> {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for the checked_add success path in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[demo_bench_macros::demo_case(
@@ -354,11 +349,6 @@ pub struct BenchmarkResponse {
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
-    ),
-    exclude(
-        typescript,
-        reason = ExclusionReason::CoverageGap,
-        details = "TypeScript has no assertion for the ErrorWithData process_value branch in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
     )
 )]
 #[export]

--- a/examples/platforms/wasm/tests/async_fns/mod.test.mjs
+++ b/examples/platforms/wasm/tests/async_fns/mod.test.mjs
@@ -29,6 +29,16 @@ export async function run() {
     assert.ok(error instanceof demo.ComputeErrorException);
     assert.deepEqual(error.value, { tag: "Overflow", value: -1, limit: 0 });
   }
+  globalThis.demoCase("case:async_fns.results.try_compute.should_return_invalid_input_for_zero");
+  try {
+    await demo.tryComputeAsync(0);
+    assert.fail("expected tryComputeAsync(0) to reject");
+  } catch (error) {
+    assert.ok(error instanceof demo.ComputeErrorException);
+    assert.deepEqual(error.value, { tag: "InvalidInput", value0: -999 });
+  }
+  globalThis.demoCase("case:async_fns.basic.get_numbers.should_return_counting_sequence");
+  assertArrayEqual(await demo.asyncGetNumbers(4), [0, 1, 2, 3]);
   globalThis.demoCase("case:async_fns.results.fetch_data.should_return_scaled_positive_id");
   assert.equal(await demo.fetchData(7), 70);
   globalThis.demoCase("case:async_fns.results.fetch_data.should_reject_non_positive_id");

--- a/examples/platforms/wasm/tests/custom_types/mod.test.mjs
+++ b/examples/platforms/wasm/tests/custom_types/mod.test.mjs
@@ -17,6 +17,9 @@ export async function run() {
   assert.equal(demo.formatTimestamp(datetime), "2023-11-29T05:09:27.890+00:00");
 
   const event = { name: "launch", timestamp: datetime };
+  globalThis.demoCase("case:custom_types.event.should_expose_datetime_field");
+  assert.equal(event.name, "launch");
+  assert.equal(event.timestamp, datetime);
   globalThis.demoCase("case:custom_types.event.should_roundtrip_datetime_field");
   assert.deepEqual(demo.echoEvent(event), event);
   globalThis.demoCase("case:custom_types.event.should_extract_timestamp_millis");

--- a/examples/platforms/wasm/tests/enums/c_style.test.mjs
+++ b/examples/platforms/wasm/tests/enums/c_style.test.mjs
@@ -1,5 +1,12 @@
 import { assert, assertArrayEqual, demo } from "../support/index.mjs";
 
+const DIRECTION_CYCLE = [
+  demo.Direction.North,
+  demo.Direction.East,
+  demo.Direction.South,
+  demo.Direction.West,
+];
+
 export async function run() {
   globalThis.demoCase("case:enums.c_style.status.should_roundtrip_values");
   assert.equal(demo.echoStatus(demo.Status.Active), demo.Status.Active);
@@ -27,4 +34,28 @@ export async function run() {
   assert.equal(demo.Direction.label(demo.Direction.South), "S");
   globalThis.demoCase("case:enums.c_style.direction.should_report_variant_count");
   assert.equal(demo.Direction.count(), 4);
+  globalThis.demoCase("case:enums.c_style.direction.should_return_degrees");
+  assert.equal(demo.directionToDegrees(demo.Direction.East), 90);
+  globalThis.demoCase("case:enums.c_style.direction.should_generate_sequence");
+  assertArrayEqual(demo.generateDirections(5), [
+    demo.Direction.North,
+    demo.Direction.East,
+    demo.Direction.South,
+    demo.Direction.West,
+    demo.Direction.North,
+  ]);
+  globalThis.demoCase("case:enums.c_style.direction.should_count_north_values");
+  assert.equal(demo.countNorth(DIRECTION_CYCLE), 1);
+  globalThis.demoCase("case:enums.c_style.direction.find_direction.should_return_some_for_known_id");
+  assert.equal(demo.findDirection(2), demo.Direction.South);
+  globalThis.demoCase("case:enums.c_style.direction.find_direction.should_return_none_for_unknown_id");
+  assert.equal(demo.findDirection(99), null);
+  globalThis.demoCase("case:enums.c_style.direction.find_directions.should_return_sequence_for_positive_count");
+  assertArrayEqual(demo.findDirections(3), [
+    demo.Direction.North,
+    demo.Direction.East,
+    demo.Direction.South,
+  ]);
+  globalThis.demoCase("case:enums.c_style.direction.find_directions.should_return_none_for_non_positive_count");
+  assert.equal(demo.findDirections(0), null);
 }

--- a/examples/platforms/wasm/tests/enums/complex_variants.test.mjs
+++ b/examples/platforms/wasm/tests/enums/complex_variants.test.mjs
@@ -15,6 +15,11 @@ export async function run() {
   assert.deepEqual(demo.echoFilter({ tag: "None" }), { tag: "None" });
   globalThis.demoCase("case:enums.complex_variants.filter.by_name.should_roundtrip_string_payload");
   assert.deepEqual(demo.echoFilter(nameFilter), nameFilter);
+  globalThis.demoCase("case:enums.complex_variants.filter.by_tags.should_roundtrip_string_vector_payload");
+  const tagFilter = { tag: "ByTags", tags: ["ffi", "jni", "café"] };
+  assert.deepEqual(demo.echoFilter(tagFilter), tagFilter);
+  globalThis.demoCase("case:enums.complex_variants.filter.by_points.should_roundtrip_record_vector_payload");
+  assert.deepEqual(demo.echoFilter(pointFilter), pointFilter);
   globalThis.demoCase("case:enums.complex_variants.filter.by_groups.should_roundtrip_nested_string_vectors");
   assert.deepEqual(demo.echoFilter(groupFilter), groupFilter);
   globalThis.demoCase("case:enums.complex_variants.filter.by_name.should_describe_string_payload");

--- a/examples/platforms/wasm/tests/enums/data_enum.test.mjs
+++ b/examples/platforms/wasm/tests/enums/data_enum.test.mjs
@@ -63,6 +63,8 @@ export async function run() {
   assert.deepEqual(demo.echoMessage(textMessage), textMessage);
   globalThis.demoCase("case:enums.data_enum.message.image.should_roundtrip_url_dimensions_payload");
   assert.deepEqual(demo.echoMessage(imageMessage), imageMessage);
+  globalThis.demoCase("case:enums.data_enum.message.ping.should_roundtrip_unit_variant");
+  assert.deepEqual(demo.echoMessage({ tag: "Ping" }), { tag: "Ping" });
   globalThis.demoCase("case:enums.data_enum.message.text.should_render_text_summary");
   assert.equal(demo.messageSummary({ tag: "Text", body: "hi" }), "text: hi");
   globalThis.demoCase("case:enums.data_enum.message.image.should_render_image_summary");
@@ -79,8 +81,13 @@ export async function run() {
   assert.deepEqual(demo.echoAnimal(dog), dog);
   globalThis.demoCase("case:enums.data_enum.animal.cat.should_roundtrip_name_and_bool_payload");
   assert.deepEqual(demo.echoAnimal(cat), cat);
+  globalThis.demoCase("case:enums.data_enum.animal.fish.should_roundtrip_count_payload");
+  const fish = { tag: "Fish", count: 5 };
+  assert.deepEqual(demo.echoAnimal(fish), fish);
   globalThis.demoCase("case:enums.data_enum.animal.fish.should_derive_count_label");
-  assert.equal(demo.animalName({ tag: "Fish", count: 5 }), "5 fish");
+  assert.equal(demo.animalName(fish), "5 fish");
+  globalThis.demoCase("case:enums.data_enum.animal.dog.should_derive_name");
+  assert.equal(demo.animalName(dog), "Rex");
   globalThis.demoCase("case:enums.data_enum.animal.cat.should_derive_name");
   assert.equal(demo.animalName(cat), "Milo");
 

--- a/examples/platforms/wasm/tests/options/complex.test.mjs
+++ b/examples/platforms/wasm/tests/options/complex.test.mjs
@@ -27,6 +27,8 @@ export async function run() {
   assertArrayEqual(demo.echoOptionalVec([1, 2, 3]), [1, 2, 3]);
   globalThis.demoCase("case:options.complex.vec.should_roundtrip_none");
   assert.equal(demo.echoOptionalVec(null), null);
+  globalThis.demoCase("case:options.complex.vec.should_roundtrip_empty_some");
+  assertArrayEqual(demo.echoOptionalVec([]), []);
   globalThis.demoCase("case:options.complex.vec.should_report_length_for_some");
   assert.equal(demo.optionalVecLength([9, 8]), 2);
   globalThis.demoCase("case:options.complex.vec.should_return_none_for_absent_length");
@@ -47,6 +49,8 @@ export async function run() {
   assert.deepEqual(demo.findApiResult(0), { tag: "Success" });
   globalThis.demoCase("case:options.complex.api_result.should_find_error_code_variant");
   assert.deepEqual(demo.findApiResult(1), { tag: "ErrorCode", value0: -1 });
+  globalThis.demoCase("case:options.complex.api_result.should_find_error_with_data_variant");
+  assert.deepEqual(demo.findApiResult(2), { tag: "ErrorWithData", code: -1, detail: -2 });
   globalThis.demoCase("case:options.complex.api_result.should_return_none_for_unknown_code");
   assert.equal(demo.findApiResult(99), null);
 
@@ -54,4 +58,6 @@ export async function run() {
   assert.deepEqual(demo.echoVecOptionalI32([1, null, 2, null, 3]), [1, null, 2, null, 3]);
   globalThis.demoCase("case:options.complex.vec_optional_i32.should_roundtrip_empty");
   assert.deepEqual(demo.echoVecOptionalI32([]), []);
+  globalThis.demoCase("case:options.complex.vec_optional_i32.should_roundtrip_all_none");
+  assert.deepEqual(demo.echoVecOptionalI32([null, null, null]), [null, null, null]);
 }

--- a/examples/platforms/wasm/tests/primitives/scalars.test.mjs
+++ b/examples/platforms/wasm/tests/primitives/scalars.test.mjs
@@ -22,4 +22,8 @@ export async function run() {
   assertApprox(demo.addF64(1.5, 2.5), 4.0, 1e-12);
   assert.equal(demo.echoUsize(123), 123, "case:primitives.scalars.usize.should_roundtrip_value");
   assert.equal(demo.echoIsize(-123), -123, "case:primitives.scalars.isize.should_roundtrip_negative_value");
+  assert.equal(demo.noop(), undefined, "case:primitives.scalars.noop.should_cross_without_values");
+  assert.equal(demo.add(2, 3), 5, "case:primitives.scalars.i32.should_add_with_benchmark_alias");
+  globalThis.demoCase("case:primitives.scalars.f64.should_multiply_two_values");
+  assertApprox(demo.multiply(1.5, 4.0), 6.0, 1e-12);
 }

--- a/examples/platforms/wasm/tests/primitives/vecs.test.mjs
+++ b/examples/platforms/wasm/tests/primitives/vecs.test.mjs
@@ -39,6 +39,14 @@ export async function run() {
   globalThis.demoCase("case:primitives.vecs.i32.should_reverse_values");
   assertArrayEqual(demo.reverseVecI32([1, 2, 3]), [3, 2, 1]);
   assert.equal(demo.incU64(BigUint64Array.from([1n, 2n])), undefined, "case:primitives.vecs.u64.should_increment_first_value_in_place");
+  globalThis.demoCase("case:primitives.vecs.i32.should_generate_sequence");
+  assertArrayEqual(demo.generateI32Vec(4), [0, 1, 2, 3]);
+  assert.equal(demo.sumI32Vec([10, 20, 30]), 60n, "case:primitives.vecs.i32.should_sum_benchmark_values");
+  globalThis.demoCase("case:primitives.vecs.f64.should_generate_sequence");
+  assertArrayEqual(demo.generateF64Vec(3), [0.0, 0.1, 0.2]);
+  globalThis.demoCase("case:primitives.vecs.f64.should_sum_values");
+  assert.equal(demo.sumF64Vec([1.5, 2.5, 4.0]), 8.0);
+  assert.equal(demo.incU64Value(41n), 42n, "case:primitives.vecs.u64.should_increment_value");
 
   globalThis.demoCase("case:primitives.vecs.nested_i32.should_roundtrip_values");
   const vvi = demo.echoVecVecI32([[1, 2, 3], [], [4, 5]]);

--- a/examples/platforms/wasm/tests/records/blittable.test.mjs
+++ b/examples/platforms/wasm/tests/records/blittable.test.mjs
@@ -1,4 +1,4 @@
-import { assert, assertPoint, assertThrowsWithMessage, demo } from "../support/index.mjs";
+import { assert, assertApprox, assertPoint, assertThrowsWithMessage, demo } from "../support/index.mjs";
 
 export async function run() {
   globalThis.demoCase("case:records.blittable.point.should_roundtrip_value");
@@ -43,4 +43,53 @@ export async function run() {
   assert.deepEqual(demo.echoColor(color), color);
   globalThis.demoCase("case:records.blittable.color.should_make_from_channels");
   assert.deepEqual(demo.makeColor(9, 8, 7, 6), { r: 9, g: 8, b: 7, a: 6 });
+
+  globalThis.demoCase("case:records.blittable.locations.should_generate_sample_vector");
+  const locations = demo.generateLocations(3);
+  assert.equal(locations.length, 3);
+  globalThis.demoCase("case:records.blittable.locations.should_count_vector_items");
+  assert.equal(demo.processLocations(locations), 3);
+  globalThis.demoCase("case:records.blittable.locations.should_count_empty_vector");
+  assert.equal(demo.processLocations([]), 0);
+  const hostLocations = [
+    { id: 1n, lat: 1.0, lng: 2.0, rating: 3.5, reviewCount: 4, isOpen: true },
+    { id: 2n, lat: 5.0, lng: 6.0, rating: 2.5, reviewCount: 8, isOpen: false },
+  ];
+  globalThis.demoCase("case:records.blittable.locations.should_count_host_constructed_vector");
+  assert.equal(demo.processLocations(hostLocations), 2);
+  globalThis.demoCase("case:records.blittable.locations.should_sum_generated_ratings");
+  assertApprox(demo.sumRatings(locations), 9.3, 1e-4);
+  globalThis.demoCase("case:records.blittable.locations.should_sum_host_constructed_ratings");
+  assertApprox(demo.sumRatings(hostLocations), 6.0, 1e-4);
+
+  globalThis.demoCase("case:records.blittable.trades.should_generate_sample_vector");
+  const trades = demo.generateTrades(3);
+  assert.equal(trades.length, 3);
+
+  globalThis.demoCase("case:records.blittable.particles.should_generate_sample_vector");
+  const particles = demo.generateParticles(3);
+  assert.equal(particles.length, 3);
+  globalThis.demoCase("case:records.blittable.particles.should_sum_masses");
+  assertApprox(demo.sumParticleMasses(particles), 3.003, 1e-4);
+
+  globalThis.demoCase("case:records.blittable.sensor_readings.should_generate_sample_vector");
+  const readings = demo.generateSensorReadings(3);
+  assert.equal(readings.length, 3);
+  globalThis.demoCase("case:records.blittable.sensor_readings.should_average_generated_temperatures");
+  assertApprox(demo.avgSensorTemperature(readings), 21.0, 1e-4);
+  globalThis.demoCase("case:records.blittable.sensor_readings.should_average_empty_vector_as_zero");
+  assert.equal(demo.avgSensorTemperature([]), 0.0);
+
+  globalThis.demoCase("case:records.blittable.locations.find_location.should_return_some_for_positive_id");
+  const foundLocation = demo.findLocation(7);
+  assert.ok(foundLocation);
+  assert.equal(foundLocation.id, 7n);
+  globalThis.demoCase("case:records.blittable.locations.find_location.should_return_none_for_non_positive_id");
+  assert.equal(demo.findLocation(0), null);
+  globalThis.demoCase("case:records.blittable.locations.find_locations.should_return_some_vector_for_positive_count");
+  const foundLocations = demo.findLocations(3);
+  assert.ok(foundLocations);
+  assert.equal(foundLocations.length, 3);
+  globalThis.demoCase("case:records.blittable.locations.find_locations.should_return_none_for_non_positive_count");
+  assert.equal(demo.findLocations(0), null);
 }

--- a/examples/platforms/wasm/tests/records/with_collections.test.mjs
+++ b/examples/platforms/wasm/tests/records/with_collections.test.mjs
@@ -29,4 +29,16 @@ export async function run() {
   assertArrayEqual(echoedTaggedScores.scores, [90, 85.5]);
   globalThis.demoCase("case:records.with_collections.tagged_scores.should_average_scores");
   assertApprox(demo.averageScore({ label: "x", scores: [80, 100] }), 90, 1e-12);
+
+  globalThis.demoCase("case:records.with_collections.user_profiles.should_generate_profiles");
+  const profiles = demo.generateUserProfiles(4);
+  assert.equal(profiles.length, 4);
+  assert.equal(profiles[0].id, 0n);
+  assert.equal(profiles[3].id, 3n);
+  globalThis.demoCase("case:records.with_collections.user_profiles.should_sum_scores");
+  const expectedScoreSum = profiles.reduce((acc, p) => acc + p.score, 0);
+  assertApprox(demo.sumUserScores(profiles), expectedScoreSum, 1e-4);
+  globalThis.demoCase("case:records.with_collections.user_profiles.should_count_active_users");
+  const expectedActive = profiles.filter((p) => p.isActive).length;
+  assert.equal(demo.countActiveUsers(profiles), expectedActive);
 }

--- a/examples/platforms/wasm/tests/records/with_options.test.mjs
+++ b/examples/platforms/wasm/tests/records/with_options.test.mjs
@@ -9,12 +9,23 @@ export async function run() {
   assert.equal(demo.userDisplayName(userProfile), "Alice <alice@example.com>");
   globalThis.demoCase("case:records.with_options.user_profile.should_make_with_absent_options");
   const userWithoutEmail = demo.makeUserProfile("Bob", 22, null, null);
+  globalThis.demoCase("case:records.with_options.user_profile.should_roundtrip_absent_options");
+  assert.deepEqual(demo.echoUserProfile(userWithoutEmail), userWithoutEmail);
+  globalThis.demoCase("case:records.with_options.user_profile.should_roundtrip_mixed_options");
+  const userMixedOptions = demo.makeUserProfile("Cleo", 27, "cleo@example.com", null);
+  assert.deepEqual(demo.echoUserProfile(userMixedOptions), userMixedOptions);
+  globalThis.demoCase("case:records.with_options.user_profile.should_roundtrip_utf8_optional_string");
+  const userUtf8 = demo.makeUserProfile("Élodie", 31, "élodie@café.example", 88.25);
+  assert.deepEqual(demo.echoUserProfile(userUtf8), userUtf8);
   globalThis.demoCase("case:records.with_options.user_profile.should_display_name_when_email_absent");
   assert.equal(demo.userDisplayName(userWithoutEmail), "Bob");
 
   globalThis.demoCase("case:records.with_options.search_result.should_roundtrip_present_options");
   const searchResult = { query: "rust ffi", total: 12, nextCursor: "cursor-1", maxScore: 0.99 };
   assert.deepEqual(demo.echoSearchResult(searchResult), searchResult);
+  globalThis.demoCase("case:records.with_options.search_result.should_roundtrip_absent_options");
+  const searchResultAbsent = { query: "rust ffi", total: 0, nextCursor: null, maxScore: null };
+  assert.deepEqual(demo.echoSearchResult(searchResultAbsent), searchResultAbsent);
   globalThis.demoCase("case:records.with_options.search_result.should_report_more_results_when_cursor_present");
   assert.equal(demo.hasMoreResults(searchResult), true);
   globalThis.demoCase("case:records.with_options.search_result.should_report_no_more_results_without_cursor");

--- a/examples/platforms/wasm/tests/results/error_enums.test.mjs
+++ b/examples/platforms/wasm/tests/results/error_enums.test.mjs
@@ -22,6 +22,8 @@ export async function run() {
     demo.MathErrorException,
     demo.MathError.NegativeInput,
   );
+  globalThis.demoCase("case:results.error_enums.checked_add.should_return_sum");
+  assert.equal(demo.checkedAdd(2, 3), 5);
   globalThis.demoCase("case:results.error_enums.checked_add.should_reject_overflow");
   assertThrowsWithCode(
     () => demo.checkedAdd(2_147_483_647, 1),
@@ -58,6 +60,8 @@ export async function run() {
   assert.deepEqual(demo.processValue(3), { tag: "Success" });
   globalThis.demoCase("case:results.error_enums.process_value.should_return_error_code_variant");
   assert.deepEqual(demo.processValue(0), { tag: "ErrorCode", value0: -1 });
+  globalThis.demoCase("case:results.error_enums.process_value.should_return_error_with_data_variant");
+  assert.deepEqual(demo.processValue(-3), { tag: "ErrorWithData", code: -3, detail: -6 });
   globalThis.demoCase("case:results.error_enums.api_result_is_success.should_report_success_variant");
   assert.equal(demo.apiResultIsSuccess({ tag: "Success" }), true);
   globalThis.demoCase("case:results.error_enums.api_result_is_success.should_report_error_variant");


### PR DESCRIPTION
This closes the coverage gaps outlined in #309 for typescript. Also filed #326 for the Option<i64> implementation gap surfaced while writing the assertions, and reclassified two trade-vector cases as implementation gaps under #202.