### PR TITLE
Fix C# Result parameters

### DIFF
--- a/boltffi_bindgen/src/render/csharp/emit.rs
+++ b/boltffi_bindgen/src/render/csharp/emit.rs
@@ -1455,6 +1455,50 @@ mod tests {
     }
 
     #[test]
+    fn emit_function_with_result_param_uses_wire_writer_and_result_runtime() {
+        let mut contract = empty_contract();
+        contract.functions.push(function_with_types(
+            "result_to_string",
+            vec![(
+                "input",
+                TypeExpr::Result {
+                    ok: Box::new(TypeExpr::Primitive(PrimitiveType::I32)),
+                    err: Box::new(TypeExpr::String),
+                },
+            )],
+            ReturnDef::Value(TypeExpr::String),
+        ));
+
+        let src = emit_contract(&contract).combined_source();
+
+        assert_source_contains(
+            &src,
+            "public static string ResultToString(BoltFFIResult<int, string> input)",
+            "Result params should be admitted and exposed on the public C# wrapper",
+        );
+        assert_source_contains(
+            &src,
+            "public readonly struct BoltFFIResult<TOk, TErr>",
+            "Result-param-only modules still need the public result carrier",
+        );
+        assert_source_contains(
+            &src,
+            "using var _wire_input = new WireWriter((1 + (input.IsOk ? 4 : (4 + Encoding.UTF8.GetByteCount(input.ErrValue)))));",
+            "Result params should allocate a wire buffer sized from the active branch",
+        );
+        assert_source_contains(
+            &src,
+            "if (input.IsOk) { _wire_input.WriteU8((byte)0); _wire_input.WriteI32(input.OkValue); } else { _wire_input.WriteU8((byte)1); _wire_input.WriteString(input.ErrValue); }",
+            "Result params should encode the tag and active payload branch",
+        );
+        assert_source_contains(
+            &src,
+            "internal static extern FfiBuf ResultToString(byte[] input, UIntPtr inputLen);",
+            "Result params should cross P/Invoke as a byte buffer plus length",
+        );
+    }
+
+    #[test]
     fn emit_record_with_void_result_branch_encodes_only_the_tag() {
         let mut contract = empty_contract();
         contract.catalog.insert_record(record_with_fields(

--- a/boltffi_bindgen/src/render/csharp/lower/predicates.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/predicates.rs
@@ -25,16 +25,20 @@ impl<'a> CSharpLowerer<'a> {
     }
 
     /// Whether the param can be handled by the C# backend. By-value is
-    /// the common case; `&mut [T]` (RefMut over a `Vec<T>`) is allowed
-    /// when T is a blittable vec element — the CLR pins primitive
-    /// arrays across P/Invoke, so the native side can mutate them in
-    /// place. Callback params have their own passing kinds.
+    /// the common case; `Result<T, E>` params ride the same wire-encoded
+    /// carrier used by record fields. `&mut [T]` (RefMut over a `Vec<T>`)
+    /// is allowed when T is a blittable vec element — the CLR pins
+    /// primitive arrays across P/Invoke, so the native side can mutate
+    /// them in place. Callback params have their own passing kinds.
     pub(super) fn is_supported_param(&self, param: &ParamDef) -> bool {
         match (&param.passing, &param.type_expr) {
             (ParamPassing::Value, TypeExpr::Option(inner))
                 if matches!(inner.as_ref(), TypeExpr::Callback(_)) =>
             {
                 self.is_supported_type(&param.type_expr)
+            }
+            (ParamPassing::Value, TypeExpr::Result { ok, err }) => {
+                self.is_supported_result_type(ok) && self.is_supported_result_type(err)
             }
             (ParamPassing::ImplTrait | ParamPassing::BoxedDyn, TypeExpr::Callback(id)) => {
                 self.is_supported_callback(id)

--- a/boltffi_bindgen/src/render/csharp/lower/types.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/types.rs
@@ -113,6 +113,11 @@ impl<'a> CSharpLowerer<'a> {
                 // primitive layout.
                 wire_encoded_kind(wire_writers, &param.name)?
             }
+            TypeExpr::Result { .. } => {
+                // Results are tagged unions on the wire, so the managed
+                // carrier is serialized into a byte buffer before P/Invoke.
+                wire_encoded_kind(wire_writers, &param.name)?
+            }
             // Primitives, bools, blittable records, and C-style enums
             // pass directly. The CLR marshals them across P/Invoke with
             // no extra setup.

--- a/boltffi_bindgen/src/render/csharp/lower/wire_writers.rs
+++ b/boltffi_bindgen/src/render/csharp/lower/wire_writers.rs
@@ -112,9 +112,7 @@ impl<'a> CSharpLowerer<'a> {
             // the wire-encoded path: the macro exposes them as wire-buffer
             // signatures on the C ABI, matching the param shape Java uses.
             WriteOp::Builtin { .. } => true,
-            WriteOp::Result { .. } => {
-                todo!("C# backend has not yet implemented param support for {op:?}")
-            }
+            WriteOp::Result { .. } => true,
         }
     }
 }

--- a/boltffi_bindgen/src/render/csharp/plan/module.rs
+++ b/boltffi_bindgen/src/render/csharp/plan/module.rs
@@ -7,7 +7,8 @@ use crate::ir::types::BuiltinKind;
 use super::super::ast::{CSharpClassName, CSharpNamespace};
 use super::{
     CFunctionName, CSharpCallablePlan, CSharpCallbackPlan, CSharpClassPlan, CSharpClosurePlan,
-    CSharpEnumPlan, CSharpFunctionPlan, CSharpRecordPlan,
+    CSharpConstructorPlan, CSharpEnumPlan, CSharpFunctionPlan, CSharpMethodPlan, CSharpParamPlan,
+    CSharpRecordPlan,
 };
 
 /// A whole C# module: namespace, library binding, and every record, enum,
@@ -127,6 +128,10 @@ impl CSharpModulePlan {
 
     pub fn needs_result_runtime(&self) -> bool {
         self.needs_callback_runtime()
+            || self.functions.iter().any(function_has_result_params)
+            || self.classes.iter().any(class_has_result_params)
+            || self.records.iter().any(record_method_has_result_params)
+            || self.enums.iter().any(enum_method_has_result_params)
             || self.records.iter().any(CSharpRecordPlan::has_result_fields)
             || self.enums.iter().any(CSharpEnumPlan::has_result_fields)
     }
@@ -280,6 +285,35 @@ impl CSharpModulePlan {
                 .any(CSharpRecordPlan::has_throwing_methods)
             || self.enums.iter().any(CSharpEnumPlan::has_throwing_methods)
     }
+}
+
+fn params_have_result(params: &[CSharpParamPlan]) -> bool {
+    params.iter().any(|p| p.csharp_type.contains_result())
+}
+
+fn function_has_result_params(function: &CSharpFunctionPlan) -> bool {
+    params_have_result(&function.params)
+}
+
+fn constructor_has_result_params(constructor: &CSharpConstructorPlan) -> bool {
+    params_have_result(&constructor.params)
+}
+
+fn method_has_result_params(method: &CSharpMethodPlan) -> bool {
+    params_have_result(&method.params)
+}
+
+fn class_has_result_params(class: &CSharpClassPlan) -> bool {
+    class.constructors.iter().any(constructor_has_result_params)
+        || class.methods.iter().any(method_has_result_params)
+}
+
+fn record_method_has_result_params(record: &CSharpRecordPlan) -> bool {
+    record.methods.iter().any(method_has_result_params)
+}
+
+fn enum_method_has_result_params(enumeration: &CSharpEnumPlan) -> bool {
+    enumeration.methods.iter().any(method_has_result_params)
 }
 
 #[cfg(test)]

--- a/examples/demo/src/results/basic.rs
+++ b/examples/demo/src/results/basic.rs
@@ -132,11 +132,6 @@ pub fn always_err(msg: String) -> Result<i32, String> {
     justification = "Ensure result_to_string receives an Ok Result value over FFI and renders its success payload.",
     directions = "Call `results::basic::result_to_string` through the generated binding and assert result_to_string receives an Ok Result value over FFI and renders its success payload.",
     exclude(
-        csharp,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#321: C# bindgen does not currently emit functions that take Result<T, E> as a parameter. Include this case when C# Result-parameter support lands."
-    ),
-    exclude(
         python,
         reason = ExclusionReason::ImplementationGap,
         details = "Python is experimental; its lowerer does not currently accept Result<T, E> parameters. Include this case when Result parameters are implemented for Python."
@@ -146,11 +141,6 @@ pub fn always_err(msg: String) -> Result<i32, String> {
     "results.basic.result_to_string.should_render_err",
     justification = "Ensure result_to_string receives an Err Result value over FFI and renders its error payload.",
     directions = "Call `results::basic::result_to_string` through the generated binding and assert result_to_string receives an Err Result value over FFI and renders its error payload.",
-    exclude(
-        csharp,
-        reason = ExclusionReason::ImplementationGap,
-        details = "#321: C# bindgen does not currently emit functions that take Result<T, E> as a parameter. Include this case when C# Result-parameter support lands."
-    ),
     exclude(
         python,
         reason = ExclusionReason::ImplementationGap,

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -2201,6 +2201,11 @@ public static class DemoTest
             Require(e.Message.Contains("boom"), "AlwaysErr error message");
         }
 
+        DemoCase("case:results.basic.result_to_string.should_render_ok");
+        Require(ResultToString(BoltFFIResult<int, string>.Ok(7)) == "ok: 7", "ResultToString Ok");
+        DemoCase("case:results.basic.result_to_string.should_render_err");
+        Require(ResultToString(BoltFFIResult<int, string>.Err("bad")) == "err: bad", "ResultToString Err");
+
         // Result<Point, String> with Ok carrying a record.
         DemoCase("case:results.basic.parse_point.should_parse_coordinates");
         Point p = ParsePoint("3.0,4.0");


### PR DESCRIPTION
This closes #321.

It stops the C# bindgen from dropping functions that take `Result<T, E>` as a value parameter. The lowerer now admits Result params when both branches are supported, classifies their ABI shape as wire-encoded, and passes the generated byte buffer into the native call instead of trying to marshal the public `BoltFFIResult` carrier directly.

The C# runtime predicate now emits `BoltFFIResult<TOk, TErr>` whenever generated public surface area names it, including Result-param-only modules. I also added renderer coverage for the `Result<i32, String> -> String` shape that triggered the demo gap.

I removed the C# implementation-gap exclusions for `results.basic.result_to_string` and added C# platform assertions for the Ok and Err cases. Python stays excluded because its Result-parameter support is separate.