### PR TITLE
support IR nullable closure crossings and enum constants

### DIFF
--- a/boltffi_ast/src/type_expr.rs
+++ b/boltffi_ast/src/type_expr.rs
@@ -77,8 +77,13 @@ pub enum TypeExpr {
         /// Whether the source value is nullable.
         presence: HandlePresence,
     },
-    /// An inline closure signature such as `impl Fn(u32) -> String`.
-    Closure(Box<ClosureType>),
+    /// An inline closure value such as `impl Fn(u32) -> String`.
+    Closure {
+        /// Closure signature written by the source.
+        signature: Box<ClosureType>,
+        /// Whether the closure value is nullable.
+        presence: HandlePresence,
+    },
     /// A custom type declaration by ID.
     Custom(CustomTypeId),
     /// The Rust `Self` type inside an impl, trait, or callback context.
@@ -164,7 +169,20 @@ impl TypeExpr {
     ///
     /// Returns a closure type expression.
     pub fn closure(closure: ClosureType) -> Self {
-        Self::Closure(Box::new(closure))
+        Self::closure_with_presence(closure, HandlePresence::Required)
+    }
+
+    /// Builds an inline closure type expression with explicit nullability.
+    ///
+    /// The `closure` parameter contains the source signature. The `presence`
+    /// parameter records whether the closure value may be absent.
+    ///
+    /// Returns a closure type expression.
+    pub fn closure_with_presence(closure: ClosureType, presence: HandlePresence) -> Self {
+        Self::Closure {
+            signature: Box::new(closure),
+            presence,
+        }
     }
 
     /// Builds a trait-reference type expression.

--- a/boltffi_binding/src/ir/callable.rs
+++ b/boltffi_binding/src/ir/callable.rs
@@ -392,17 +392,23 @@ where
 {
     pub(crate) fn new(
         form: ClosureForm,
+        presence: HandlePresence,
         registration: ClosureRegistration<S, D>,
         invoke: CallableDecl<S, D::InvokeScope>,
     ) -> Self {
         Self {
-            crossing: ClosureCrossing::new(form, registration, invoke),
+            crossing: ClosureCrossing::new(form, presence, registration, invoke),
         }
     }
 
     /// Returns the source spelling.
     pub fn form(&self) -> ClosureForm {
         self.crossing.form()
+    }
+
+    /// Returns whether the closure crossing may be absent.
+    pub fn presence(&self) -> HandlePresence {
+        self.crossing.presence()
     }
 
     /// Returns the handle registration.
@@ -439,17 +445,23 @@ where
 {
     pub(crate) fn new(
         form: ClosureForm,
+        presence: HandlePresence,
         registration: ClosureRegistration<S, D>,
         invoke: CallableDecl<S, D::InvokeScope>,
     ) -> Self {
         Self {
-            crossing: ClosureCrossing::new(form, registration, invoke),
+            crossing: ClosureCrossing::new(form, presence, registration, invoke),
         }
     }
 
     /// Returns the source spelling.
     pub fn form(&self) -> ClosureForm {
         self.crossing.form()
+    }
+
+    /// Returns whether the closure crossing may be absent.
+    pub fn presence(&self) -> HandlePresence {
+        self.crossing.presence()
     }
 
     /// Returns the handle registration.
@@ -477,6 +489,7 @@ where
     D::Opposite: ParamDirection<S>,
 {
     form: ClosureForm,
+    presence: HandlePresence,
     registration: ClosureRegistration<S, D>,
     invoke: Box<CallableDecl<S, D::InvokeScope>>,
 }
@@ -487,11 +500,13 @@ where
 {
     fn new(
         form: ClosureForm,
+        presence: HandlePresence,
         registration: ClosureRegistration<S, D>,
         invoke: CallableDecl<S, D::InvokeScope>,
     ) -> Self {
         Self {
             form,
+            presence,
             registration,
             invoke: Box::new(invoke),
         }
@@ -499,6 +514,10 @@ where
 
     pub fn form(&self) -> ClosureForm {
         self.form
+    }
+
+    pub fn presence(&self) -> HandlePresence {
+        self.presence
     }
 
     pub fn registration(&self) -> &ClosureRegistration<S, D> {

--- a/boltffi_binding/src/ir/decl.rs
+++ b/boltffi_binding/src/ir/decl.rs
@@ -1333,6 +1333,17 @@ impl<S: Surface> ConstantValueDecl<S> {
             _surface: PhantomData,
         }
     }
+
+    /// Builds an accessor constant value.
+    ///
+    /// `symbol` is the native symbol foreign code links against to read
+    /// the value at runtime. `callable` is the zero-argument exported
+    /// getter that returns the constant's declared type. Used for values
+    /// that have no portable inline literal (byte strings, arrays,
+    /// tuples, and unevaluated expressions).
+    pub fn accessor(symbol: NativeSymbol, callable: Box<ExportedCallable<S>>) -> Self {
+        Self::Accessor { symbol, callable }
+    }
 }
 
 /// A user-defined type that maps to an existing binding shape.

--- a/boltffi_binding/src/lower/callable/mod.rs
+++ b/boltffi_binding/src/lower/callable/mod.rs
@@ -63,7 +63,8 @@ use boltffi_ast::{
 
 use crate::{
     ClosureForm, ClosureParameter, ClosureRegistration, ClosureReturn, Direction, ExecutionDecl,
-    ExportedCallable, ForeignBody, ImportedCallable, IntoRust, OutOfRust, Receive, RustBody,
+    ExportedCallable, ForeignBody, HandlePresence, ImportedCallable, IntoRust, OutOfRust, Receive,
+    RustBody,
 };
 
 use super::{
@@ -202,10 +203,12 @@ pub(super) fn lower_closure_param_into_rust<S: SurfaceLower>(
     ids: &DeclarationIds,
     allocator: &mut SymbolAllocator,
     closure: &ClosureType,
+    presence: boltffi_ast::HandlePresence,
 ) -> Result<ClosureParameter<S, IntoRust>, LowerError> {
-    let parts = lower_closure_into_rust_parts(idx, ids, allocator, closure)?;
+    let parts = lower_closure_into_rust_parts(idx, ids, allocator, closure, presence)?;
     Ok(ClosureParameter::new(
         parts.form,
+        parts.presence,
         parts.registration,
         parts.invoke,
     ))
@@ -216,10 +219,12 @@ pub(super) fn lower_closure_return_into_rust<S: SurfaceLower>(
     ids: &DeclarationIds,
     allocator: &mut SymbolAllocator,
     closure: &ClosureType,
+    presence: boltffi_ast::HandlePresence,
 ) -> Result<ClosureReturn<S, IntoRust>, LowerError> {
-    let parts = lower_closure_into_rust_parts(idx, ids, allocator, closure)?;
+    let parts = lower_closure_into_rust_parts(idx, ids, allocator, closure, presence)?;
     Ok(ClosureReturn::new(
         parts.form,
+        parts.presence,
         parts.registration,
         parts.invoke,
     ))
@@ -227,6 +232,7 @@ pub(super) fn lower_closure_return_into_rust<S: SurfaceLower>(
 
 struct ClosureIntoRustParts<S: crate::Surface> {
     form: ClosureForm,
+    presence: HandlePresence,
     registration: ClosureRegistration<S, IntoRust>,
     invoke: ImportedCallable<S>,
 }
@@ -236,6 +242,7 @@ fn lower_closure_into_rust_parts<S: SurfaceLower>(
     ids: &DeclarationIds,
     allocator: &mut SymbolAllocator,
     closure: &ClosureType,
+    presence: boltffi_ast::HandlePresence,
 ) -> Result<ClosureIntoRustParts<S>, LowerError> {
     let (parameters, returns, error) =
         lower_closure_invoke_parts::<S, ForeignBody>(idx, ids, allocator, closure)?;
@@ -252,6 +259,7 @@ fn lower_closure_into_rust_parts<S: SurfaceLower>(
     );
     Ok(ClosureIntoRustParts {
         form: ClosureForm::from(closure.kind),
+        presence: lower_handle_presence(presence),
         registration,
         invoke,
     })
@@ -272,10 +280,12 @@ pub(super) fn lower_closure_param_out_of_rust<S: SurfaceLower>(
     ids: &DeclarationIds,
     allocator: &mut SymbolAllocator,
     closure: &ClosureType,
+    presence: boltffi_ast::HandlePresence,
 ) -> Result<ClosureParameter<S, OutOfRust>, LowerError> {
-    let parts = lower_closure_out_of_rust_parts(idx, ids, allocator, closure)?;
+    let parts = lower_closure_out_of_rust_parts(idx, ids, allocator, closure, presence)?;
     Ok(ClosureParameter::new(
         parts.form,
+        parts.presence,
         parts.registration,
         parts.invoke,
     ))
@@ -286,10 +296,12 @@ pub(super) fn lower_closure_return_out_of_rust<S: SurfaceLower>(
     ids: &DeclarationIds,
     allocator: &mut SymbolAllocator,
     closure: &ClosureType,
+    presence: boltffi_ast::HandlePresence,
 ) -> Result<ClosureReturn<S, OutOfRust>, LowerError> {
-    let parts = lower_closure_out_of_rust_parts(idx, ids, allocator, closure)?;
+    let parts = lower_closure_out_of_rust_parts(idx, ids, allocator, closure, presence)?;
     Ok(ClosureReturn::new(
         parts.form,
+        parts.presence,
         parts.registration,
         parts.invoke,
     ))
@@ -297,6 +309,7 @@ pub(super) fn lower_closure_return_out_of_rust<S: SurfaceLower>(
 
 struct ClosureOutOfRustParts<S: crate::Surface> {
     form: ClosureForm,
+    presence: HandlePresence,
     registration: ClosureRegistration<S, OutOfRust>,
     invoke: ExportedCallable<S>,
 }
@@ -306,6 +319,7 @@ fn lower_closure_out_of_rust_parts<S: SurfaceLower>(
     ids: &DeclarationIds,
     allocator: &mut SymbolAllocator,
     closure: &ClosureType,
+    presence: boltffi_ast::HandlePresence,
 ) -> Result<ClosureOutOfRustParts<S>, LowerError> {
     let (parameters, returns, error) =
         lower_closure_invoke_parts::<S, RustBody>(idx, ids, allocator, closure)?;
@@ -322,6 +336,7 @@ fn lower_closure_out_of_rust_parts<S: SurfaceLower>(
     let registration = ClosureRegistration::<S, OutOfRust>::new(shape, receive);
     Ok(ClosureOutOfRustParts {
         form: ClosureForm::from(closure.kind),
+        presence: lower_handle_presence(presence),
         registration,
         invoke,
     })
@@ -446,8 +461,11 @@ pub(super) fn substitute_self_type(
             ok: Box::new(substitute_self_type(owner, ok)?),
             err: Box::new(substitute_self_type(owner, err)?),
         },
-        TypeExpr::Closure(closure) => {
-            let mut closure = (**closure).clone();
+        TypeExpr::Closure {
+            signature,
+            presence,
+        } => {
+            let mut closure = (**signature).clone();
             closure.parameters = closure
                 .parameters
                 .iter()
@@ -459,7 +477,10 @@ pub(super) fn substitute_self_type(
                     boltffi_ast::ReturnDef::Value(substitute_self_type(owner, &value)?)
                 }
             };
-            TypeExpr::Closure(Box::new(closure))
+            TypeExpr::Closure {
+                signature: Box::new(closure),
+                presence: *presence,
+            }
         }
         TypeExpr::Primitive(_)
         | TypeExpr::Unit
@@ -472,4 +493,11 @@ pub(super) fn substitute_self_type(
         | TypeExpr::Custom(_)
         | TypeExpr::Parameter(_) => type_expr.clone(),
     })
+}
+
+fn lower_handle_presence(presence: boltffi_ast::HandlePresence) -> HandlePresence {
+    match presence {
+        boltffi_ast::HandlePresence::Required => HandlePresence::Required,
+        boltffi_ast::HandlePresence::Nullable => HandlePresence::Nullable,
+    }
 }

--- a/boltffi_binding/src/lower/callable/mod.rs
+++ b/boltffi_binding/src/lower/callable/mod.rs
@@ -401,6 +401,34 @@ pub(super) fn lower_function<S: SurfaceLower>(
     )?)
 }
 
+/// Lowers a zero-argument getter for a constant whose value cannot be
+/// delivered as an inline literal.
+///
+/// The accessor is a synchronous [`ExportedCallable<S>`] (Rust
+/// implements, foreign calls in) with no receiver, no parameters, and no
+/// error channel, returning the constant's declared type. Foreign code
+/// reads the value by calling it once. The owner context is
+/// [`CallableOwner::Function`], so any `Self` in the constant type is
+/// rejected; top-level constants do not carry `Self`.
+pub(super) fn lower_constant_accessor<S: SurfaceLower>(
+    idx: &Index<'_>,
+    ids: &DeclarationIds,
+    allocator: &mut SymbolAllocator,
+    type_expr: &boltffi_ast::TypeExpr,
+) -> Result<ExportedCallable<S>, LowerError> {
+    let owner = CallableOwner::Function;
+    let return_def = boltffi_ast::ReturnDef::Value(type_expr.clone());
+    let (returns, error) = returns::lower::<S, _>(idx, ids, allocator, owner, &return_def)?;
+
+    Ok(ExportedCallable::<S>::new(
+        None,
+        Vec::new(),
+        returns,
+        error,
+        ExecutionDecl::synchronous(),
+    )?)
+}
+
 fn lower_execution<S: SurfaceLower>(
     allocator: &mut SymbolAllocator,
     execution: ExecutionKind,

--- a/boltffi_binding/src/lower/callable/params.rs
+++ b/boltffi_binding/src/lower/callable/params.rs
@@ -60,13 +60,25 @@ where
     let receive = receive_for_passing(parameter.passing);
     let canonical_name = CanonicalName::from(&parameter.name);
     let meta = metadata::element_meta(parameter.doc.as_ref(), None, parameter.default.as_ref())?;
-    if let TypeExpr::Closure(closure) = &type_expr {
+    if let TypeExpr::Closure {
+        signature,
+        presence,
+    } = &type_expr
+    {
         if !matches!(receive, Receive::ByValue) {
             return Err(LowerError::unsupported_type(
                 UnsupportedType::BorrowedCallbackParameter,
             ));
         }
-        return D::lower_closure_param(idx, ids, allocator, canonical_name, meta, closure);
+        return D::lower_closure_param(
+            idx,
+            ids,
+            allocator,
+            canonical_name,
+            meta,
+            signature,
+            *presence,
+        );
     }
     let value = ValueRef::named(canonical_name.clone());
     let plan = lower_plain_plan::<S, D>(idx, ids, &type_expr, value, receive)?;
@@ -179,7 +191,7 @@ fn lower_plan<S: SurfaceLower, D: Direction>(
                 receive: D::receive_from(receive),
             })
         }
-        TypeExpr::Closure(_) => unreachable!("closures are handled before lower_plan"),
+        TypeExpr::Closure { .. } => unreachable!("closures are handled before lower_plan"),
         TypeExpr::Class { id, presence } => Ok(ParamPlan::Handle {
             target: HandleTarget::Class(ids.class(id)?),
             carrier: S::class_handle_carrier(),
@@ -238,6 +250,7 @@ where
         ids: &DeclarationIds,
         allocator: &mut SymbolAllocator,
         closure: &ClosureType,
+        presence: boltffi_ast::HandlePresence,
     ) -> Result<ClosureParameter<S, Self>, LowerError>;
 
     fn lower_closure_return(
@@ -245,6 +258,7 @@ where
         ids: &DeclarationIds,
         allocator: &mut SymbolAllocator,
         closure: &ClosureType,
+        presence: boltffi_ast::HandlePresence,
     ) -> Result<ClosureReturn<S, Self>, LowerError>;
 
     fn lower_closure_param(
@@ -254,6 +268,7 @@ where
         name: CanonicalName,
         meta: ElementMeta,
         closure: &ClosureType,
+        presence: boltffi_ast::HandlePresence,
     ) -> Result<ParamDecl<S, Self>, LowerError>;
 }
 
@@ -263,8 +278,9 @@ impl<S: SurfaceLower> LowerClosure<S> for IntoRust {
         ids: &DeclarationIds,
         allocator: &mut SymbolAllocator,
         closure: &ClosureType,
+        presence: boltffi_ast::HandlePresence,
     ) -> Result<ClosureParameter<S, IntoRust>, LowerError> {
-        super::lower_closure_param_into_rust::<S>(idx, ids, allocator, closure)
+        super::lower_closure_param_into_rust::<S>(idx, ids, allocator, closure, presence)
     }
 
     fn lower_closure_return(
@@ -272,8 +288,9 @@ impl<S: SurfaceLower> LowerClosure<S> for IntoRust {
         ids: &DeclarationIds,
         allocator: &mut SymbolAllocator,
         closure: &ClosureType,
+        presence: boltffi_ast::HandlePresence,
     ) -> Result<ClosureReturn<S, IntoRust>, LowerError> {
-        super::lower_closure_return_into_rust::<S>(idx, ids, allocator, closure)
+        super::lower_closure_return_into_rust::<S>(idx, ids, allocator, closure, presence)
     }
 
     fn lower_closure_param(
@@ -283,8 +300,9 @@ impl<S: SurfaceLower> LowerClosure<S> for IntoRust {
         name: CanonicalName,
         meta: ElementMeta,
         closure: &ClosureType,
+        presence: boltffi_ast::HandlePresence,
     ) -> Result<ParamDecl<S, IntoRust>, LowerError> {
-        let param = Self::lower_closure_parameter(idx, ids, allocator, closure)?;
+        let param = Self::lower_closure_parameter(idx, ids, allocator, closure, presence)?;
         Ok(<ParamDecl<S, IntoRust>>::closure(name, meta, param))
     }
 }
@@ -295,8 +313,9 @@ impl<S: SurfaceLower> LowerClosure<S> for OutOfRust {
         ids: &DeclarationIds,
         allocator: &mut SymbolAllocator,
         closure: &ClosureType,
+        presence: boltffi_ast::HandlePresence,
     ) -> Result<ClosureParameter<S, OutOfRust>, LowerError> {
-        super::lower_closure_param_out_of_rust::<S>(idx, ids, allocator, closure)
+        super::lower_closure_param_out_of_rust::<S>(idx, ids, allocator, closure, presence)
     }
 
     fn lower_closure_return(
@@ -304,8 +323,9 @@ impl<S: SurfaceLower> LowerClosure<S> for OutOfRust {
         ids: &DeclarationIds,
         allocator: &mut SymbolAllocator,
         closure: &ClosureType,
+        presence: boltffi_ast::HandlePresence,
     ) -> Result<ClosureReturn<S, OutOfRust>, LowerError> {
-        super::lower_closure_return_out_of_rust::<S>(idx, ids, allocator, closure)
+        super::lower_closure_return_out_of_rust::<S>(idx, ids, allocator, closure, presence)
     }
 
     fn lower_closure_param(
@@ -315,8 +335,9 @@ impl<S: SurfaceLower> LowerClosure<S> for OutOfRust {
         name: CanonicalName,
         meta: ElementMeta,
         closure: &ClosureType,
+        presence: boltffi_ast::HandlePresence,
     ) -> Result<ParamDecl<S, OutOfRust>, LowerError> {
-        let param = Self::lower_closure_parameter(idx, ids, allocator, closure)?;
+        let param = Self::lower_closure_parameter(idx, ids, allocator, closure, presence)?;
         Ok(<ParamDecl<S, OutOfRust>>::closure(name, meta, param))
     }
 }

--- a/boltffi_binding/src/lower/callable/returns.rs
+++ b/boltffi_binding/src/lower/callable/returns.rs
@@ -188,8 +188,12 @@ where
                 shape: S::encoded_return_shape(),
             })
         }
-        TypeExpr::Closure(closure) => {
-            let closure_return = D::lower_closure_return(idx, ids, allocator, closure)?;
+        TypeExpr::Closure {
+            signature,
+            presence,
+        } => {
+            let closure_return =
+                D::lower_closure_return(idx, ids, allocator, signature, *presence)?;
             Ok(ReturnPlan::ClosureViaOutPointer(closure_return))
         }
         TypeExpr::Class { id, presence } => Ok(ReturnPlan::HandleViaReturnSlot {

--- a/boltffi_binding/src/lower/callbacks.rs
+++ b/boltffi_binding/src/lower/callbacks.rs
@@ -227,11 +227,11 @@ fn wasm_callback_method_surface(
 #[cfg(test)]
 mod tests {
     use boltffi_ast::{
-        CanonicalName as SourceName, ClassDef, DeprecationInfo as SourceDeprecationInfo,
-        DocComment as SourceDocComment, FieldDef, HandlePresence as SourcePresence, MethodDef,
-        MethodId as SourceMethodId, PackageInfo as SourcePackage, ParameterDef, ParameterPassing,
-        Primitive, Receiver, RecordDef, ReturnDef, SourceContract, TraitDef, TraitUseForm,
-        TypeExpr,
+        CanonicalName as SourceName, ClassDef, ClosureKind, ClosureType,
+        DeprecationInfo as SourceDeprecationInfo, DocComment as SourceDocComment, FieldDef,
+        HandlePresence as SourcePresence, MethodDef, MethodId as SourceMethodId,
+        PackageInfo as SourcePackage, ParameterDef, ParameterPassing, Primitive, Receiver,
+        RecordDef, ReturnDef, SourceContract, TraitDef, TraitUseForm, TypeExpr,
     };
 
     use crate::lower::lower;
@@ -256,6 +256,17 @@ mod tests {
 
     fn listener_type(form: TraitUseForm, presence: SourcePresence) -> TypeExpr {
         TypeExpr::r#trait("demo::Listener".into(), form, presence)
+    }
+
+    fn closure_type(presence: SourcePresence) -> TypeExpr {
+        TypeExpr::closure_with_presence(
+            ClosureType::new(
+                ClosureKind::Fn,
+                vec![TypeExpr::Primitive(Primitive::U32)],
+                ReturnDef::Void,
+            ),
+            presence,
+        )
     }
 
     fn method(method_name: &str, receiver: Receiver) -> MethodDef {
@@ -520,6 +531,7 @@ mod tests {
             .as_closure()
             .expect("expected outgoing closure param");
         assert_eq!(outgoing.form(), crate::ClosureForm::Fn);
+        assert_eq!(outgoing.presence(), HandlePresence::Required);
         assert_eq!(outgoing.invoke().params().len(), 1);
         match outgoing.invoke().params()[0].as_value().unwrap() {
             ParamPlan::Direct {
@@ -528,6 +540,35 @@ mod tests {
             } => {}
             other => panic!("expected u32 direct param on invoke, got {other:?}"),
         }
+        assert!(matches!(
+            outgoing.invoke().returns().plan(),
+            ReturnPlan::Void
+        ));
+    }
+
+    #[test]
+    fn callback_method_with_nullable_closure_param_lowers_to_nullable_outgoing_closure() {
+        let mut callback = listener_callback();
+        let mut handle = method("on_event", Receiver::Shared);
+        handle.parameters = vec![value_param(
+            "callback",
+            closure_type(SourcePresence::Nullable),
+        )];
+        callback.methods.push(handle);
+
+        let bindings = lower_callback::<Native>(callback);
+        let methods = first_callback(&bindings).protocol().vtable().methods();
+        let params = methods[0].callable().params();
+
+        let outgoing = params[0]
+            .as_closure()
+            .expect("expected nullable outgoing closure param");
+        assert_eq!(outgoing.presence(), HandlePresence::Nullable);
+        assert_eq!(outgoing.form(), crate::ClosureForm::Fn);
+        assert!(matches!(
+            outgoing.registration().shape(),
+            native::ClosureRegistration::InvokeContext
+        ));
         assert!(matches!(
             outgoing.invoke().returns().plan(),
             ReturnPlan::Void
@@ -559,6 +600,7 @@ mod tests {
             .as_closure()
             .expect("expected outgoing closure param");
         assert_eq!(outgoing.form(), crate::ClosureForm::Fn);
+        assert_eq!(outgoing.presence(), HandlePresence::Required);
         assert_eq!(
             outgoing.registration().shape().call().name().as_str(),
             "boltffi_closure_1____closure__u32_call"
@@ -615,6 +657,7 @@ mod tests {
             other => panic!("expected ClosureViaOutPointer, got {other:?}"),
         };
         assert_eq!(closure_crossing.form(), crate::ClosureForm::Fn);
+        assert_eq!(closure_crossing.presence(), HandlePresence::Required);
         let invoke = closure_crossing.invoke();
         assert_eq!(invoke.params().len(), 1);
         match invoke.params()[0].as_value().unwrap() {
@@ -644,6 +687,36 @@ mod tests {
     }
 
     #[test]
+    fn callback_method_returning_nullable_closure_lowers_to_nullable_crossing() {
+        let mut callback = listener_callback();
+        let mut handler_factory = method("handler", Receiver::Shared);
+        handler_factory.returns = ReturnDef::Value(TypeExpr::closure_with_presence(
+            ClosureType::new(
+                ClosureKind::Fn,
+                vec![TypeExpr::Primitive(Primitive::U32)],
+                ReturnDef::Value(TypeExpr::Primitive(Primitive::U32)),
+            ),
+            SourcePresence::Nullable,
+        ));
+        callback.methods.push(handler_factory);
+
+        let bindings = lower_callback::<Wasm32>(callback);
+        let methods = first_callback(&bindings).protocol().methods();
+
+        match methods[0].callable().returns().plan() {
+            ReturnPlan::ClosureViaOutPointer(closure) => {
+                assert_eq!(closure.presence(), HandlePresence::Nullable);
+                assert_eq!(closure.form(), crate::ClosureForm::Fn);
+                assert_eq!(
+                    closure.registration().shape().call().module().as_str(),
+                    "env"
+                );
+            }
+            other => panic!("expected nullable closure return, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn native_callback_method_returning_closure_lowers_to_closure_via_out_pointer() {
         use boltffi_ast::{ClosureKind, ClosureType, ReturnDef};
 
@@ -669,6 +742,7 @@ mod tests {
         // plan forces out-pointer carriage; parameter closure handling cannot
         // accidentally cover this case.
         assert_eq!(closure_crossing.form(), crate::ClosureForm::Fn);
+        assert_eq!(closure_crossing.presence(), HandlePresence::Required);
         assert_eq!(
             closure_crossing.registration().shape(),
             &native::ClosureRegistration::InvokeContext

--- a/boltffi_binding/src/lower/codecs.rs
+++ b/boltffi_binding/src/lower/codecs.rs
@@ -46,7 +46,7 @@ pub(super) fn node(
         }
         TypeExpr::Class { id, .. } => CodecNode::ClassHandle(ids.class(id)?),
         TypeExpr::Trait { id, .. } => CodecNode::CallbackHandle(ids.callback(id)?),
-        TypeExpr::Closure(_) => {
+        TypeExpr::Closure { .. } => {
             return Err(LowerError::unsupported_type(
                 super::error::UnsupportedType::ClosureInValuePosition,
             ));

--- a/boltffi_binding/src/lower/constants.rs
+++ b/boltffi_binding/src/lower/constants.rs
@@ -5,13 +5,15 @@
 //! [`TypeRef`] foreign code observes, and carries the literal value as
 //! [`ConstantValueDecl::Inline`].
 //!
-//! Only inline literals are produced today. Constants whose source
-//! expression cannot be expressed as a binding [`DefaultValue`] (paths,
-//! tuples, arrays, floating-point or byte-string literals, raw
-//! expressions) are rejected with [`UnsupportedType::DefaultValue`]
-//! because the value-emission machinery does not yet model them and
-//! [`ConstantValueDecl::Accessor`] needs a Rust-side reader symbol the
-//! source AST does not carry.
+//! Only inline literals are produced today. Bool, integer (range-
+//! checked against the declared primitive width), float, string, and
+//! enum-variant (via `ConstExpr::Path(...)` on an enum-typed constant)
+//! all lower to the matching [`DefaultValue`] variant. Byte-string,
+//! array, tuple, and raw constant expressions remain rejected with
+//! [`UnsupportedType::DefaultValue`]: their values are not expressible
+//! as a single literal in every target language, and supporting them
+//! requires the [`ConstantValueDecl::Accessor`] path (a Rust-side
+//! reader symbol the source AST does not carry yet).
 //!
 //! [`ConstantDef`]: boltffi_ast::ConstantDef
 //! [`ConstantDecl<S>`]: crate::ConstantDecl
@@ -22,7 +24,8 @@
 //! [`UnsupportedType::DefaultValue`]: super::error::UnsupportedType::DefaultValue
 
 use boltffi_ast::{
-    ConstExpr, ConstantDef as SourceConstant, Literal, Primitive as SourcePrimitive, TypeExpr,
+    CanonicalName as SourceName, ConstExpr, ConstantDef as SourceConstant, EnumDef as SourceEnum,
+    Literal, Path as SourcePath, Primitive as SourcePrimitive, TypeExpr, VariantPayload,
 };
 
 use crate::{CanonicalName, ConstantDecl, ConstantValueDecl, DefaultValue, IntegerValue};
@@ -38,17 +41,18 @@ pub(super) fn lower<S: SurfaceLower>(
 ) -> Result<Vec<ConstantDecl<S>>, LowerError> {
     idx.constants()
         .iter()
-        .map(|constant| lower_one::<S>(ids, constant))
+        .map(|constant| lower_one::<S>(idx, ids, constant))
         .collect()
 }
 
 fn lower_one<S: SurfaceLower>(
+    idx: &Index<'_>,
     ids: &DeclarationIds,
     constant: &SourceConstant,
 ) -> Result<ConstantDecl<S>, LowerError> {
     let constant_id = ids.constant(&constant.id)?;
     let ty = types::lower(ids, &constant.type_expr)?;
-    let value = inline_value(constant)?;
+    let value = inline_value(idx, constant)?;
     Ok(ConstantDecl::new(
         constant_id,
         CanonicalName::from(&constant.name),
@@ -57,28 +61,32 @@ fn lower_one<S: SurfaceLower>(
     ))
 }
 
-fn inline_value(constant: &SourceConstant) -> Result<DefaultValue, LowerError> {
-    let Some(expected) = InlineConstantType::from_type_expr(&constant.type_expr) else {
+fn inline_value(idx: &Index<'_>, constant: &SourceConstant) -> Result<DefaultValue, LowerError> {
+    let Some(expected) = InlineConstantType::from_type_expr(idx, &constant.type_expr) else {
         return Err(LowerError::unsupported_type(UnsupportedType::DefaultValue));
     };
     expected.lower_value(constant)
 }
 
 #[derive(Clone, Copy)]
-enum InlineConstantType {
+enum InlineConstantType<'src> {
     Bool,
     Integer(IntegerBounds),
+    Float,
     String,
+    Enum(&'src SourceEnum),
 }
 
-impl InlineConstantType {
-    fn from_type_expr(type_expr: &TypeExpr) -> Option<Self> {
+impl<'src> InlineConstantType<'src> {
+    fn from_type_expr(idx: &Index<'src>, type_expr: &TypeExpr) -> Option<Self> {
         match type_expr {
             TypeExpr::Primitive(SourcePrimitive::Bool) => Some(Self::Bool),
+            TypeExpr::Primitive(SourcePrimitive::F32 | SourcePrimitive::F64) => Some(Self::Float),
             TypeExpr::Primitive(primitive) => {
                 IntegerBounds::for_primitive(*primitive).map(Self::Integer)
             }
             TypeExpr::String => Some(Self::String),
+            TypeExpr::Enum(id) => idx.enumeration(id).map(Self::Enum),
             _ => None,
         }
     }
@@ -93,11 +101,19 @@ impl InlineConstantType {
             {
                 Ok(DefaultValue::Integer(IntegerValue::new(value.value)))
             }
+            (Self::Float, ConstExpr::Literal(Literal::Float(literal))) => {
+                metadata::parse_float_literal(literal)
+                    .map(DefaultValue::Float)
+                    .ok_or_else(|| LowerError::invalid_constant_value(&constant.id))
+            }
             (Self::String, ConstExpr::Literal(Literal::String(value))) => {
                 Ok(DefaultValue::String(value.clone()))
             }
-            (_, ConstExpr::Literal(Literal::Float(_) | Literal::Bytes(_)))
-            | (_, ConstExpr::Path(_))
+            (Self::Enum(enumeration), ConstExpr::Path(path)) => {
+                enum_variant_from_path(enumeration, path)
+                    .ok_or_else(|| LowerError::invalid_constant_value(&constant.id))
+            }
+            (_, ConstExpr::Literal(Literal::Bytes(_)))
             | (_, ConstExpr::Array(_))
             | (_, ConstExpr::Tuple(_))
             | (_, ConstExpr::Raw(_)) => {
@@ -106,6 +122,34 @@ impl InlineConstantType {
             _ => Err(LowerError::invalid_constant_value(&constant.id)),
         }
     }
+}
+
+fn enum_variant_from_path(enumeration: &SourceEnum, path: &SourcePath) -> Option<DefaultValue> {
+    let (enum_segment, variant_segment) = enum_variant_path_segments(path)?;
+    if !canonical_name_matches_segment(&enumeration.name, enum_segment.name.as_str()) {
+        return None;
+    }
+    let variant = enumeration.variants.iter().find(|variant| {
+        matches!(variant.payload, VariantPayload::Unit)
+            && canonical_name_matches_segment(&variant.name, variant_segment.name.as_str())
+    })?;
+    Some(DefaultValue::EnumVariant {
+        enum_name: CanonicalName::from(&enumeration.name),
+        variant_name: CanonicalName::from(&variant.name),
+    })
+}
+
+fn enum_variant_path_segments(
+    path: &SourcePath,
+) -> Option<(&boltffi_ast::PathSegment, &boltffi_ast::PathSegment)> {
+    let variant = path.segments.last()?;
+    let enum_name = path.segments.get(path.segments.len().checked_sub(2)?)?;
+    Some((enum_name, variant))
+}
+
+fn canonical_name_matches_segment(name: &SourceName, segment: &str) -> bool {
+    let mut parts = name.parts();
+    matches!(parts.next(), Some(part) if part.as_str() == segment) && parts.next().is_none()
 }
 
 #[derive(Clone, Copy)]
@@ -315,18 +359,62 @@ mod tests {
     }
 
     #[test]
-    fn float_constant_is_rejected_until_inline_floats_land() {
-        let error = lower_constants::<Native>(vec![constant(
-            "demo::PI",
-            "PI",
+    fn float_constant_lowers_inline_with_float_default() {
+        let bindings = lower_constants_ok::<Native>(vec![constant(
+            "demo::HALF",
+            "HALF",
             TypeExpr::Primitive(Primitive::F64),
-            ConstExpr::Literal(Literal::Float(FloatLiteral::new("3.14"))),
+            ConstExpr::Literal(Literal::Float(FloatLiteral::new("0.5"))),
+        )]);
+        let decl = only_constant(&bindings);
+
+        match decl.value() {
+            ConstantValueDecl::Inline { ty, value, .. } => {
+                assert_eq!(ty, &TypeRef::Primitive(BindingPrimitive::F64));
+                match value {
+                    DefaultValue::Float(float) => {
+                        assert!((float.to_f64() - 0.5).abs() < 1e-12);
+                    }
+                    other => panic!("expected DefaultValue::Float, got {other:?}"),
+                }
+            }
+            other => panic!("expected inline float constant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn float_constant_strips_type_suffix_and_underscores() {
+        let bindings = lower_constants_ok::<Native>(vec![constant(
+            "demo::HZ",
+            "HZ",
+            TypeExpr::Primitive(Primitive::F64),
+            ConstExpr::Literal(Literal::Float(FloatLiteral::new("1_000.5f64"))),
+        )]);
+
+        match only_constant(&bindings).value() {
+            ConstantValueDecl::Inline {
+                value: DefaultValue::Float(float),
+                ..
+            } => {
+                assert!((float.to_f64() - 1000.5).abs() < 1e-12);
+            }
+            other => panic!("expected inline float constant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn float_constant_with_garbled_source_is_rejected_with_invalid_value() {
+        let error = lower_constants::<Native>(vec![constant(
+            "demo::BAD",
+            "BAD",
+            TypeExpr::Primitive(Primitive::F64),
+            ConstExpr::Literal(Literal::Float(FloatLiteral::new("not_a_number"))),
         )])
-        .expect_err("float constant must reject");
+        .expect_err("unparseable float literal must reject");
 
         assert!(matches!(
             error.kind(),
-            LowerErrorKind::UnsupportedType(UnsupportedType::DefaultValue)
+            LowerErrorKind::InvalidConstantValue(constant) if constant == "demo::BAD"
         ));
     }
 
@@ -347,18 +435,224 @@ mod tests {
     }
 
     #[test]
-    fn path_constant_is_rejected_until_accessor_or_enum_variant_lands() {
+    fn path_constant_on_non_enum_type_is_rejected_with_invalid_value() {
         let error = lower_constants::<Native>(vec![constant(
             "demo::ALIAS",
             "ALIAS",
             TypeExpr::String,
             ConstExpr::Path(SourcePath::single("OTHER")),
         )])
-        .expect_err("path constant must reject");
+        .expect_err("path value on a String-typed constant must reject");
 
         assert!(matches!(
             error.kind(),
-            LowerErrorKind::UnsupportedType(UnsupportedType::DefaultValue)
+            LowerErrorKind::InvalidConstantValue(constant) if constant == "demo::ALIAS"
+        ));
+    }
+
+    #[test]
+    fn enum_constant_lowers_inline_with_enum_variant_default() {
+        use boltffi_ast::{EnumDef, EnumId as SourceEnumId, PathRoot, PathSegment, VariantDef};
+
+        // Set up an enum `demo::Mode` with variants Fast/Slow, then a
+        // constant `DEFAULT_MODE: Mode = Mode::Fast`.
+        let mut contract = package();
+        let mut mode = EnumDef::new(SourceEnumId::new("demo::Mode"), name("Mode"));
+        mode.variants.push(VariantDef::unit(name("Fast")));
+        mode.variants.push(VariantDef::unit(name("Slow")));
+        contract.enums.push(mode);
+        contract.constants.push(constant(
+            "demo::DEFAULT_MODE",
+            "DEFAULT_MODE",
+            TypeExpr::Enum(SourceEnumId::new("demo::Mode")),
+            ConstExpr::Path(SourcePath::new(
+                PathRoot::Relative,
+                vec![PathSegment::new("Mode"), PathSegment::new("Fast")],
+            )),
+        ));
+
+        let bindings = lower::<Native>(&contract).expect("enum constant should lower");
+        let decl = only_constant(&bindings);
+
+        match decl.value() {
+            ConstantValueDecl::Inline {
+                value:
+                    DefaultValue::EnumVariant {
+                        enum_name,
+                        variant_name,
+                    },
+                ..
+            } => {
+                assert_eq!(enum_name, &CanonicalName::single("Mode"));
+                assert_eq!(variant_name, &CanonicalName::single("Fast"));
+            }
+            other => panic!("expected inline enum-variant constant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enum_constant_accepts_qualified_path() {
+        use boltffi_ast::{EnumDef, EnumId as SourceEnumId, PathRoot, PathSegment, VariantDef};
+
+        let mut contract = package();
+        let mut mode = EnumDef::new(SourceEnumId::new("demo::Mode"), name("Mode"));
+        mode.variants.push(VariantDef::unit(name("Fast")));
+        contract.enums.push(mode);
+        contract.constants.push(constant(
+            "demo::DEFAULT_MODE",
+            "DEFAULT_MODE",
+            TypeExpr::Enum(SourceEnumId::new("demo::Mode")),
+            ConstExpr::Path(SourcePath::new(
+                PathRoot::Crate,
+                vec![
+                    PathSegment::new("demo"),
+                    PathSegment::new("Mode"),
+                    PathSegment::new("Fast"),
+                ],
+            )),
+        ));
+
+        let bindings =
+            lower::<Native>(&contract).expect("qualified enum-path constant should lower");
+
+        match only_constant(&bindings).value() {
+            ConstantValueDecl::Inline {
+                value:
+                    DefaultValue::EnumVariant {
+                        enum_name,
+                        variant_name,
+                    },
+                ..
+            } => {
+                assert_eq!(enum_name, &CanonicalName::single("Mode"));
+                assert_eq!(variant_name, &CanonicalName::single("Fast"));
+            }
+            other => panic!("expected enum-variant default, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enum_constant_rejects_path_for_another_enum() {
+        use boltffi_ast::{EnumDef, EnumId as SourceEnumId, PathSegment, VariantDef};
+
+        let mut contract = package();
+        let mut mode = EnumDef::new(SourceEnumId::new("demo::Mode"), name("Mode"));
+        mode.variants.push(VariantDef::unit(name("Fast")));
+        contract.enums.push(mode);
+        contract.constants.push(constant(
+            "demo::DEFAULT_MODE",
+            "DEFAULT_MODE",
+            TypeExpr::Enum(SourceEnumId::new("demo::Mode")),
+            ConstExpr::Path(SourcePath::new(
+                boltffi_ast::PathRoot::Relative,
+                vec![PathSegment::new("Other"), PathSegment::new("Fast")],
+            )),
+        ));
+
+        let error = lower::<Native>(&contract).expect_err("wrong enum path must reject");
+
+        assert!(matches!(
+            error.kind(),
+            LowerErrorKind::InvalidConstantValue(constant) if constant == "demo::DEFAULT_MODE"
+        ));
+    }
+
+    #[test]
+    fn enum_constant_rejects_unknown_variant_path() {
+        use boltffi_ast::{EnumDef, EnumId as SourceEnumId, PathSegment, VariantDef};
+
+        let mut contract = package();
+        let mut mode = EnumDef::new(SourceEnumId::new("demo::Mode"), name("Mode"));
+        mode.variants.push(VariantDef::unit(name("Fast")));
+        contract.enums.push(mode);
+        contract.constants.push(constant(
+            "demo::DEFAULT_MODE",
+            "DEFAULT_MODE",
+            TypeExpr::Enum(SourceEnumId::new("demo::Mode")),
+            ConstExpr::Path(SourcePath::new(
+                boltffi_ast::PathRoot::Relative,
+                vec![PathSegment::new("Mode"), PathSegment::new("Slow")],
+            )),
+        ));
+
+        let error = lower::<Native>(&contract).expect_err("unknown enum variant must reject");
+
+        assert!(matches!(
+            error.kind(),
+            LowerErrorKind::InvalidConstantValue(constant) if constant == "demo::DEFAULT_MODE"
+        ));
+    }
+
+    #[test]
+    fn enum_constant_rejects_payload_variant_path() {
+        use boltffi_ast::{
+            EnumDef, EnumId as SourceEnumId, FieldDef, PathSegment, VariantDef, VariantPayload,
+        };
+
+        let mut contract = package();
+        let mut mode = EnumDef::new(SourceEnumId::new("demo::Mode"), name("Mode"));
+        mode.variants.push(VariantDef {
+            name: name("Fast"),
+            discriminant: None,
+            payload: VariantPayload::Tuple(vec![TypeExpr::Primitive(Primitive::U32)]),
+            doc: None,
+            user_attrs: Vec::new(),
+            source: boltffi_ast::Source::exported(),
+            source_span: None,
+        });
+        mode.variants.push(VariantDef {
+            name: name("Slow"),
+            discriminant: None,
+            payload: VariantPayload::Struct(vec![FieldDef::new(
+                name("value"),
+                TypeExpr::Primitive(Primitive::U32),
+            )]),
+            doc: None,
+            user_attrs: Vec::new(),
+            source: boltffi_ast::Source::exported(),
+            source_span: None,
+        });
+        contract.enums.push(mode);
+        contract.constants.push(constant(
+            "demo::DEFAULT_MODE",
+            "DEFAULT_MODE",
+            TypeExpr::Enum(SourceEnumId::new("demo::Mode")),
+            ConstExpr::Path(SourcePath::new(
+                boltffi_ast::PathRoot::Relative,
+                vec![PathSegment::new("Mode"), PathSegment::new("Fast")],
+            )),
+        ));
+
+        let error = lower::<Native>(&contract).expect_err("payload enum variant must reject");
+
+        assert!(matches!(
+            error.kind(),
+            LowerErrorKind::InvalidConstantValue(constant) if constant == "demo::DEFAULT_MODE"
+        ));
+    }
+
+    #[test]
+    fn enum_constant_with_bare_variant_path_is_rejected() {
+        use boltffi_ast::{EnumDef, EnumId as SourceEnumId};
+
+        let mut contract = package();
+        let mut mode = EnumDef::new(SourceEnumId::new("demo::Mode"), name("Mode"));
+        mode.variants
+            .push(boltffi_ast::VariantDef::unit(name("Fast")));
+        contract.enums.push(mode);
+        contract.constants.push(constant(
+            "demo::DEFAULT_MODE",
+            "DEFAULT_MODE",
+            TypeExpr::Enum(SourceEnumId::new("demo::Mode")),
+            ConstExpr::Path(SourcePath::single("Fast")),
+        ));
+
+        let error =
+            lower::<Native>(&contract).expect_err("bare-variant path must reject (enum unknown)");
+
+        assert!(matches!(
+            error.kind(),
+            LowerErrorKind::InvalidConstantValue(constant) if constant == "demo::DEFAULT_MODE"
         ));
     }
 

--- a/boltffi_binding/src/lower/constants.rs
+++ b/boltffi_binding/src/lower/constants.rs
@@ -1,27 +1,33 @@
 //! Constant declaration lowering.
 //!
 //! Walks every [`ConstantDef`] the source contract exposes and produces
-//! a [`ConstantDecl<S>`] that names the constant, records the binding
-//! [`TypeRef`] foreign code observes, and carries the literal value as
-//! [`ConstantValueDecl::Inline`].
+//! a [`ConstantDecl<S>`] that names the constant, records its
+//! declaration metadata, and carries the value as a
+//! [`ConstantValueDecl`].
 //!
-//! Only inline literals are produced today. Bool, integer (range-
-//! checked against the declared primitive width), float, string, and
-//! enum-variant (via `ConstExpr::Path(...)` on an enum-typed constant)
-//! all lower to the matching [`DefaultValue`] variant. Byte-string,
-//! array, tuple, and raw constant expressions remain rejected with
-//! [`UnsupportedType::DefaultValue`]: their values are not expressible
-//! as a single literal in every target language, and supporting them
-//! requires the [`ConstantValueDecl::Accessor`] path (a Rust-side
-//! reader symbol the source AST does not carry yet).
+//! Delivery splits on whether the value has a portable inline spelling:
+//!
+//! - Bool, integer (range-checked against the declared primitive
+//!   width), float, string, and enum-variant (via `ConstExpr::Path(...)`
+//!   on an enum-typed constant) lower to [`ConstantValueDecl::Inline`]:
+//!   the literal is emitted directly in generated source.
+//! - Byte-string, array, tuple, and raw (unevaluated) expressions, and
+//!   any constant whose declared type is not an inline scalar type,
+//!   lower to [`ConstantValueDecl::Accessor`]: a synchronous Rust-side
+//!   getter foreign code calls once to read the value. To a foreign
+//!   consumer the result is still a named immutable value; inline versus
+//!   accessor is only how the bytes are delivered.
+//!
+//! A value that cannot inhabit its declared type (a bool literal on a
+//! string constant, a path to an unknown enum variant) is rejected with
+//! [`LowerErrorKind::InvalidConstantValue`].
 //!
 //! [`ConstantDef`]: boltffi_ast::ConstantDef
 //! [`ConstantDecl<S>`]: crate::ConstantDecl
+//! [`ConstantValueDecl`]: crate::ConstantValueDecl
 //! [`ConstantValueDecl::Inline`]: crate::ConstantValueDecl::Inline
 //! [`ConstantValueDecl::Accessor`]: crate::ConstantValueDecl::Accessor
-//! [`DefaultValue`]: crate::DefaultValue
-//! [`TypeRef`]: crate::TypeRef
-//! [`UnsupportedType::DefaultValue`]: super::error::UnsupportedType::DefaultValue
+//! [`LowerErrorKind::InvalidConstantValue`]: super::error::LowerErrorKind::InvalidConstantValue
 
 use boltffi_ast::{
     CanonicalName as SourceName, ConstExpr, ConstantDef as SourceConstant, EnumDef as SourceEnum,
@@ -31,39 +37,78 @@ use boltffi_ast::{
 use crate::{CanonicalName, ConstantDecl, ConstantValueDecl, DefaultValue, IntegerValue};
 
 use super::{
-    LowerError, error::UnsupportedType, ids::DeclarationIds, index::Index, metadata,
-    surface::SurfaceLower, types,
+    LowerError, callable,
+    ids::DeclarationIds,
+    index::Index,
+    metadata,
+    surface::SurfaceLower,
+    symbol::{SymbolAllocator, constant_accessor_symbol_name},
+    types,
 };
 
 pub(super) fn lower<S: SurfaceLower>(
     idx: &Index<'_>,
     ids: &DeclarationIds,
+    allocator: &mut SymbolAllocator,
 ) -> Result<Vec<ConstantDecl<S>>, LowerError> {
     idx.constants()
         .iter()
-        .map(|constant| lower_one::<S>(idx, ids, constant))
+        .map(|constant| lower_one::<S>(idx, ids, allocator, constant))
         .collect()
 }
 
 fn lower_one<S: SurfaceLower>(
     idx: &Index<'_>,
     ids: &DeclarationIds,
+    allocator: &mut SymbolAllocator,
     constant: &SourceConstant,
 ) -> Result<ConstantDecl<S>, LowerError> {
     let constant_id = ids.constant(&constant.id)?;
-    let ty = types::lower(ids, &constant.type_expr)?;
-    let value = inline_value(idx, constant)?;
+    let value = lower_value_decl::<S>(idx, ids, allocator, constant)?;
     Ok(ConstantDecl::new(
         constant_id,
         CanonicalName::from(&constant.name),
         metadata::decl_meta(constant.doc.as_ref(), constant.deprecated.as_ref()),
-        ConstantValueDecl::inline(ty, value),
+        value,
     ))
 }
 
-fn inline_value(idx: &Index<'_>, constant: &SourceConstant) -> Result<DefaultValue, LowerError> {
+fn lower_value_decl<S: SurfaceLower>(
+    idx: &Index<'_>,
+    ids: &DeclarationIds,
+    allocator: &mut SymbolAllocator,
+    constant: &SourceConstant,
+) -> Result<ConstantValueDecl<S>, LowerError> {
+    // Chooses inline versus accessor delivery for one constant.
+    //
+    // A constant inlines when its value is a literal that inhabits the
+    // declared type and has a portable spelling. Everything else is
+    // delivered through a Rust-side getter the foreign side calls once:
+    // byte-string, array, tuple, and raw (unevaluated) expressions, plus
+    // any constant whose declared type is not an inline scalar type.
+    match inline_default(idx, constant)? {
+        Some(value) => {
+            let ty = types::lower(ids, &constant.type_expr)?;
+            Ok(ConstantValueDecl::inline(ty, value))
+        }
+        None => {
+            let symbol = allocator.mint(constant_accessor_symbol_name(constant.id.as_str()))?;
+            let callable =
+                callable::lower_constant_accessor::<S>(idx, ids, allocator, &constant.type_expr)?;
+            Ok(ConstantValueDecl::accessor(symbol, Box::new(callable)))
+        }
+    }
+}
+
+fn inline_default(
+    idx: &Index<'_>,
+    constant: &SourceConstant,
+) -> Result<Option<DefaultValue>, LowerError> {
+    // Returns the inline literal for a constant, `None` when the value
+    // must be delivered through an accessor, or an error when the value
+    // cannot inhabit its declared type.
     let Some(expected) = InlineConstantType::from_type_expr(idx, &constant.type_expr) else {
-        return Err(LowerError::unsupported_type(UnsupportedType::DefaultValue));
+        return Ok(None);
     };
     expected.lower_value(constant)
 }
@@ -91,42 +136,42 @@ impl<'src> InlineConstantType<'src> {
         }
     }
 
-    fn lower_value(self, constant: &SourceConstant) -> Result<DefaultValue, LowerError> {
+    fn lower_value(self, constant: &SourceConstant) -> Result<Option<DefaultValue>, LowerError> {
         match (self, &constant.value) {
             (Self::Bool, ConstExpr::Literal(Literal::Bool(value))) => {
-                Ok(DefaultValue::Bool(*value))
+                Ok(Some(DefaultValue::Bool(*value)))
             }
             (Self::Integer(bounds), ConstExpr::Literal(Literal::Integer(value)))
                 if bounds.contains(value.value) =>
             {
-                Ok(DefaultValue::Integer(IntegerValue::new(value.value)))
+                Ok(Some(DefaultValue::Integer(IntegerValue::new(value.value))))
             }
             (Self::Float, ConstExpr::Literal(Literal::Float(literal))) => {
                 metadata::parse_float_literal(literal)
                     .map(DefaultValue::Float)
+                    .map(Some)
                     .ok_or_else(|| LowerError::invalid_constant_value(&constant.id))
             }
             (Self::String, ConstExpr::Literal(Literal::String(value))) => {
-                Ok(DefaultValue::String(value.clone()))
+                Ok(Some(DefaultValue::String(value.clone())))
             }
             (Self::Enum(enumeration), ConstExpr::Path(path)) => {
                 enum_variant_from_path(enumeration, path)
+                    .map(Some)
                     .ok_or_else(|| LowerError::invalid_constant_value(&constant.id))
             }
             (_, ConstExpr::Literal(Literal::Bytes(_)))
             | (_, ConstExpr::Array(_))
             | (_, ConstExpr::Tuple(_))
-            | (_, ConstExpr::Raw(_)) => {
-                Err(LowerError::unsupported_type(UnsupportedType::DefaultValue))
-            }
+            | (_, ConstExpr::Raw(_)) => Ok(None),
             _ => Err(LowerError::invalid_constant_value(&constant.id)),
         }
     }
 }
 
 fn enum_variant_from_path(enumeration: &SourceEnum, path: &SourcePath) -> Option<DefaultValue> {
-    let (enum_segment, variant_segment) = enum_variant_path_segments(path)?;
-    if !canonical_name_matches_segment(&enumeration.name, enum_segment.name.as_str()) {
+    let (variant_segment, qualifier) = path.segments.split_last()?;
+    if !enum_qualifier_matches(enumeration, qualifier) {
         return None;
     }
     let variant = enumeration.variants.iter().find(|variant| {
@@ -139,12 +184,39 @@ fn enum_variant_from_path(enumeration: &SourceEnum, path: &SourcePath) -> Option
     })
 }
 
-fn enum_variant_path_segments(
-    path: &SourcePath,
-) -> Option<(&boltffi_ast::PathSegment, &boltffi_ast::PathSegment)> {
-    let variant = path.segments.last()?;
-    let enum_name = path.segments.get(path.segments.len().checked_sub(2)?)?;
-    Some((enum_name, variant))
+fn enum_qualifier_matches(
+    enumeration: &SourceEnum,
+    qualifier: &[boltffi_ast::PathSegment],
+) -> bool {
+    // Checks that the path's qualifier (every segment before the
+    // variant) names the enum the constant is typed as.
+    //
+    // The qualifier is matched against the enum's canonical id (the raw
+    // `::`-path the scanner derived the identity from), allowing the
+    // leading module path to be omitted: an enum `demo::Mode` accepts
+    // `Mode::Fast` and `demo::Mode::Fast`, but rejects
+    // `other::Mode::Fast`, which names a different enum that happens to
+    // share the leaf name. Matching the id rather than the normalized
+    // name also keeps a multi-word enum identifier (which splits into
+    // several canonical-name parts) comparable to its single raw path
+    // segment.
+    if qualifier.is_empty() {
+        return false;
+    }
+    let id_segments: Vec<&str> = enumeration
+        .id
+        .as_str()
+        .split("::")
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    if qualifier.len() > id_segments.len() {
+        return false;
+    }
+    let id_suffix = &id_segments[id_segments.len() - qualifier.len()..];
+    qualifier
+        .iter()
+        .zip(id_suffix)
+        .all(|(segment, id_segment)| segment.name.as_str() == *id_segment)
 }
 
 fn canonical_name_matches_segment(name: &SourceName, segment: &str) -> bool {
@@ -193,7 +265,7 @@ mod tests {
         SourceContract, TypeExpr,
     };
 
-    use crate::lower::{LowerError, LowerErrorKind, UnsupportedType, lower};
+    use crate::lower::{LowerError, LowerErrorKind, lower};
     use crate::{
         Bindings, CanonicalName, ConstantDecl, ConstantId, ConstantValueDecl, Decl, DefaultValue,
         IntegerValue, Native, Primitive as BindingPrimitive, SurfaceLower, TypeRef, Wasm32,
@@ -419,19 +491,23 @@ mod tests {
     }
 
     #[test]
-    fn bytes_constant_is_rejected_until_inline_bytes_land() {
-        let error = lower_constants::<Native>(vec![constant(
+    fn bytes_constant_lowers_via_accessor() {
+        let bindings = lower_constants_ok::<Native>(vec![constant(
             "demo::MAGIC",
             "MAGIC",
             TypeExpr::Bytes,
             ConstExpr::Literal(Literal::Bytes(vec![0xCA, 0xFE])),
-        )])
-        .expect_err("bytes constant must reject");
+        )]);
+        let decl = only_constant(&bindings);
 
-        assert!(matches!(
-            error.kind(),
-            LowerErrorKind::UnsupportedType(UnsupportedType::DefaultValue)
-        ));
+        match decl.value() {
+            ConstantValueDecl::Accessor { symbol, callable } => {
+                assert_eq!(symbol.name().as_str(), "boltffi_const_demo_magic");
+                assert!(callable.receiver().is_none());
+                assert!(callable.params().is_empty());
+            }
+            other => panic!("expected accessor constant value, got {other:?}"),
+        }
     }
 
     #[test]
@@ -529,6 +605,42 @@ mod tests {
             }
             other => panic!("expected enum-variant default, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn enum_constant_rejects_qualified_path_for_same_named_enum_in_other_module() {
+        use boltffi_ast::{EnumDef, EnumId as SourceEnumId, PathRoot, PathSegment, VariantDef};
+
+        // The constant is typed `demo::Mode`, but the value path is
+        // `other::Mode::Fast`. The leaf enum segment (`Mode`) and variant
+        // (`Fast`) match, yet the qualifier names a different enum. The
+        // full qualifier must be validated against the enum id, not just
+        // the segment adjacent to the variant.
+        let mut contract = package();
+        let mut mode = EnumDef::new(SourceEnumId::new("demo::Mode"), name("Mode"));
+        mode.variants.push(VariantDef::unit(name("Fast")));
+        contract.enums.push(mode);
+        contract.constants.push(constant(
+            "demo::DEFAULT_MODE",
+            "DEFAULT_MODE",
+            TypeExpr::Enum(SourceEnumId::new("demo::Mode")),
+            ConstExpr::Path(SourcePath::new(
+                PathRoot::Relative,
+                vec![
+                    PathSegment::new("other"),
+                    PathSegment::new("Mode"),
+                    PathSegment::new("Fast"),
+                ],
+            )),
+        ));
+
+        let error = lower::<Native>(&contract)
+            .expect_err("qualified path naming a different module's enum must reject");
+
+        assert!(matches!(
+            error.kind(),
+            LowerErrorKind::InvalidConstantValue(constant) if constant == "demo::DEFAULT_MODE"
+        ));
     }
 
     #[test]
@@ -657,19 +769,63 @@ mod tests {
     }
 
     #[test]
-    fn raw_constant_is_rejected_until_accessor_lands() {
-        let error = lower_constants::<Native>(vec![constant(
+    fn raw_constant_lowers_via_accessor() {
+        let bindings = lower_constants_ok::<Native>(vec![constant(
             "demo::COMPUTED",
             "COMPUTED",
             TypeExpr::Primitive(Primitive::U32),
             ConstExpr::Raw("1 + 2".to_owned()),
-        )])
-        .expect_err("raw constant expression must reject");
+        )]);
+
+        match only_constant(&bindings).value() {
+            ConstantValueDecl::Accessor { symbol, callable } => {
+                assert_eq!(symbol.name().as_str(), "boltffi_const_demo_computed");
+                assert!(callable.params().is_empty());
+            }
+            other => panic!("expected accessor constant value, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tuple_constant_lowers_via_accessor() {
+        let bindings = lower_constants_ok::<Native>(vec![constant(
+            "demo::PAIR",
+            "PAIR",
+            TypeExpr::Tuple(vec![
+                TypeExpr::Primitive(Primitive::U32),
+                TypeExpr::Primitive(Primitive::U32),
+            ]),
+            ConstExpr::Tuple(vec![
+                ConstExpr::Literal(Literal::Integer(IntegerLiteral::new(1, "1"))),
+                ConstExpr::Literal(Literal::Integer(IntegerLiteral::new(2, "2"))),
+            ]),
+        )]);
 
         assert!(matches!(
-            error.kind(),
-            LowerErrorKind::UnsupportedType(UnsupportedType::DefaultValue)
+            only_constant(&bindings).value(),
+            ConstantValueDecl::Accessor { .. }
         ));
+    }
+
+    #[test]
+    fn accessor_constant_registers_native_symbol() {
+        let bindings = lower_constants_ok::<Native>(vec![constant(
+            "demo::MAGIC",
+            "MAGIC",
+            TypeExpr::Bytes,
+            ConstExpr::Literal(Literal::Bytes(vec![0xCA, 0xFE])),
+        )]);
+        let names: Vec<&str> = bindings
+            .symbols()
+            .symbols()
+            .iter()
+            .map(|symbol| symbol.name().as_str())
+            .collect();
+
+        assert!(
+            names.contains(&"boltffi_const_demo_magic"),
+            "accessor symbol missing from {names:?}"
+        );
     }
 
     #[test]

--- a/boltffi_binding/src/lower/metadata.rs
+++ b/boltffi_binding/src/lower/metadata.rs
@@ -1,9 +1,11 @@
 use boltffi_ast::{
     DefaultValue as SourceDefaultValue, DeprecationInfo as SourceDeprecationInfo,
-    DocComment as SourceDocComment,
+    DocComment as SourceDocComment, FloatLiteral as SourceFloatLiteral,
 };
 
-use crate::{DeclMeta, DefaultValue, DeprecationInfo, DocComment, ElementMeta, IntegerValue};
+use crate::{
+    DeclMeta, DefaultValue, DeprecationInfo, DocComment, ElementMeta, FloatValue, IntegerValue,
+};
 
 use super::{LowerError, error::UnsupportedType};
 
@@ -47,13 +49,34 @@ impl TryFrom<&SourceDefaultValue> for DefaultValue {
             SourceDefaultValue::Integer(value) => {
                 Ok(DefaultValue::Integer(IntegerValue::new(value.value)))
             }
+            SourceDefaultValue::Float(literal) => parse_float_literal(literal)
+                .map(DefaultValue::Float)
+                .ok_or_else(|| LowerError::unsupported_type(UnsupportedType::DefaultValue)),
             SourceDefaultValue::String(value) => Ok(DefaultValue::String(value.clone())),
             SourceDefaultValue::None => Ok(DefaultValue::Null),
-            SourceDefaultValue::Float(_)
-            | SourceDefaultValue::Bytes(_)
-            | SourceDefaultValue::Path(_) => {
+            SourceDefaultValue::Bytes(_) | SourceDefaultValue::Path(_) => {
                 Err(LowerError::unsupported_type(UnsupportedType::DefaultValue))
             }
         }
     }
+}
+
+/// Parses a Rust-source float literal spelling into an
+/// [`FloatValue`] by IEEE-754 bit pattern.
+///
+/// Strips the `f32`/`f64` type suffix and any digit separators, then
+/// parses through `f64::from_str`. Returns `None` for unparseable
+/// literals; callers route that to a categorical rejection. `FloatValue`
+/// stores the f64 bits, so f32 source literals round-trip through f64.
+pub(super) fn parse_float_literal(literal: &SourceFloatLiteral) -> Option<FloatValue> {
+    let raw = literal.source.as_str();
+    let trimmed = raw
+        .trim_end_matches("f64")
+        .trim_end_matches("f32")
+        .trim_end_matches('_');
+    let normalized: String = trimmed
+        .chars()
+        .filter(|character| *character != '_')
+        .collect();
+    normalized.parse::<f64>().ok().map(FloatValue::from_f64)
 }

--- a/boltffi_binding/src/lower/methods.rs
+++ b/boltffi_binding/src/lower/methods.rs
@@ -386,6 +386,27 @@ fn symbol_owner(owner: callable::CallableOwner<'_>) -> SymbolOwner<'_> {
 
 fn reject_owned_class_receiver(method: &MethodDef) -> Result<(), LowerError> {
     if matches!(method.receiver, Receiver::Owned) {
+        // A class crosses FFI as a handle: an opaque integer or pointer
+        // that names a Rust-side instance. The handle's lifetime is
+        // managed by reference counts or explicit drops; the foreign
+        // side calls `release_class_<class_id>(handle)` to dispose of
+        // it.
+        //
+        // `&self` and `&mut self` are borrows. The method runs with
+        // temporary access to the handle's target. The handle stays
+        // valid on the foreign side afterward. No lifecycle change.
+        //
+        // `self` (owned) means the method consumes the instance. After
+        // it returns, the handle on the foreign side must be invalid.
+        // Calling any other method on it (including the release
+        // function) would be use-after-free.
+        //
+        // The IR does not model handle consumption today. There is no
+        // protocol that tells the foreign side "this method invalidated
+        // your handle, do not release it." Until that protocol exists
+        // (handle poisoning, foreign-language move semantics, or an
+        // explicit consumed flag on the method decl), this rejection
+        // prevents the unsound case from reaching renderers.
         Err(LowerError::unsupported_type(
             UnsupportedType::OwnedClassReceiver,
         ))

--- a/boltffi_binding/src/lower/mod.rs
+++ b/boltffi_binding/src/lower/mod.rs
@@ -84,7 +84,7 @@ pub fn lower<S: SurfaceLower>(source: &SourceContract) -> Result<Bindings<S>, Lo
     let callbacks = callbacks::lower::<S>(&index, &ids, &mut allocator)?;
     let functions = functions::lower::<S>(&index, &ids, &mut allocator)?;
     let streams = streams::lower::<S>(&index, &ids, &mut allocator)?;
-    let constants = constants::lower::<S>(&index, &ids)?;
+    let constants = constants::lower::<S>(&index, &ids, &mut allocator)?;
     let customs = customs::lower(&index, &ids)?;
 
     let decls = records

--- a/boltffi_binding/src/lower/records.rs
+++ b/boltffi_binding/src/lower/records.rs
@@ -133,20 +133,20 @@ mod tests {
     use boltffi_ast::{
         CanonicalName as SourceName, ClosureKind, ClosureType, DefaultValue as SourceDefaultValue,
         DeprecationInfo as SourceDeprecationInfo, DocComment as SourceDocComment, EnumDef,
-        ExecutionKind, FieldDef, IntegerLiteral, MethodDef, MethodId as SourceMethodId,
-        PackageInfo as SourcePackage, ParameterDef, ParameterPassing, Primitive, Receiver,
-        RecordDef, ReprAttr, ReprItem, ReturnDef, Source, SourceContract, TypeExpr, VariantDef,
-        VariantPayload,
+        ExecutionKind, FieldDef, HandlePresence as SourcePresence, IntegerLiteral, MethodDef,
+        MethodId as SourceMethodId, PackageInfo as SourcePackage, ParameterDef, ParameterPassing,
+        Path as SourcePath, Primitive, Receiver, RecordDef, ReprAttr, ReprItem, ReturnDef, Source,
+        SourceContract, TypeExpr, VariantDef, VariantPayload,
     };
 
     use crate::lower::lower;
     use crate::{
         BindingErrorKind, Bindings, ByteSize, CanonicalName, CodecNode, Decl, DefaultValue,
         DirectRecordDecl, EncodedRecordDecl, EnumId, ErrorDecl, ExecutionDecl, ExportedMethodDecl,
-        FieldKey, InitializerDecl, IntegerValue, IntrinsicOp, LowerError, LowerErrorKind, Native,
-        NativeSymbol, OpNode, OutOfRust, ParamPlan, Primitive as BindingPrimitive, ReadPlan,
-        Receive, RecordDecl, RecordId, ReturnPlan, SurfaceLower, TypeRef, UnsupportedType,
-        ValueRef, Wasm32, native, wasm32,
+        FieldKey, HandlePresence, InitializerDecl, IntegerValue, IntrinsicOp, LowerError,
+        LowerErrorKind, Native, NativeSymbol, OpNode, OutOfRust, ParamPlan,
+        Primitive as BindingPrimitive, ReadPlan, Receive, RecordDecl, RecordId, ReturnPlan,
+        SurfaceLower, TypeRef, UnsupportedType, ValueRef, Wasm32, native, wasm32,
     };
 
     fn package() -> SourceContract {
@@ -851,6 +851,17 @@ mod tests {
         TypeExpr::closure(ClosureType::new(kind, parameters, returns))
     }
 
+    fn closure_with_presence(
+        parameters: Vec<TypeExpr>,
+        returns: ReturnDef,
+        presence: SourcePresence,
+    ) -> TypeExpr {
+        TypeExpr::closure_with_presence(
+            ClosureType::new(ClosureKind::Fn, parameters, returns),
+            presence,
+        )
+    }
+
     fn data_enum(id: &str, enum_name: &str) -> EnumDef {
         let mut enumeration = EnumDef::new(id.into(), name(enum_name));
         enumeration.variants = vec![
@@ -1269,6 +1280,7 @@ mod tests {
         let closure = methods[0].callable().params()[0]
             .as_closure()
             .expect("expected ParamPlan::Closure");
+        assert_eq!(closure.presence(), HandlePresence::Required);
         assert!(matches!(
             closure.registration().shape(),
             native::ClosureRegistration::InvokeContext
@@ -1284,6 +1296,38 @@ mod tests {
             }
         ));
         assert!(matches!(callable.returns().plan(), ReturnPlan::Void));
+    }
+
+    #[test]
+    fn nullable_closure_parameter_lowers_to_nullable_crossing() {
+        let bindings = lower_point_method::<Native>(method_with(
+            "maybe_each",
+            Receiver::Shared,
+            vec![value_param(
+                "callback",
+                closure_with_presence(
+                    vec![TypeExpr::Primitive(Primitive::F64)],
+                    ReturnDef::Void,
+                    SourcePresence::Nullable,
+                ),
+            )],
+            ReturnDef::Void,
+        ));
+        let methods = first_record_methods(&bindings);
+
+        let closure = methods[0].callable().params()[0]
+            .as_closure()
+            .expect("expected nullable closure param");
+        assert_eq!(closure.presence(), HandlePresence::Nullable);
+        assert_eq!(closure.form(), crate::ClosureForm::Fn);
+        assert!(matches!(
+            closure.registration().shape(),
+            native::ClosureRegistration::InvokeContext
+        ));
+        assert!(matches!(
+            closure.invoke().returns().plan(),
+            ReturnPlan::Void
+        ));
     }
 
     #[test]
@@ -1350,6 +1394,7 @@ mod tests {
             other => panic!("expected ClosureViaOutPointer, got {other:?}"),
         };
         assert_eq!(closure_crossing.form(), crate::ClosureForm::Fn);
+        assert_eq!(closure_crossing.presence(), HandlePresence::Required);
         // Native closure params and returns share the same logical invoke/context
         // marker, but the parent enum keeps the wire positions separate.
         // Parameter closures can only appear through IncomingParam/OutgoingParam;
@@ -1372,6 +1417,33 @@ mod tests {
                 ty: TypeRef::Primitive(BindingPrimitive::F64),
             } => {}
             other => panic!("expected f64 direct invoke return, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nullable_closure_return_lowers_to_nullable_closure_via_out_pointer() {
+        let mut record = point_record();
+        record.methods.push(method_with(
+            "maybe_project",
+            Receiver::Shared,
+            Vec::new(),
+            ReturnDef::Value(closure_with_presence(
+                vec![TypeExpr::Primitive(Primitive::F64)],
+                ReturnDef::Value(TypeExpr::Primitive(Primitive::F64)),
+                SourcePresence::Nullable,
+            )),
+        ));
+
+        let bindings =
+            lower_record_result::<Native>(record).expect("nullable closure return should lower");
+        let methods = direct_record(&bindings).methods();
+
+        match methods[0].callable().returns().plan() {
+            ReturnPlan::ClosureViaOutPointer(closure) => {
+                assert_eq!(closure.presence(), HandlePresence::Nullable);
+                assert_eq!(closure.form(), crate::ClosureForm::Fn);
+            }
+            other => panic!("expected nullable ClosureViaOutPointer, got {other:?}"),
         }
     }
 
@@ -1603,10 +1675,11 @@ mod tests {
         ));
         let methods = first_record_methods(&bindings);
 
-        let callable = methods[0].callable().params()[0]
+        let closure = methods[0].callable().params()[0]
             .as_closure()
-            .expect("expected ParamPlan::Closure for {kind:?}")
-            .invoke();
+            .expect("expected ParamPlan::Closure for {kind:?}");
+        assert_eq!(closure.presence(), HandlePresence::Required);
+        let callable = closure.invoke();
         assert_eq!(callable.params().len(), 1);
         assert!(matches!(callable.returns().plan(), ReturnPlan::Void));
     }
@@ -1906,6 +1979,7 @@ mod tests {
         let closure = methods[0].callable().params()[0]
             .as_closure()
             .expect("expected ParamPlan::Closure on wasm32");
+        assert_eq!(closure.presence(), HandlePresence::Required);
         assert_eq!(
             closure.registration().shape().call().name().as_str(),
             "__boltffi_callback_closure____closure__f64_call"
@@ -1925,6 +1999,37 @@ mod tests {
             }
         ));
         assert!(matches!(callable.returns().plan(), ReturnPlan::Void));
+    }
+
+    #[test]
+    fn wasm32_nullable_closure_parameter_lowers_to_nullable_crossing() {
+        let bindings = lower_point_method::<Wasm32>(method_with(
+            "maybe_each",
+            Receiver::Shared,
+            vec![value_param(
+                "callback",
+                closure_with_presence(
+                    vec![TypeExpr::Primitive(Primitive::F64)],
+                    ReturnDef::Void,
+                    SourcePresence::Nullable,
+                ),
+            )],
+            ReturnDef::Void,
+        ));
+        let methods = first_record_methods(&bindings);
+
+        let closure = methods[0].callable().params()[0]
+            .as_closure()
+            .expect("expected nullable wasm32 closure param");
+        assert_eq!(closure.presence(), HandlePresence::Nullable);
+        assert_eq!(
+            closure.registration().shape().call().name().as_str(),
+            "__boltffi_callback_closure____closure__f64_call"
+        );
+        assert!(matches!(
+            closure.invoke().returns().plan(),
+            ReturnPlan::Void
+        ));
     }
 
     #[test]
@@ -2118,6 +2223,25 @@ mod tests {
             Some(DefaultValue::Integer(value)) => assert_eq!(value, &IntegerValue::new(1)),
             other => panic!("expected integer default, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parameter_path_default_is_rejected_without_type_context() {
+        let mut factor = value_param("factor", TypeExpr::Primitive(Primitive::I32));
+        factor.default = Some(SourceDefaultValue::Path(SourcePath::single("Mode")));
+
+        let error = lower_record_result::<Native>(point_record_with_methods(vec![method_with(
+            "scale",
+            Receiver::Mutable,
+            vec![factor],
+            ReturnDef::Void,
+        )]))
+        .expect_err("path defaults need declared-type validation and must reject here");
+
+        assert!(matches!(
+            error.kind(),
+            LowerErrorKind::UnsupportedType(UnsupportedType::DefaultValue)
+        ));
     }
 
     #[test]

--- a/boltffi_binding/src/lower/streams.rs
+++ b/boltffi_binding/src/lower/streams.rs
@@ -124,7 +124,7 @@ fn validate_item_type(type_expr: &TypeExpr) -> Result<(), LowerError> {
     match type_expr {
         TypeExpr::Class { .. }
         | TypeExpr::Trait { .. }
-        | TypeExpr::Closure(_)
+        | TypeExpr::Closure { .. }
         | TypeExpr::Unit
         | TypeExpr::SelfType
         | TypeExpr::Parameter(_) => Err(LowerError::unsupported_type(UnsupportedType::StreamItem)),

--- a/boltffi_binding/src/lower/symbol.rs
+++ b/boltffi_binding/src/lower/symbol.rs
@@ -127,6 +127,16 @@ pub(super) fn function_symbol_name(function_id: &str) -> String {
     format!("{}_function_{}", FFI_PREFIX, symbol_path(function_id))
 }
 
+/// Builds the symbol foreign code links to read a constant whose value
+/// is delivered through an accessor rather than an inline literal.
+///
+/// Constants have no owning type, so the symbol carries only the `const`
+/// lane and the source id snake-cased, matching the convention the
+/// free-function lane uses.
+pub(super) fn constant_accessor_symbol_name(constant_id: &str) -> String {
+    format!("{}_const_{}", FFI_PREFIX, symbol_path(constant_id))
+}
+
 /// Builds the Rust-side symbol that installs a foreign-provided vtable.
 pub(super) fn callback_register_symbol_name(callback_id: &str) -> String {
     format!(
@@ -422,6 +432,14 @@ mod tests {
         assert_eq!(
             initializer_symbol_name(SymbolOwner::record("demo::Point"), "new"),
             "boltffi_init_record_demo_point_new"
+        );
+    }
+
+    #[test]
+    fn constant_accessor_symbol_name_uses_const_lane() {
+        assert_eq!(
+            constant_accessor_symbol_name("demo::MAGIC"),
+            "boltffi_const_demo_magic"
         );
     }
 

--- a/boltffi_binding/src/lower/types.rs
+++ b/boltffi_binding/src/lower/types.rs
@@ -38,7 +38,7 @@ pub(super) fn lower(ids: &DeclarationIds, type_expr: &TypeExpr) -> Result<TypeRe
             key: Box::new(lower(ids, key)?),
             value: Box::new(lower(ids, value)?),
         },
-        TypeExpr::Closure(_) => {
+        TypeExpr::Closure { .. } => {
             return Err(LowerError::unsupported_type(
                 UnsupportedType::ClosureInValuePosition,
             ));

--- a/boltffi_binding/src/lower/wasm_closure.rs
+++ b/boltffi_binding/src/lower/wasm_closure.rs
@@ -111,7 +111,7 @@ impl fmt::Display for ClosureTypeSignature<'_> {
             TypeExpr::Enum(id) => formatter.write_str(&source_type_signature(id.as_str())),
             TypeExpr::Class { id, .. } => formatter.write_str(&source_type_signature(id.as_str())),
             TypeExpr::Trait { id, .. } => formatter.write_str(&source_type_signature(id.as_str())),
-            TypeExpr::Closure(_) => formatter.write_str("Closure"),
+            TypeExpr::Closure { .. } => formatter.write_str("Closure"),
             TypeExpr::Custom(id) => formatter.write_str(&source_type_signature(id.as_str())),
             TypeExpr::SelfType => formatter.write_str("Self"),
             TypeExpr::Vec(inner) => write!(formatter, "Vec{}", ClosureTypeSignature(inner)),


### PR DESCRIPTION
The IR now distinguishes closure parameters from closure returns with separate enum variants, so a backend must handle each position explicitly. It also preserves closure presence (`Required` / `Nullable`) on the closure crossing itself.

examples: 

```rust
#[export]
impl Engine {
    // A nullable closure parameter.
    // IR: parameter closure crossing with presence = Nullable.
    pub fn install(&self, handler: Option<impl Fn(u32) -> u32>) {}

    // A closure returned from Rust.
    // IR: ReturnPlan::ClosureViaOutPointer.
    pub fn make_handler(&self) -> impl Fn(u32) -> u32 {
        |value| value + 1
    }

    // A nullable closure returned from Rust.
    // IR: ReturnPlan::ClosureViaOutPointer with presence = Nullable.
    pub fn maybe_handler(&self) -> Option<impl Fn(u32) -> u32> {
        Some(|value| value + 1)
    }

    // A fallible closure return.
    // IR: closure success uses the out-pointer lane, while the error
    // channel keeps the return slot.
    pub fn try_handler(&self) -> Result<impl Fn(u32) -> u32, String> {
        Ok(|value| value + 1)
    }
}
```

Callback trait methods get the same direction-safe closure modeling:

```rust
#[export]
pub trait Listener {
    // Rust passes a Rust-owned closure to foreign code.
    // IR: outgoing closure parameter with an exported invoke contract.
    fn accept_handler(&self, handler: impl Fn(u32));

    // Foreign code returns a foreign-owned closure back to Rust.
    // IR: closure return with an imported invoke contract.
    fn make_handler(&self) -> impl Fn(u32) -> u32;
}
```

Enum constants are also tightened so path constants only lower when they refer to the declared enum and a real unit variant:

```rust
#[export]
pub enum Mode {
    Fast,
    Slow,
}

// IR: DefaultValue::EnumVariant { enum_name: "Mode", variant_name: "Fast" }
#[export]
pub const DEFAULT_MODE: Mode = Mode::Fast;
```
