### PR TITLE
Fix Windows verbatim manifest paths passed to Cargo

### DIFF
--- a/boltffi_cli/Cargo.toml
+++ b/boltffi_cli/Cargo.toml
@@ -33,5 +33,8 @@ console = "0.16"
 indicatif = "0.18"
 object = "0.39"
 
+[target.'cfg(windows)'.dependencies]
+dunce = "1.0"
+
 [lints]
 workspace = true

--- a/boltffi_cli/src/cargo/args.rs
+++ b/boltffi_cli/src/cargo/args.rs
@@ -255,14 +255,22 @@ impl CargoArguments {
             working_directory.join(manifest_path)
         };
 
-        manifest_path
-            .canonicalize()
-            .map_err(|source| CliError::CommandFailed {
-                command: format!(
-                    "canonicalize manifest path {}: {source}",
-                    manifest_path.display()
-                ),
-                status: None,
-            })
+        canonicalize_manifest_path(&manifest_path).map_err(|source| CliError::CommandFailed {
+            command: format!(
+                "canonicalize manifest path {}: {source}",
+                manifest_path.display()
+            ),
+            status: None,
+        })
     }
+}
+
+#[cfg(windows)]
+fn canonicalize_manifest_path(path: &Path) -> std::io::Result<PathBuf> {
+    dunce::canonicalize(path)
+}
+
+#[cfg(not(windows))]
+fn canonicalize_manifest_path(path: &Path) -> std::io::Result<PathBuf> {
+    path.canonicalize()
 }

--- a/boltffi_cli/src/cargo/mod.rs
+++ b/boltffi_cli/src/cargo/mod.rs
@@ -160,7 +160,7 @@ impl Cargo {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use super::Cargo;
     use crate::cargo::fixture::{CargoMetadataFixture, CargoPackageFixture, CargoTargetFixture};
@@ -195,6 +195,25 @@ mod tests {
 
     fn metadata_fixture() -> CargoMetadataFixture {
         CargoMetadataFixture::new("/tmp/boltffi-target")
+    }
+
+    #[cfg(windows)]
+    fn expected_canonical_manifest_path() -> PathBuf {
+        dunce::canonicalize(
+            std::env::current_dir()
+                .expect("current dir")
+                .join("Cargo.toml"),
+        )
+        .expect("canonical manifest path")
+    }
+
+    #[cfg(not(windows))]
+    fn expected_canonical_manifest_path() -> PathBuf {
+        std::env::current_dir()
+            .expect("current dir")
+            .join("Cargo.toml")
+            .canonicalize()
+            .expect("canonical manifest path")
     }
 
     #[test]
@@ -245,11 +264,7 @@ mod tests {
 
     #[test]
     fn canonicalizes_manifest_path_from_split_cargo_args() {
-        let expected = std::env::current_dir()
-            .expect("current dir")
-            .join("Cargo.toml")
-            .canonicalize()
-            .expect("canonical manifest path");
+        let expected = expected_canonical_manifest_path();
 
         let manifest_path = cargo(&["--manifest-path", "Cargo.toml"])
             .manifest_path()
@@ -260,11 +275,7 @@ mod tests {
 
     #[test]
     fn canonicalizes_manifest_path_from_equals_cargo_arg() {
-        let expected = std::env::current_dir()
-            .expect("current dir")
-            .join("Cargo.toml")
-            .canonicalize()
-            .expect("canonical manifest path");
+        let expected = expected_canonical_manifest_path();
 
         let manifest_path = cargo(&["--manifest-path=Cargo.toml"])
             .manifest_path()
@@ -275,15 +286,32 @@ mod tests {
 
     #[test]
     fn canonicalizes_implicit_manifest_path() {
-        let expected = std::env::current_dir()
-            .expect("current dir")
-            .join("Cargo.toml")
-            .canonicalize()
-            .expect("canonical manifest path");
+        let expected = expected_canonical_manifest_path();
 
         let manifest_path = cargo(&[]).manifest_path().expect("manifest path");
 
         assert_eq!(manifest_path, expected);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn canonical_manifest_path_omits_windows_verbatim_prefix() {
+        use std::path::{Component, Prefix};
+
+        let manifest_path = cargo(&[]).manifest_path().expect("manifest path");
+        let has_verbatim_prefix = matches!(
+            manifest_path.components().next(),
+            Some(Component::Prefix(prefix)) if matches!(
+                prefix.kind(),
+                Prefix::Verbatim(_) | Prefix::VerbatimDisk(_) | Prefix::VerbatimUNC(_, _)
+            )
+        );
+
+        assert!(
+            !has_verbatim_prefix,
+            "{} should not use a Windows verbatim prefix",
+            manifest_path.display()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #383.

Found while fixing the Windows example build for Crux's BoltFFI migration. The Rust side is fine when Cargo is invoked directly, but `boltffi pack csharp` fails before compiling because the C# pack path feeds Cargo a Windows verbatim `\\?\...` manifest path.

With `boltffi -v pack csharp --release`, the failing command looked like this:

```text
Cargo build command: cargo build --target x86_64-pc-windows-msvc --manifest-path '\\?\D:\a\crux\crux\examples\counter\shared\Cargo.toml' -p shared --release
```

Cargo then mis-resolves workspace inheritance while loading the workspace, which collapses the non-verbose C# pack failure down to `build failed for targets: ["win-x64"]`.

This changes `CargoArguments::canonical_manifest_path` so Windows manifest paths are canonicalized with `dunce::canonicalize`, which strips the Windows verbatim prefix before the path is stored in pack contexts and passed back into Cargo subprocesses. Non-Windows targets continue to use `Path::canonicalize`, and `dunce` is a Windows-only dependency.

I also updated the manifest path tests so the expected canonical path matches the platform-specific behavior, and added a Windows-only assertion that `Cargo::manifest_path()` does not keep a verbatim prefix.

Validation:

- `cargo fmt --check`
- `git diff --check`
- `cargo test --offline -p boltffi_cli cargo::`
- `cargo test -p boltffi_cli`
- `cargo tree --offline -p boltffi_cli --target aarch64-apple-darwin --depth 1` shows no `dunce`
- `cargo tree --offline -p boltffi_cli --target x86_64-pc-windows-msvc --depth 1` includes `dunce v1.0.5`