### PR TITLE
fix data impl string constructors

### DIFF
--- a/boltffi_bindgen/src/render/swift/lower.rs
+++ b/boltffi_bindgen/src/render/swift/lower.rs
@@ -390,6 +390,7 @@ impl<'a> SwiftLowerer<'a> {
                 ..
             } => SwiftConstructor::Designated {
                 ffi_symbol: call.symbol.as_str().to_string(),
+                closure_return_type: self.value_type_constructor_closure_return_type(call),
                 params: ctor
                     .params()
                     .into_iter()
@@ -430,6 +431,7 @@ impl<'a> SwiftLowerer<'a> {
                 SwiftConstructor::Convenience {
                     name: label,
                     ffi_symbol: call.symbol.as_str().to_string(),
+                    closure_return_type: self.value_type_constructor_closure_return_type(call),
                     params: std::iter::once(first).chain(rest).collect(),
                     is_fallible: *is_fallible,
                     is_optional: *is_optional,
@@ -437,6 +439,21 @@ impl<'a> SwiftLowerer<'a> {
                     doc: doc.clone(),
                 }
             }
+        }
+    }
+
+    fn value_type_constructor_closure_return_type(&self, call: &AbiCall) -> String {
+        match (&call.error, &call.returns.transport) {
+            (ErrorTransport::Encoded { .. }, _) => "FfiBuf_u8".to_string(),
+            (ErrorTransport::StatusCode, None) => "FfiStatus".to_string(),
+            (_, None) => "Void".to_string(),
+            (_, Some(Transport::Scalar(origin))) => {
+                self.abi_to_swift(&AbiType::from(origin.primitive()))
+            }
+            (_, Some(Transport::Composite(layout))) => format!("___{}", layout.record_id.as_str()),
+            (_, Some(Transport::Span(_))) => "FfiBuf_u8".to_string(),
+            (_, Some(Transport::Handle { .. })) => "OpaquePointer?".to_string(),
+            (_, Some(Transport::Callback { .. })) => "BoltFFICallbackHandle".to_string(),
         }
     }
 
