### PR TITLE
Fix Java/C# records with Result fields

### DIFF
--- a/boltffi_bindgen/src/render/csharp/ast/code.rs
+++ b/boltffi_bindgen/src/render/csharp/ast/code.rs
@@ -141,6 +141,13 @@ pub(crate) enum CSharpExpression {
         type_args: Vec<CSharpType>,
         args: CSharpArgumentList,
     },
+    /// `{receiver}.{method}({arg0}, ...)` where the receiver is a
+    /// generic type expression such as `BoltFFIResult<T, E>`.
+    StaticMethodCall {
+        receiver: CSharpType,
+        method: CSharpMethodName,
+        args: CSharpArgumentList,
+    },
     /// `({target}){inner}`: a C-style cast.
     Cast {
         target: CSharpType,
@@ -206,6 +213,11 @@ impl fmt::Display for CSharpExpression {
                 }
                 write!(f, "({args})")
             }
+            Self::StaticMethodCall {
+                receiver,
+                method,
+                args,
+            } => write!(f, "{receiver}.{method}({args})"),
             Self::Cast { target, inner } => write!(f, "({target}){inner}"),
             Self::Binary { op, left, right } => write!(f, "{left} {op} {right}"),
             Self::Paren(inner) => write!(f, "({inner})"),

--- a/boltffi_bindgen/src/render/csharp/ast/type_shape.rs
+++ b/boltffi_bindgen/src/render/csharp/ast/type_shape.rs
@@ -62,6 +62,15 @@ pub(crate) enum CSharpType {
     Array(Box<CSharpType>),
     /// `T?`: a value or reference type that may be `null`.
     Nullable(Box<CSharpType>),
+    /// `BoltFFIResult<TOk, TErr>`: the public carrier for a nested
+    /// Rust `Result<T, E>` value, used when `Result` appears inside a
+    /// record field or data-enum payload rather than as a throwing
+    /// top-level return.
+    Result {
+        carrier: CSharpTypeReference,
+        ok: Box<CSharpType>,
+        err: Box<CSharpType>,
+    },
 }
 
 impl CSharpType {
@@ -80,6 +89,18 @@ impl CSharpType {
         match self {
             Self::String => true,
             Self::Array(inner) | Self::Nullable(inner) => inner.contains_string(),
+            Self::Result { ok, err, .. } => ok.contains_string() || err.contains_string(),
+            _ => false,
+        }
+    }
+
+    /// Whether this type contains a nested `BoltFFIResult<_, _>` carrier.
+    /// Used to emit the C# runtime helper only when the public surface
+    /// names it.
+    pub(crate) fn contains_result(&self) -> bool {
+        match self {
+            Self::Result { .. } => true,
+            Self::Array(inner) | Self::Nullable(inner) => inner.contains_result(),
             _ => false,
         }
     }
@@ -113,6 +134,11 @@ impl CSharpType {
             Self::Nullable(inner) => {
                 Self::Nullable(Box::new((*inner).qualify_if_shadowed(shadowed, namespace)))
             }
+            Self::Result { carrier, ok, err } => Self::Result {
+                carrier: carrier.qualify_if_shadowed(shadowed, namespace),
+                ok: Box::new((*ok).qualify_if_shadowed(shadowed, namespace)),
+                err: Box::new((*err).qualify_if_shadowed(shadowed, namespace)),
+            },
             other => other,
         }
     }
@@ -177,9 +203,18 @@ impl CSharpType {
                 Self::from_read_op(underlying.ops.first().expect("custom underlying read op"))
             }
             ReadOp::Builtin { id, .. } => Self::Builtin(id.clone()),
-            ReadOp::Result { .. } => {
-                todo!("CSharpType::from_read_op: {:?}", op)
-            }
+            ReadOp::Result { ok, err, .. } => Self::Result {
+                carrier: Self::boltffi_result_reference(),
+                ok: Box::new(Self::from_result_branch_read_seq(ok)),
+                err: Box::new(Self::from_result_branch_read_seq(err)),
+            },
+        }
+    }
+
+    fn from_result_branch_read_seq(seq: &crate::ir::ops::ReadSeq) -> Self {
+        match seq.ops.first() {
+            Some(op) => Self::from_read_op(op),
+            None => Self::boltffi_unit(),
         }
     }
 
@@ -203,11 +238,32 @@ impl CSharpType {
                 Self::DataEnum(class_name.into())
             }
             TypeExpr::Builtin(id) => Self::Builtin(id.clone()),
-            TypeExpr::Result { .. }
-            | TypeExpr::Callback(_)
-            | TypeExpr::Custom(_)
-            | TypeExpr::Handle(_) => todo!("CSharpType::from_type_expr: {:?}", expr),
+            TypeExpr::Result { ok, err } => Self::Result {
+                carrier: Self::boltffi_result_reference(),
+                ok: Box::new(Self::from_result_branch_type_expr(ok)),
+                err: Box::new(Self::from_result_branch_type_expr(err)),
+            },
+            TypeExpr::Callback(_) | TypeExpr::Custom(_) | TypeExpr::Handle(_) => {
+                todo!("CSharpType::from_type_expr: {:?}", expr)
+            }
         }
+    }
+
+    fn from_result_branch_type_expr(expr: &TypeExpr) -> Self {
+        match expr {
+            TypeExpr::Void => Self::boltffi_unit(),
+            other => Self::from_type_expr(other),
+        }
+    }
+
+    pub(crate) fn boltffi_unit() -> Self {
+        Self::Named(CSharpTypeReference::Plain(CSharpClassName::new(
+            "BoltFFIUnit",
+        )))
+    }
+
+    pub(crate) fn boltffi_result_reference() -> CSharpTypeReference {
+        CSharpTypeReference::Plain(CSharpClassName::new("BoltFFIResult"))
     }
 }
 
@@ -274,6 +330,7 @@ impl fmt::Display for CSharpType {
             Self::Record(r) | Self::CStyleEnum(r) | Self::DataEnum(r) | Self::Named(r) => r.fmt(f),
             Self::Array(inner) => write!(f, "{inner}[]"),
             Self::Nullable(inner) => write!(f, "{inner}?"),
+            Self::Result { carrier, ok, err } => write!(f, "{carrier}<{ok}, {err}>"),
         }
     }
 }
@@ -328,6 +385,23 @@ mod tests {
                 .qualify_if_shadowed(&shadowed, &namespace)
                 .to_string(),
             "global::Demo.WireReader"
+        );
+    }
+
+    #[test]
+    fn result_runtime_type_qualifies_when_shadowed() {
+        let shadowed: HashSet<CSharpClassName> =
+            std::iter::once(CSharpClassName::new("BoltFFIResult")).collect();
+        let namespace = CSharpNamespace::from_source("demo");
+        let ty = CSharpType::Result {
+            carrier: CSharpType::boltffi_result_reference(),
+            ok: Box::new(CSharpType::Int),
+            err: Box::new(CSharpType::String),
+        };
+
+        assert_eq!(
+            ty.qualify_if_shadowed(&shadowed, &namespace).to_string(),
+            "global::Demo.BoltFFIResult<int, string>"
         );
     }
 

