### PR TITLE
Fix C# fallible class constructors

### DIFF
--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -3301,6 +3301,16 @@ mod tests {
             "public static Inventory WithCapacity(uint capacity)",
             "demo Inventory's `pub fn with_capacity(u32)` lifts to a static factory",
         );
+        assert_source_contains(
+            &inventory.source,
+            "public static Inventory TryNew(uint capacity)",
+            "demo Inventory's fallible `pub fn try_new(u32)` lifts to a static factory",
+        );
+        assert_source_contains(
+            &inventory.source,
+            "if (_handle == IntPtr.Zero) throw new BoltException(NativeMethods.TakeLastErrorMessage(\"Factory constructor failed\"));",
+            "fallible class constructors check for the null handle returned by Rust Err and throw the last error message",
+        );
 
         let counter = output
             .files
@@ -3373,6 +3383,21 @@ mod tests {
             &main.source,
             "internal static extern IntPtr InventoryWithCapacity(uint capacity);",
             "Inventory's named-init constructor takes its explicit param through DllImport",
+        );
+        assert_source_contains(
+            &main.source,
+            r#"[DllImport(LibName, EntryPoint = "boltffi_inventory_try_new")]"#,
+            "demo crate emit registers Inventory's fallible constructor DllImport",
+        );
+        assert_source_contains(
+            &main.source,
+            "internal static extern IntPtr InventoryTryNew(uint capacity);",
+            "Inventory's fallible constructor returns an IntPtr handle through DllImport",
+        );
+        assert_source_contains(
+            &main.source,
+            r#"[DllImport(LibName, EntryPoint = "boltffi_last_error_message")]"#,
+            "fallible constructors read the native last-error message before throwing",
         );
         assert_source_contains(
             &main.source,

--- a/boltffi_bindgen/src/render/csharp/lower/classes.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/classes.rs
@@ -39,10 +39,11 @@ impl<'a> CSharpLowerer<'a> {
     }
 
     /// Walks `class.constructors` and produces the corresponding
-    /// [`CSharpConstructorPlan`]s. Fallible (`Result<Self, _>`) and
-    /// optional (`Option<Self>`) constructors are dropped silently;
-    /// the C# backend doesn't model failure paths yet, matching how
-    /// enum constructor lowering handles them.
+    /// [`CSharpConstructorPlan`]s. Fallible (`Result<Self, _>`)
+    /// constructors are kept so the renderer can null-check the
+    /// returned handle; optional (`Option<Self>`) constructors are
+    /// still skipped because the C# class surface doesn't model
+    /// nullable construction yet.
     fn lower_class_constructors(
         &self,
         class: &ClassDef,
@@ -52,7 +53,7 @@ impl<'a> CSharpLowerer<'a> {
             .constructors
             .iter()
             .enumerate()
-            .filter(|(_, ctor)| !ctor.is_fallible() && !ctor.is_optional())
+            .filter(|(_, ctor)| !ctor.is_optional())
             .filter_map(|(index, ctor)| {
                 let call = self.abi.calls.iter().find(|c| {
                     c.id == CallId::Constructor {
@@ -111,6 +112,7 @@ impl<'a> CSharpLowerer<'a> {
             kind,
             native_method_name,
             ffi_name: (&call.symbol).into(),
+            is_fallible: ctor.is_fallible(),
             params,
             wire_writers,
         })

--- a/boltffi_bindgen/src/render/csharp/plan/class.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/class.rs
@@ -88,6 +88,10 @@ pub struct CSharpConstructorPlan {
     pub native_method_name: CSharpMethodName,
     /// The C function this constructor calls across the ABI.
     pub ffi_name: CFunctionName,
+    /// Whether the Rust constructor returns `Result<Self, _>`. The
+    /// generated FFI export returns a null handle on Err, so C# checks
+    /// the handle and throws instead of adopting it.
+    pub is_fallible: bool,
     /// Explicit params on the public surface.
     pub params: Vec<CSharpParamPlan>,
     /// For each non-blittable record / data-enum / option / nested-vec
@@ -184,11 +188,20 @@ impl CSharpClassPlan {
             || self.methods.iter().any(|m| !m.wire_writers.is_empty())
     }
 
-    /// Whether any method returns `Result<_, _>`. Used by the
-    /// module-level predicate that decides whether to emit the runtime
-    /// `BoltException` class.
+    pub fn has_fallible_constructors(&self) -> bool {
+        self.constructors.iter().any(|c| c.is_fallible)
+    }
+
+    /// Whether any method returns `Result<_, _>`.
     pub fn has_throwing_methods(&self) -> bool {
         self.methods.iter().any(|m| m.return_kind.is_result())
+    }
+
+    /// Whether any class member can throw the runtime `BoltException`.
+    /// Fallible constructors throw when the native side returns a null
+    /// handle; methods throw when they decode a non-typed `Result` Err.
+    pub fn has_throwing_members(&self) -> bool {
+        self.has_fallible_constructors() || self.has_throwing_methods()
     }
 
     pub fn has_async_methods(&self) -> bool {
@@ -225,15 +238,36 @@ mod tests {
         CSharpExpression::Identity(CSharpIdentity::Local(CSharpLocalName::new("placeholder")))
     }
 
-    fn class_with_methods(methods: Vec<CSharpMethodPlan>) -> CSharpClassPlan {
+    fn class_with_members(
+        constructors: Vec<CSharpConstructorPlan>,
+        methods: Vec<CSharpMethodPlan>,
+    ) -> CSharpClassPlan {
         CSharpClassPlan {
             summary_doc: None,
             class_name: CSharpClassName::from_source("counter"),
             ffi_free: CFunctionName::new("boltffi_counter_free".to_string()),
             native_free_method_name: CSharpMethodName::from_source("CounterFree"),
-            constructors: vec![],
+            constructors,
             methods,
             streams: vec![],
+        }
+    }
+
+    fn class_with_methods(methods: Vec<CSharpMethodPlan>) -> CSharpClassPlan {
+        class_with_members(vec![], methods)
+    }
+
+    fn constructor_with_fallibility(is_fallible: bool) -> CSharpConstructorPlan {
+        CSharpConstructorPlan {
+            summary_doc: None,
+            kind: CSharpConstructorKind::Primary {
+                helper_method_name: CSharpMethodName::from_source("counter_new_handle"),
+            },
+            native_method_name: CSharpMethodName::from_source("CounterNew"),
+            ffi_name: CFunctionName::new("boltffi_counter_new".to_string()),
+            is_fallible,
+            params: vec![],
+            wire_writers: vec![],
         }
     }
 
@@ -278,5 +312,20 @@ mod tests {
             method_with_return_kind(CSharpReturnKind::WireDecodeString),
         ]);
         assert!(!class.has_throwing_methods());
+    }
+
+    #[test]
+    fn has_throwing_members_is_true_when_a_constructor_is_fallible() {
+        let class = class_with_members(vec![constructor_with_fallibility(true)], vec![]);
+        assert!(class.has_throwing_members());
+    }
+
+    #[test]
+    fn has_throwing_members_is_false_when_constructors_and_methods_cannot_throw() {
+        let class = class_with_members(
+            vec![constructor_with_fallibility(false)],
+            vec![method_with_return_kind(CSharpReturnKind::Direct)],
+        );
+        assert!(!class.has_throwing_members());
     }
 }

--- a/boltffi_bindgen/src/render/csharp/plan/module.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/module.rs
@@ -126,7 +126,13 @@ impl CSharpModulePlan {
     }
 
     pub fn needs_ffi_status(&self) -> bool {
-        self.has_async() || self.needs_callback_runtime()
+        self.has_async() || self.needs_callback_runtime() || self.needs_last_error()
+    }
+
+    pub fn needs_last_error(&self) -> bool {
+        self.classes
+            .iter()
+            .any(CSharpClassPlan::has_fallible_constructors)
     }
 
     /// Whether the module needs `using System.Text;`. True when any function
@@ -223,13 +229,6 @@ impl CSharpModulePlan {
                 .any(|closure| closure.needs_wire_writer)
     }
 
-    /// Whether the runtime `BoltException` class is emitted. True when
-    /// any throwing function or method in the module ends up calling
-    /// `new BoltException(...)` — i.e., any `Result<_, _>` whose Err
-    /// type isn't a typed `#[error]` enum or record. Mirrors the
-    /// Kotlin/Swift/Dart pattern of a generated runtime FFI exception
-    /// type; Java reuses the built-in `RuntimeException` instead and
-    /// has no equivalent.
     /// Whether the module references `std::time::Duration`. Gates the
     /// `WireReader.ReadDuration` / `WireWriter.WriteDuration` helpers in
     /// the runtime template — modules that don't take or return a
@@ -256,12 +255,19 @@ impl CSharpModulePlan {
         self.builtins.uses_url()
     }
 
+    /// Whether the runtime `BoltException` class is emitted. True when
+    /// any throwing function, method, or fallible class constructor in
+    /// the module ends up calling `new BoltException(...)` — i.e., any
+    /// `Result<_, _>` whose Err type isn't a typed `#[error]` enum or
+    /// record. Mirrors the Kotlin/Swift/Dart pattern of a generated
+    /// runtime FFI exception type; Java reuses the built-in
+    /// `RuntimeException` instead and has no equivalent.
     pub fn needs_bolt_exception(&self) -> bool {
         self.functions.iter().any(|f| f.return_kind.is_result())
             || self
                 .classes
                 .iter()
-                .any(CSharpClassPlan::has_throwing_methods)
+                .any(CSharpClassPlan::has_throwing_members)
             || self
                 .records
                 .iter()
@@ -276,8 +282,8 @@ mod tests {
         CSharpExpression, CSharpIdentity, CSharpLocalName, CSharpMethodName, CSharpType,
     };
     use super::super::{
-        CFunctionName, CSharpEnumKind, CSharpFunctionPlan, CSharpMethodPlan, CSharpReceiver,
-        CSharpReturnKind,
+        CFunctionName, CSharpConstructorKind, CSharpConstructorPlan, CSharpEnumKind,
+        CSharpFunctionPlan, CSharpMethodPlan, CSharpReceiver, CSharpReturnKind,
     };
     use super::*;
 
@@ -348,6 +354,32 @@ mod tests {
         }
     }
 
+    fn fallible_constructor_plan() -> CSharpConstructorPlan {
+        CSharpConstructorPlan {
+            summary_doc: None,
+            kind: CSharpConstructorKind::StaticFactory {
+                name: CSharpMethodName::from_source("try_new"),
+            },
+            native_method_name: CSharpMethodName::from_source("CounterTryNew"),
+            ffi_name: CFunctionName::new("boltffi_counter_try_new".to_string()),
+            is_fallible: true,
+            params: vec![],
+            wire_writers: vec![],
+        }
+    }
+
+    fn fallible_constructor_class_plan() -> CSharpClassPlan {
+        CSharpClassPlan {
+            summary_doc: None,
+            class_name: CSharpClassName::from_source("counter"),
+            ffi_free: CFunctionName::new("boltffi_counter_free".to_string()),
+            native_free_method_name: CSharpMethodName::from_source("CounterFree"),
+            constructors: vec![fallible_constructor_plan()],
+            methods: vec![],
+            streams: vec![],
+        }
+    }
+
     fn throwing_record_plan() -> CSharpRecordPlan {
         CSharpRecordPlan {
             summary_doc: None,
@@ -401,6 +433,24 @@ mod tests {
         let mut module = empty_module();
         module.classes.push(throwing_class_plan());
         assert!(module.needs_bolt_exception());
+    }
+
+    /// A fallible class constructor throws `BoltException` when the
+    /// native export returns a null handle, so the runtime exception
+    /// class must be emitted even if no method returns `Result`.
+    #[test]
+    fn needs_bolt_exception_is_true_when_a_class_constructor_is_fallible() {
+        let mut module = empty_module();
+        module.classes.push(fallible_constructor_class_plan());
+        assert!(module.needs_bolt_exception());
+    }
+
+    #[test]
+    fn needs_last_error_is_true_when_a_class_constructor_is_fallible() {
+        let mut module = empty_module();
+        module.classes.push(fallible_constructor_class_plan());
+        assert!(module.needs_last_error());
+        assert!(module.needs_ffi_status());
     }
 
     /// A record method that returns `Result<_, _>` flips the predicate

--- a/boltffi_bindgen/src/render/csharp/templates.rs
+++ b/boltffi_bindgen/src/render/csharp/templates.rs
@@ -1428,6 +1428,7 @@ mod tests {
                 &CSharpMethodName::new("New"),
             ),
             ffi_name: CFunctionName::new("boltffi_inventory_new".to_string()),
+            is_fallible: false,
             params: vec![],
             wire_writers: vec![],
         };
@@ -1442,6 +1443,7 @@ mod tests {
                 &with_capacity_name,
             ),
             ffi_name: CFunctionName::new("boltffi_inventory_with_capacity".to_string()),
+            is_fallible: false,
             params: vec![CSharpParamPlan {
                 name: CSharpParamName::from_source("capacity"),
                 csharp_type: CSharpType::UInt,
@@ -1729,6 +1731,7 @@ mod tests {
                 &CSharpMethodName::new("New"),
             ),
             ffi_name: CFunctionName::new("boltffi_counter_new".to_string()),
+            is_fallible: false,
             params: vec![],
             wire_writers: vec![],
         };

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/class.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/class.txt
@@ -61,7 +61,13 @@ namespace {{ namespace }}
 {%- when _ %}
 {%- endmatch %}
 {%- endfor %}
+{%- if ctor.is_fallible %}
+                IntPtr _handle = NativeMethods.{{ ctor.native_method_name }}({{ ctor.native_call_args() }});
+                if (_handle == IntPtr.Zero) throw new BoltException(NativeMethods.TakeLastErrorMessage("Constructor failed"));
+                return _handle;
+{%- else %}
                 return NativeMethods.{{ ctor.native_method_name }}({{ ctor.native_call_args() }});
+{%- endif %}
 {%- for param in ctor.params %}
 {%- if param.is_pinned() %}
                 }
@@ -69,7 +75,13 @@ namespace {{ namespace }}
 {%- endfor %}
             }
 {%- else %}
+{%- if ctor.is_fallible %}
+            IntPtr _handle = NativeMethods.{{ ctor.native_method_name }}({{ ctor.native_call_args() }});
+            if (_handle == IntPtr.Zero) throw new BoltException(NativeMethods.TakeLastErrorMessage("Constructor failed"));
+            return _handle;
+{%- else %}
             return NativeMethods.{{ ctor.native_method_name }}({{ ctor.native_call_args() }});
+{%- endif %}
 {%- endif %}
         }
 {%- when CSharpConstructorKind::StaticFactory with { name } %}
@@ -99,7 +111,13 @@ namespace {{ namespace }}
 {%- when _ %}
 {%- endmatch %}
 {%- endfor %}
+{%- if ctor.is_fallible %}
+                IntPtr _handle = NativeMethods.{{ ctor.native_method_name }}({{ ctor.native_call_args() }});
+                if (_handle == IntPtr.Zero) throw new BoltException(NativeMethods.TakeLastErrorMessage("Factory constructor failed"));
+                return new {{ class.class_name }}(_handle);
+{%- else %}
                 return new {{ class.class_name }}(NativeMethods.{{ ctor.native_method_name }}({{ ctor.native_call_args() }}));
+{%- endif %}
 {%- for param in ctor.params %}
 {%- if param.is_pinned() %}
                 }
@@ -107,7 +125,13 @@ namespace {{ namespace }}
 {%- endfor %}
             }
 {%- else %}
+{%- if ctor.is_fallible %}
+            IntPtr _handle = NativeMethods.{{ ctor.native_method_name }}({{ ctor.native_call_args() }});
+            if (_handle == IntPtr.Zero) throw new BoltException(NativeMethods.TakeLastErrorMessage("Factory constructor failed"));
+            return new {{ class.class_name }}(_handle);
+{%- else %}
             return new {{ class.class_name }}(NativeMethods.{{ ctor.native_method_name }}({{ ctor.native_call_args() }}));
+{%- endif %}
 {%- endif %}
         }
 {%- endmatch %}

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
@@ -6,6 +6,16 @@
     }
 
 {% endif %}
+{%- if module.needs_last_error() %}
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FfiString
+    {
+        public IntPtr ptr;
+        public UIntPtr len;
+        public UIntPtr cap;
+    }
+
+{% endif %}
 {%- if module.needs_ffi_buf() %}
     [StructLayout(LayoutKind.Sequential)]
     internal struct FfiBuf
@@ -589,11 +599,11 @@
 {% endif %}
 {%- if module.needs_bolt_exception() %}
     /// <summary>
-    /// Thrown by generated wrapper methods when a Rust <c>Result</c>
-    /// returns an <c>Err</c> whose payload isn't a typed
-    /// <c>#[error]</c> enum or record. The message is the underlying
-    /// error rendered as a string. Catch this to handle plain
-    /// <c>Result&lt;_, String&gt;</c> errors and untyped <c>Err</c>
+    /// Thrown by generated wrapper methods and fallible constructors
+    /// when a Rust <c>Result</c> returns an <c>Err</c> whose payload
+    /// isn't a typed <c>#[error]</c> enum or record. The message is the
+    /// underlying error rendered as a string. Catch this to handle
+    /// plain <c>Result&lt;_, String&gt;</c> errors and untyped <c>Err</c>
     /// payloads; catch a typed <c>&lt;Name&gt;Exception</c> instead
     /// when the Rust side declared an <c>#[error]</c> type.
     /// </summary>
@@ -921,6 +931,30 @@
     internal static class NativeMethods
     {
         internal const string LibName = "{{ module.lib_name }}";
+{%- if module.needs_last_error() %}
+
+        [DllImport(LibName, EntryPoint = "boltffi_last_error_message")]
+        private static extern FfiStatus LastErrorMessage(out FfiString message);
+
+        [DllImport(LibName, EntryPoint = "boltffi_free_string")]
+        private static extern void FreeString(FfiString message);
+
+        internal static string TakeLastErrorMessage(string fallback)
+        {
+            FfiStatus status = LastErrorMessage(out FfiString message);
+            if (status.code != 0) return fallback;
+
+            try
+            {
+                if (message.ptr == IntPtr.Zero || message.len == UIntPtr.Zero) return fallback;
+                return Marshal.PtrToStringUTF8(message.ptr, checked((int)(nuint)message.len)) ?? fallback;
+            }
+            finally
+            {
+                FreeString(message);
+            }
+        }
+{%- endif %}
 {%- if module.needs_ffi_buf() %}
 
         [DllImport(LibName, EntryPoint = "{{ module.free_buf_ffi_name }}")]

--- a/examples/demo/src/classes/constructors.rs
+++ b/examples/demo/src/classes/constructors.rs
@@ -28,6 +28,26 @@ impl Inventory {
     }
 
     /// Creates an inventory, or fails if capacity is zero.
+    #[demo_bench_macros::demo_case(
+        "classes.constructors.inventory.try_new.should_return_inventory_for_positive_capacity",
+        justification = "Ensure a fallible class constructor returns an owned class handle through Result Ok.",
+        directions = "Call `classes::constructors::Inventory::try_new` through the generated binding with a positive capacity and assert it returns a usable Inventory instance.",
+        exclude(
+            python,
+            reason = ExclusionReason::ImplementationGap,
+            details = "Python is experimental; its lowerer does not currently emit class/object bindings. Include this case when Python class bindings are implemented."
+        )
+    )]
+    #[demo_bench_macros::demo_case(
+        "classes.constructors.inventory.try_new.should_reject_zero_capacity",
+        justification = "Ensure a fallible class constructor reports Result Err through the target language failure path.",
+        directions = "Call `classes::constructors::Inventory::try_new` through the generated binding with zero capacity and assert the target language observes the constructor failure.",
+        exclude(
+            python,
+            reason = ExclusionReason::ImplementationGap,
+            details = "Python is experimental; its lowerer does not currently emit class/object bindings. Include this case when Python class bindings are implemented."
+        )
+    )]
     pub fn try_new(capacity: u32) -> Result<Self, String> {
         if capacity == 0 {
             Err("capacity must be greater than zero".to_string())

--- a/examples/platforms/apple/Tests/DemoConsumerTests/classes/ConstructorsTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/classes/ConstructorsTests.swift
@@ -18,11 +18,12 @@ final class ConstructorsTests: DemoTestCase {
         XCTAssertEqual(smallInventory.add(item: "c"), false)
         XCTAssertEqual(smallInventory.getAll(), ["a", "b"])
 
+        demoCase("case:classes.constructors.inventory.try_new.should_return_inventory_for_positive_capacity")
         let tryInventory = try Inventory(tryNew: 1)
         XCTAssertEqual(tryInventory.capacity(), 1)
         XCTAssertEqual(tryInventory.add(item: "only"), true)
         XCTAssertEqual(tryInventory.add(item: "overflow"), false)
+        demoCase("case:classes.constructors.inventory.try_new.should_reject_zero_capacity")
         assertThrowsMessageContains("capacity must be greater than zero", try Inventory(tryNew: 0))
     }
 }
-

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -1789,6 +1789,24 @@ public static class DemoTest
             Require(!inv.Add("third"), "Add past capacity returns false");
         }
 
