### PR TITLE
chore: fill csharp coverage gaps

### DIFF
--- a/examples/demo/src/async_fns/mod.rs
+++ b/examples/demo/src/async_fns/mod.rs
@@ -110,11 +110,6 @@ pub async fn async_concat(strings: Vec<String>) -> String {
     justification = "Ensure an async Result function rejects negative input with the typed overflow error.",
     directions = "Call `async_fns::try_compute_async` through the generated binding and assert an async Result function rejects negative input with the typed overflow error.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# covers the zero-input invalid case for that branch today; add a separate assertion for the negative overflow case."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently omits async functions. Include this case when async Python bindings are implemented."

--- a/examples/demo/src/builtins/mod.rs
+++ b/examples/demo/src/builtins/mod.rs
@@ -11,8 +11,8 @@ use uuid::Uuid;
     directions = "Call `builtins::echo_duration` through the generated binding and assert a Duration value crosses the wire and returns unchanged.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for built-in Duration values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320: C# bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant C# built-in binding is implemented."
     ),
     exclude(
         java,
@@ -36,8 +36,8 @@ pub fn echo_duration(d: Duration) -> Duration {
     directions = "Call `builtins::make_duration` through the generated binding and assert Duration seconds and nanoseconds cross the wire and return as a Duration value.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for built-in Duration values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320: C# bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant C# built-in binding is implemented."
     ),
     exclude(
         java,
@@ -61,8 +61,8 @@ pub fn make_duration(secs: u64, nanos: u32) -> Duration {
     directions = "Call `builtins::duration_as_millis` through the generated binding and assert a Duration value crosses the wire and returns its millisecond count.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for built-in Duration values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320: C# bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant C# built-in binding is implemented."
     ),
     exclude(
         java,
@@ -86,8 +86,8 @@ pub fn duration_as_millis(d: Duration) -> u64 {
     directions = "Call `builtins::echo_system_time` through the generated binding and assert a SystemTime value crosses the wire and returns unchanged.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for built-in SystemTime values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320: C# bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant C# built-in binding is implemented."
     ),
     exclude(
         java,
@@ -111,8 +111,8 @@ pub fn echo_system_time(t: SystemTime) -> SystemTime {
     directions = "Call `builtins::system_time_to_millis` through the generated binding and assert a SystemTime value crosses the wire and returns Unix epoch milliseconds.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for built-in SystemTime values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320: C# bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant C# built-in binding is implemented."
     ),
     exclude(
         java,
@@ -136,8 +136,8 @@ pub fn system_time_to_millis(t: SystemTime) -> u64 {
     directions = "Call `builtins::millis_to_system_time` through the generated binding and assert Unix epoch milliseconds cross the wire and return as a SystemTime value.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for built-in SystemTime values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320: C# bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant C# built-in binding is implemented."
     ),
     exclude(
         java,
@@ -162,8 +162,8 @@ pub fn millis_to_system_time(millis: u64) -> SystemTime {
     directions = "Call `builtins::echo_uuid` through the generated binding and assert a UUID value crosses the wire and returns unchanged.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for built-in UUID values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320: C# bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant C# built-in binding is implemented."
     ),
     exclude(
         java,
@@ -187,8 +187,8 @@ pub fn echo_uuid(id: Uuid) -> Uuid {
     directions = "Call `builtins::uuid_to_string` through the generated binding and assert a UUID value crosses the wire and returns its canonical string representation.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for built-in UUID values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320: C# bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant C# built-in binding is implemented."
     ),
     exclude(
         java,
@@ -212,8 +212,8 @@ pub fn uuid_to_string(id: Uuid) -> String {
     directions = "Call `builtins::echo_url` through the generated binding and assert a URL value crosses the wire and returns unchanged.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for built-in URL values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320: C# bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant C# built-in binding is implemented."
     ),
     exclude(
         java,
@@ -237,8 +237,8 @@ pub fn echo_url(url: Url) -> Url {
     directions = "Call `builtins::url_to_string` through the generated binding and assert a URL value crosses the wire and returns its string representation.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for built-in URL values in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#320: C# bindgen does not currently emit functions whose signatures use built-in value types (Duration, SystemTime, URL, UUID). Include this case when the relevant C# built-in binding is implemented."
     ),
     exclude(
         java,

--- a/examples/demo/src/bytes/mod.rs
+++ b/examples/demo/src/bytes/mod.rs
@@ -4,13 +4,7 @@ use demo_bench_macros::benchmark_candidate;
 #[demo_bench_macros::demo_case(
     "bytes.bytes.should_roundtrip_values",
     justification = "Ensure a byte buffer crosses the wire and returns unchanged.",
-    directions = "Call `bytes::echo_bytes` through the generated binding and assert a byte buffer crosses the wire and returns unchanged.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises byte buffers through primitives::vecs::echo_vec_u8; this case is still waiting on a focused assertion for the dedicated bytes module."
-    )
-)]
+    directions = "Call `bytes::echo_bytes` through the generated binding and assert a byte buffer crosses the wire and returns unchanged.")]
 #[export]
 #[benchmark_candidate(function, uniffi, wasm_bindgen)]
 pub fn echo_bytes(data: Vec<u8>) -> Vec<u8> {
@@ -20,13 +14,7 @@ pub fn echo_bytes(data: Vec<u8>) -> Vec<u8> {
 #[demo_bench_macros::demo_case(
     "bytes.bytes.should_report_length",
     justification = "Ensure a byte buffer crosses the wire and returns its element count.",
-    directions = "Call `bytes::bytes_length` through the generated binding and assert a byte buffer crosses the wire and returns its element count.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises byte buffers through primitives::vecs::echo_vec_u8; this case is still waiting on a focused assertion for the dedicated bytes module."
-    )
-)]
+    directions = "Call `bytes::bytes_length` through the generated binding and assert a byte buffer crosses the wire and returns its element count.")]
 #[export]
 pub fn bytes_length(data: Vec<u8>) -> u32 {
     data.len() as u32
@@ -35,13 +23,7 @@ pub fn bytes_length(data: Vec<u8>) -> u32 {
 #[demo_bench_macros::demo_case(
     "bytes.bytes.should_sum_values",
     justification = "Ensure a byte buffer crosses the wire and returns the sum of its values.",
-    directions = "Call `bytes::bytes_sum` through the generated binding and assert a byte buffer crosses the wire and returns the sum of its values.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises byte buffers through primitives::vecs::echo_vec_u8; this case is still waiting on a focused assertion for the dedicated bytes module."
-    )
-)]
+    directions = "Call `bytes::bytes_sum` through the generated binding and assert a byte buffer crosses the wire and returns the sum of its values.")]
 #[export]
 pub fn bytes_sum(data: Vec<u8>) -> u32 {
     data.iter().map(|&b| b as u32).sum()
@@ -50,13 +32,7 @@ pub fn bytes_sum(data: Vec<u8>) -> u32 {
 #[demo_bench_macros::demo_case(
     "bytes.bytes.should_make_sequential_values",
     justification = "Ensure a requested byte-buffer length crosses the wire and returns sequential values.",
-    directions = "Call `bytes::make_bytes` through the generated binding and assert a requested byte-buffer length crosses the wire and returns sequential values.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises byte buffers through primitives::vecs::echo_vec_u8; this case is still waiting on a focused assertion for the dedicated bytes module."
-    )
-)]
+    directions = "Call `bytes::make_bytes` through the generated binding and assert a requested byte-buffer length crosses the wire and returns sequential values.")]
 #[export]
 pub fn make_bytes(len: u32) -> Vec<u8> {
     (0..len).map(|i| (i % 256) as u8).collect()
@@ -65,13 +41,7 @@ pub fn make_bytes(len: u32) -> Vec<u8> {
 #[demo_bench_macros::demo_case(
     "bytes.bytes.should_reverse_values",
     justification = "Ensure a byte buffer crosses the wire and returns in reverse order.",
-    directions = "Call `bytes::reverse_bytes` through the generated binding and assert a byte buffer crosses the wire and returns in reverse order.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises byte buffers through primitives::vecs::echo_vec_u8; this case is still waiting on a focused assertion for the dedicated bytes module."
-    )
-)]
+    directions = "Call `bytes::reverse_bytes` through the generated binding and assert a byte buffer crosses the wire and returns in reverse order.")]
 #[export]
 pub fn reverse_bytes(data: Vec<u8>) -> Vec<u8> {
     data.into_iter().rev().collect()

--- a/examples/demo/src/custom_types/mod.rs
+++ b/examples/demo/src/custom_types/mod.rs
@@ -53,11 +53,6 @@ custom_type!(
     justification = "Ensure the generated Event record exposes a custom DateTime field through the host-language surface.",
     directions = "Inspect or construct `custom_types::Event` through the generated binding and assert the generated Event record exposes a custom DateTime field through the host-language surface.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# constructs the surrounding value but still needs an assertion for Event fields before crossing FFI."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently map custom FFI types or records containing custom fields. Include this case when custom-type Python bindings are implemented."

--- a/examples/demo/src/enums/c_style.rs
+++ b/examples/demo/src/enums/c_style.rs
@@ -189,11 +189,6 @@ pub fn opposite_direction(d: Direction) -> Direction {
     justification = "Ensure direction_to_degrees maps Direction variants to compass degrees.",
     directions = "Call `enums::c_style::direction_to_degrees` through the generated binding and assert direction_to_degrees maps Direction variants to compass degrees.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for direction_to_degrees in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports C-style enum parameters and primitive returns, but the demo suite has no assertion for direction_to_degrees yet."
@@ -258,11 +253,6 @@ pub fn count_north(directions: Vec<Direction>) -> i32 {
     justification = "Ensure find_direction returns Some(Direction) for a known id.",
     directions = "Call `enums::c_style::find_direction` through the generated binding and assert find_direction returns Some(Direction) for a known id.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for find_direction in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; C-style enums are emitted, but Option<Direction> returns are not. Include this case when optional enum returns are implemented for Python."
@@ -272,11 +262,6 @@ pub fn count_north(directions: Vec<Direction>) -> i32 {
     "enums.c_style.direction.find_direction.should_return_none_for_unknown_id",
     justification = "Ensure find_direction returns None for an unknown id.",
     directions = "Call `enums::c_style::find_direction` through the generated binding and assert find_direction returns None for an unknown id.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for find_direction in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -300,11 +285,6 @@ pub fn find_direction(id: i32) -> Option<Direction> {
     justification = "Ensure find_directions returns Some generated directions for a positive count.",
     directions = "Call `enums::c_style::find_directions` through the generated binding and assert find_directions returns Some generated directions for a positive count.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for find_directions in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; C-style enum vectors are emitted, but Option<Vec<Direction>> returns are not. Include this case when optional enum-vector returns are implemented for Python."
@@ -314,11 +294,6 @@ pub fn find_direction(id: i32) -> Option<Direction> {
     "enums.c_style.direction.find_directions.should_return_none_for_non_positive_count",
     justification = "Ensure find_directions returns None for a non-positive count.",
     directions = "Call `enums::c_style::find_directions` through the generated binding and assert find_directions returns None for a non-positive count.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for find_directions in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/enums/complex_variants.rs
+++ b/examples/demo/src/enums/complex_variants.rs
@@ -18,11 +18,6 @@ pub enum Filter {
     justification = "Ensure the unit Filter::None variant crosses the FFI boundary unchanged.",
     directions = "Call `enums::complex_variants::echo_filter` through the generated binding and assert the unit Filter::None variant crosses the FFI boundary unchanged.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# reaches the surrounding surface but still needs a round-trip assertion for the Filter::None variant."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -32,11 +27,6 @@ pub enum Filter {
     "enums.complex_variants.filter.by_name.should_roundtrip_string_payload",
     justification = "Ensure the Filter::ByName variant preserves its string payload when round-tripped.",
     directions = "Call `enums::complex_variants::echo_filter` through the generated binding and assert the Filter::ByName variant preserves its string payload when round-tripped.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# reaches the surrounding surface but still needs a round-trip assertion for the Filter::ByName variant."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -83,11 +73,6 @@ pub fn echo_filter(f: Filter) -> Filter {
     justification = "Ensure describe_filter renders a ByName string payload in the summary.",
     directions = "Call `enums::complex_variants::describe_filter` through the generated binding and assert describe_filter renders a ByName string payload in the summary.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# reaches the complex enum helpers but still needs an assertion for describing the Filter::ByName variant."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -97,11 +82,6 @@ pub fn echo_filter(f: Filter) -> Filter {
     "enums.complex_variants.filter.by_range.should_describe_numeric_bounds",
     justification = "Ensure describe_filter renders a ByRange numeric lower and upper bound.",
     directions = "Call `enums::complex_variants::describe_filter` through the generated binding and assert describe_filter renders a ByRange numeric lower and upper bound.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# reaches the complex enum helpers but still needs an assertion for describing the Filter::ByRange variant."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -164,11 +144,6 @@ pub enum ApiResponse {
     justification = "Ensure the ApiResponse::Success variant preserves its string payload when round-tripped.",
     directions = "Call `enums::complex_variants::echo_api_response` through the generated binding and assert the ApiResponse::Success variant preserves its string payload when round-tripped.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises Filter complex variants; this case is still waiting on a focused assertion for ApiResponse helpers."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -178,11 +153,6 @@ pub enum ApiResponse {
     "enums.complex_variants.api_response.redirect.should_roundtrip_url_payload",
     justification = "Ensure the ApiResponse::Redirect variant preserves its URL payload when round-tripped.",
     directions = "Call `enums::complex_variants::echo_api_response` through the generated binding and assert the ApiResponse::Redirect variant preserves its URL payload when round-tripped.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises Filter complex variants; this case is still waiting on a focused assertion for ApiResponse helpers."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -199,11 +169,6 @@ pub fn echo_api_response(response: ApiResponse) -> ApiResponse {
     justification = "Ensure is_success returns true for the ApiResponse::Success variant.",
     directions = "Call `enums::complex_variants::is_success` through the generated binding and assert is_success returns true for the ApiResponse::Success variant.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises Filter complex variants; this case is still waiting on a focused assertion for ApiResponse helpers."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -213,11 +178,6 @@ pub fn echo_api_response(response: ApiResponse) -> ApiResponse {
     "enums.complex_variants.api_response.empty.should_not_identify_as_success",
     justification = "Ensure is_success returns false for the ApiResponse::Empty variant.",
     directions = "Call `enums::complex_variants::is_success` through the generated binding and assert is_success returns false for the ApiResponse::Empty variant.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises Filter complex variants; this case is still waiting on a focused assertion for ApiResponse helpers."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/enums/data_enum.rs
+++ b/examples/demo/src/enums/data_enum.rs
@@ -94,7 +94,7 @@ impl Shape {
         exclude(
             csharp,
             reason = ExclusionReason::ImplementationGap,
-            details = "C# does not currently emit Result-returning data-enum static methods, so Shape::try_circle is absent from the generated surface. Include this case when fallible data-enum factories are implemented for C#."
+            details = "#328: C# bindgen does not currently emit Result-returning data-enum static methods, so Shape::try_circle is absent from the generated surface. Include this case when fallible data-enum factories are implemented for C#."
         ),
         exclude(
             python,
@@ -109,7 +109,7 @@ impl Shape {
         exclude(
             csharp,
             reason = ExclusionReason::ImplementationGap,
-            details = "C# does not currently emit Result-returning data-enum static methods, so Shape::try_circle is absent from the generated surface. Include this case when fallible data-enum factories are implemented for C#."
+            details = "#328: C# bindgen does not currently emit Result-returning data-enum static methods, so Shape::try_circle is absent from the generated surface. Include this case when fallible data-enum factories are implemented for C#."
         ),
         exclude(
             python,
@@ -365,11 +365,6 @@ pub fn echo_message(m: Message) -> Message {
     justification = "Ensure message_summary renders the Image dimensions and URL in the summary.",
     directions = "Call `enums::data_enum::message_summary` through the generated binding and assert message_summary renders the Image dimensions and URL in the summary.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# round-trips the value but still needs an assertion for the the Message::Image variant summary."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only C-style enums, not data-enum payloads. Include this case when Python data-enum bindings are implemented."
@@ -451,11 +446,6 @@ pub fn echo_animal(a: Animal) -> Animal {
     "enums.data_enum.animal.cat.should_derive_name",
     justification = "Ensure animal_name derives the cat name from an Animal::Cat payload.",
     directions = "Call `enums::data_enum::animal_name` through the generated binding and assert animal_name derives the cat name from an Animal::Cat payload.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# round-trips the enum family but still needs an assertion for the derived a name from Animal::Cat behavior."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/enums/repr_int.rs
+++ b/examples/demo/src/enums/repr_int.rs
@@ -17,12 +17,7 @@ pub enum Priority {
 #[demo_bench_macros::demo_case(
     "enums.repr_int.priority.should_roundtrip_value",
     justification = "Ensure a repr(i32) Priority enum value crosses the FFI boundary and returns unchanged.",
-    directions = "Call `enums::repr_int::echo_priority` through the generated binding and assert a repr(i32) Priority enum value crosses the FFI boundary and returns unchanged.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for Priority helper functions in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `enums::repr_int::echo_priority` through the generated binding and assert a repr(i32) Priority enum value crosses the FFI boundary and returns unchanged."
 )]
 #[export]
 pub fn echo_priority(p: Priority) -> Priority {
@@ -32,12 +27,7 @@ pub fn echo_priority(p: Priority) -> Priority {
 #[demo_bench_macros::demo_case(
     "enums.repr_int.priority.should_render_label",
     justification = "Ensure priority_label maps Priority enum values to their string labels.",
-    directions = "Call `enums::repr_int::priority_label` through the generated binding and assert priority_label maps Priority enum values to their string labels.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for Priority helper functions in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `enums::repr_int::priority_label` through the generated binding and assert priority_label maps Priority enum values to their string labels."
 )]
 #[export]
 pub fn priority_label(p: Priority) -> String {
@@ -52,12 +42,7 @@ pub fn priority_label(p: Priority) -> String {
 #[demo_bench_macros::demo_case(
     "enums.repr_int.priority.should_identify_high_priority",
     justification = "Ensure is_high_priority returns true for High and Critical priorities.",
-    directions = "Call `enums::repr_int::is_high_priority` through the generated binding and assert is_high_priority returns true for High and Critical priorities.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for Priority helper functions in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    )
+    directions = "Call `enums::repr_int::is_high_priority` through the generated binding and assert is_high_priority returns true for High and Critical priorities."
 )]
 #[export]
 pub fn is_high_priority(p: Priority) -> bool {

--- a/examples/demo/src/primitives/scalars.rs
+++ b/examples/demo/src/primitives/scalars.rs
@@ -184,11 +184,6 @@ pub fn echo_isize(v: isize) -> isize {
     justification = "Ensure a no-argument no-op call crosses the wire without returning a value.",
     directions = "Call `primitives::scalars::noop` through the generated binding and assert a no-argument no-op call crosses the wire without returning a value.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for the scalar noop helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive scalar calls, but the demo suite has no assertion for the scalar noop benchmark helper yet."
@@ -202,11 +197,6 @@ pub fn noop() {}
     "primitives.scalars.i32.should_add_with_benchmark_alias",
     justification = "Ensure two i32 values cross the wire through the benchmark add alias and return as their sum.",
     directions = "Call `primitives::scalars::add` through the generated binding and assert two i32 values cross the wire through the benchmark add alias and return as their sum.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for the benchmark add alias in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::CoverageGap,
@@ -223,11 +213,6 @@ pub fn add(a: i32, b: i32) -> i32 {
     "primitives.scalars.f64.should_multiply_two_values",
     justification = "Ensure two f64 values cross the wire and return as their product.",
     directions = "Call `primitives::scalars::multiply` through the generated binding and assert two f64 values cross the wire and return as their product.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for the scalar multiply helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::CoverageGap,

--- a/examples/demo/src/primitives/vecs.rs
+++ b/examples/demo/src/primitives/vecs.rs
@@ -221,11 +221,6 @@ pub fn generate_i32_vec(count: i32) -> Vec<i32> {
     justification = "Ensure an i32 vector crosses the wire through the benchmark sum helper and returns as an i64 sum.",
     directions = "Call `primitives::vecs::sum_i32_vec` through the generated binding and assert an i32 vector crosses the wire through the benchmark sum helper and returns as an i64 sum.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for the i32 benchmark sum helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::CoverageGap,
         details = "Python supports primitive vector parameters and primitive returns, but the demo suite has no assertion for this benchmark sum helper yet."
@@ -276,8 +271,8 @@ pub fn sum_f64_vec(values: Vec<f64>) -> f64 {
     directions = "Call `primitives::vecs::inc_u64` through the generated binding and assert a mutable u64 slice crosses the wire and increments its first value in place.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for the in-place u64 slice helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#328: C# bindgen does not currently emit free functions with `&mut [T]` slice parameters, so inc_u64 is absent from the generated surface. Include this case when in-place sequence parameters are implemented for C#."
     ),
     exclude(
         python,
@@ -296,11 +291,6 @@ pub fn inc_u64(values: &mut [u64]) {
     "primitives.vecs.u64.should_increment_value",
     justification = "Ensure a u64 value crosses the wire and returns incremented by one.",
     directions = "Call `primitives::vecs::inc_u64_value` through the generated binding and assert a u64 value crosses the wire and returns incremented by one.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for the u64 value increment helper in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::CoverageGap,
@@ -422,11 +412,6 @@ pub fn echo_vec_vec_string(v: Vec<Vec<String>>) -> Vec<Vec<String>> {
     "primitives.vecs.nested_i32.should_flatten_empty",
     justification = "Ensure an empty nested i32 vector crosses the wire and returns as an empty i32 vector.",
     directions = "Call `primitives::vecs::flatten_vec_vec_i32` through the generated binding and assert an empty nested i32 vector crosses the wire and returns as an empty i32 vector.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for flattening an empty nested vector in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/records/blittable.rs
+++ b/examples/demo/src/records/blittable.rs
@@ -19,11 +19,6 @@ impl Point {
         justification = "Ensure Point::new returns a blittable Point containing the provided coordinates.",
         directions = "Call `records::blittable::Point::new` through the generated binding and assert Point::new returns a blittable Point containing the provided coordinates.",
         exclude(
-            csharp,
-            reason = ExclusionReason::CoverageGap,
-            details = "C# has no assertion for the Point::new constructor in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-        ),
-        exclude(
             java,
             reason = ExclusionReason::ImplementationGap,
             details = "#323: Java bindgen drops static methods whose Rust name collides with a Java keyword. Java cannot expose Point::new because new is a Java keyword. Include this case when Java keyword-safe renaming lands."
@@ -60,8 +55,8 @@ impl Point {
         directions = "Call `records::blittable::Point::try_unit` through the generated binding and assert Point::try_unit returns a normalized Point for non-zero coordinates.",
         exclude(
             csharp,
-            reason = ExclusionReason::CoverageGap,
-            details = "C# has no assertion for the fallible Point::try_unit method in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+            reason = ExclusionReason::ImplementationGap,
+            details = "#328: C# bindgen does not currently emit Result-returning record static methods, so Point::try_unit is absent from the generated surface. Include this case when fallible record methods are implemented for C#."
         ),
         exclude(
             python,
@@ -75,8 +70,8 @@ impl Point {
         directions = "Call `records::blittable::Point::try_unit` through the generated binding and assert Point::try_unit rejects zero coordinates instead of returning an invalid unit vector.",
         exclude(
             csharp,
-            reason = ExclusionReason::CoverageGap,
-            details = "C# has no assertion for the fallible Point::try_unit method in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+            reason = ExclusionReason::ImplementationGap,
+            details = "#328: C# bindgen does not currently emit Result-returning record static methods, so Point::try_unit is absent from the generated surface. Include this case when fallible record methods are implemented for C#."
         ),
         exclude(
             python,
@@ -102,8 +97,8 @@ impl Point {
         directions = "Call `records::blittable::Point::checked_unit` through the generated binding and assert Point::checked_unit returns Some normalized Point for non-zero coordinates.",
         exclude(
             csharp,
-            reason = ExclusionReason::CoverageGap,
-            details = "C# has no assertion for the optional Point::checked_unit method in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+            reason = ExclusionReason::ImplementationGap,
+            details = "#328: C# bindgen does not currently emit Option-returning record static methods, so Point::checked_unit is absent from the generated surface. Include this case when optional record methods are implemented for C#."
         ),
         exclude(
             python,
@@ -117,8 +112,8 @@ impl Point {
         directions = "Call `records::blittable::Point::checked_unit` through the generated binding and assert Point::checked_unit returns None for zero coordinates.",
         exclude(
             csharp,
-            reason = ExclusionReason::CoverageGap,
-            details = "C# has no assertion for the optional Point::checked_unit method in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+            reason = ExclusionReason::ImplementationGap,
+            details = "#328: C# bindgen does not currently emit Option-returning record static methods, so Point::checked_unit is absent from the generated surface. Include this case when optional record methods are implemented for C#."
         ),
         exclude(
             python,
@@ -153,8 +148,8 @@ impl Point {
         directions = "Call `records::blittable::Point::scale` through the generated binding and assert Point::scale multiplies both coordinates by the provided factor.",
         exclude(
             csharp,
-            reason = ExclusionReason::CoverageGap,
-            details = "C# has no assertion for the Point::scale method in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+            reason = ExclusionReason::ImplementationGap,
+            details = "#328: C# bindgen does not currently emit `&mut self` record instance methods, so Point::scale is absent from the generated surface. Include this case when in-place record methods are implemented for C#."
         )
     )]
     pub fn scale(&mut self, factor: f64) {
@@ -220,11 +215,6 @@ pub fn echo_point(p: Point) -> Point {
     justification = "Ensure try_make_point returns Some Point when the provided coordinates are not both zero.",
     directions = "Call `records::blittable::try_make_point` through the generated binding and assert try_make_point returns Some Point when the provided coordinates are not both zero.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for try_make_point in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Option<T> around blittable records. Include this case when optional record returns are implemented for Python."
@@ -234,11 +224,6 @@ pub fn echo_point(p: Point) -> Point {
     "records.blittable.point.should_return_none_for_origin_coordinates",
     justification = "Ensure try_make_point returns None when both coordinates are zero.",
     directions = "Call `records::blittable::try_make_point` through the generated binding and assert try_make_point returns None when both coordinates are zero.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for try_make_point in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -755,11 +740,6 @@ pub fn avg_sensor_temperature(readings: Vec<SensorReading>) -> f64 {
     justification = "Ensure find_location returns Some(Location) for a positive id.",
     directions = "Call `records::blittable::find_location` through the generated binding and assert find_location returns Some(Location) for a positive id.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for find_location in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Vec<Record> parameters or returns, even for blittable records. Include this case when record-vector support is implemented for Python."
@@ -769,11 +749,6 @@ pub fn avg_sensor_temperature(readings: Vec<SensorReading>) -> f64 {
     "records.blittable.locations.find_location.should_return_none_for_non_positive_id",
     justification = "Ensure find_location returns None for a non-positive id.",
     directions = "Call `records::blittable::find_location` through the generated binding and assert find_location returns None for a non-positive id.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for find_location in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -802,11 +777,6 @@ pub fn find_location(id: i32) -> Option<Location> {
     justification = "Ensure find_locations returns Some generated Location vector for a positive count.",
     directions = "Call `records::blittable::find_locations` through the generated binding and assert find_locations returns Some generated Location vector for a positive count.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for find_locations in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently handle Vec<Record> parameters or returns, even for blittable records. Include this case when record-vector support is implemented for Python."
@@ -816,11 +786,6 @@ pub fn find_location(id: i32) -> Option<Location> {
     "records.blittable.locations.find_locations.should_return_none_for_non_positive_count",
     justification = "Ensure find_locations returns None for a non-positive count.",
     directions = "Call `records::blittable::find_locations` through the generated binding and assert find_locations returns None for a non-positive count.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for find_locations in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/records/mixed.rs
+++ b/examples/demo/src/records/mixed.rs
@@ -48,11 +48,6 @@ impl MixedRecord {
     justification = "Ensure a MixedRecord composed from strings, records, enums, options, and vectors crosses the wire and returns unchanged.",
     directions = "Call `records::mixed::echo_mixed_record` through the generated binding and assert a MixedRecord composed from strings, records, enums, options, and vectors crosses the wire and returns unchanged.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises MixedRecord through class and async APIs; this case is still waiting on a focused assertion for the records::mixed free functions."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when non-blittable records are implemented for Python."
@@ -67,11 +62,6 @@ pub fn echo_mixed_record(record: MixedRecord) -> MixedRecord {
     "records.mixed.should_make_from_composed_parts",
     justification = "Ensure make_mixed_record constructs a MixedRecord from nested records, data enums, repr-int enums, options, and vectors.",
     directions = "Call `records::mixed::make_mixed_record` through the generated binding and assert make_mixed_record constructs a MixedRecord from nested records, data enums, repr-int enums, options, and vectors.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises MixedRecord through class and async APIs; this case is still waiting on a focused assertion for the records::mixed free functions."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/records/with_enums.rs
+++ b/examples/demo/src/records/with_enums.rs
@@ -32,11 +32,6 @@ pub fn echo_task(task: Task) -> Task {
     justification = "Ensure make_task constructs a Task with the requested Priority enum and completed set to false.",
     directions = "Call `records::with_enums::make_task` through the generated binding and assert make_task constructs a Task with the requested Priority enum and completed set to false.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises Task round-trip; this case is still waiting on a focused assertion for make_task."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when records with enum fields are implemented for Python."
@@ -55,11 +50,6 @@ pub fn make_task(title: String, priority: Priority) -> Task {
     "records.with_enums.task.should_detect_urgent_priority",
     justification = "Ensure is_urgent reads the Priority enum field from a Task record and classifies urgent priorities.",
     directions = "Call `records::with_enums::is_urgent` through the generated binding and assert is_urgent reads the Priority enum field from a Task record and classifies urgent priorities.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# already exercises Task round-trip; this case is still waiting on a focused assertion for is_urgent."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/results/basic.rs
+++ b/examples/demo/src/results/basic.rs
@@ -36,11 +36,6 @@ pub fn safe_divide(a: i32, b: i32) -> Result<i32, String> {
     justification = "Ensure safe_sqrt returns the square root for non-negative floating-point input.",
     directions = "Call `results::basic::safe_sqrt` through the generated binding and assert safe_sqrt returns the square root for non-negative floating-point input.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for safe_sqrt in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result-returning functions. Include this case when Result returns are implemented for Python."
@@ -50,11 +45,6 @@ pub fn safe_divide(a: i32, b: i32) -> Result<i32, String> {
     "results.basic.safe_sqrt.should_reject_negative_input",
     justification = "Ensure safe_sqrt returns a language-native error for negative floating-point input.",
     directions = "Call `results::basic::safe_sqrt` through the generated binding and assert safe_sqrt returns a language-native error for negative floating-point input.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for safe_sqrt in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -143,8 +133,8 @@ pub fn always_err(msg: String) -> Result<i32, String> {
     directions = "Call `results::basic::result_to_string` through the generated binding and assert result_to_string receives an Ok Result value over FFI and renders its success payload.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for Result parameters in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#321: C# bindgen does not currently emit functions that take Result<T, E> as a parameter. Include this case when C# Result-parameter support lands."
     ),
     exclude(
         java,
@@ -163,8 +153,8 @@ pub fn always_err(msg: String) -> Result<i32, String> {
     directions = "Call `results::basic::result_to_string` through the generated binding and assert result_to_string receives an Err Result value over FFI and renders its error payload.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for Result parameters in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#321: C# bindgen does not currently emit functions that take Result<T, E> as a parameter. Include this case when C# Result-parameter support lands."
     ),
     exclude(
         java,
@@ -190,11 +180,6 @@ pub fn result_to_string(v: Result<i32, String>) -> String {
     justification = "Ensure divide returns the integer quotient when the divisor is non-zero.",
     directions = "Call `results::basic::divide` through the generated binding and assert divide returns the integer quotient when the divisor is non-zero.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for the divide alias in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result-returning functions. Include this case when Result returns are implemented for Python."
@@ -204,11 +189,6 @@ pub fn result_to_string(v: Result<i32, String>) -> String {
     "results.basic.divide.should_reject_division_by_zero",
     justification = "Ensure divide returns a language-native error when the divisor is zero.",
     directions = "Call `results::basic::divide` through the generated binding and assert divide returns a language-native error when the divisor is zero.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for the divide alias in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -225,11 +205,6 @@ pub fn divide(a: i32, b: i32) -> Result<i32, String> {
     justification = "Ensure parse_int parses a decimal string into an i32 value.",
     directions = "Call `results::basic::parse_int` through the generated binding and assert parse_int parses a decimal string into an i32 value.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for the top-level parse_int export in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result-returning functions. Include this case when Result returns are implemented for Python."
@@ -239,11 +214,6 @@ pub fn divide(a: i32, b: i32) -> Result<i32, String> {
     "results.basic.parse_int.should_reject_invalid_integer",
     justification = "Ensure parse_int returns a language-native error when the string is not a valid i32.",
     directions = "Call `results::basic::parse_int` through the generated binding and assert parse_int returns a language-native error when the string is not a valid i32.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for the top-level parse_int export in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -262,11 +232,6 @@ pub fn parse_int(input: String) -> Result<i32, String> {
     justification = "Ensure validate_name returns a greeting for a non-empty name within the length limit.",
     directions = "Call `results::basic::validate_name` through the generated binding and assert validate_name returns a greeting for a non-empty name within the length limit.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for validate_name in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result-returning functions. Include this case when Result returns are implemented for Python."
@@ -276,11 +241,6 @@ pub fn parse_int(input: String) -> Result<i32, String> {
     "results.basic.validate_name.should_reject_empty_name",
     justification = "Ensure validate_name returns a language-native error when the provided name is empty.",
     directions = "Call `results::basic::validate_name` through the generated binding and assert validate_name returns a language-native error when the provided name is empty.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for validate_name in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/demo/src/results/error_enums.rs
+++ b/examples/demo/src/results/error_enums.rs
@@ -311,11 +311,6 @@ pub struct BenchmarkResponse {
     justification = "Ensure process_value returns the Success data enum variant for positive input.",
     directions = "Call `results::error_enums::process_value` through the generated binding and assert process_value returns the Success data enum variant for positive input.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
@@ -326,11 +321,6 @@ pub struct BenchmarkResponse {
     justification = "Ensure process_value returns the ErrorCode data enum variant for zero input.",
     directions = "Call `results::error_enums::process_value` through the generated binding and assert process_value returns the ErrorCode data enum variant for zero input.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
@@ -340,11 +330,6 @@ pub struct BenchmarkResponse {
     "results.error_enums.process_value.should_return_error_with_data_variant",
     justification = "Ensure process_value returns the ErrorWithData data enum variant for negative input.",
     directions = "Call `results::error_enums::process_value` through the generated binding and assert process_value returns the ErrorWithData data enum variant for negative input.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -370,11 +355,6 @@ pub fn process_value(value: i32) -> ApiResult {
     justification = "Ensure api_result_is_success returns true for the Success data enum variant.",
     directions = "Call `results::error_enums::api_result_is_success` through the generated binding and assert api_result_is_success returns true for the Success data enum variant.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
@@ -384,11 +364,6 @@ pub fn process_value(value: i32) -> ApiResult {
     "results.error_enums.api_result_is_success.should_report_error_variant",
     justification = "Ensure api_result_is_success returns false for non-success data enum variants.",
     directions = "Call `results::error_enums::api_result_is_success` through the generated binding and assert api_result_is_success returns false for non-success data enum variants.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for ApiResult data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -405,11 +380,6 @@ pub fn api_result_is_success(result: ApiResult) -> bool {
     justification = "Ensure try_compute returns an Ok value containing positive input doubled.",
     directions = "Call `results::error_enums::try_compute` through the generated binding and assert try_compute returns an Ok value containing positive input doubled.",
     exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for ComputeError data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
@@ -419,11 +389,6 @@ pub fn api_result_is_success(result: ApiResult) -> bool {
     "results.error_enums.try_compute.should_return_overflow_error",
     justification = "Ensure try_compute returns the Overflow typed error for negative input.",
     directions = "Call `results::error_enums::try_compute` through the generated binding and assert try_compute returns the Overflow typed error for negative input.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for ComputeError data enum results in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -447,8 +412,8 @@ pub fn try_compute(value: i32) -> Result<i32, ComputeError> {
     directions = "Call `results::error_enums::create_success_response` through the generated binding and assert create_success_response returns a BenchmarkResponse carrying an Ok DataPoint result.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for BenchmarkResponse result fields in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#322: C# bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when C# nested-Result-in-record support lands."
     ),
     exclude(
         java,
@@ -475,8 +440,8 @@ pub fn create_success_response(request_id: i64, point: DataPoint) -> BenchmarkRe
     directions = "Call `results::error_enums::create_error_response` through the generated binding and assert create_error_response returns or surfaces a BenchmarkResponse carrying an Err ComputeError result.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for BenchmarkResponse result fields in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#322: C# bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when C# nested-Result-in-record support lands."
     ),
     exclude(
         java,
@@ -503,8 +468,8 @@ pub fn create_error_response(request_id: i64, error: ComputeError) -> BenchmarkR
     directions = "Call `results::error_enums::is_response_success` through the generated binding and assert is_response_success returns true for a BenchmarkResponse carrying an Ok result.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for BenchmarkResponse result fields in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#322: C# bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when C# nested-Result-in-record support lands."
     ),
     exclude(
         java,
@@ -523,8 +488,8 @@ pub fn create_error_response(request_id: i64, error: ComputeError) -> BenchmarkR
     directions = "Call `results::error_enums::is_response_success` through the generated binding and assert is_response_success returns false for a BenchmarkResponse carrying an Err result.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for BenchmarkResponse result fields in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#322: C# bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when C# nested-Result-in-record support lands."
     ),
     exclude(
         java,
@@ -548,8 +513,8 @@ pub fn is_response_success(response: BenchmarkResponse) -> bool {
     directions = "Call `results::error_enums::get_response_value` through the generated binding and assert get_response_value returns Some(DataPoint) for a BenchmarkResponse carrying an Ok result.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for BenchmarkResponse result fields in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#322: C# bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when C# nested-Result-in-record support lands."
     ),
     exclude(
         java,
@@ -568,8 +533,8 @@ pub fn is_response_success(response: BenchmarkResponse) -> bool {
     directions = "Call `results::error_enums::get_response_value` through the generated binding and assert get_response_value returns None for a BenchmarkResponse carrying an Err result.",
     exclude(
         csharp,
-        reason = ExclusionReason::CoverageGap,
-        details = "C# has no assertion for BenchmarkResponse result fields in the demo suite yet; add the marker at the scenario-specific test when coverage lands."
+        reason = ExclusionReason::ImplementationGap,
+        details = "#322: C# bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when C# nested-Result-in-record support lands."
     ),
     exclude(
         java,

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -40,6 +40,7 @@ public static class DemoTest
             TestDataEnums();
             TestRecordsWithEnumFields();
             TestPrimitiveVecs();
+            TestBytes();
             TestStringAndNestedVecs();
             TestBlittableRecordVecs();
             TestEnumVecs();
@@ -118,6 +119,9 @@ public static class DemoTest
         Require(EchoI32(42) == 42, "echoI32(42)");
         Require(EchoI32(-100) == -100, "case:primitives.scalars.i32.should_roundtrip_negative_value echoI32(-100)");
         Require(AddI32(10, 20) == 30, "case:primitives.scalars.i32.should_add_two_values addI32(10, 20)");
+        Require(Add(7, 9) == 16, "case:primitives.scalars.i32.should_add_with_benchmark_alias add(7, 9)");
+        DemoCase("case:primitives.scalars.noop.should_cross_without_values");
+        Noop();
         Console.WriteLine("  PASS\n");
     }
 
@@ -158,6 +162,7 @@ public static class DemoTest
         Console.WriteLine("Testing f64...");
         Require(Math.Abs(EchoF64(3.14159265359) - 3.14159265359) < 0.0000001, "case:primitives.scalars.f64.should_roundtrip_pi_with_tolerance echoF64(pi)");
         Require(Math.Abs(AddF64(1.5, 2.5) - 4.0) < 0.0000001, "case:primitives.scalars.f64.should_add_two_values_with_tolerance addF64(1.5, 2.5)");
+        Require(Math.Abs(Multiply(1.5, 4.0) - 6.0) < 0.0000001, "case:primitives.scalars.f64.should_multiply_two_values multiply(1.5, 4.0)");
         Console.WriteLine("  PASS\n");
     }
 
@@ -231,6 +236,8 @@ public static class DemoTest
         Require(echoed.Timestamp == ts, "EchoEvent.Timestamp");
         DemoCase("case:custom_types.event.should_extract_timestamp_millis");
         Require(EventTimestamp(evt) == ts, "EventTimestamp");
+        DemoCase("case:custom_types.event.should_expose_datetime_field");
+        Require(evt.Timestamp == ts, "Event.Timestamp datetime field");
 
         string[] emails = new[] { "café@example.com", "user@example.org" };
         DemoCase("case:custom_types.vectors.emails.should_roundtrip_values");
@@ -281,8 +288,15 @@ public static class DemoTest
 
         // Static factories on a blittable record — return by value across
         // the ABI as a [StructLayout(Sequential)] struct.
+        DemoCase("case:records.blittable.point.should_construct_with_static_new");
+        Require(Point.New(1.5, 2.5) == new Point(1.5, 2.5), "Point.New");
         DemoCase("case:records.blittable.point.should_return_origin");
         Require(Point.Origin() == new Point(0.0, 0.0), "Point.Origin()");
+        DemoCase("case:records.blittable.point.should_return_some_for_nonzero_coordinates");
+        Point? tryNonzero = TryMakePoint(1.0, 2.0);
+        Require(tryNonzero.HasValue && tryNonzero.Value == new Point(1.0, 2.0), "TryMakePoint(1,2)");
+        DemoCase("case:records.blittable.point.should_return_none_for_origin_coordinates");
+        Require(!TryMakePoint(0.0, 0.0).HasValue, "TryMakePoint(0,0)");
         DemoCase("case:records.blittable.point.should_construct_from_polar_coordinates");
         Point fromPolar = Point.FromPolar(2.0, Math.PI / 2.0);
         Require(Math.Abs(fromPolar.X) < 1e-9 && Math.Abs(fromPolar.Y - 2.0) < 1e-9, "Point.FromPolar");
@@ -478,9 +492,35 @@ public static class DemoTest
         DemoCase("case:enums.c_style.direction.should_construct_from_raw_value");
         Require(DirectionMethods.New(2) == Direction.East, "New(2) == East");
 
+        DemoCase("case:enums.c_style.direction.should_return_degrees");
+        Require(DirectionToDegrees(Direction.North) == 0, "DirectionToDegrees(North)");
+        Require(DirectionToDegrees(Direction.East) == 90, "DirectionToDegrees(East)");
+
+        DemoCase("case:enums.c_style.direction.find_direction.should_return_some_for_known_id");
+        Direction? foundDir = FindDirection(1);
+        Require(foundDir.HasValue && foundDir.Value == Direction.East, "FindDirection(1)");
+        DemoCase("case:enums.c_style.direction.find_direction.should_return_none_for_unknown_id");
+        Require(!FindDirection(99).HasValue, "FindDirection(99)");
+
+        DemoCase("case:enums.c_style.direction.find_directions.should_return_sequence_for_positive_count");
+        Direction[] someDirs = FindDirections(3);
+        Require(someDirs is not null && someDirs.Length == 3, "FindDirections(3)");
+        DemoCase("case:enums.c_style.direction.find_directions.should_return_none_for_non_positive_count");
+        Require(FindDirections(0) is null, "FindDirections(0)");
+
         // Non-default backing type: LogLevel is #[repr(u8)] on the Rust side,
         // so these direct P/Invoke calls catch any accidental `enum : int`
         // projection in the generated C# surface.
+        DemoCase("case:enums.repr_int.priority.should_roundtrip_value");
+        Require(EchoPriority(Priority.High) == Priority.High, "EchoPriority(High)");
+        DemoCase("case:enums.repr_int.priority.should_render_label");
+        Require(PriorityLabel(Priority.Low) == "low", "PriorityLabel(Low)");
+        Require(PriorityLabel(Priority.Critical) == "critical", "PriorityLabel(Critical)");
+        DemoCase("case:enums.repr_int.priority.should_identify_high_priority");
+        Require(IsHighPriority(Priority.High), "IsHighPriority(High)");
+        Require(IsHighPriority(Priority.Critical), "IsHighPriority(Critical)");
+        Require(!IsHighPriority(Priority.Low), "IsHighPriority(Low) == false");
+
         DemoCase("case:enums.repr_int.log_level.should_roundtrip_value");
         Require(EchoLogLevel(LogLevel.Trace) == LogLevel.Trace, "EchoLogLevel(Trace)");
         Require(EchoLogLevel(LogLevel.Error) == LogLevel.Error, "EchoLogLevel(Error)");
@@ -677,6 +717,12 @@ public static class DemoTest
         );
         DemoCase("case:enums.data_enum.message.ping.should_render_ping_summary");
         Require(MessageSummary(new Message.Ping()) == "ping", "MessageSummary(Ping)");
+        DemoCase("case:enums.data_enum.message.image.should_render_image_summary");
+        Require(
+            MessageSummary(new Message.Image("https://example.com/a.png", 1920, 1080))
+                == "image: 1920x1080 at https://example.com/a.png",
+            "MessageSummary(Image)"
+        );
 
         // Animal — three struct variants, one with a bool field.
         DemoCase("case:enums.data_enum.animal.dog.should_roundtrip_string_payloads");
@@ -702,6 +748,8 @@ public static class DemoTest
 
         DemoCase("case:enums.data_enum.animal.dog.should_derive_name");
         Require(AnimalName(new Animal.Dog("Rex", "Lab")) == "Rex", "AnimalName(Dog)");
+        DemoCase("case:enums.data_enum.animal.cat.should_derive_name");
+        Require(AnimalName(new Animal.Cat("Whiskers", true)) == "Whiskers", "AnimalName(Cat)");
         DemoCase("case:enums.data_enum.animal.fish.should_derive_count_label");
         Require(AnimalName(new Animal.Fish(5u)) == "5 fish", "AnimalName(Fish)");
 
@@ -746,6 +794,14 @@ public static class DemoTest
         global::Demo.Task echoedTask = EchoTask(task);
         Require(echoedTask == task, "EchoTask round-trip");
         Require(echoedTask.Priority == Priority.High, "Task.Priority preserved");
+
+        DemoCase("case:records.with_enums.task.should_make_incomplete_task");
+        global::Demo.Task made = MakeTask("New task", Priority.Low);
+        Require(made.Title == "New task" && made.Priority == Priority.Low && !made.Completed, "MakeTask defaults");
+
+        DemoCase("case:records.with_enums.task.should_detect_urgent_priority");
+        Require(IsUrgent(new global::Demo.Task("urgent", Priority.Critical, false)), "IsUrgent(Critical)");
+        Require(!IsUrgent(new global::Demo.Task("normal", Priority.Low, false)), "IsUrgent(Low) false");
 
         Notification notification = new Notification("Build failed", Priority.Critical, false);
         DemoCase("case:records.with_enums.notification.should_roundtrip_priority_field");
@@ -840,6 +896,12 @@ public static class DemoTest
         Require(SumVecI32(new int[] { 10, 20, 30 }) == 60L, "sumVecI32");
         Require(SumVecI32(Array.Empty<int>()) == 0L, "sumVecI32 empty");
 
+        DemoCase("case:primitives.vecs.i32.should_sum_benchmark_values");
+        Require(SumI32Vec(new int[] { 1, 2, 3, 4 }) == 10L, "sumI32Vec");
+
+        DemoCase("case:primitives.vecs.u64.should_increment_value");
+        Require(IncU64Value(41UL) == 42UL, "incU64Value");
+
         DemoCase("case:primitives.vecs.i32.should_make_range");
         Require(MakeRange(0, 5).SequenceEqual(new int[] { 0, 1, 2, 3, 4 }), "makeRange");
         DemoCase("case:primitives.vecs.i32.should_reverse_values");
@@ -850,6 +912,24 @@ public static class DemoTest
         Require(GenerateF64Vec(3).Length == 3, "generateF64Vec length");
         DemoCase("case:primitives.vecs.f64.should_sum_values");
         Require(Math.Abs(SumF64Vec(new double[] { 0.5, 1.5, 2.0 }) - 4.0) < 1e-9, "sumF64Vec");
+
+        Console.WriteLine("  PASS\n");
+    }
+
+    private static void TestBytes()
+    {
+        Console.WriteLine("Testing bytes...");
+
+        DemoCase("case:bytes.bytes.should_roundtrip_values");
+        Require(EchoBytes(new byte[] { 1, 2, 3, 4 }).SequenceEqual(new byte[] { 1, 2, 3, 4 }), "echoBytes");
+        DemoCase("case:bytes.bytes.should_report_length");
+        Require(BytesLength(new byte[] { 9, 8, 7 }) == 3u, "bytesLength");
+        DemoCase("case:bytes.bytes.should_sum_values");
+        Require(BytesSum(new byte[] { 1, 2, 3, 4 }) == 10u, "bytesSum");
+        DemoCase("case:bytes.bytes.should_make_sequential_values");
+        Require(MakeBytes(4).SequenceEqual(new byte[] { 0, 1, 2, 3 }), "makeBytes");
+        DemoCase("case:bytes.bytes.should_reverse_values");
+        Require(ReverseBytes(new byte[] { 1, 2, 3, 4 }).SequenceEqual(new byte[] { 4, 3, 2, 1 }), "reverseBytes");
 
         Console.WriteLine("  PASS\n");
     }
@@ -936,6 +1016,8 @@ public static class DemoTest
         DemoCase("case:primitives.vecs.nested_i32.should_flatten_values");
         int[] flattened = FlattenVecVecI32(nestedInts);
         Require(flattened.SequenceEqual(new[] { 1, 2, 3, -1 }), "flattenVecVecI32");
+        DemoCase("case:primitives.vecs.nested_i32.should_flatten_empty");
+        Require(FlattenVecVecI32(Array.Empty<int[]>()).Length == 0, "flattenVecVecI32 empty");
 
         DemoCase("case:primitives.vecs.nested_string.should_roundtrip_utf8_values");
         string[][] nestedStrings = new[]
@@ -1020,6 +1102,18 @@ public static class DemoTest
         Require(ProcessLocations(handmade) == 2, "processLocations handmade");
         DemoCase("case:records.blittable.locations.should_sum_host_constructed_ratings");
         Require(Math.Abs(SumRatings(handmade) - 6.5) < 1e-9, "sumRatings handmade");
+
+        DemoCase("case:records.blittable.locations.find_location.should_return_some_for_positive_id");
+        Location? foundLoc = FindLocation(1);
+        Require(foundLoc.HasValue && foundLoc.Value.Id == 1L, "findLocation(1)");
+        DemoCase("case:records.blittable.locations.find_location.should_return_none_for_non_positive_id");
+        Require(!FindLocation(0).HasValue, "findLocation(0)");
+
+        DemoCase("case:records.blittable.locations.find_locations.should_return_some_vector_for_positive_count");
+        Location[] foundLocs = FindLocations(3);
+        Require(foundLocs is not null && foundLocs.Length == 3, "findLocations(3)");
+        DemoCase("case:records.blittable.locations.find_locations.should_return_none_for_non_positive_count");
+        Require(FindLocations(0) is null, "findLocations(0)");
 
         Console.WriteLine("  PASS\n");
     }
@@ -1154,6 +1248,20 @@ public static class DemoTest
         Require(Math.Abs(AverageScore(scores) - 20.0) < 1e-9, "averageScore");
         Require(AverageScore(new TaggedScores("empty", Array.Empty<double>())) == 0.0, "averageScore empty");
 
+        DemoCase("case:enums.complex_variants.filter.none.should_roundtrip_unit_variant");
+        Filter noneFilter = new Filter.None();
+        Require(EchoFilter(noneFilter) is Filter.None, "echoFilter None");
+
+        Filter byName = new Filter.ByName("query");
+        DemoCase("case:enums.complex_variants.filter.by_name.should_roundtrip_string_payload");
+        Require(EchoFilter(byName) is Filter.ByName n && n.Name == "query", "echoFilter ByName");
+        DemoCase("case:enums.complex_variants.filter.by_name.should_describe_string_payload");
+        Require(DescribeFilter(byName) == "filter by name: query", "describeFilter ByName");
+
+        Filter byRange = new Filter.ByRange(1.5, 9.0);
+        DemoCase("case:enums.complex_variants.filter.by_range.should_describe_numeric_bounds");
+        Require(DescribeFilter(byRange) == "filter by range: 1.5..9", "describeFilter ByRange");
+
         Filter byTags = new Filter.ByTags(new[] { "café", "🌍" });
         DemoCase("case:enums.complex_variants.filter.by_tags.should_roundtrip_string_vector_payload");
         Filter echoedTags = EchoFilter(byTags);
@@ -1188,6 +1296,19 @@ public static class DemoTest
         Require(echoedPts is Filter.ByPoints p2 && p2.Anchors.SequenceEqual(((Filter.ByPoints)byPoints).Anchors), "echoFilter ByPoints");
         DemoCase("case:enums.complex_variants.filter.by_points.should_describe_record_vector_payload");
         Require(DescribeFilter(byPoints) == "filter by 2 anchor points", "describeFilter ByPoints");
+
+        ApiResponse successResp = new ApiResponse.Success("payload");
+        DemoCase("case:enums.complex_variants.api_response.success.should_roundtrip_string_payload");
+        Require(EchoApiResponse(successResp) is ApiResponse.Success s && s.Data == "payload", "echoApiResponse Success");
+        DemoCase("case:enums.complex_variants.api_response.success.should_identify_success");
+        Require(IsSuccess(successResp), "isSuccess Success");
+
+        ApiResponse redirectResp = new ApiResponse.Redirect("https://example.com/r");
+        DemoCase("case:enums.complex_variants.api_response.redirect.should_roundtrip_url_payload");
+        Require(EchoApiResponse(redirectResp) is ApiResponse.Redirect r2 && r2.Url == "https://example.com/r", "echoApiResponse Redirect");
+
+        DemoCase("case:enums.complex_variants.api_response.empty.should_not_identify_as_success");
+        Require(!IsSuccess(new ApiResponse.Empty()), "isSuccess Empty");
 
         DemoCase("case:records.with_collections.user_profiles.should_generate_profiles");
         BenchmarkUserProfile[] profiles = GenerateUserProfiles(4);
@@ -1673,6 +1794,16 @@ public static class DemoTest
                 parameters
             );
 
+            DemoCase("case:records.mixed.should_roundtrip_composed_record");
+            MixedRecord freeEchoed = EchoMixedRecord(record);
+            Require(freeEchoed.Name == "demo" && freeEchoed.Priority == Priority.High, "EchoMixedRecord free fn");
+
+            DemoCase("case:records.mixed.should_make_from_composed_parts");
+            MixedRecord freeMade = MakeMixedRecord("free-made", new Point(7.0, 8.0), Priority.Medium,
+                new Shape.Circle(1.0), parameters);
+            Require(freeMade.Name == "free-made" && freeMade.Anchor == new Point(7.0, 8.0)
+                && freeMade.Priority == Priority.Medium, "MakeMixedRecord free fn");
+
             MixedRecord echoed = svc.EchoRecord(record);
             Require(echoed.Name == "demo", "EchoRecord round-trips Name");
             Require(echoed.Anchor.X == 1.0 && echoed.Anchor.Y == 2.0, "EchoRecord round-trips Anchor");
@@ -1873,6 +2004,46 @@ public static class DemoTest
         {
             Require(e.Message.Contains("division by zero"), "SafeDivide error message");
         }
+
+        DemoCase("case:results.basic.divide.should_return_quotient");
+        Require(Divide(20, 4) == 5, "Divide(20, 4) == 5");
+        DemoCase("case:results.basic.divide.should_reject_division_by_zero");
+        try
+        {
+            Divide(1, 0);
+            Require(false, "Divide(1, 0) should throw");
+        }
+        catch (BoltException) { }
+
+        DemoCase("case:results.basic.parse_int.should_parse_integer");
+        Require(ParseInt("42") == 42, "ParseInt(42)");
+        DemoCase("case:results.basic.parse_int.should_reject_invalid_integer");
+        try
+        {
+            ParseInt("not a number");
+            Require(false, "ParseInt(bad) should throw");
+        }
+        catch (BoltException) { }
+
+        DemoCase("case:results.basic.safe_sqrt.should_return_square_root");
+        Require(Math.Abs(SafeSqrt(9.0) - 3.0) < 1e-9, "SafeSqrt(9)");
+        DemoCase("case:results.basic.safe_sqrt.should_reject_negative_input");
+        try
+        {
+            SafeSqrt(-1.0);
+            Require(false, "SafeSqrt(-1) should throw");
+        }
+        catch (BoltException) { }
+
+        DemoCase("case:results.basic.validate_name.should_greet_valid_name");
+        Require(ValidateName("Ada") == "Hello, Ada!", "ValidateName(Ada)");
+        DemoCase("case:results.basic.validate_name.should_reject_empty_name");
+        try
+        {
+            ValidateName("");
+            Require(false, "ValidateName(empty) should throw");
+        }
+        catch (BoltException) { }
 
         DemoCase("case:results.basic.always_ok.should_return_doubled_value");
         Require(AlwaysOk(21) == 42, "AlwaysOk doubles its input");
@@ -2076,6 +2247,32 @@ public static class DemoTest
             Require(e.Error.Message == "Division by zero", "DivideApp AppError.Message");
         }
 
+        DemoCase("case:results.error_enums.process_value.should_return_success_variant");
+        Require(ProcessValue(5) is ApiResult.Success, "ProcessValue(5) -> Success");
+        DemoCase("case:results.error_enums.process_value.should_return_error_code_variant");
+        Require(ProcessValue(0) is ApiResult.ErrorCode ec && ec.Value0 == -1, "ProcessValue(0) -> ErrorCode(-1)");
+        DemoCase("case:results.error_enums.process_value.should_return_error_with_data_variant");
+        Require(ProcessValue(-3) is ApiResult.ErrorWithData ed && ed.Code == -3 && ed.Detail == -6,
+            "ProcessValue(-3) -> ErrorWithData(-3,-6)");
+
+        DemoCase("case:results.error_enums.api_result_is_success.should_report_success_variant");
+        Require(ApiResultIsSuccess(new ApiResult.Success()), "ApiResultIsSuccess(Success)");
+        DemoCase("case:results.error_enums.api_result_is_success.should_report_error_variant");
+        Require(!ApiResultIsSuccess(new ApiResult.ErrorCode(1)), "ApiResultIsSuccess(ErrorCode) false");
+
+        DemoCase("case:results.error_enums.try_compute.should_return_doubled_value");
+        Require(TryCompute(7) == 14, "TryCompute(7) == 14");
+        DemoCase("case:results.error_enums.try_compute.should_return_overflow_error");
+        try
+        {
+            TryCompute(-1);
+            Require(false, "TryCompute(-1) should throw");
+        }
+        catch (ComputeErrorException e)
+        {
+            Require(e.Error is ComputeError.Overflow, "TryCompute(-1) Overflow variant");
+        }
+
         Console.WriteLine("  PASS\n");
     }
 
@@ -2158,6 +2355,16 @@ public static class DemoTest
         {
             Require(e.Error is ComputeError.InvalidInput invalid && invalid.Value0 == -999,
                 "TryComputeAsync typed ComputeError");
+        }
+        DemoCase("case:async_fns.results.try_compute.should_return_overflow_for_negative_value");
+        try
+        {
+            await TryComputeAsync(-2);
+            Require(false, "TryComputeAsync(-2) should throw");
+        }
+        catch (ComputeErrorException e)
+        {
+            Require(e.Error is ComputeError.Overflow, "TryComputeAsync(-2) Overflow variant");
         }
 
         DemoCase("case:async_fns.results.fetch_data.should_return_scaled_positive_id");


### PR DESCRIPTION
This closes the coverage gaps outlined in #309 for csharp. Also filed #328 (and updated #320, #321, #322 to cover C# alongside Java) for implementation gaps surfaced while writing the assertions.