### PR TITLE
fix(dart): avoids using global callback vtables

### DIFF
--- a/boltffi_bindgen/src/render/dart/lower/callback.rs
+++ b/boltffi_bindgen/src/render/dart/lower/callback.rs
@@ -108,7 +108,6 @@ impl<'a> super::DartLowerer<'a> {
         let abi_cb = self.abi_callback_for(&cb_def.id).unwrap();
 
         let class_name = NamingConvention::class_name(cb_def.id.as_str());
-        let native_decls_class_name = format!("_$$Native${}", class_name);
         let impl_class_name = format!("_I${}", class_name);
         let vtable_struct_name = format!(
             "_I${}",
@@ -116,8 +115,6 @@ impl<'a> super::DartLowerer<'a> {
         );
         let handle_map_class_name = format!("{}HandleMap", impl_class_name);
         let handle_map_instance_name = format!("_k${}HandleMap", class_name);
-        let create_handle_fn_name = abi_cb.create_fn.to_string();
-        let vtable_register_fn_name = abi_cb.register_fn.to_string();
 
         let methods = cb_def
             .methods
@@ -138,10 +135,7 @@ impl<'a> super::DartLowerer<'a> {
             handle_map_instance_name,
             methods,
             native: DartNativeCallback {
-                native_decls_class_name,
-                create_handle_fn_name,
                 vtable_struct_name,
-                vtable_register_fn_name,
                 methods: native_methods,
             },
         }

--- a/boltffi_bindgen/src/render/dart/plan/callback.rs
+++ b/boltffi_bindgen/src/render/dart/plan/callback.rs
@@ -16,10 +16,7 @@ impl DartNativeCallbackMethod {
 
 #[derive(Debug, Clone)]
 pub struct DartNativeCallback {
-    pub native_decls_class_name: String,
-    pub create_handle_fn_name: String,
     pub vtable_struct_name: String,
-    pub vtable_register_fn_name: String,
     pub methods: Vec<DartNativeCallbackMethod>,
 }
 

--- a/boltffi_bindgen/src/render/dart/snapshots/boltffi_bindgen__render__dart__templates__tests__snapshot_async_callback.snap
+++ b/boltffi_bindgen/src/render/dart/snapshots/boltffi_bindgen__render__dart__templates__tests__snapshot_async_callback.snap
@@ -63,18 +63,6 @@ final class _I$ICallbackVTable extends $$ffi.Struct {
   > processBytes;
 }
 
-final class _$$Native$ICallback {
-  @$$ffi.Native<
-    $$ffi.Void Function($$ffi.Pointer<_I$ICallbackVTable>)
-  >()
-  external static void boltffi_register_i_callback_vtable($$ffi.Pointer<_I$ICallbackVTable> vtable);
-
-  @$$ffi.Native<
-    _$$BoltFFICallbackHandle Function($$ffi.Uint64)
-  >()
-  external static _$$BoltFFICallbackHandle boltffi_create_i_callback_handle(int handle);
-}
-
 abstract interface class ICallback {
   Future<int> mapU32(
     int n,
@@ -213,8 +201,6 @@ final class _I$ICallbackHandleMap implements $$ffi.Finalizable {
       _vtable.cast(),
       detach: this,
     );
-
-    _$$Native$ICallback.boltffi_register_i_callback_vtable(_vtable);
   }
 
   void dispose() {
@@ -227,6 +213,12 @@ final class _I$ICallbackHandleMap implements $$ffi.Finalizable {
     _counter = handle;
     _map[handle] = value;
     return handle;
+  }
+
+  _$$BoltFFICallbackHandle createHandle(ICallback value) {
+    return $$ffi.Struct.create()
+      ..handle = insert(value)
+      ..vtable = _vtable.cast();
   }
 
   ICallback? get(int handle) => _map[handle];

--- a/boltffi_bindgen/src/render/dart/snapshots/boltffi_bindgen__render__dart__templates__tests__snapshot_sync_callback.snap
+++ b/boltffi_bindgen/src/render/dart/snapshots/boltffi_bindgen__render__dart__templates__tests__snapshot_sync_callback.snap
@@ -64,18 +64,6 @@ final class _I$ICallbackVTable extends $$ffi.Struct {
   > processBytes;
 }
 
-final class _$$Native$ICallback {
-  @$$ffi.Native<
-    $$ffi.Void Function($$ffi.Pointer<_I$ICallbackVTable>)
-  >()
-  external static void boltffi_register_i_callback_vtable($$ffi.Pointer<_I$ICallbackVTable> vtable);
-
-  @$$ffi.Native<
-    _$$BoltFFICallbackHandle Function($$ffi.Uint64)
-  >()
-  external static _$$BoltFFICallbackHandle boltffi_create_i_callback_handle(int handle);
-}
-
 abstract interface class ICallback {
   int mapU32(
     int n,
@@ -215,8 +203,6 @@ final class _I$ICallbackHandleMap implements $$ffi.Finalizable {
       _vtable.cast(),
       detach: this,
     );
-
-    _$$Native$ICallback.boltffi_register_i_callback_vtable(_vtable);
   }
 
   void dispose() {
@@ -229,6 +215,12 @@ final class _I$ICallbackHandleMap implements $$ffi.Finalizable {
     _counter = handle;
     _map[handle] = value;
     return handle;
+  }
+
+  _$$BoltFFICallbackHandle createHandle(ICallback value) {
+    return $$ffi.Struct.create()
+      ..handle = insert(value)
+      ..vtable = _vtable.cast();
   }
 
   ICallback? get(int handle) => _map[handle];

--- a/boltffi_bindgen/src/render/dart/templates/render_dart/callback.txt
+++ b/boltffi_bindgen/src/render/dart/templates/render_dart/callback.txt
@@ -23,18 +23,6 @@ final class {{ cb.native.vtable_struct_name }} extends $$ffi.Struct {
 {% endfor -%}
 }
 
-final class {{ cb.native.native_decls_class_name }} {
-  @$$ffi.Native<
-    $$ffi.Void Function($$ffi.Pointer<{{ cb.native.vtable_struct_name }}>)
-  >()
-  external static void {{ cb.native.vtable_register_fn_name }}($$ffi.Pointer<{{ cb.native.vtable_struct_name }}> vtable);
-
-  @$$ffi.Native<
-    _$$BoltFFICallbackHandle Function($$ffi.Uint64)
-  >()
-  external static _$$BoltFFICallbackHandle {{ cb.native.create_handle_fn_name }}(int handle);
-}
-
 abstract interface class {{ cb.class_name }} {
 {%- for method in cb.methods %}
   {% if method.is_async() %}Future<{{ method.ret_ty.dart_type() }}>{% else %}{{ method.ret_ty.dart_type() }}{% endif %} {{ method.name }}(
@@ -99,8 +87,6 @@ final class {{ cb.handle_map_class_name }} implements $$ffi.Finalizable {
       _vtable.cast(),
       detach: this,
     );
-
-    {{ cb.native.native_decls_class_name }}.{{ cb.native.vtable_register_fn_name }}(_vtable);
   }
 
   void dispose() {
@@ -113,6 +99,12 @@ final class {{ cb.handle_map_class_name }} implements $$ffi.Finalizable {
     _counter = handle;
     _map[handle] = value;
     return handle;
+  }
+
+  _$$BoltFFICallbackHandle createHandle({{ cb.class_name }} value) {
+    return $$ffi.Struct.create()
+      ..handle = insert(value)
+      ..vtable = _vtable.cast();
   }
 
   {{ cb.class_name }}? get(int handle) => _map[handle];


### PR DESCRIPTION
This allows using callback objects from different isolates.
Each isolate has its own memory space and thus can't share a global vtable.