+        DemoCase("case:classes.constructors.inventory.try_new.should_return_inventory_for_positive_capacity");
+        using (var inv = Inventory.TryNew(1))
+        {
+            Require(inv.Capacity() == 1u, "Inventory.TryNew(1).Capacity()");
+            Require(inv.Count() == 0u, "Inventory.TryNew(1).Count() starts at 0");
+        }
+
+        DemoCase("case:classes.constructors.inventory.try_new.should_reject_zero_capacity");
+        try
+        {
+            using var unexpected = Inventory.TryNew(0);
+            Require(false, "Inventory.TryNew(0) should throw");
+        }
+        catch (BoltException e)
+        {
+            Require(e.Message.Contains("capacity must be greater than zero"), "Inventory.TryNew(0) error message");
+        }
+
         // Counter exercises every method-return shape that lands in
         // this PR: primitive direct, void mutator, Option<primitive>
         // through FfiBuf, and a blittable record return.

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -50,6 +50,7 @@ public final class DemoTest {
             testBlittableRecordVecs();
             testOptions();
             testRecordsWithVecs();
+            testInventoryConstructors();
             testConstructorCoverageMatrix();
             testClosures();
             testSyncCallbacks();
@@ -1466,6 +1467,27 @@ public final class DemoTest {
             record.shape(),
             record.parameters()
         ).equals(record) : "makeMixedRecord";
+
+        System.out.println("  PASS\n");
+    }
+
+    private static void testInventoryConstructors() {
+        System.out.println("Testing class constructors (Inventory)...");
+
+        demoCase("case:classes.constructors.inventory.try_new.should_return_inventory_for_positive_capacity");
+        try (Inventory inventory = Inventory.tryNew(1)) {
+            assert inventory.capacity() == 1 : "Inventory.tryNew(1).capacity";
+            assert inventory.count() == 0 : "Inventory.tryNew(1).count";
+            assert inventory.add("only") : "Inventory.tryNew(1).add only";
+            assert !inventory.add("overflow") : "Inventory.tryNew(1).add overflow";
+        }
+
+        demoCase("case:classes.constructors.inventory.try_new.should_reject_zero_capacity");
+        try (Inventory unexpected = Inventory.tryNew(0)) {
+            assert false : "Inventory.tryNew(0) should fail";
+        } catch (RuntimeException expected) {
+            assert expected.getMessage().contains("Factory constructor failed") : "Inventory.tryNew(0) error";
+        }
 
         System.out.println("  PASS\n");
     }

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoClassesAndStreamsTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoClassesAndStreamsTest.kt
@@ -32,12 +32,14 @@ class DemoClassesAndStreamsTest {
             assertEquals(listOf("a", "b"), inventory.getAll())
         }
 
