### PR TITLE
Support C# NuGet metadata

### DIFF
--- a/BOLTFFI_TOML_SPEC.md
+++ b/BOLTFFI_TOML_SPEC.md
@@ -405,6 +405,29 @@ Controls npm package generation in `boltffi pack wasm`.
   - `--no-build`: skips cross-host build toolchain validation and reuses existing artifacts from `target/{rust-target-triple}/{profile}/`.
   - For `win-x64` with `--no-build`, `{rust-target-triple}` defaults to `x86_64-pc-windows-msvc`; configure Cargo `build.target` to use another compatible Windows Rust target.
 
+### `[targets.csharp.nuget]` (optional)
+
+Controls NuGet metadata rendered into the generated `BoltFFI.CSharp.csproj` during `boltffi pack csharp`.
+
+- `title` (string, optional): NuGet `Title`.
+- `authors` (array of strings, optional): NuGet `Authors`, rendered as a semicolon-separated MSBuild value.
+- `owners` (array of strings, optional): MSBuild `Owners`, rendered as a semicolon-separated value.
+- `project_url` (string, optional): NuGet `PackageProjectUrl`.
+- `repository_url` (string, optional): NuGet `RepositoryUrl`.
+  - Default: `{package.repository}` or from `Cargo.toml`.
+- `repository_type` (string, optional): NuGet `RepositoryType`, for example `git`.
+- `license_expression` (string, optional): NuGet `PackageLicenseExpression`.
+  - Default: `{package.license}` or from `Cargo.toml`.
+- `icon` (path, optional): Source path to a package icon file.
+  - Renders `PackageIcon` using the file name and includes the file at the NuGet package root.
+- `readme` (path, optional): Source path to a package readme file.
+  - Renders `PackageReadmeFile` using the file name and includes the file at the NuGet package root.
+- `tags` (array of strings, optional): NuGet `PackageTags`, rendered as a semicolon-separated MSBuild value.
+- `release_notes` (string, optional): NuGet `PackageReleaseNotes`.
+- `require_license_acceptance` (bool, optional): NuGet `PackageRequireLicenseAcceptance`.
+
+`[package].description` continues to render as NuGet `Description` when set, and `targets.csharp.package_id` continues to render as NuGet `PackageId`.
+
 `boltffi pack csharp` rejects explicit Cargo `--target` passthrough args because the native asset matrix is controlled by `targets.csharp.runtime_identifiers`. Current-host packaging works on `osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`, and `win-x64`. When building native libraries, cross-host support follows the shared desktop toolchain support used by JVM packaging and unsupported host/target pairs fail during preflight.
 
 ## Apple SwiftPM layouts

--- a/boltffi_cli/src/config.rs
+++ b/boltffi_cli/src/config.rs
@@ -172,7 +172,25 @@ pub struct CSharpConfig {
     pub package_output: Option<PathBuf>,
     pub runtime_identifiers: Option<Vec<CSharpRuntimeIdentifier>>,
     #[serde(default)]
+    pub nuget: CSharpNugetConfig,
+    #[serde(default)]
     pub enabled: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct CSharpNugetConfig {
+    pub title: Option<String>,
+    pub authors: Option<Vec<String>>,
+    pub owners: Option<Vec<String>>,
+    pub project_url: Option<String>,
+    pub repository_url: Option<String>,
+    pub repository_type: Option<String>,
+    pub license_expression: Option<String>,
+    pub icon: Option<PathBuf>,
+    pub readme: Option<PathBuf>,
+    pub tags: Option<Vec<String>>,
+    pub release_notes: Option<String>,
+    pub require_license_acceptance: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -205,6 +223,7 @@ impl Default for CSharpConfig {
             target_framework: None,
             package_output: None,
             runtime_identifiers: None,
+            nuget: CSharpNugetConfig::default(),
             enabled: false,
         }
     }
@@ -903,6 +922,51 @@ impl Config {
                     "targets.csharp.target_framework must not be empty".to_string(),
                 ));
             }