--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -1381,6 +1381,118 @@ mod tests {
         );
     }
 
+    #[test]
+    fn emit_record_with_result_field_keeps_record_and_functions() {
+        let mut contract = empty_contract();
+        contract.catalog.insert_record(record_with_fields(
+            "data_point",
+            true,
+            vec![("value", TypeExpr::Primitive(PrimitiveType::F64))],
+        ));
+        contract
+            .catalog
+            .insert_enum(c_style_enum("compute_error", vec!["Overflow", "Timeout"]));
+        contract.catalog.insert_record(record_with_fields(
+            "benchmark_response",
+            false,
+            vec![
+                ("request_id", TypeExpr::Primitive(PrimitiveType::I64)),
+                (
+                    "result",
+                    TypeExpr::Result {
+                        ok: Box::new(TypeExpr::Record(RecordId::new("data_point"))),
+                        err: Box::new(TypeExpr::Enum(EnumId::new("compute_error"))),
+                    },
+                ),
+            ],
+        ));
+        contract.functions.push(function_with_types(
+            "create_success_response",
+            vec![],
+            ReturnDef::Value(TypeExpr::Record(RecordId::new("benchmark_response"))),
+        ));
+        contract.functions.push(function_with_types(
+            "is_response_success",
+            vec![(
+                "response",
+                TypeExpr::Record(RecordId::new("benchmark_response")),
+            )],
+            ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::Bool)),
+        ));
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "public readonly record struct BenchmarkResponse(",
+            "the record containing a Result field should be emitted",
+        );
+        assert_source_contains(
+            &src,
+            "BoltFFIResult<DataPoint, ComputeError> Result",
+            "the Result field should be exposed with the generated C# result carrier",
+        );
+        assert_source_contains(
+            &src,
+            "public readonly struct BoltFFIResult<TOk, TErr>",
+            "the public result carrier should be emitted even without callbacks",
+        );
+        assert_source_contains(
+            &src,
+            "reader.ReadU8() == 0 ? BoltFFIResult<DataPoint, ComputeError>.Ok(DataPoint.Decode(reader)) : BoltFFIResult<DataPoint, ComputeError>.Err(ComputeErrorWire.Decode(reader))",
+            "record field decode should reconstruct the nested Result value",
+        );
+        assert_source_contains(
+            &src,
+            "public static BenchmarkResponse CreateSuccessResponse()",
+            "functions returning the record should no longer be dropped",
+        );
+        assert_source_contains(
+            &src,
+            "public static bool IsResponseSuccess(BenchmarkResponse response)",
+            "functions taking the record should no longer be dropped",
+        );
+    }
+
+    #[test]
+    fn emit_record_with_void_result_branch_encodes_only_the_tag() {
+        let mut contract = empty_contract();
+        contract.catalog.insert_record(record_with_fields(
+            "ack",
+            false,
+            vec![(
+                "result",
+                TypeExpr::Result {
+                    ok: Box::new(TypeExpr::Void),
+                    err: Box::new(TypeExpr::String),
+                },
+            )],
+        ));
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "BoltFFIResult<BoltFFIUnit, string> Result",
+            "void Result branch should use the unit carrier type",
+        );
+        assert_source_contains(
+            &src,
+            "BoltFFIResult<BoltFFIUnit, string>.Ok(new BoltFFIUnit())",
+            "void Ok branch should decode as BoltFFIUnit",
+        );
+        assert_source_contains(
+            &src,
+            "wire.WriteU8((byte)0);",
+            "void Ok branch should still write the Result tag",
+        );
+        assert_source_contains(
+            &src,
+            "wire.WriteString(this.Result.ErrValue);",
+            "Err branch should still encode its payload",
+        );
+    }
+
     /// A nested record's `WireEncodeTo` must delegate to the inner
     /// record's `WireEncodeTo` via the field accessor, and its `Decode`
     /// must call the inner record's `Decode`. This is the recursive

--- a/boltffi_bindgen/src/render/csharp/lower/admission.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/admission.rs
@@ -121,6 +121,10 @@ fn is_field_type_supported(
             !matches!(inner.as_ref(), TypeExpr::Option(_))
                 && is_field_type_supported(ffi, inner, records, enums)
         }
+        TypeExpr::Result { ok, err } => {
+            is_field_type_supported(ffi, ok, records, enums)
+                && is_field_type_supported(ffi, err, records, enums)
+        }
         _ => false,
     }
 }

--- a/boltffi_bindgen/src/render/csharp/lower/decode.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/decode.rs
@@ -151,6 +151,35 @@ pub(crate) fn lower_decode_expr(
                 otherwise: Box::new(inner),
             }
         }
+        ReadOp::Result { ok, err, .. } => {
+            let result_ty =
+                CSharpType::from_read_op(op).qualify_if_shadowed_opt(shadowed, namespace);
+            let ok_expr = lower_result_branch_decode_expr(ok, reader, shadowed, namespace, locals);
+            let err_expr =
+                lower_result_branch_decode_expr(err, reader, shadowed, namespace, locals);
+            CSharpExpression::Ternary {
+                cond: Box::new(CSharpExpression::Binary {
+                    op: CSharpBinaryOp::Eq,
+                    left: Box::new(CSharpExpression::MethodCall {
+                        receiver: Box::new(reader.clone()),
+                        method: CSharpMethodName::from_source("read_u8"),
+                        type_args: vec![],
+                        args: CSharpArgumentList::default(),
+                    }),
+                    right: Box::new(CSharpExpression::Literal(CSharpLiteral::Int(0))),
+                }),
+                then: Box::new(CSharpExpression::StaticMethodCall {
+                    receiver: result_ty.clone(),
+                    method: CSharpMethodName::from_source("ok"),
+                    args: vec![ok_expr].into(),
+                }),
+                otherwise: Box::new(CSharpExpression::StaticMethodCall {
+                    receiver: result_ty,
+                    method: CSharpMethodName::from_source("err"),
+                    args: vec![err_expr].into(),
+                }),
+            }
+        }
         ReadOp::Vec {
             element_type: TypeExpr::Primitive(p),
             layout: VecLayout::Blittable { .. },
@@ -217,6 +246,23 @@ pub(crate) fn lower_decode_expr(
             "C# backend has not yet implemented decode support for {:?}",
             other
         ),
+    }
+}
+
+fn lower_result_branch_decode_expr(
+    seq: &ReadSeq,
+    reader: &CSharpExpression,
+    shadowed: Option<&HashSet<CSharpClassName>>,
+    namespace: &CSharpNamespace,
+    locals: &mut DecodeLocalCounters,
+) -> CSharpExpression {
+    if seq.ops.is_empty() {
+        CSharpExpression::New {
+            target: CSharpType::boltffi_unit(),
+            args: CSharpArgumentList::default(),
+        }
+    } else {
+        lower_decode_expr(seq, reader, shadowed, namespace, locals)
     }
 }
 