+        demoCase("case:classes.constructors.inventory.try_new.should_return_inventory_for_positive_capacity")
         Inventory.tryNew(1u).use { inventory ->
             assertEquals(1u, inventory.capacity())
             assertEquals(true, inventory.add("only"))
             assertEquals(false, inventory.add("overflow"))
         }
 
+        demoCase("case:classes.constructors.inventory.try_new.should_reject_zero_capacity")
         assertMessageContains(assertFailsWith<FfiException> { Inventory.tryNew(0u) }, "capacity must be greater than zero")
 
         Counter(2).use { counter ->

--- a/examples/platforms/wasm/tests/classes/constructors.test.mjs
+++ b/examples/platforms/wasm/tests/classes/constructors.test.mjs
@@ -18,6 +18,7 @@ export async function run() {
   assertArrayEqual(fixedCapacityInventory.getAll(), ["a", "b"]);
   fixedCapacityInventory.dispose();
 
+  globalThis.demoCase("case:classes.constructors.inventory.try_new.should_return_inventory_for_positive_capacity");
   const tinyInventory = demo.Inventory.tryNew(1);
   assert.notEqual(tinyInventory, null);
   assert.equal(tinyInventory.capacity(), 1);
@@ -25,5 +26,6 @@ export async function run() {
   assert.equal(tinyInventory.add("overflow"), false);
   tinyInventory.dispose();
 
+  globalThis.demoCase("case:classes.constructors.inventory.try_new.should_reject_zero_capacity");
   assert.equal(demo.Inventory.tryNew(0), null);
 }


### PR DESCRIPTION
This closes #348.

It stops the C# class lowerer from filtering out fallible `Result<Self, _>` constructors, carries that fallibility through the constructor plan, and has the generated wrapper treat a null native handle as the constructor error path. The wrapper now throws `BoltException` instead of adopting the null handle, and it reads the Rust last-error message before freeing the returned FFI string so plain string errors surface in C# the same way they do for other generated Result wrappers.

The runtime predicates now account for fallible constructors when deciding whether to emit `BoltException`, `FfiStatus`, and the last-error helpers. Optional `Option<Self>` class constructors are still left unsupported for C# because that is a separate nullable-construction surface.

I also added demo catalogue cases for `Inventory::try_new` covering both the successful handle-return path and the rejected zero-capacity path. C#, Java, Swift, Kotlin, and WASM now mark those cases directly in their platform demos; Python remains excluded as an implementation gap because it still does not emit class/object bindings.