+
+            validate_optional_non_empty_string(
+                self.targets.csharp.nuget.title.as_deref(),
+                "targets.csharp.nuget.title",
+            )?;
+            validate_optional_non_empty_string(
+                self.targets.csharp.nuget.project_url.as_deref(),
+                "targets.csharp.nuget.project_url",
+            )?;
+            validate_optional_non_empty_string(
+                self.targets.csharp.nuget.repository_url.as_deref(),
+                "targets.csharp.nuget.repository_url",
+            )?;
+            validate_optional_non_empty_string(
+                self.targets.csharp.nuget.repository_type.as_deref(),
+                "targets.csharp.nuget.repository_type",
+            )?;
+            validate_optional_non_empty_string(
+                self.targets.csharp.nuget.license_expression.as_deref(),
+                "targets.csharp.nuget.license_expression",
+            )?;
+            validate_optional_non_empty_path(
+                self.targets.csharp.nuget.icon.as_deref(),
+                "targets.csharp.nuget.icon",
+            )?;
+            validate_optional_non_empty_path(
+                self.targets.csharp.nuget.readme.as_deref(),
+                "targets.csharp.nuget.readme",
+            )?;
+            validate_optional_non_empty_string(
+                self.targets.csharp.nuget.release_notes.as_deref(),
+                "targets.csharp.nuget.release_notes",
+            )?;
+            validate_optional_non_empty_strings(
+                self.targets.csharp.nuget.authors.as_deref(),
+                "targets.csharp.nuget.authors",
+            )?;
+            validate_optional_non_empty_strings(
+                self.targets.csharp.nuget.owners.as_deref(),
+                "targets.csharp.nuget.owners",
+            )?;
+            validate_optional_non_empty_strings(
+                self.targets.csharp.nuget.tags.as_deref(),
+                "targets.csharp.nuget.tags",
+            )?;
         }
 
         Ok(())
@@ -1722,6 +1786,59 @@ where
                 canonical_name(*value)
             )));
         }