--- a/boltffi_bindgen/src/render/csharp/lower/encode.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/encode.rs
@@ -177,9 +177,19 @@ pub(crate) fn lower_encode_expr(
             );
 
             let mut then = vec![tag_byte(0)];
-            then.extend(lower_encode_expr(ok, writer, &ok_renames, locals));
+            then.extend(lower_result_branch_encode_expr(
+                ok,
+                writer,
+                &ok_renames,
+                locals,
+            ));
             let mut otherwise = vec![tag_byte(1)];
-            otherwise.extend(lower_encode_expr(err, writer, &err_renames, locals));
+            otherwise.extend(lower_result_branch_encode_expr(
+                err,
+                writer,
+                &err_renames,
+                locals,
+            ));
 
             vec![CSharpStatement::If {
                 cond: CSharpExpression::MemberAccess {
@@ -262,6 +272,19 @@ pub(crate) fn lower_encode_expr(
             "C# backend has not yet implemented write support for {:?}",
             other
         ),
+    }
+}
+
+fn lower_result_branch_encode_expr(
+    seq: &WriteSeq,
+    writer: &CSharpExpression,
+    renames: &Renames,
+    locals: &mut EncodeLocalCounters,
+) -> Vec<CSharpStatement> {
+    if seq.ops.is_empty() {
+        Vec::new()
+    } else {
+        lower_encode_expr(seq, writer, renames, locals)
     }
 }
 

--- a/boltffi_bindgen/src/render/csharp/lower/types.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/types.rs
@@ -182,10 +182,22 @@ impl<'a> CSharpLowerer<'a> {
                 let inner_type = self.lower_type(inner)?;
                 Some(CSharpType::Nullable(Box::new(inner_type)))
             }
+            TypeExpr::Result { ok, err } => Some(CSharpType::Result {
+                carrier: CSharpType::boltffi_result_reference(),
+                ok: Box::new(self.lower_result_branch_type(ok)?),
+                err: Box::new(self.lower_result_branch_type(err)?),
+            }),
             TypeExpr::Callback(id) => Some(CSharpType::Record(
                 self.callback_public_class_name(id).into(),
             )),
             _ => None,
+        }
+    }
+
+    fn lower_result_branch_type(&self, type_expr: &TypeExpr) -> Option<CSharpType> {
+        match type_expr {
+            TypeExpr::Void => Some(CSharpType::boltffi_unit()),
+            other => self.lower_type(other),
         }
     }
 

--- a/boltffi_bindgen/src/render/csharp/plan/enumeration.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/enumeration.rs
@@ -125,6 +125,13 @@ impl CSharpEnumPlan {
             .any(|f| f.csharp_type.contains_string())
     }
 
+    pub fn has_result_fields(&self) -> bool {
+        self.variants
+            .iter()
+            .flat_map(|v| v.fields.iter())
+            .any(|f| f.csharp_type.contains_result())
+    }
+
     /// Whether any method on this enum returns `Result<_, _>`. Used by
     /// the module-level predicate that decides whether to emit the
     /// runtime `BoltException` class.

--- a/boltffi_bindgen/src/render/csharp/plan/module.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/module.rs
@@ -125,6 +125,12 @@ impl CSharpModulePlan {
         self.has_callbacks() || self.has_closures()
     }
 
+    pub fn needs_result_runtime(&self) -> bool {
+        self.needs_callback_runtime()
+            || self.records.iter().any(CSharpRecordPlan::has_result_fields)
+            || self.enums.iter().any(CSharpEnumPlan::has_result_fields)
+    }
+
     pub fn needs_ffi_status(&self) -> bool {
         self.has_async() || self.needs_callback_runtime() || self.needs_last_error()
     }

--- a/boltffi_bindgen/src/render/csharp/plan/record.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/record.rs
@@ -59,6 +59,10 @@ impl CSharpRecordPlan {
         self.fields.iter().any(|f| f.csharp_type.contains_string())
     }
 
+    pub fn has_result_fields(&self) -> bool {
+        self.fields.iter().any(|f| f.csharp_type.contains_result())
+    }
+
     /// Whether any record method needs `using System.Runtime.CompilerServices`
     /// for `Unsafe.SizeOf<T>()` in a pinned-array argument length expression.
     pub fn has_pinned_params(&self) -> bool {

--- a/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
+++ b/boltffi_bindgen/src/render/csharp/templates/render_csharp/native.txt
@@ -624,11 +624,13 @@
         internal bool IsNull => handle == 0 || vtable == IntPtr.Zero;
     }
 
-    internal readonly struct BoltFFIUnit
+{% endif %}
+{%- if module.needs_result_runtime() %}
+    public readonly struct BoltFFIUnit
     {
     }
 
-    internal readonly struct BoltFFIResult<TOk, TErr>
+    public readonly struct BoltFFIResult<TOk, TErr>
     {
         private readonly TOk _okValue;
         private readonly TErr _errValue;
@@ -640,14 +642,16 @@
             IsOk = isOk;
         }
 
-        internal bool IsOk { get; }
-        internal TOk OkValue => _okValue;
-        internal TErr ErrValue => _errValue;
+        public bool IsOk { get; }
+        public TOk OkValue => _okValue;
+        public TErr ErrValue => _errValue;
 
-        internal static BoltFFIResult<TOk, TErr> Ok(TOk value) => new(value, default!, true);
-        internal static BoltFFIResult<TOk, TErr> Err(TErr value) => new(default!, value, false);
+        public static BoltFFIResult<TOk, TErr> Ok(TOk value) => new(value, default!, true);
+        public static BoltFFIResult<TOk, TErr> Err(TErr value) => new(default!, value, false);
     }
 
+{% endif %}
+{%- if module.needs_callback_runtime() %}
     internal static class BoltFFICallbackReturn
     {
         internal static unsafe void Store(byte[] bytes, out IntPtr outPtr, out UIntPtr outLen)

--- a/boltffi_bindgen/src/render/java/emit.rs
+++ b/boltffi_bindgen/src/render/java/emit.rs
@@ -336,12 +336,23 @@ fn emit_reader_read_with_context(seq: &ReadSeq, context: &mut JavaEmitContext) -
             layout,
             ..
         } => emit_reader_vec_with_context(element_type, element, layout, context),
