### PR TITLE
Support C# namespace override

### DIFF
--- a/BOLTFFI_TOML_SPEC.md
+++ b/BOLTFFI_TOML_SPEC.md
@@ -388,6 +388,9 @@ Controls npm package generation in `boltffi pack wasm`.
   - Default: `dist/csharp`
   - `boltffi generate csharp` writes `.cs` files directly here.
   - `boltffi pack csharp` writes generated sources under `{output}/src`, native assets under `{output}/runtimes/<rid>/native`, and a generated project file at `{output}/BoltFFI.CSharp.csproj`.
+- `namespace` (string, optional): C# namespace for generated sources.
+  - Default: PascalCase of `{package.crate}` (or `{package.name}` when `package.crate` is unset).
+  - Must be dot-separated C# identifiers, for example `CounterApp.Shared`.
 - `package_id` (string, optional): NuGet package ID.
   - Default: `{package.name}`
 - `target_framework` (string, optional): Target framework for the generated NuGet package project.

--- a/boltffi_bindgen/src/render/csharp/ast/identifier.rs
+++ b/boltffi_bindgen/src/render/csharp/ast/identifier.rs
@@ -434,6 +434,11 @@ impl CSharpNamespace {
     pub(crate) fn from_source(source: &str) -> Self {
         Self(naming::to_upper_camel_case(source))
     }
+
+    /// Wraps an explicit namespace chosen by configuration.
+    pub(crate) fn new(namespace: impl Into<String>) -> Self {
+        Self(namespace.into())
+    }
 }
 
 impl fmt::Display for CSharpNamespace {

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -280,6 +280,26 @@ mod tests {
     }
 
     #[test]
+    fn emit_uses_configured_namespace_override() {
+        let contract = empty_contract();
+        let abi = IrLowerer::new(&contract).to_abi_contract();
+        let output = CSharpEmitter::emit(
+            &contract,
+            &abi,
+            &CSharpOptions {
+                namespace: Some("CounterApp.Shared".to_string()),
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            output
+                .combined_source()
+                .contains("namespace CounterApp.Shared")
+        );
+    }
+
+    #[test]
     fn emit_escapes_csharp_keywords_in_param_names() {
         let mut contract = empty_contract();
         contract.functions.push(primitive_function(

--- a/boltffi_bindgen/src/render/csharp/lower/lowerer.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/lowerer.rs
@@ -34,7 +34,11 @@ pub struct CSharpLowerer<'a> {
 impl<'a> CSharpLowerer<'a> {
     pub fn new(ffi: &'a FfiContract, abi: &'a AbiContract, options: &'a CSharpOptions) -> Self {
         let (supported_records, supported_enums) = Self::compute_supported_sets(ffi);
-        let namespace = CSharpNamespace::from_source(&ffi.package.name);
+        let namespace = options
+            .namespace
+            .as_deref()
+            .map(CSharpNamespace::new)
+            .unwrap_or_else(|| CSharpNamespace::from_source(&ffi.package.name));
         Self {
             ffi,
             abi,
@@ -256,6 +260,19 @@ mod tests {
                 .map(ToString::to_string),
             Some("Returns the current value.".to_string())
         );
+    }
+
+    #[test]
+    fn lowerer_uses_configured_namespace_override() {
+        let contract = empty_contract();
+        let abi = IrLowerer::new(&contract).to_abi_contract();
+        let options = CSharpOptions {
+            namespace: Some("CounterApp.Shared".to_string()),
+            ..Default::default()
+        };
+        let module = CSharpLowerer::new(&contract, &abi, &options).lower();
+
+        assert_eq!(module.namespace.to_string(), "CounterApp.Shared");
     }
 
     #[test]

--- a/boltffi_bindgen/src/render/csharp/mod.rs
+++ b/boltffi_bindgen/src/render/csharp/mod.rs
@@ -51,6 +51,9 @@ use boltffi_ffi_rules::naming::{LibraryName, Name};
 
 #[derive(Debug, Clone, Default)]
 pub struct CSharpOptions {
+    /// Override the C# namespace used for all generated bindings.
+    /// Defaults to PascalCase of the crate/package name when `None`.
+    pub namespace: Option<String>,
     /// Override the native library name used in `[DllImport("...")]` declarations.
     /// Defaults to the crate/package name when `None`.
     pub library_name: Option<Name<LibraryName>>,

--- a/boltffi_cli/src/commands/generate/languages/csharp.rs
+++ b/boltffi_cli/src/commands/generate/languages/csharp.rs
@@ -11,6 +11,15 @@ use crate::config::{Config, Target};
 pub struct CSharpGenerator;
 
 impl CSharpGenerator {
+    fn csharp_options(request: &GenerateRequest<'_>) -> CSharpOptions {
+        CSharpOptions {
+            namespace: request.config().csharp_namespace().map(str::to_string),
+            library_name: Some(boltffi_bindgen::library_name(
+                request.source_crate().crate_name(),
+            )),
+        }
+    }
+
     pub fn generate_from_source_directory(
         config: &Config,
         output: Option<PathBuf>,
@@ -48,11 +57,51 @@ impl LanguageGenerator for CSharpGenerator {
         let output = CSharpEmitter::emit(
             &lowered_crate.ffi_contract,
             &lowered_crate.abi_contract,
-            &CSharpOptions::default(),
+            &Self::csharp_options(request),
         );
 
         output.files.iter().try_for_each(|file| {
             request.write_output(&output_directory.join(&file.file_name), &file.source)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{CSharpConfig, CargoConfig, PackageConfig, TargetsConfig};
+
+    fn config(namespace: Option<String>) -> Config {
+        Config {
+            experimental: Vec::new(),
+            cargo: CargoConfig::default(),
+            package: PackageConfig {
+                name: "logical-package".to_string(),
+                crate_name: Some("native-crate".to_string()),
+                version: None,
+                description: None,
+                license: None,
+                repository: None,
+            },
+            targets: TargetsConfig {
+                csharp: CSharpConfig {
+                    enabled: true,
+                    namespace,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn csharp_options_use_configured_namespace_and_source_crate_library_name() {
+        let config = config(Some("CounterApp.Shared".to_string()));
+        let request = GenerateRequest::new(&config, None, SourceCrate::new(".", "native-crate"));
+
+        let options = CSharpGenerator::csharp_options(&request);
+
+        assert_eq!(options.namespace.as_deref(), Some("CounterApp.Shared"));
+        assert_eq!(options.library_name.unwrap().as_str(), "native_crate");
     }
 }

--- a/boltffi_cli/src/config.rs
+++ b/boltffi_cli/src/config.rs
@@ -166,6 +166,7 @@ pub struct PythonWheelConfig {
 pub struct CSharpConfig {
     #[serde(default = "default_csharp_output")]
     pub output: PathBuf,
+    pub namespace: Option<String>,
     pub package_id: Option<String>,
     pub target_framework: Option<String>,
     pub package_output: Option<PathBuf>,
@@ -199,6 +200,7 @@ impl Default for CSharpConfig {
     fn default() -> Self {
         Self {
             output: default_csharp_output(),
+            namespace: None,
             package_id: None,
             target_framework: None,
             package_output: None,
@@ -885,6 +887,15 @@ impl Config {
                 ));
             }
 
+            if let Some(namespace) = self.targets.csharp.namespace.as_deref()
+                && !is_valid_csharp_namespace(namespace)
+            {
+                return Err(ConfigError::Validation(format!(
+                    "targets.csharp.namespace must be a dot-separated C# namespace, got '{}'",
+                    namespace
+                )));
+            }
+
             if let Some(target_framework) = self.targets.csharp.target_framework.as_deref()
                 && target_framework.trim().is_empty()
             {
@@ -1415,6 +1426,10 @@ impl Config {
         self.targets.csharp.output.clone()
     }
 
+    pub fn csharp_namespace(&self) -> Option<&str> {
+        self.targets.csharp.namespace.as_deref()
+    }
+
     pub fn csharp_package_id(&self) -> String {
         self.targets
             .csharp
@@ -1668,6 +1683,22 @@ fn normalize_module_name(input: &str) -> String {
     } else {
         normalized
     }
+}
+
+fn is_valid_csharp_namespace(namespace: &str) -> bool {
+    namespace.trim() == namespace
+        && !namespace.is_empty()
+        && namespace.split('.').all(is_valid_csharp_namespace_segment)
+}
+
+fn is_valid_csharp_namespace_segment(segment: &str) -> bool {
+    let mut characters = segment.chars();
+    let Some(first_character) = characters.next() else {
+        return false;
+    };
+
+    (first_character == '_' || first_character.is_alphabetic())
+        && characters.all(|character| character == '_' || character.is_alphanumeric())
 }
 
 fn validate_unique<T, F>(
@@ -2869,6 +2900,7 @@ enabled = true
             PathBuf::from("dist/csharp/packages")
         );
         assert_eq!(config.csharp_package_id(), "my-lib");
+        assert_eq!(config.csharp_namespace(), None);
         assert_eq!(config.csharp_target_framework(), "net10.0");
         assert_eq!(
             config.csharp_requested_runtime_identifiers(),
@@ -2889,6 +2921,7 @@ enabled = true
 output = "artifacts/csharp"
 package_output = "artifacts/nuget"
 package_id = "Company.MyLib"
+namespace = "Company.MyLib.Bindings"
 target_framework = "net9.0"
 runtime_identifiers = ["current", "linux-x64"]
 "#,
@@ -2900,6 +2933,7 @@ runtime_identifiers = ["current", "linux-x64"]
             PathBuf::from("artifacts/nuget")
         );
         assert_eq!(config.csharp_package_id(), "Company.MyLib");
+        assert_eq!(config.csharp_namespace(), Some("Company.MyLib.Bindings"));
         assert_eq!(config.csharp_target_framework(), "net9.0");
         assert_eq!(
             config.csharp_requested_runtime_identifiers(),
@@ -2929,6 +2963,27 @@ runtime_identifiers = []
             parsed.validate(),
             Err(ConfigError::Validation(message))
                 if message.contains("targets.csharp.runtime_identifiers must be non-empty")
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_csharp_namespace() {
+        let parsed: Config = toml::from_str(
+            r#"
+[package]
+name = "my-lib"
+
+[targets.csharp]
+enabled = true
+namespace = "CounterApp."
+"#,
+        )
+        .expect("toml parse failed");
+
+        assert!(matches!(
+            parsed.validate(),
+            Err(ConfigError::Validation(message))
+                if message.contains("targets.csharp.namespace must be a dot-separated C# namespace")
         ));
     }
 

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -565,6 +565,16 @@ boltffi pack csharp       # builds the NuGet package with native runtime assets
 
 `generate csharp` writes one `.cs` file for the top-level module/runtime helpers plus additional `.cs` files for generated records, enums, classes, callbacks, and stream-owning types directly under `output`. `pack csharp` writes the generated sources under `{output}/src`, builds the Rust `cdylib` for each configured runtime identifier into `{output}/runtimes/<rid>/native/`, and emits a `.nupkg` under `{output}/packages/` that bundles everything together.
 
+### Namespace
+
+By default, C# sources use a namespace derived from the Rust crate name. Set `namespace` when your generated C# types need to live under an application or product namespace:
+
+```toml
+[targets.csharp]
+enabled = true
+namespace = "CounterApp.Shared"
+```
+
 ### Runtime Identifiers
 
 Choose which .NET runtime identifiers `pack csharp` builds native assets for:


### PR DESCRIPTION
This closes #371.

It adds a `[targets.csharp].namespace` override that is threaded through `generate csharp` and the `pack csharp` regeneration path, while keeping the existing crate-name fallback when unset.

I also wired the C# generator to pass the selected native library name into `CSharpOptions`, since that was getting dropped in the same default-options path.

Validated with:

- `cargo fmt --check`
- `cargo test -p boltffi_bindgen render::csharp --lib`
- `cargo test -p boltffi_cli csharp`