+    }
+
+    Ok(())
+}
+
+fn validate_optional_non_empty_string(
+    value: Option<&str>,
+    field_name: &str,
+) -> Result<(), ConfigError> {
+    if let Some(value) = value
+        && value.trim().is_empty()
+    {
+        return Err(ConfigError::Validation(format!(
+            "{field_name} must not be empty"
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_optional_non_empty_path(
+    value: Option<&Path>,
+    field_name: &str,
+) -> Result<(), ConfigError> {
+    if let Some(value) = value
+        && value.as_os_str().is_empty()
+    {
+        return Err(ConfigError::Validation(format!(
+            "{field_name} must not be empty"
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_optional_non_empty_strings(
+    values: Option<&[String]>,
+    field_name: &str,
+) -> Result<(), ConfigError> {
+    let Some(values) = values else {
+        return Ok(());
+    };
+
+    if values.is_empty() {
+        return Err(ConfigError::Validation(format!(
+            "{field_name} must be non-empty when provided"
+        )));
+    }
+
+    if values.iter().any(|value| value.trim().is_empty()) {
+        return Err(ConfigError::Validation(format!(
+            "{field_name} must not contain empty values"
+        )));
     }
 
     Ok(())
@@ -2943,6 +3060,70 @@ runtime_identifiers = ["current", "linux-x64"]
             ]
         );
         assert!(config.should_process(Target::CSharp, false));
+    }
+
+    #[test]
+    fn csharp_configuration_supports_nuget_metadata() {
+        let config = parse_config(
+            r#"
+[package]
+name = "my-lib"
+version = "1.2.3"
+description = "Shared runtime"
+license = "Apache-2.0"
+repository = "https://github.com/company/my-lib"
+
+[targets.csharp]
+enabled = true
+package_id = "Company.MyLib"
+
+[targets.csharp.nuget]
+title = "Company MyLib"
+authors = ["Company Name", "Runtime Team"]
+owners = ["Company Name"]
+project_url = "https://company.example/my-lib"
+repository_url = "https://github.com/company/my-lib-csharp"
+repository_type = "git"
+license_expression = "MIT"
+icon = "assets/icon.png"
+readme = "README.md"
+tags = ["ffi", "rust", "native"]
+release_notes = "Initial C# bindings package."
+require_license_acceptance = false
+"#,
+        );
+
+        let nuget = &config.targets.csharp.nuget;
+        assert_eq!(nuget.title.as_deref(), Some("Company MyLib"));
+        assert_eq!(
+            nuget.authors.as_deref(),
+            Some(["Company Name".to_string(), "Runtime Team".to_string()].as_slice())
+        );
+        assert_eq!(
+            nuget.owners.as_deref(),
+            Some(["Company Name".to_string()].as_slice())
+        );
+        assert_eq!(
+            nuget.project_url.as_deref(),
+            Some("https://company.example/my-lib")
+        );
+        assert_eq!(
+            nuget.repository_url.as_deref(),
+            Some("https://github.com/company/my-lib-csharp")
+        );
+        assert_eq!(nuget.repository_type.as_deref(), Some("git"));
+        assert_eq!(nuget.license_expression.as_deref(), Some("MIT"));
+        assert_eq!(nuget.icon.as_deref(), Some(Path::new("assets/icon.png")));
+        assert_eq!(nuget.readme.as_deref(), Some(Path::new("README.md")));
+        assert_eq!(
+            nuget.tags.as_deref(),
+            Some(["ffi".to_string(), "rust".to_string(), "native".to_string()].as_slice())
+        );
+        assert_eq!(
+            nuget.release_notes.as_deref(),
+            Some("Initial C# bindings package.")
+        );
+        assert_eq!(nuget.require_license_acceptance, Some(false));
     }
 
     #[test]

--- a/boltffi_cli/src/pack/csharp/mod.rs
+++ b/boltffi_cli/src/pack/csharp/mod.rs
@@ -442,45 +442,208 @@ fn sync_csharp_project(config: &Config, plan: &CSharpPackagingPlan) -> Result<()
 #[template(path = "BoltFFI.CSharp.csproj.xml", escape = "html")]
 struct CSharpProjectTemplate<'a> {
     target_framework: &'a str,
-    runtime_identifiers: &'a str,
+    runtime_identifiers: &'a [CSharpRuntimeIdentifier],
     package_id: &'a str,
     package_version: &'a str,
-    has_description: bool,
-    description: &'a str,
-    has_license: bool,
-    license: &'a str,
-    has_repository: bool,
-    repository: &'a str,
+    nuget: &'a CSharpNugetProjectMetadata,
+}
+
+#[derive(Default)]
+struct CSharpNugetProjectMetadata {
+    title: Option<String>,
+    authors: Option<Vec<String>>,
+    owners: Option<Vec<String>>,
+    description: Option<String>,
+    package_project_url: Option<String>,
+    repository_url: Option<String>,
+    repository_type: Option<String>,
+    package_license_expression: Option<String>,
+    package_icon: Option<CSharpPackageFile>,
+    package_readme_file: Option<CSharpPackageFile>,
+    package_tags: Option<Vec<String>>,
+    package_release_notes: Option<String>,
+    package_require_license_acceptance: Option<bool>,
+}
+
+struct CSharpPackageFile {
+    include_path: PathBuf,
+    package_path: PathBuf,
+}
+
+impl CSharpNugetProjectMetadata {
+    fn from_config(config: &Config, plan: &CSharpPackagingPlan) -> Result<Self> {
+        let nuget = &config.targets.csharp.nuget;
+
+        Ok(Self {
+            title: nuget.title.clone(),
+            authors: nuget.authors.clone(),
+            owners: nuget.owners.clone(),
+            description: config.package.description.clone(),
+            package_project_url: nuget.project_url.clone(),
+            repository_url: nuget
+                .repository_url
+                .clone()
+                .or_else(|| config.package_repository()),
+            repository_type: nuget.repository_type.clone(),
+            package_license_expression: nuget
+                .license_expression
+                .clone()
+                .or_else(|| config.package_license()),
+            package_icon: nuget
+                .icon
+                .as_deref()
+                .map(|path| CSharpPackageFile::from_config_path(&plan.layout.root_directory, path))
+                .transpose()?,
+            package_readme_file: nuget
+                .readme
+                .as_deref()
+                .map(|path| CSharpPackageFile::from_config_path(&plan.layout.root_directory, path))
+                .transpose()?,
+            package_tags: nuget.tags.clone(),
+            package_release_notes: nuget.release_notes.clone(),
+            package_require_license_acceptance: nuget.require_license_acceptance,
+        })
+    }
+
+    fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    fn authors(&self) -> Option<&[String]> {
+        self.authors.as_deref()
+    }
+
+    fn owners(&self) -> Option<&[String]> {
+        self.owners.as_deref()
+    }
+
+    fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    fn package_project_url(&self) -> Option<&str> {
+        self.package_project_url.as_deref()
+    }
+
+    fn repository_url(&self) -> Option<&str> {
+        self.repository_url.as_deref()
+    }
+
+    fn repository_type(&self) -> Option<&str> {
+        self.repository_type.as_deref()
+    }
+
+    fn package_license_expression(&self) -> Option<&str> {
+        self.package_license_expression.as_deref()
+    }
+
+    fn package_icon(&self) -> Option<&CSharpPackageFile> {
+        self.package_icon.as_ref()
+    }
+
+    fn package_readme_file(&self) -> Option<&CSharpPackageFile> {
+        self.package_readme_file.as_ref()
+    }
+
+    fn package_tags(&self) -> Option<&[String]> {
+        self.package_tags.as_deref()
+    }
+
+    fn package_release_notes(&self) -> Option<&str> {
+        self.package_release_notes.as_deref()
+    }
+
+    fn package_require_license_acceptance(&self) -> Option<bool> {
+        self.package_require_license_acceptance
+    }
+}
+
+impl CSharpPackageFile {
+    fn from_config_path(project_root: &Path, configured_path: &Path) -> Result<Self> {
+        Ok(Self {
+            include_path: project_relative_config_path(project_root, configured_path)?,
+            package_path: package_file_name(configured_path)?,
+        })
+    }
+
+    fn include_path(&self) -> std::path::Display<'_> {
+        self.include_path.display()
+    }
+
+    fn package_path(&self) -> std::path::Display<'_> {
+        self.package_path.display()
+    }
 }
 
 fn render_csharp_project(config: &Config, plan: &CSharpPackagingPlan) -> Result<String> {
     let runtime_identifiers = plan
         .packaging_targets
         .iter()
-        .map(|target| target.runtime_identifier.canonical_name())
-        .collect::<Vec<_>>()
-        .join(";");
-    let description = config.package.description.as_deref().unwrap_or_default();
-    let license = config.package_license();
-    let repository = config.package_repository();
+        .map(|target| target.runtime_identifier)
+        .collect::<Vec<_>>();
+    let nuget = CSharpNugetProjectMetadata::from_config(config, plan)?;
 
     CSharpProjectTemplate {
         target_framework: &plan.target_framework,
         runtime_identifiers: &runtime_identifiers,
         package_id: &plan.package_id,
         package_version: &plan.package_version,
-        has_description: config.package.description.is_some(),
-        description,
-        has_license: license.is_some(),
-        license: license.as_deref().unwrap_or_default(),
-        has_repository: repository.is_some(),
-        repository: repository.as_deref().unwrap_or_default(),
+        nuget: &nuget,
     }
     .render()
     .map_err(|source| CliError::CommandFailed {
         command: format!("render C# project template: {source}"),
         status: None,
     })
+}
+
+fn package_file_name(path: &Path) -> Result<PathBuf> {
+    path.file_name()
+        .map(PathBuf::from)
+        .ok_or_else(|| CliError::CommandFailed {
+            command: "C# NuGet package files must include a file name".to_string(),
+            status: None,
+        })
+}
+
+fn project_relative_config_path(project_root: &Path, configured_path: &Path) -> Result<PathBuf> {
+    let current_dir = std::env::current_dir().map_err(|source| CliError::CommandFailed {
+        command: format!("current_dir: {source}"),
+        status: None,
+    })?;
+    let from_dir = absolute_from_current_dir(&current_dir, project_root);
+    let to_path = absolute_from_current_dir(&current_dir, configured_path);
+
+    Ok(relative_path(&from_dir, &to_path))
+}
+
+fn absolute_from_current_dir(current_dir: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        current_dir.join(path)
+    }
+}
+
+fn relative_path(from_dir: &Path, to_path: &Path) -> PathBuf {
+    if from_dir == Path::new(".") || from_dir == Path::new("") {
+        return to_path.to_path_buf();
+    }
+
+    let from_components = from_dir.components().collect::<Vec<_>>();
+    let to_components = to_path.components().collect::<Vec<_>>();
+
+    let common_len = from_components
+        .iter()
+        .zip(to_components.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let parent_count = from_components.len().saturating_sub(common_len);
+    let parent_prefix = (0..parent_count).map(|_| std::path::Component::ParentDir);
+    let suffix = to_components.iter().skip(common_len).copied();
+
+    parent_prefix.chain(suffix).collect()
 }
 
 fn dotnet_pack(plan: &CSharpPackagingPlan, step: &Step) -> Result<PathBuf> {
@@ -544,7 +707,9 @@ mod tests {
     use crate::cargo::{Cargo, CargoCrateType};
     use crate::cli::CliError;
     use crate::commands::pack::{PackCSharpOptions, PackExecutionOptions};
-    use crate::config::{CSharpConfig, CargoConfig, Config, PackageConfig, TargetsConfig};
+    use crate::config::{
+        CSharpConfig, CSharpNugetConfig, CargoConfig, Config, PackageConfig, TargetsConfig,
+    };
     use crate::reporter::{Reporter, Verbosity};
     use crate::target::{CSharpRuntimeIdentifier, NativeHostPlatform};
     use std::path::{Path, PathBuf};
@@ -669,6 +834,23 @@ mod tests {
         ]
     }
 
+    fn csharp_packaging_plan(root_directory: PathBuf) -> CSharpPackagingPlan {
+        CSharpPackagingPlan {
+            package_id: "Demo.Runtime".to_string(),
+            package_version: "1.2.3".to_string(),
+            target_framework: "net10.0".to_string(),
+            artifact_name: "demo".to_string(),
+            source_directory: PathBuf::from("/tmp/demo"),
+            layout: CSharpPackageLayout {
+                source_directory: root_directory.join("src"),
+                package_output: root_directory.join("packages"),
+                project_path: root_directory.join("BoltFFI.CSharp.csproj"),
+                root_directory,
+            },
+            packaging_targets: Vec::new(),
+        }
+    }
+
     fn unsupported_csharp_runtime_identifier() -> CSharpRuntimeIdentifier {
         match NativeHostPlatform::current().expect("supported host for C# packaging tests") {
             NativeHostPlatform::WindowsX86_64 => CSharpRuntimeIdentifier::OsxArm64,
@@ -741,20 +923,7 @@ mod tests {
 
     #[test]
     fn csharp_project_includes_packable_native_assets() {
-        let plan = CSharpPackagingPlan {
-            package_id: "Demo.Runtime".to_string(),
-            package_version: "1.2.3".to_string(),
-            target_framework: "net10.0".to_string(),
-            artifact_name: "demo".to_string(),
-            source_directory: PathBuf::from("/tmp/demo"),
-            layout: CSharpPackageLayout {
-                root_directory: PathBuf::from("/tmp/dist/csharp"),
-                source_directory: PathBuf::from("/tmp/dist/csharp/src"),
-                package_output: PathBuf::from("/tmp/dist/csharp/packages"),
-                project_path: PathBuf::from("/tmp/dist/csharp/BoltFFI.CSharp.csproj"),
-            },
-            packaging_targets: Vec::new(),
-        };
+        let plan = csharp_packaging_plan(PathBuf::from("/tmp/dist/csharp"));
 
         let project = render_csharp_project(&config(), &plan).expect("C# project should render");
 
@@ -770,7 +939,75 @@ mod tests {
             )
         );
         assert!(project.contains("<Description>Demo &#60;runtime&#62;</Description>"));
+        assert!(project.contains("<PackageLicenseExpression>MIT</PackageLicenseExpression>"));
         assert!(project.contains("<RepositoryUrl>https://example.com/demo</RepositoryUrl>"));
+    }
+
+    #[test]
+    fn csharp_project_renders_configured_nuget_metadata() {
+        let mut config = config();
+        config.package.license = Some("Apache-2.0".to_string());
+        config.package.repository = Some("https://example.com/default".to_string());
+        config.targets.csharp.nuget = CSharpNugetConfig {
+            title: Some("Company MyLib".to_string()),
+            authors: Some(vec!["Company Name".to_string(), "Runtime Team".to_string()]),
+            owners: Some(vec!["Company Name".to_string()]),
+            project_url: Some("https://company.example/my-lib".to_string()),
+            repository_url: Some("https://github.com/company/my-lib".to_string()),
+            repository_type: Some("git".to_string()),
+            license_expression: Some("MIT".to_string()),
+            icon: Some(PathBuf::from("assets/icon.png")),
+            readme: Some(PathBuf::from("docs/README.md")),
+            tags: Some(vec![
+                "ffi".to_string(),
+                "rust".to_string(),
+                "native".to_string(),
+            ]),
+            release_notes: Some("Initial C# bindings package.".to_string()),
+            require_license_acceptance: Some(false),
+        };
+        let plan = csharp_packaging_plan(PathBuf::from("dist/csharp"));
+
+        let project = render_csharp_project(&config, &plan).expect("C# project should render");
+
+        assert!(project.contains("<Title>Company MyLib</Title>"));
+        assert!(project.contains("<Authors>Company Name;Runtime Team</Authors>"));
+        assert!(project.contains("<Owners>Company Name</Owners>"));
+        assert!(project.contains("<Description>Demo &#60;runtime&#62;</Description>"));
+        assert!(
+            project
+                .contains("<PackageProjectUrl>https://company.example/my-lib</PackageProjectUrl>")
+        );
+        assert!(
+            project.contains("<RepositoryUrl>https://github.com/company/my-lib</RepositoryUrl>")
+        );
+        assert!(project.contains("<RepositoryType>git</RepositoryType>"));
+        assert!(project.contains("<PackageLicenseExpression>MIT</PackageLicenseExpression>"));
+        assert!(project.contains("<PackageIcon>icon.png</PackageIcon>"));
+        assert!(project.contains("<PackageReadmeFile>README.md</PackageReadmeFile>"));
+        assert!(project.contains("<PackageTags>ffi;rust;native</PackageTags>"));
+        assert!(
+            project.contains(
+                "<PackageReleaseNotes>Initial C# bindings package.</PackageReleaseNotes>"
+            )
+        );
+        assert!(
+            project.contains(
+                "<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>"
+            )
+        );
+        assert!(
+            project
+                .contains(r#"<None Include="../../assets/icon.png" Pack="true" PackagePath="" />"#)
+        );
+        assert!(
+            project
+                .contains(r#"<None Include="../../docs/README.md" Pack="true" PackagePath="" />"#)
+        );
+        assert!(!project.contains("https://example.com/default"));
+        assert!(
+            !project.contains("<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>")
+        );
     }
 
     #[test]

--- a/boltffi_cli/templates/BoltFFI.CSharp.csproj.xml
+++ b/boltffi_cli/templates/BoltFFI.CSharp.csproj.xml
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>{{ target_framework }}</TargetFramework>
-    <RuntimeIdentifiers>{{ runtime_identifiers }}</RuntimeIdentifiers>
+    <RuntimeIdentifiers>{% for runtime_identifier in runtime_identifiers %}{{ runtime_identifier.canonical_name() }}{% if !loop.last %};{% endif %}{% endfor %}</RuntimeIdentifiers>
     <PackageId>{{ package_id }}</PackageId>
     <Version>{{ package_version }}</Version>
     <Nullable>enable</Nullable>
@@ -10,14 +10,27 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ImplicitUsings>disable</ImplicitUsings>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-{% if has_description %}    <Description>{{ description }}</Description>
-{% endif %}{% if has_license %}    <PackageLicenseExpression>{{ license }}</PackageLicenseExpression>
-{% endif %}{% if has_repository %}    <RepositoryUrl>{{ repository }}</RepositoryUrl>
+{% if let Some(title) = nuget.title() %}    <Title>{{ title }}</Title>
+{% endif %}{% if let Some(authors) = nuget.authors() %}    <Authors>{% for author in authors %}{{ author }}{% if !loop.last %};{% endif %}{% endfor %}</Authors>
+{% endif %}{% if let Some(owners) = nuget.owners() %}    <Owners>{% for owner in owners %}{{ owner }}{% if !loop.last %};{% endif %}{% endfor %}</Owners>
+{% endif %}{% if let Some(description) = nuget.description() %}    <Description>{{ description }}</Description>
+{% endif %}{% if let Some(package_project_url) = nuget.package_project_url() %}    <PackageProjectUrl>{{ package_project_url }}</PackageProjectUrl>
+{% endif %}{% if let Some(repository_url) = nuget.repository_url() %}    <RepositoryUrl>{{ repository_url }}</RepositoryUrl>
+{% endif %}{% if let Some(repository_type) = nuget.repository_type() %}    <RepositoryType>{{ repository_type }}</RepositoryType>
+{% endif %}{% if let Some(package_license_expression) = nuget.package_license_expression() %}    <PackageLicenseExpression>{{ package_license_expression }}</PackageLicenseExpression>
+{% endif %}{% if let Some(package_icon) = nuget.package_icon() %}    <PackageIcon>{{ package_icon.package_path() }}</PackageIcon>
+{% endif %}{% if let Some(package_readme_file) = nuget.package_readme_file() %}    <PackageReadmeFile>{{ package_readme_file.package_path() }}</PackageReadmeFile>
+{% endif %}{% if let Some(package_tags) = nuget.package_tags() %}    <PackageTags>{% for tag in package_tags %}{{ tag }}{% if !loop.last %};{% endif %}{% endfor %}</PackageTags>
+{% endif %}{% if let Some(package_release_notes) = nuget.package_release_notes() %}    <PackageReleaseNotes>{{ package_release_notes }}</PackageReleaseNotes>
+{% endif %}{% if let Some(package_require_license_acceptance) = nuget.package_require_license_acceptance() %}    <PackageRequireLicenseAcceptance>{{ package_require_license_acceptance }}</PackageRequireLicenseAcceptance>
 {% endif %}  </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="src/**/*.cs" />
     <None Include="runtimes/**/*" Pack="true" PackagePath="%(Identity)" />
+{% if let Some(package_icon) = nuget.package_icon() %}    <None Include="{{ package_icon.include_path() }}" Pack="true" PackagePath="" />
+{% endif %}{% if let Some(package_readme_file) = nuget.package_readme_file() %}    <None Include="{{ package_readme_file.include_path() }}" Pack="true" PackagePath="" />
+{% endif %}
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This closes #379.

It adds a typed `[targets.csharp.nuget]` table and threads those values into the generated C# package project. The existing package-level metadata still feeds the NuGet defaults when a more specific C# override is not set.

The C# project renderer now has a small typed metadata shape that the template renders into MSBuild properties for package title, authors, owners, project and repository metadata, license expression, tags, release notes, and license acceptance. It also packs configured icon and readme files at the NuGet package root so the generated `PackageIcon` and `PackageReadmeFile` values point at real package contents.

I also updated the TOML spec and added config parsing plus project rendering coverage for the new metadata table.