-        ReadOp::Result { .. } => {
-            panic!(
-                "ReadOp::Result should be handled via ResultDecode strategy, not emit_reader_read"
+        ReadOp::Result { ok, err, .. } => {
+            let ok_expr = emit_reader_read_or_null(ok, context);
+            let err_expr = emit_reader_read_or_null(err, context);
+            format!(
+                "reader.readI8() == 0 ? BoltFFIResult.ok({}) : BoltFFIResult.err({})",
+                ok_expr, err_expr,
             )
         }
         other => panic!("unsupported Java read op: {:?}", other),
+    }
+}
+
+fn emit_reader_read_or_null(seq: &ReadSeq, context: &mut JavaEmitContext) -> String {
+    if seq.ops.is_empty() {
+        "null".to_string()
+    } else {
+        emit_reader_read_with_context(seq, context)
     }
 }
 
@@ -470,16 +481,15 @@ fn emit_write_expr_with_context(
         },
         WriteOp::Result { value, ok, err } => {
             let result_expr = render_value(value);
-            let ok_inner = emit_write_expr_with_context(ok, writer_name, context);
-            let err_inner = emit_write_expr_with_context(err, writer_name, context);
             let ok_value_expr = format!("({}).okValue()", result_expr);
             let err_value_expr = format!("({}).errValue()", result_expr);
-            let remapped_ok = replace_identifier_occurrences(&ok_inner, "okVal", &ok_value_expr);
-            let remapped_err =
-                replace_identifier_occurrences(&err_inner, "errVal", &err_value_expr);
+            let ok_payload =
+                emit_result_branch_write(ok, writer_name, context, "okVal", &ok_value_expr);
+            let err_payload =
+                emit_result_branch_write(err, writer_name, context, "errVal", &err_value_expr);
             format!(
-                "if (({}).isOk()) {{ {}.writeI8((byte)0); {}; }} else {{ {}.writeI8((byte)1); {}; }}",
-                result_expr, writer_name, remapped_ok, writer_name, remapped_err,
+                "if (({}).isOk()) {{ {}.writeI8((byte)0);{} }} else {{ {}.writeI8((byte)1);{} }}",
+                result_expr, writer_name, ok_payload, writer_name, err_payload,
             )
         }
         WriteOp::Vec {
@@ -496,6 +506,22 @@ fn emit_write_expr_with_context(
             context,
         ),
         other => panic!("unsupported Java write op: {:?}", other),
+    }
+}
+
+fn emit_result_branch_write(
+    seq: &WriteSeq,
+    writer_name: &str,
+    context: &mut JavaEmitContext,
+    binding: &str,
+    replacement: &str,
+) -> String {
+    if seq.ops.is_empty() {
+        String::new()
+    } else {
+        let inner = emit_write_expr_with_context(seq, writer_name, context);
+        let remapped = replace_identifier_occurrences(&inner, binding, replacement);
+        format!(" {remapped};")
     }
 }
 
@@ -570,12 +596,20 @@ fn java_type_for_iteration(ty: &TypeExpr) -> String {
         TypeExpr::Option(inner) => {
             format!("java.util.Optional<{}>", java_type_for_iteration(inner))
         }
+        TypeExpr::Result { ok, err } => {
+            format!(
+                "BoltFFIResult<{}, {}>",
+                java_type_for_iteration(ok),
+                java_type_for_iteration(err)
+            )
+        }
         TypeExpr::Vec(inner) => match inner.as_ref() {
             TypeExpr::Primitive(primitive) => {
                 mappings::java_primitive_array_type(*primitive).to_string()
             }
             _ => format!("java.util.List<{}>", java_type_for_iteration(inner)),
         },
+        TypeExpr::Void => "Void".to_string(),
         _ => "Object".to_string(),
     }
 }

--- a/boltffi_bindgen/src/render/java/lower.rs
+++ b/boltffi_bindgen/src/render/java/lower.rs
@@ -180,9 +180,39 @@ impl<'a> JavaLowerer<'a> {
             TypeExpr::Builtin(_) => true,
             TypeExpr::Option(inner) => Self::is_leaf_supported(ffi, inner, supported),
             TypeExpr::Vec(inner) => Self::is_leaf_supported(ffi, inner, supported),
+            TypeExpr::Result { ok, err } => {
+                Self::is_wire_result_branch_supported(ffi, ok, supported)
+                    && Self::is_wire_result_branch_supported(ffi, err, supported)
+            }
             TypeExpr::Callback(_) => true,
             TypeExpr::Handle(_) => true,
-            _ => false,
+        }
+    }
+
+    fn is_wire_result_branch_supported(
+        ffi: &FfiContract,
+        ty: &TypeExpr,
+        supported: &HashSet<String>,
+    ) -> bool {
+        match ty {
+            TypeExpr::Primitive(_)
+            | TypeExpr::String
+            | TypeExpr::Bytes
+            | TypeExpr::Void
+            | TypeExpr::Builtin(_) => true,
+            TypeExpr::Option(inner) | TypeExpr::Vec(inner) => {
+                Self::is_wire_result_branch_supported(ffi, inner, supported)
+            }
+            TypeExpr::Result { ok, err } => {
+                Self::is_wire_result_branch_supported(ffi, ok, supported)
+                    && Self::is_wire_result_branch_supported(ffi, err, supported)
+            }
+            TypeExpr::Custom(id) => ffi.catalog.resolve_custom(id).is_some_and(|custom| {
+                Self::is_wire_result_branch_supported(ffi, &custom.repr, supported)
+            }),
+            TypeExpr::Record(id) => supported.contains(id.as_str()),
+            TypeExpr::Enum(id) => supported.contains(id.as_str()),
+            TypeExpr::Handle(_) | TypeExpr::Callback(_) => false,
         }
     }
 