@@ -700,6 +717,7 @@ impl<'a> SwiftLowerer<'a> {
                                 ..
                             } => SwiftConstructor::Designated {
                                 ffi_symbol: call.symbol.as_str().to_string(),
+                                closure_return_type: "OpaquePointer?".to_string(),
                                 params: ctor
                                     .params()
                                     .into_iter()
@@ -740,6 +758,7 @@ impl<'a> SwiftLowerer<'a> {
                                 SwiftConstructor::Convenience {
                                     name: label,
                                     ffi_symbol: call.symbol.as_str().to_string(),
+                                    closure_return_type: "OpaquePointer?".to_string(),
                                     params: std::iter::once(first).chain(rest).collect(),
                                     is_fallible: *is_fallible,
                                     is_optional: *is_optional,

--- a/boltffi_bindgen/src/render/swift/plan.rs
+++ b/boltffi_bindgen/src/render/swift/plan.rs
@@ -634,6 +634,7 @@ pub enum SwiftStreamMode {
 pub enum SwiftConstructor {
     Designated {
         ffi_symbol: String,
+        closure_return_type: String,
         params: Vec<SwiftParam>,
         is_fallible: bool,
         is_optional: bool,
@@ -651,6 +652,7 @@ pub enum SwiftConstructor {
     Convenience {
         name: String,
         ffi_symbol: String,
+        closure_return_type: String,
         params: Vec<SwiftParam>,
         is_fallible: bool,
         is_optional: bool,
@@ -677,6 +679,20 @@ impl SwiftConstructor {
             Self::Designated { ffi_symbol, .. }
             | Self::Factory { ffi_symbol, .. }
             | Self::Convenience { ffi_symbol, .. } => ffi_symbol,
+        }
+    }
+
+    fn closure_return_type(&self) -> &str {
+        match self {
+            Self::Designated {
+                closure_return_type,
+                ..
+            }
+            | Self::Convenience {
+                closure_return_type,
+                ..
+            } => closure_return_type,
+            Self::Factory { .. } => "Void",
         }
     }
 
@@ -741,7 +757,7 @@ impl SwiftConstructor {
         if let Some(first) = wrappers.first_mut()
             && let Some(in_pos) = first.rfind(" in")
         {
-            first.replace_range(in_pos.., " -> OpaquePointer? in");
+            first.replace_range(in_pos.., &format!(" -> {} in", self.closure_return_type()));
         }
         wrappers
     }

--- a/boltffi_bindgen/src/render/swift/templates.rs
+++ b/boltffi_bindgen/src/render/swift/templates.rs
@@ -616,6 +616,49 @@ mod tests {
     }
 
     #[test]
+    fn record_constructor_with_string_param_annotates_wire_buffer_return() {
+        let record = SwiftRecord {
+            class_name: "ServiceConfig".to_string(),
+            fields: vec![field(
+                "name",
+                "String",
+                read_string(offset("pos")),
+                write_string("name"),
+                None,
+                None,
+            )],
+            is_blittable: false,
+            is_error: false,
+            blittable_size: None,
+            constructors: vec![SwiftConstructor::Convenience {
+                name: "fromName".to_string(),
+                ffi_symbol: "boltffi_service_config_from_name".to_string(),
+                closure_return_type: "FfiBuf_u8".to_string(),
+                params: vec![SwiftParam {
+                    label: Some("fromName".to_string()),
+                    name: "name".to_string(),
+                    swift_type: "String".to_string(),
+                    conversion: SwiftConversion::ToString,
+                }],
+                is_fallible: false,
+                is_optional: false,
+                throw_decode_expr: None,
+                doc: None,
+            }],
+            methods: vec![],
+            doc: None,
+        };
+
+        let rendered = render_record(&record, "boltffi");
+        assert!(
+            rendered.contains(
+                "name.withUTF8 { nameBuf -> FfiBuf_u8 in boltffi_service_config_from_name"
+            )
+        );
+        assert!(!rendered.contains("-> OpaquePointer? in boltffi_service_config_from_name"));
+    }
+
+    #[test]
     fn snapshot_record_with_default_value() {
         let record = SwiftRecord {
             class_name: "Config".to_string(),
@@ -1140,6 +1183,7 @@ mod tests {
             constructors: vec![
                 SwiftConstructor::Designated {
                     ffi_symbol: "boltffi_data_store_new".to_string(),
+                    closure_return_type: "OpaquePointer?".to_string(),
                     params: vec![SwiftParam {
                         label: None,
                         name: "capacity".to_string(),
@@ -1190,6 +1234,7 @@ mod tests {
             ffi_free: "boltffi_database_free".to_string(),
             constructors: vec![SwiftConstructor::Designated {
                 ffi_symbol: "boltffi_database_open".to_string(),
+                closure_return_type: "OpaquePointer?".to_string(),
                 params: vec![SwiftParam {
                     label: None,
                     name: "path".to_string(),
@@ -1304,6 +1349,7 @@ mod tests {
             ffi_free: "boltffi_connection_free".to_string(),
             constructors: vec![SwiftConstructor::Designated {
                 ffi_symbol: "boltffi_connection_open".to_string(),
+                closure_return_type: "OpaquePointer?".to_string(),
                 params: vec![SwiftParam {
                     label: None,
                     name: "url".to_string(),
@@ -1330,6 +1376,7 @@ mod tests {
             constructors: vec![SwiftConstructor::Convenience {
                 name: "tryOpen".to_string(),
                 ffi_symbol: "boltffi_connection_open".to_string(),
+                closure_return_type: "OpaquePointer?".to_string(),
                 params: vec![
                     SwiftParam {
                         label: None,

--- a/boltffi_macros/src/data/expansion/record_impl.rs
+++ b/boltffi_macros/src/data/expansion/record_impl.rs
@@ -455,21 +455,13 @@ fn generate_value_return_export(
         ))
     } else if let Some(strategy) = return_abi.encoded_return_strategy() {
         let inner_ty = return_abi.rust_type();
-        let encoded_call = if conversions.is_empty() {
-            call_expr
-        } else {
-            quote! {
-                #(#conversions)*
-                #call_expr
-            }
-        };
         let result_ident = syn::Ident::new("result", export_name.span());
         let body = encoded_return_body(
             inner_ty,
             strategy,
             &result_ident,
-            encoded_call,
-            &[],
+            call_expr,
+            conversions,
             custom_types,
         );
         Some(emit_ffi_function(

--- a/boltffi_macros/src/lowering/params/mod.rs
+++ b/boltffi_macros/src/lowering/params/mod.rs
@@ -239,6 +239,7 @@ impl<'a> AsyncParamLowerer<'a> {
                 "boltffi: async exports do not support trait object callback parameters (`Box<dyn Trait>`, `Arc<dyn Trait>`, `Option<Box<dyn Trait>>`, `Option<Arc<dyn Trait>>`) yet",
             ),
             ParamTransform::StrRef
+            | ParamTransform::StringRef
             | ParamTransform::OwnedString
             | ParamTransform::SliceRef(_)
             | ParamTransform::VecPrimitive(_)
@@ -309,6 +310,7 @@ fn param_transform_name(param_transform: &ParamTransform) -> &'static str {
     match param_transform {
         ParamTransform::PassThrough => "PassThrough",
         ParamTransform::StrRef => "StrRef",
+        ParamTransform::StringRef => "StringRef",
         ParamTransform::OwnedString => "OwnedString",
         ParamTransform::Callback { .. } => "Callback",
         ParamTransform::SliceRef(_) => "SliceRef",
@@ -454,7 +456,7 @@ mod tests {
     #[test]
     fn accepts_supported_async_params() {
         let function: syn::ItemFn = parse_quote! {
-            async fn demo(name: String, ids: Vec<i32>, scores: &[i32], id: i64) {}
+            async fn demo(name: String, label: &String, ids: Vec<i32>, scores: &[i32], id: i64) {}
         };
 
         assert!(

--- a/boltffi_macros/src/lowering/params/transform.rs
+++ b/boltffi_macros/src/lowering/params/transform.rs
@@ -29,6 +29,7 @@ pub(super) fn len_ident(base: &syn::Ident) -> syn::Ident {
 pub(super) enum ParamTransform {
     PassThrough,
     StrRef,
+    StringRef,
     OwnedString,
     Callback {
         params: Vec<syn::Type>,
@@ -315,6 +316,16 @@ impl<'a> ParamTransformClassifier<'a> {
             };
         }
 
+        if param_syntax.is_string_ref() {
+            return ClassifiedParamTransform {
+                contract: ParamContract::new(
+                    ParamValueStrategy::Utf8String,
+                    ParamPassingStrategy::SharedRef,
+                ),
+                transform: ParamTransform::StringRef,
+            };
+        }
+
         if let Type::Reference(type_ref) = ty
             && self
                 .named_type_transport_classifier
@@ -448,6 +459,22 @@ impl<'a> ParamSyntax<'a> {
     fn is_str_ref(&self) -> bool {
         self.spelling == "&str"
             || (self.spelling.starts_with("&'") && self.spelling.ends_with("str"))
+    }
+
+    fn is_string_ref(&self) -> bool {
+        let Type::Reference(reference) = self.ty else {
+            return false;
+        };
+
+        matches!(
+            reference.elem.as_ref(),
+            Type::Path(type_path)
+                if type_path
+                    .path
+                    .segments
+                    .last()
+                    .is_some_and(|segment| segment.ident == "String")
+        )
     }
 
     fn is_owned_string(&self) -> bool {

--- a/boltffi_macros/src/lowering/params/value.rs
+++ b/boltffi_macros/src/lowering/params/value.rs
@@ -277,6 +277,45 @@ impl<'a> ValueParamDecoder<'a> {
         acc.call_args.push(quote! { #name });
     }
 
+    fn lower_sync_string_ref_param(&self, acc: &mut ParamLoweringState, name: &Ident) {
+        let ptr_name = ptr_ident(name);
+        let len_name = len_ident(name);
+        let sync_string_expr = self.utf8_string_expression(name, &ptr_name, &len_name, false);
+        let owned_name = Ident::new(&format!("{}_owned", name), name.span());
+        acc.ffi_params.push(quote! { #ptr_name: *const u8 });
+        acc.ffi_params.push(quote! { #len_name: usize });
+        acc.setup.push(quote! {
+            let #owned_name: String = if #ptr_name.is_null() {
+                String::new()
+            } else {
+                #sync_string_expr
+            };
+            let #name: &String = &#owned_name;
+        });
+        acc.call_args.push(quote! { #name });
+    }
+
+    fn lower_async_string_ref_param(&self, acc: &mut ParamLoweringState, name: &Ident) {
+        let ptr_name = ptr_ident(name);
+        let len_name = len_ident(name);
+        let async_string_expr = self.utf8_string_expression(name, &ptr_name, &len_name, true);
+        let owned_name = Ident::new(&format!("{}_owned", name), name.span());
+        acc.ffi_params.push(quote! { #ptr_name: *const u8 });
+        acc.ffi_params.push(quote! { #len_name: usize });
+        acc.setup.push(quote! {
+            let #owned_name: String = if #ptr_name.is_null() {
+                String::new()
+            } else {
+                #async_string_expr
+            };
+        });
+        acc.thread_setup.push(quote! {
+            let #name: &String = &#owned_name;
+        });
+        acc.move_vars.push(owned_name);
+        acc.call_args.push(quote! { #name });
+    }
+
     fn lower_sync_owned_string_param(&self, acc: &mut ParamLoweringState, name: &Ident) {
         let ptr_name = ptr_ident(name);
         let len_name = len_ident(name);
@@ -645,6 +684,7 @@ impl<'a> SyncValueParamLowerer<'a> {
     ) {
         match param_transform {
             ParamTransform::StrRef => self.decoder.lower_sync_str_ref_param(acc, name),
+            ParamTransform::StringRef => self.decoder.lower_sync_string_ref_param(acc, name),
             ParamTransform::OwnedString => self.decoder.lower_sync_owned_string_param(acc, name),
             ParamTransform::SliceRef(inner_type) => {
                 self.decoder
@@ -718,6 +758,7 @@ impl<'a> AsyncValueParamLowerer<'a> {
     ) {
         match param_transform {
             ParamTransform::StrRef => self.decoder.lower_async_str_ref_param(acc, name),
+            ParamTransform::StringRef => self.decoder.lower_async_string_ref_param(acc, name),
             ParamTransform::OwnedString => self.decoder.lower_async_owned_string_param(acc, name),
             ParamTransform::SliceRef(inner_type) => {
                 self.decoder

--- a/boltffi_tests/src/lib.rs
+++ b/boltffi_tests/src/lib.rs
@@ -32,6 +32,13 @@ pub struct FixtureMessageRecord {
     pub status: FixtureStatus,
 }
 
+#[data]
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct FixtureStringConfig {
+    pub name: String,
+    pub source: String,
+}
+
 #[export]
 pub trait SyncValueCallback {
     fn on_value(&self, value: i32) -> i32;
@@ -932,6 +939,23 @@ impl FixturePoint {
         FixturePoint {
             x: (a.x + b.x) / 2.0,
             y: (a.y + b.y) / 2.0,
+        }
+    }
+}
+
+#[data(impl)]
+impl FixtureStringConfig {
+    pub fn from_owned_name(name: String) -> Self {
+        Self {
+            name,
+            source: "owned".to_string(),
+        }
+    }
+
+    pub fn from_borrowed_name(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            source: "borrowed".to_string(),
         }
     }
 }

--- a/boltffi_tests/src/lib.rs
+++ b/boltffi_tests/src/lib.rs
@@ -958,4 +958,12 @@ impl FixtureStringConfig {
             source: "borrowed".to_string(),
         }
     }
+
+    #[allow(clippy::ptr_arg)]
+    pub fn from_string_ref_name(name: &String) -> Self {
+        Self {
+            name: name.clone(),
+            source: "string_ref".to_string(),
+        }
+    }
 }

--- a/boltffi_tests/tests/record_methods.rs
+++ b/boltffi_tests/tests/record_methods.rs
@@ -1,4 +1,11 @@
-use boltffi_tests::FixturePoint;
+use boltffi::__private::FfiBuf;
+use boltffi_core::wire::WireDecode;
+use boltffi_tests::{FixturePoint, FixtureStringConfig};
+
+fn decode_buf<T: WireDecode>(buf: &FfiBuf) -> T {
+    let (result, _) = T::decode_from(unsafe { buf.as_byte_slice() }).unwrap();
+    result
+}
 
 unsafe extern "C" {
     fn boltffi_fixture_point_origin() -> FixturePoint;
@@ -6,6 +13,14 @@ unsafe extern "C" {
     fn boltffi_fixture_point_distance_to_origin(self_value: FixturePoint) -> f64;
     fn boltffi_fixture_point_scale(self_value: FixturePoint, factor: f64) -> FixturePoint;
     fn boltffi_fixture_point_midpoint_to(a: FixturePoint, b: FixturePoint) -> FixturePoint;
+    fn boltffi_fixture_string_config_from_owned_name(
+        name_ptr: *const u8,
+        name_len: usize,
+    ) -> FfiBuf;
+    fn boltffi_fixture_string_config_from_borrowed_name(
+        name_ptr: *const u8,
+        name_len: usize,
+    ) -> FfiBuf;
 }
 
 mod constructors {
@@ -21,6 +36,36 @@ mod constructors {
     fn new_at_returns_specified_coordinates() {
         let point = unsafe { boltffi_fixture_point_new_at(3.0, 4.0) };
         assert_eq!(point, FixturePoint { x: 3.0, y: 4.0 });
+    }
+
+    #[test]
+    fn owned_string_constructor_returns_wire_encoded_record() {
+        let name = "owned config";
+        let buf =
+            unsafe { boltffi_fixture_string_config_from_owned_name(name.as_ptr(), name.len()) };
+        let config: FixtureStringConfig = decode_buf(&buf);
+        assert_eq!(
+            config,
+            FixtureStringConfig {
+                name: name.to_string(),
+                source: "owned".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn borrowed_string_constructor_returns_wire_encoded_record() {
+        let name = "borrowed config";
+        let buf =
+            unsafe { boltffi_fixture_string_config_from_borrowed_name(name.as_ptr(), name.len()) };
+        let config: FixtureStringConfig = decode_buf(&buf);
+        assert_eq!(
+            config,
+            FixtureStringConfig {
+                name: name.to_string(),
+                source: "borrowed".to_string(),
+            }
+        );
     }
 }
 

--- a/boltffi_tests/tests/record_methods.rs
+++ b/boltffi_tests/tests/record_methods.rs
@@ -21,6 +21,10 @@ unsafe extern "C" {
         name_ptr: *const u8,
         name_len: usize,
     ) -> FfiBuf;
+    fn boltffi_fixture_string_config_from_string_ref_name(
+        name_ptr: *const u8,
+        name_len: usize,
+    ) -> FfiBuf;
 }
 
 mod constructors {
@@ -64,6 +68,22 @@ mod constructors {
             FixtureStringConfig {
                 name: name.to_string(),
                 source: "borrowed".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn string_ref_constructor_returns_wire_encoded_record() {
+        let name = "string ref config";
+        let buf = unsafe {
+            boltffi_fixture_string_config_from_string_ref_name(name.as_ptr(), name.len())
+        };
+        let config: FixtureStringConfig = decode_buf(&buf);
+        assert_eq!(
+            config,
+            FixtureStringConfig {
+                name: name.to_string(),
+                source: "string_ref".to_string(),
             }
         );
     }

--- a/examples/demo/src/records/default_values.rs
+++ b/examples/demo/src/records/default_values.rs
@@ -17,6 +17,46 @@ pub struct ServiceConfig {
 #[data(impl)]
 impl ServiceConfig {
     #[demo_bench_macros::demo_case(
+        "records.default_values.service_config.from_owned_name.should_return_config",
+        justification = "Ensure a non-blittable record constructor accepts an owned String and returns the encoded record.",
+        directions = "Call `records::default_values::ServiceConfig::from_owned_name` through the generated binding and assert it returns a ServiceConfig using the provided name.",
+        exclude(
+            python,
+            reason = ExclusionReason::ImplementationGap,
+            details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when non-blittable records are implemented for Python."
+        )
+    )]
+    pub fn from_owned_name(name: String) -> Self {
+        Self {
+            name,
+            retries: 3,
+            region: "standard".to_string(),
+            endpoint: None,
+            backup_endpoint: Some("https://default".to_string()),
+        }
+    }
+
+    #[demo_bench_macros::demo_case(
+        "records.default_values.service_config.from_borrowed_name.should_return_config",
+        justification = "Ensure a non-blittable record constructor accepts a borrowed string and returns the encoded record.",
+        directions = "Call `records::default_values::ServiceConfig::from_borrowed_name` through the generated binding and assert it returns a ServiceConfig using the provided name.",
+        exclude(
+            python,
+            reason = ExclusionReason::ImplementationGap,
+            details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when non-blittable records are implemented for Python."
+        )
+    )]
+    pub fn from_borrowed_name(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            retries: 3,
+            region: "standard".to_string(),
+            endpoint: None,
+            backup_endpoint: Some("https://default".to_string()),
+        }
+    }
+
+    #[demo_bench_macros::demo_case(
         "records.default_values.service_config.should_describe_values",
         justification = "Ensure ServiceConfig::describe formats defaulted and explicit fields into a stable string.",
         directions = "Call `records::default_values::ServiceConfig::describe` through the generated binding and assert ServiceConfig::describe formats defaulted and explicit fields into a stable string.",

--- a/examples/demo/src/records/default_values.rs
+++ b/examples/demo/src/records/default_values.rs
@@ -57,6 +57,27 @@ impl ServiceConfig {
     }
 
     #[demo_bench_macros::demo_case(
+        "records.default_values.service_config.from_string_ref_name.should_return_config",
+        justification = "Ensure a non-blittable record constructor accepts a borrowed String reference and returns the encoded record.",
+        directions = "Call `records::default_values::ServiceConfig::from_string_ref_name` through the generated binding and assert it returns a ServiceConfig using the provided name.",
+        exclude(
+            python,
+            reason = ExclusionReason::ImplementationGap,
+            details = "Python is experimental; its lowerer currently emits only primitive-field blittable records. Include this case when non-blittable records are implemented for Python."
+        )
+    )]
+    #[allow(clippy::ptr_arg)]
+    pub fn from_string_ref_name(name: &String) -> Self {
+        Self {
+            name: name.clone(),
+            retries: 3,
+            region: "standard".to_string(),
+            endpoint: None,
+            backup_endpoint: Some("https://default".to_string()),
+        }
+    }
+
+    #[demo_bench_macros::demo_case(
         "records.default_values.service_config.should_describe_values",
         justification = "Ensure ServiceConfig::describe formats defaulted and explicit fields into a stable string.",
         directions = "Call `records::default_values::ServiceConfig::describe` through the generated binding and assert ServiceConfig::describe formats defaulted and explicit fields into a stable string.",

--- a/examples/platforms/apple/Tests/DemoConsumerTests/records/DefaultValuesRecordsTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/records/DefaultValuesRecordsTests.swift
@@ -61,5 +61,7 @@ final class DefaultValuesRecordsTests: DemoTestCase {
         XCTAssertEqual(ServiceConfig(fromOwnedName: "owned").describe(), "owned:3:standard:none:https://default")
         demoCase("case:records.default_values.service_config.from_borrowed_name.should_return_config")
         XCTAssertEqual(ServiceConfig(fromBorrowedName: "borrowed").describe(), "borrowed:3:standard:none:https://default")
+        demoCase("case:records.default_values.service_config.from_string_ref_name.should_return_config")
+        XCTAssertEqual(ServiceConfig(fromStringRefName: "stringref").describe(), "stringref:3:standard:none:https://default")
     }
 }

--- a/examples/platforms/apple/Tests/DemoConsumerTests/records/DefaultValuesRecordsTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/records/DefaultValuesRecordsTests.swift
@@ -56,5 +56,10 @@ final class DefaultValuesRecordsTests: DemoTestCase {
         XCTAssertEqual(explicitBackupEndpoint.describe(), "worker:9:eu-west:https://edge:https://backup")
         demoCase("case:records.default_values.service_config.should_describe_with_prefix")
         XCTAssertEqual(explicitBackupEndpoint.describeWithPrefix(prefix: "cfg"), "cfg:worker:9:eu-west:https://edge:https://backup")
+
+        demoCase("case:records.default_values.service_config.from_owned_name.should_return_config")
+        XCTAssertEqual(ServiceConfig(fromOwnedName: "owned").describe(), "owned:3:standard:none:https://default")
+        demoCase("case:records.default_values.service_config.from_borrowed_name.should_return_config")
+        XCTAssertEqual(ServiceConfig(fromBorrowedName: "borrowed").describe(), "borrowed:3:standard:none:https://default")
     }
 }

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -516,6 +516,11 @@ public static class DemoTest
             ServiceConfig.FromBorrowedName("borrowed").Describe() == "borrowed:3:standard:none:https://default",
             "ServiceConfig.FromBorrowedName(string)"
         );
+        DemoCase("case:records.default_values.service_config.from_string_ref_name.should_return_config");
+        Require(
+            ServiceConfig.FromStringRefName("stringref").Describe() == "stringref:3:standard:none:https://default",
+            "ServiceConfig.FromStringRefName(string)"
+        );
 
         Console.WriteLine("  PASS\n");
     }

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -506,6 +506,17 @@ public static class DemoTest
         DemoCase("case:records.default_values.service_config.maybe_with_retries.should_return_none");
         Require(ServiceConfig.MaybeWithRetries(-1) is null, "ServiceConfig.MaybeWithRetries(-1) == null");
 
+        DemoCase("case:records.default_values.service_config.from_owned_name.should_return_config");
+        Require(
+            ServiceConfig.FromOwnedName("owned").Describe() == "owned:3:standard:none:https://default",
+            "ServiceConfig.FromOwnedName(string)"
+        );
+        DemoCase("case:records.default_values.service_config.from_borrowed_name.should_return_config");
+        Require(
+            ServiceConfig.FromBorrowedName("borrowed").Describe() == "borrowed:3:standard:none:https://default",
+            "ServiceConfig.FromBorrowedName(string)"
+        );
+
         Console.WriteLine("  PASS\n");
     }
 

--- a/examples/platforms/csharp/test-demo.sh
+++ b/examples/platforms/csharp/test-demo.sh
@@ -25,17 +25,17 @@ while [[ $# -gt 0 ]]; do
 done
 
 cargo_profile="debug"
-pack_flags=()
+pack_command=(cargo run --quiet --manifest-path "$manifest_path" -p boltffi_cli -- pack csharp)
 if [[ "$configuration" == "Release" ]]; then
   cargo_profile="release"
-  pack_flags=(--release)
+  pack_command+=(--release)
 fi
 
 package_dir="$script_dir/dist/packages"
 packages_cache="$script_dir/dist/.nuget/packages"
 
 echo "=== boltffi pack csharp ($cargo_profile) ==="
-(cd "$demo_dir" && cargo run --quiet --manifest-path "$manifest_path" -p boltffi_cli -- pack csharp "${pack_flags[@]}")
+(cd "$demo_dir" && "${pack_command[@]}")
 
 echo "=== dotnet build DemoTest ==="
 rm -rf "$packages_cache"

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -492,6 +492,10 @@ public final class DemoTest {
         assert explicitBackupEndpoint.describe().equals("worker:9:eu-west:https://edge:https://backup") : "ServiceConfig.describe(explicitBackupEndpoint)";
         demoCase("case:records.default_values.service_config.should_describe_with_prefix");
         assert explicitBackupEndpoint.describeWithPrefix("cfg").equals("cfg:worker:9:eu-west:https://edge:https://backup") : "ServiceConfig.describeWithPrefix";
+        demoCase("case:records.default_values.service_config.from_owned_name.should_return_config");
+        assert ServiceConfig.fromOwnedName("owned").describe().equals("owned:3:standard:none:https://default") : "ServiceConfig.fromOwnedName";
+        demoCase("case:records.default_values.service_config.from_borrowed_name.should_return_config");
+        assert ServiceConfig.fromBorrowedName("borrowed").describe().equals("borrowed:3:standard:none:https://default") : "ServiceConfig.fromBorrowedName";
         System.out.println("  PASS\n");
     }
 

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -496,6 +496,8 @@ public final class DemoTest {
         assert ServiceConfig.fromOwnedName("owned").describe().equals("owned:3:standard:none:https://default") : "ServiceConfig.fromOwnedName";
         demoCase("case:records.default_values.service_config.from_borrowed_name.should_return_config");
         assert ServiceConfig.fromBorrowedName("borrowed").describe().equals("borrowed:3:standard:none:https://default") : "ServiceConfig.fromBorrowedName";
+        demoCase("case:records.default_values.service_config.from_string_ref_name.should_return_config");
+        assert ServiceConfig.fromStringRefName("stringref").describe().equals("stringref:3:standard:none:https://default") : "ServiceConfig.fromStringRefName";
         System.out.println("  PASS\n");
     }
 

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
@@ -931,5 +931,10 @@ class DemoValueTypesTest {
         assertEquals("worker:9:eu-west:https://edge:https://backup", explicitBackupEndpoint.describe())
         demoCase("case:records.default_values.service_config.should_describe_with_prefix")
         assertEquals("cfg:worker:9:eu-west:https://edge:https://backup", explicitBackupEndpoint.describeWithPrefix("cfg"))
+
+        demoCase("case:records.default_values.service_config.from_owned_name.should_return_config")
+        assertEquals("owned:3:standard:none:https://default", ServiceConfig.fromOwnedName("owned").describe())
+        demoCase("case:records.default_values.service_config.from_borrowed_name.should_return_config")
+        assertEquals("borrowed:3:standard:none:https://default", ServiceConfig.fromBorrowedName("borrowed").describe())
     }
 }

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoValueTypesTest.kt
@@ -936,5 +936,7 @@ class DemoValueTypesTest {
         assertEquals("owned:3:standard:none:https://default", ServiceConfig.fromOwnedName("owned").describe())
         demoCase("case:records.default_values.service_config.from_borrowed_name.should_return_config")
         assertEquals("borrowed:3:standard:none:https://default", ServiceConfig.fromBorrowedName("borrowed").describe())
+        demoCase("case:records.default_values.service_config.from_string_ref_name.should_return_config")
+        assertEquals("stringref:3:standard:none:https://default", ServiceConfig.fromStringRefName("stringref").describe())
     }
 }

--- a/examples/platforms/wasm/tests/records/default_values.test.mjs
+++ b/examples/platforms/wasm/tests/records/default_values.test.mjs
@@ -31,4 +31,6 @@ export async function run() {
   assert.equal(demo.ServiceConfig.describe(demo.ServiceConfig.fromOwnedName("owned")), "owned:3:standard:none:https://default");
   globalThis.demoCase("case:records.default_values.service_config.from_borrowed_name.should_return_config");
   assert.equal(demo.ServiceConfig.describe(demo.ServiceConfig.fromBorrowedName("borrowed")), "borrowed:3:standard:none:https://default");
+  globalThis.demoCase("case:records.default_values.service_config.from_string_ref_name.should_return_config");
+  assert.equal(demo.ServiceConfig.describe(demo.ServiceConfig.fromStringRefName("stringref")), "stringref:3:standard:none:https://default");
 }

--- a/examples/platforms/wasm/tests/records/default_values.test.mjs
+++ b/examples/platforms/wasm/tests/records/default_values.test.mjs
@@ -26,4 +26,9 @@ export async function run() {
   assert.equal(demo.ServiceConfig.describe(explicitConfig), "worker:9:eu-west:https://edge:https://backup");
   globalThis.demoCase("case:records.default_values.service_config.should_describe_with_prefix");
   assert.equal(demo.ServiceConfig.describeWithPrefix(explicitConfig, "cfg"), "cfg:worker:9:eu-west:https://edge:https://backup");
+
+  globalThis.demoCase("case:records.default_values.service_config.from_owned_name.should_return_config");
+  assert.equal(demo.ServiceConfig.describe(demo.ServiceConfig.fromOwnedName("owned")), "owned:3:standard:none:https://default");
+  globalThis.demoCase("case:records.default_values.service_config.from_borrowed_name.should_return_config");
+  assert.equal(demo.ServiceConfig.describe(demo.ServiceConfig.fromBorrowedName("borrowed")), "borrowed:3:standard:none:https://default");
 }


### PR DESCRIPTION
fixes #481

Fixes `#[data(impl)]` constructors that take `String `or `&str` and return a nonblittable data record. The macro was splicing string conversion setup into an expression position which produced invalid Rust for encoded record returns.