@@ -1070,6 +1100,7 @@ impl<'a> JavaLowerer<'a> {
             TypeExpr::String | TypeExpr::Record(_) | TypeExpr::Enum(_) | TypeExpr::Builtin(_) => {
                 format!("java.util.Objects.equals({left}, {right})")
             }
+            TypeExpr::Result { .. } => format!("java.util.Objects.equals({left}, {right})"),
             TypeExpr::Bytes => format!("java.util.Arrays.equals({left}, {right})"),
             TypeExpr::Option(inner) => {
                 let left_is_null = format!("({left}) == null");
@@ -1132,6 +1163,7 @@ impl<'a> JavaLowerer<'a> {
             TypeExpr::String | TypeExpr::Record(_) | TypeExpr::Enum(_) | TypeExpr::Builtin(_) => {
                 format!("java.util.Objects.hashCode({value})")
             }
+            TypeExpr::Result { .. } => format!("java.util.Objects.hashCode({value})"),
             TypeExpr::Bytes => format!("java.util.Arrays.hashCode({value})"),
             TypeExpr::Option(inner) => {
                 let inner_value = format!("({value}).get()");
@@ -2220,6 +2252,7 @@ impl<'a> JavaLowerer<'a> {
 
     fn java_type(&self, ty: &TypeExpr) -> String {
         match ty {
+            TypeExpr::Void => "void".to_string(),
             TypeExpr::Primitive(p) => mappings::java_type(*p).to_string(),
             TypeExpr::String => "String".to_string(),
             TypeExpr::Bytes => "byte[]".to_string(),
@@ -2240,7 +2273,6 @@ impl<'a> JavaLowerer<'a> {
                 )
             }
             TypeExpr::Vec(inner) => self.java_vec_type(inner),
-            _ => "Object".to_string(),
         }
     }
 
@@ -2254,6 +2286,7 @@ impl<'a> JavaLowerer<'a> {
 
     fn java_boxed_type(&self, ty: &TypeExpr) -> String {
         match ty {
+            TypeExpr::Void => "Void".to_string(),
             TypeExpr::Primitive(p) => mappings::java_boxed_type(*p).to_string(),
             TypeExpr::String => "String".to_string(),
             TypeExpr::Bytes => "byte[]".to_string(),
@@ -2274,7 +2307,6 @@ impl<'a> JavaLowerer<'a> {
                 )
             }
             TypeExpr::Vec(inner) => self.java_vec_type(inner),
-            _ => "Object".to_string(),
         }
     }
 
@@ -2450,6 +2482,8 @@ impl<'a> JavaLowerer<'a> {
             ".wireEncodedSize(",
             ".decodeBlittableVec(",
             ".encodeBlittableVec(",
+            ".ok(",
+            ".err(",
         ];
         for name in sibling_names {
             for suffix in static_call_suffixes {
@@ -3618,6 +3652,29 @@ mod tests {
         }
     }
 
+    fn c_style_enum(id: &str, variants: Vec<&str>) -> EnumDef {
+        EnumDef {
+            id: EnumId::new(id),
+            repr: EnumRepr::CStyle {
+                tag_type: PrimitiveType::I32,
+                variants: variants
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, name)| CStyleVariant {
+                        name: VariantName::new(name),
+                        discriminant: i as i128,
+                        doc: None,
+                    })
+                    .collect(),
+            },
+            is_error: false,
+            constructors: vec![],
+            methods: vec![],
+            doc: None,
+            deprecated: None,
+        }
+    }
+
     fn field(name: &str, ty: TypeExpr) -> FieldDef {
         FieldDef {
             name: FieldName::new(name),
@@ -4324,6 +4381,183 @@ mod tests {
         assert_eq!(result_param.java_type, "BoltFFIResult<Integer, String>");
         assert_eq!(result_param.native_type, "ByteBuffer");
         assert_eq!(func.input_bindings.wire_writers.len(), 1);
+    }
+
+    #[test]
+    fn record_with_result_field_is_admitted_and_decoded() {
+        let mut contract = empty_contract();
+        contract.catalog.insert_record(record_def(
+            "data_point",
+            vec![field("value", TypeExpr::Primitive(PrimitiveType::F64))],
+        ));
+        contract
+            .catalog
+            .insert_enum(c_style_enum("compute_error", vec!["Overflow", "Timeout"]));
+        contract.catalog.insert_record(record_def(
+            "benchmark_response",
+            vec![
+                field("request_id", TypeExpr::Primitive(PrimitiveType::I64)),
+                field(
+                    "result",
+                    TypeExpr::Result {
+                        ok: Box::new(TypeExpr::Record(RecordId::new("data_point"))),
+                        err: Box::new(TypeExpr::Enum(EnumId::new("compute_error"))),
+                    },
+                ),
+            ],
+        ));
+        contract.functions.push(function(
+            "create_success_response",
+            vec![],
+            ReturnDef::Value(TypeExpr::Record(RecordId::new("benchmark_response"))),
+        ));
+        contract.functions.push(function(
+            "is_response_success",
+            vec![param(
+                "response",
+                TypeExpr::Record(RecordId::new("benchmark_response")),
+            )],
+            ReturnDef::Value(TypeExpr::Primitive(PrimitiveType::Bool)),
+        ));
+
+        let module = lower(&contract);
+        let response = module
+            .records
+            .iter()
+            .find(|record| record.class_name == "BenchmarkResponse")
+            .expect("BenchmarkResponse should be emitted");
+        let result_field = response
+            .fields
+            .iter()
+            .find(|field| field.name == "result")
+            .expect("result field should be emitted");
+
+        assert_eq!(
+            result_field.java_type,
+            "BoltFFIResult<DataPoint, ComputeError>"
+        );
+        assert!(
+            result_field
+                .wire_decode_expr
+                .contains("BoltFFIResult.ok(DataPoint.decode(reader))"),
+            "Result field should decode the Ok branch, got: {}",
+            result_field.wire_decode_expr,
+        );
+        assert!(
+            result_field
+                .wire_decode_expr
+                .contains("BoltFFIResult.err(ComputeError.fromTag(reader.readI32()))"),
+            "Result field should decode the Err branch, got: {}",
+            result_field.wire_decode_expr,
+        );
+        assert_eq!(
+            module.functions.len(),
+            2,
+            "functions using BenchmarkResponse should not be dropped",
+        );
+    }
+
+    #[test]
+    fn record_with_void_result_branch_encodes_only_the_tag() {
+        let mut contract = empty_contract();
+        contract.catalog.insert_record(record_def(
+            "ack",
+            vec![field(
+                "result",
+                TypeExpr::Result {
+                    ok: Box::new(TypeExpr::Void),
+                    err: Box::new(TypeExpr::String),
+                },
+            )],
+        ));
+
+        let module = lower(&contract);
+        let result_field = &module.records[0].fields[0];
+
+        assert_eq!(result_field.java_type, "BoltFFIResult<Void, String>");
+        assert!(
+            result_field
+                .wire_decode_expr
+                .contains("BoltFFIResult.ok(null)"),
+            "void Ok branch should decode as null, got: {}",
+            result_field.wire_decode_expr,
+        );
+        assert!(
+            result_field
+                .wire_encode_expr
+                .contains("if ((result).isOk()) { wire.writeI8((byte)0); }"),
+            "void Ok branch should write only the tag, got: {}",
+            result_field.wire_encode_expr,
+        );
+        assert!(
+            result_field
+                .wire_encode_expr
+                .contains("wire.writeString((result).errValue())"),
+            "Err branch should still encode its payload, got: {}",
+            result_field.wire_encode_expr,
+        );
+    }
+
+    #[test]
+    fn result_field_qualifies_factory_calls_shadowed_by_variant_name() {
+        let mut contract = empty_contract();
+        contract.catalog.insert_record(record_def(
+            "data_point",
+            vec![field("value", TypeExpr::Primitive(PrimitiveType::F64))],
+        ));
+        contract.catalog.insert_enum(EnumDef {
+            id: EnumId::new("response"),
+            repr: EnumRepr::Data {
+                tag_type: PrimitiveType::I32,
+                variants: vec![
+                    DataVariant {
+                        name: VariantName::new("BoltFFIResult"),
+                        discriminant: 0,
+                        payload: VariantPayload::Unit,
+                        doc: None,
+                    },
+                    DataVariant {
+                        name: VariantName::new("payload"),
+                        discriminant: 1,
+                        payload: VariantPayload::Struct(vec![field(
+                            "result",
+                            TypeExpr::Result {
+                                ok: Box::new(TypeExpr::Record(RecordId::new("data_point"))),
+                                err: Box::new(TypeExpr::String),
+                            },
+                        )]),
+                        doc: None,
+                    },
+                ],
+            },
+            is_error: false,
+            constructors: vec![],
+            methods: vec![],
+            doc: None,
+            deprecated: None,
+        });
+
+        let module = lower(&contract);
+        let result_field = &module.enums[0].variants[1].fields[0];
+
+        assert_eq!(
+            result_field.java_type,
+            "com.test.BoltFFIResult<DataPoint, String>"
+        );
+        assert!(
+            result_field
+                .wire_decode_expr
+                .contains("com.test.BoltFFIResult.ok(DataPoint.decode(reader))"),
+            "shadowed helper should qualify Ok factory, got: {}",
+            result_field.wire_decode_expr,
+        );
+        assert!(
+            result_field
+                .wire_decode_expr
+                .contains("com.test.BoltFFIResult.err(reader.readString())"),
+            "shadowed helper should qualify Err factory, got: {}",
+            result_field.wire_decode_expr,
+        );
     }
 
     #[test]

--- a/boltffi_bindgen/src/render/java/templates.rs
+++ b/boltffi_bindgen/src/render/java/templates.rs
@@ -153,6 +153,9 @@ mod tests {
         JavaRecordField, JavaReturnPlan, JavaReturnRender, JavaStream, JavaStreamMode,
         JavaWireWriter,
     };
+    use std::fs;
+    use std::process::Command;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn java_param(name: &str, java_type: &str, native_type: &str, native_expr: &str) -> JavaParam {
         JavaParam {
@@ -195,6 +198,97 @@ mod tests {
             functions: vec![],
             classes,
         }
+    }
+
+    #[test]
+    fn result_template_deep_compares_array_payloads_when_java_available() {
+        if Command::new("javac").arg("-version").output().is_err()
+            || Command::new("java").arg("-version").output().is_err()
+        {
+            return;
+        }
+
+        let source = ResultTemplate {
+            package_name: "com.test",
+        }
+        .render()
+        .expect("result template should render");
+
+        let smoke = r#"package com.test;
+
+public final class ResultEqualitySmoke {
+    public static void main(String[] args) {
+        BoltFFIResult<byte[], String> leftBytes = BoltFFIResult.ok(new byte[] {1, 2, 3});
+        BoltFFIResult<byte[], String> rightBytes = BoltFFIResult.ok(new byte[] {1, 2, 3});
+        if (!leftBytes.equals(rightBytes)) throw new AssertionError("byte[] payloads should compare by contents");
+        if (leftBytes.hashCode() != rightBytes.hashCode()) throw new AssertionError("equal byte[] payloads should hash equally");
+
+        BoltFFIResult<int[], String> leftInts = BoltFFIResult.ok(new int[] {4, 5, 6});
+        BoltFFIResult<int[], String> rightInts = BoltFFIResult.ok(new int[] {4, 5, 6});
+        if (!leftInts.equals(rightInts)) throw new AssertionError("int[] payloads should compare by contents");
+        if (leftInts.hashCode() != rightInts.hashCode()) throw new AssertionError("equal int[] payloads should hash equally");
+
+        BoltFFIResult<java.util.List<int[]>, String> leftRows =
+            BoltFFIResult.ok(java.util.Arrays.asList(new int[] {1, 2}, new int[] {3, 4}));
+        BoltFFIResult<java.util.List<int[]>, String> rightRows =
+            BoltFFIResult.ok(java.util.Arrays.asList(new int[] {1, 2}, new int[] {3, 4}));
+        if (!leftRows.equals(rightRows)) throw new AssertionError("List<int[]> payloads should compare by nested contents");
+        if (leftRows.hashCode() != rightRows.hashCode()) throw new AssertionError("equal List<int[]> payloads should hash equally");
+
+        BoltFFIResult<java.util.Optional<byte[]>, String> leftOptional =
+            BoltFFIResult.ok(java.util.Optional.of(new byte[] {7, 8}));
+        BoltFFIResult<java.util.Optional<byte[]>, String> rightOptional =
+            BoltFFIResult.ok(java.util.Optional.of(new byte[] {7, 8}));
+        if (!leftOptional.equals(rightOptional)) throw new AssertionError("Optional<byte[]> payloads should compare by nested contents");
+        if (leftOptional.hashCode() != rightOptional.hashCode()) throw new AssertionError("equal Optional<byte[]> payloads should hash equally");
+
+        if (leftBytes.equals(BoltFFIResult.ok(new byte[] {1, 2, 4}))) throw new AssertionError("different arrays must not compare equal");
+        if (leftBytes.equals(BoltFFIResult.err("boom"))) throw new AssertionError("Ok and Err must not compare equal");
+    }
+}
+"#;
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be monotonic")
+            .as_nanos();
+        let tmp_root = std::env::temp_dir().join(format!("boltffi-java-result-eq-{nanos}"));
+        let package_dir = tmp_root.join("com/test");
+        let classes_dir = tmp_root.join("classes");
+        fs::create_dir_all(&package_dir).expect("should create package directory");
+        fs::create_dir_all(&classes_dir).expect("should create classes directory");
+
+        let result_path = package_dir.join("BoltFFIResult.java");
+        let smoke_path = package_dir.join("ResultEqualitySmoke.java");
+        fs::write(&result_path, source).expect("should write result source");
+        fs::write(&smoke_path, smoke).expect("should write smoke source");
+
+        let javac = Command::new("javac")
+            .arg("-d")
+            .arg(&classes_dir)
+            .arg(&result_path)
+            .arg(&smoke_path)
+            .output()
+            .expect("javac should execute");
+        assert!(
+            javac.status.success(),
+            "result equality smoke sources should compile: {}",
+            String::from_utf8_lossy(&javac.stderr)
+        );
+
+        let java = Command::new("java")
+            .arg("-cp")
+            .arg(&classes_dir)
+            .arg("com.test.ResultEqualitySmoke")
+            .output()
+            .expect("java should execute");
+        assert!(
+            java.status.success(),
+            "result equality smoke should pass: {}",
+            String::from_utf8_lossy(&java.stderr)
+        );
+
+        let _ = fs::remove_dir_all(tmp_root);
     }
 
     #[test]

--- a/boltffi_bindgen/src/render/java/templates/render_java/result.txt
+++ b/boltffi_bindgen/src/render/java/templates/render_java/result.txt
@@ -31,4 +31,141 @@ public final class BoltFFIResult<Ok, Err> {
     public Err errValue() {
         return errValue;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof BoltFFIResult<?, ?>)) return false;
+        BoltFFIResult<?, ?> other = (BoltFFIResult<?, ?>) obj;
+        return ok == other.ok
+            && (ok ? valuesEqual(okValue, other.okValue) : valuesEqual(errValue, other.errValue));
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * Boolean.hashCode(ok) + valueHash(ok ? okValue : errValue);
+    }
+
+    @Override
+    public String toString() {
+        return ok ? "Ok(" + okValue + ")" : "Err(" + errValue + ")";
+    }
+
+    private static boolean valuesEqual(Object left, Object right) {
+        if (left == right) return true;
+        if (left == null || right == null) return false;
+        if (left instanceof byte[] && right instanceof byte[]) {
+            return java.util.Arrays.equals((byte[]) left, (byte[]) right);
+        }
+        if (left instanceof boolean[] && right instanceof boolean[]) {
+            return java.util.Arrays.equals((boolean[]) left, (boolean[]) right);
+        }
+        if (left instanceof short[] && right instanceof short[]) {
+            return java.util.Arrays.equals((short[]) left, (short[]) right);
+        }
+        if (left instanceof int[] && right instanceof int[]) {
+            return java.util.Arrays.equals((int[]) left, (int[]) right);
+        }
+        if (left instanceof long[] && right instanceof long[]) {
+            return java.util.Arrays.equals((long[]) left, (long[]) right);
+        }
+        if (left instanceof char[] && right instanceof char[]) {
+            return java.util.Arrays.equals((char[]) left, (char[]) right);
+        }
+        if (left instanceof float[] && right instanceof float[]) {
+            return java.util.Arrays.equals((float[]) left, (float[]) right);
+        }
+        if (left instanceof double[] && right instanceof double[]) {
+            return java.util.Arrays.equals((double[]) left, (double[]) right);
+        }
+        if (left instanceof java.util.Optional && right instanceof java.util.Optional) {
+            return optionalsEqual((java.util.Optional<?>) left, (java.util.Optional<?>) right);
+        }
+        if (left instanceof java.util.List && right instanceof java.util.List) {
+            return listsEqual((java.util.List<?>) left, (java.util.List<?>) right);
+        }
+        if (left instanceof Object[] && right instanceof Object[]) {
+            return objectArraysEqual((Object[]) left, (Object[]) right);
+        }
+        return java.util.Objects.equals(left, right);
+    }
+
+    private static int valueHash(Object value) {
+        if (value == null) return 0;
+        if (value instanceof byte[]) {
+            return java.util.Arrays.hashCode((byte[]) value);
+        }
+        if (value instanceof boolean[]) {
+            return java.util.Arrays.hashCode((boolean[]) value);
+        }
+        if (value instanceof short[]) {
+            return java.util.Arrays.hashCode((short[]) value);
+        }
+        if (value instanceof int[]) {
+            return java.util.Arrays.hashCode((int[]) value);
+        }
+        if (value instanceof long[]) {
+            return java.util.Arrays.hashCode((long[]) value);
+        }
+        if (value instanceof char[]) {
+            return java.util.Arrays.hashCode((char[]) value);
+        }
+        if (value instanceof float[]) {
+            return java.util.Arrays.hashCode((float[]) value);
+        }
+        if (value instanceof double[]) {
+            return java.util.Arrays.hashCode((double[]) value);
+        }
+        if (value instanceof java.util.Optional) {
+            return optionalHash((java.util.Optional<?>) value);
+        }
+        if (value instanceof java.util.List) {
+            return listHash((java.util.List<?>) value);
+        }
+        if (value instanceof Object[]) {
+            return objectArrayHash((Object[]) value);
+        }
+        return java.util.Objects.hashCode(value);
+    }
+
+    private static boolean optionalsEqual(java.util.Optional<?> left, java.util.Optional<?> right) {
+        if (left.isPresent() != right.isPresent()) return false;
+        return !left.isPresent() || valuesEqual(left.get(), right.get());
+    }
+
+    private static int optionalHash(java.util.Optional<?> value) {
+        return value.isPresent() ? 31 + valueHash(value.get()) : 0;
+    }
+
+    private static boolean listsEqual(java.util.List<?> left, java.util.List<?> right) {
+        if (left.size() != right.size()) return false;
+        for (int index = 0; index < left.size(); index++) {
+            if (!valuesEqual(left.get(index), right.get(index))) return false;
+        }
+        return true;
+    }
+
+    private static int listHash(java.util.List<?> value) {
+        int result = 1;
+        for (Object item : value) {
+            result = 31 * result + valueHash(item);
+        }
+        return result;
+    }
+
+    private static boolean objectArraysEqual(Object[] left, Object[] right) {
+        if (left.length != right.length) return false;
+        for (int index = 0; index < left.length; index++) {
+            if (!valuesEqual(left[index], right[index])) return false;
+        }
+        return true;
+    }
+
+    private static int objectArrayHash(Object[] value) {
+        int result = 1;
+        for (Object item : value) {
+            result = 31 * result + valueHash(item);
+        }
+        return result;
+    }
 }

--- a/examples/demo/src/results/error_enums.rs
+++ b/examples/demo/src/results/error_enums.rs
@@ -411,16 +411,6 @@ pub fn try_compute(value: i32) -> Result<i32, ComputeError> {
     justification = "Ensure create_success_response returns a BenchmarkResponse carrying an Ok DataPoint result.",
     directions = "Call `results::error_enums::create_success_response` through the generated binding and assert create_success_response returns a BenchmarkResponse carrying an Ok DataPoint result.",
     exclude(
-        csharp,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#322: C# bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when C# nested-Result-in-record support lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#322: Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
@@ -438,16 +428,6 @@ pub fn create_success_response(request_id: i64, point: DataPoint) -> BenchmarkRe
     "results.error_enums.benchmark_response.should_make_error_response",
     justification = "Ensure create_error_response returns or surfaces a BenchmarkResponse carrying an Err ComputeError result.",
     directions = "Call `results::error_enums::create_error_response` through the generated binding and assert create_error_response returns or surfaces a BenchmarkResponse carrying an Err ComputeError result.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#322: C# bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when C# nested-Result-in-record support lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#322: Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -467,16 +447,6 @@ pub fn create_error_response(request_id: i64, error: ComputeError) -> BenchmarkR
     justification = "Ensure is_response_success returns true for a BenchmarkResponse carrying an Ok result.",
     directions = "Call `results::error_enums::is_response_success` through the generated binding and assert is_response_success returns true for a BenchmarkResponse carrying an Ok result.",
     exclude(
-        csharp,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#322: C# bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when C# nested-Result-in-record support lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#322: Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
@@ -486,16 +456,6 @@ pub fn create_error_response(request_id: i64, error: ComputeError) -> BenchmarkR
     "results.error_enums.benchmark_response.should_report_error_response",
     justification = "Ensure is_response_success returns false for a BenchmarkResponse carrying an Err result.",
     directions = "Call `results::error_enums::is_response_success` through the generated binding and assert is_response_success returns false for a BenchmarkResponse carrying an Err result.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#322: C# bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when C# nested-Result-in-record support lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#322: Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
@@ -512,16 +472,6 @@ pub fn is_response_success(response: BenchmarkResponse) -> bool {
     justification = "Ensure get_response_value returns Some(DataPoint) for a BenchmarkResponse carrying an Ok result.",
     directions = "Call `results::error_enums::get_response_value` through the generated binding and assert get_response_value returns Some(DataPoint) for a BenchmarkResponse carrying an Ok result.",
     exclude(
-        csharp,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#322: C# bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when C# nested-Result-in-record support lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#322: Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently emit Result returns or structured error payloads. Include this case when typed Result support is implemented for Python."
@@ -531,16 +481,6 @@ pub fn is_response_success(response: BenchmarkResponse) -> bool {
     "results.error_enums.benchmark_response.should_return_none_for_error_response",
     justification = "Ensure get_response_value returns None for a BenchmarkResponse carrying an Err result.",
     directions = "Call `results::error_enums::get_response_value` through the generated binding and assert get_response_value returns None for a BenchmarkResponse carrying an Err result.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#322: C# bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when C# nested-Result-in-record support lands."
-    ),
-    exclude(
-        java,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#322: Java bindgen does not currently emit functions whose signatures involve records containing Result<T, E> fields. Include this case when Java nested-Result-in-record support lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -2416,6 +2416,33 @@ public static class DemoTest
             Require(e.Error is ComputeError.Overflow, "TryCompute(-1) Overflow variant");
         }
 
+        DataPoint benchmarkPoint = new DataPoint(1.0, 2.0, 123L);
+        DemoCase("case:results.error_enums.benchmark_response.should_make_success_response");
+        BenchmarkResponse successResponse = CreateSuccessResponse(42L, benchmarkPoint);
+        Require(successResponse.RequestId == 42L, "BenchmarkResponse success RequestId");
+        Require(successResponse.Result.IsOk, "BenchmarkResponse success Result is Ok");
+        Require(successResponse.Result.OkValue == benchmarkPoint, "BenchmarkResponse success DataPoint");
+
+        ComputeError.Overflow benchmarkError = new ComputeError.Overflow(-5, 0);
+        DemoCase("case:results.error_enums.benchmark_response.should_make_error_response");
+        BenchmarkResponse errorResponse = CreateErrorResponse(43L, benchmarkError);
+        Require(errorResponse.RequestId == 43L, "BenchmarkResponse error RequestId");
+        Require(!errorResponse.Result.IsOk, "BenchmarkResponse error Result is Err");
+        Require(errorResponse.Result.ErrValue == benchmarkError, "BenchmarkResponse error payload");
+
+        DemoCase("case:results.error_enums.benchmark_response.should_report_success_response");
+        Require(IsResponseSuccess(successResponse), "IsResponseSuccess should report Ok");
+        DemoCase("case:results.error_enums.benchmark_response.should_report_error_response");
+        Require(!IsResponseSuccess(errorResponse), "IsResponseSuccess should report Err");
+
+        DemoCase("case:results.error_enums.benchmark_response.should_return_value_for_success_response");
+        DataPoint? responseValue = GetResponseValue(successResponse);
+        Require(responseValue.HasValue && responseValue.Value == benchmarkPoint,
+            "GetResponseValue should return success payload");
+
+        DemoCase("case:results.error_enums.benchmark_response.should_return_none_for_error_response");
+        Require(GetResponseValue(errorResponse) == null, "GetResponseValue should return null for Err payload");
+
         Console.WriteLine("  PASS\n");
     }
 

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -2371,6 +2371,34 @@ public final class DemoTest {
             assert ovf.value == -3 && ovf.limit == 0 : "tryCompute Overflow payload";
         }
 
+        DataPoint benchmarkPoint = new DataPoint(1.0, 2.0, 123L);
+        demoCase("case:results.error_enums.benchmark_response.should_make_success_response");
+        BenchmarkResponse successResponse = Demo.createSuccessResponse(42L, benchmarkPoint);
+        assert successResponse.requestId() == 42L : "BenchmarkResponse success request_id";
+        assert successResponse.result().isOk() : "BenchmarkResponse success result is Ok";
+        assert successResponse.result().okValue().equals(benchmarkPoint) : "BenchmarkResponse success point";
+
+        ComputeError.Overflow benchmarkError = new ComputeError.Overflow(-5, 0);
+        demoCase("case:results.error_enums.benchmark_response.should_make_error_response");
+        BenchmarkResponse errorResponse = Demo.createErrorResponse(43L, benchmarkError);
+        assert errorResponse.requestId() == 43L : "BenchmarkResponse error request_id";
+        assert !errorResponse.result().isOk() : "BenchmarkResponse error result is Err";
+        assert errorResponse.result().errValue().equals(benchmarkError) : "BenchmarkResponse error payload";
+
+        demoCase("case:results.error_enums.benchmark_response.should_report_success_response");
+        assert Demo.isResponseSuccess(successResponse) : "isResponseSuccess should report Ok";
+        demoCase("case:results.error_enums.benchmark_response.should_report_error_response");
+        assert !Demo.isResponseSuccess(errorResponse) : "isResponseSuccess should report Err";
+
+        demoCase("case:results.error_enums.benchmark_response.should_return_value_for_success_response");
+        Optional<DataPoint> responseValue = Demo.getResponseValue(successResponse);
+        assert responseValue.isPresent() && responseValue.get().equals(benchmarkPoint)
+            : "getResponseValue should return success payload";
+
+        demoCase("case:results.error_enums.benchmark_response.should_return_none_for_error_response");
+        assert !Demo.getResponseValue(errorResponse).isPresent()
+            : "getResponseValue should return empty for Err payload";
+
         demoCase("case:results.error_enums.divide_app.should_return_quotient");
         assert Demo.divideApp(10, 2) == 5 : "divideApp ok";
         demoCase("case:results.error_enums.divide_app.should_return_app_error_for_division_by_zero");


### PR DESCRIPTION
This closes #322.

It stops the Java and C# bindgens from dropping records and data-enum payloads that embed `Result<T, E>` as a field. Both backends now admit nested `Result` shapes, lower them to public `BoltFFIResult` carriers, and decode the tagged wire payload back into the right Ok/Err branch.

The C# runtime helper is now emitted whenever generated public surface area names `BoltFFIResult`, not only when callbacks are present. Java also gives `BoltFFIResult` real equality/hash behavior, including array, optional, and list payloads, so record equality keeps working for nested wire shapes.

I also removed the Java/C# implementation gaps for the `BenchmarkResponse` demo catalogue cases and added matching platform assertions for the six success/error/value cases. Python stays excluded because that support is still separate.