### PR TITLE
fix python nested vector writes

### DIFF
--- a/boltffi_backend/src/target/python/codec/operation.rs
+++ b/boltffi_backend/src/target/python/codec/operation.rs
@@ -1,4 +1,4 @@
-use boltffi_binding::{DirectValueType, FieldKey, IntrinsicOp, OpRender, ValueRef};
+use boltffi_binding::{DirectValueType, FieldKey, IntrinsicOp, OpRender, ValueRef, ValueRoot};
 
 use crate::{
     core::{Error, Result},
@@ -9,9 +9,24 @@ use crate::{
     },
 };
 
-pub struct Operation;
+pub struct Operation {
+    self_value: ValueRef,
+}
 
 impl Operation {
+    pub fn with_self_value(value: &ValueRef) -> Self {
+        Self {
+            self_value: value.clone(),
+        }
+    }
+
+    fn value_ref(&self, value: &ValueRef) -> ValueRef {
+        match value.root() {
+            ValueRoot::SelfValue => self.self_value.clone(),
+            _ => value.clone(),
+        }
+    }
+
     fn binary(
         left: Result<Expression>,
         right: Result<Expression>,
@@ -36,7 +51,7 @@ impl OpRender for Operation {
     type Expr = Result<Expression>;
 
     fn value(&mut self, value: &ValueRef) -> Self::Expr {
-        ValueExpression::new(value).render()
+        ValueExpression::new(&self.value_ref(value)).render()
     }
 
     fn byte_count(&mut self, bytes: u64) -> Self::Expr {

--- a/boltffi_backend/src/target/python/codec/write.rs
+++ b/boltffi_backend/src/target/python/codec/write.rs
@@ -209,12 +209,12 @@ impl<'package> CodecWrite for Writer<'package> {
         binder: BinderId,
         element: Vec<Self::Stmt>,
     ) -> Vec<Self::Stmt> {
-        vec![self.value(value).and_then(|value| {
-            let count = len.render_with(&mut Operation);
+        vec![self.value(value).and_then(|wire_value| {
+            let count = len.render_with(&mut Operation::with_self_value(value));
             Self::call(
                 Identifier::parse("_boltffi_wire_sequence")?,
                 [
-                    value,
+                    wire_value,
                     count?,
                     Expression::lambda(Self::binder(binder)?, Self::single(element)?),
                 ],

--- a/boltffi_backend/src/target/python/cpython/mod.rs
+++ b/boltffi_backend/src/target/python/cpython/mod.rs
@@ -576,6 +576,58 @@ mod tests {
     }
 
     #[test]
+    fn python_target_renders_nested_vector_lengths_from_bound_value() {
+        let output = target()
+            .render(&bindings(
+                r#"
+                #[export]
+                pub fn echo_values(values: Vec<Vec<i32>>) -> Vec<Vec<i32>> {
+                    values
+                }
+                "#,
+            ))
+            .expect("Python target should render nested vector");
+        let init = file(&output, "demo/__init__.py");
+        let stub = file(&output, "demo/__init__.pyi");
+
+        assert!(init.contains(
+            "_boltffi_wire_sequence(__boltffi_value_0, len(__boltffi_value_0), lambda __boltffi_value_1: _boltffi_wire_i32(__boltffi_value_1))"
+        ));
+        assert!(!init.contains("len(self)"));
+        assert!(stub.contains("from collections.abc import Sequence"));
+        assert!(
+            stub.contains(
+                "def echo_values(values: Sequence[Sequence[int]]) -> list[list[int]]: ..."
+            )
+        );
+    }
+
+    #[test]
+    fn python_target_renders_record_vector_lengths_from_field_value() {
+        let output = target()
+            .render(&bindings(
+                r#"
+                #[data]
+                pub struct Profile {
+                    tags: Vec<String>,
+                }
+
+                #[export]
+                pub fn echo_profile(profile: Profile) -> Profile {
+                    profile
+                }
+                "#,
+            ))
+            .expect("Python target should render record vector");
+        let init = file(&output, "demo/__init__.py");
+
+        assert!(init.contains(
+            "_boltffi_wire_sequence(self.tags, len(self.tags), lambda __boltffi_value_0: _boltffi_wire_string(__boltffi_value_0))"
+        ));
+        assert!(!init.contains("self.tags.tags"));
+    }
+
+    #[test]
     fn python_target_renders_direct_record_associated_callables() {
         let output = target()
             .render(&bindings(

--- a/examples/demo/src/primitives/vecs.rs
+++ b/examples/demo/src/primitives/vecs.rs
@@ -266,22 +266,12 @@ pub fn inc_u64_value(value: u64) -> u64 {
 #[demo_bench_macros::demo_case(
     "primitives.vecs.nested_i32.should_roundtrip_values",
     justification = "Ensure a nested i32 vector crosses the wire and returns unchanged.",
-    directions = "Call `primitives::vecs::echo_vec_vec_i32` through the generated binding and assert a nested i32 vector crosses the wire and returns unchanged.",
-    exclude(
-        python,
-        reason = ExclusionReason::ImplementationGap,
-        details = "Python is experimental; its lowerer does not currently handle nested Vec<T> shapes. Include this case when nested vectors are implemented for Python."
-    )
+    directions = "Call `primitives::vecs::echo_vec_vec_i32` through the generated binding and assert a nested i32 vector crosses the wire and returns unchanged."
 )]
 #[demo_bench_macros::demo_case(
     "primitives.vecs.nested_i32.should_roundtrip_empty_outer",
     justification = "Ensure an empty outer i32 vector crosses the wire and returns as an empty nested vector.",
-    directions = "Call `primitives::vecs::echo_vec_vec_i32` through the generated binding and assert an empty outer i32 vector crosses the wire and returns as an empty nested vector.",
-    exclude(
-        python,
-        reason = ExclusionReason::ImplementationGap,
-        details = "Python is experimental; its lowerer does not currently handle nested Vec<T> shapes. Include this case when nested vectors are implemented for Python."
-    )
+    directions = "Call `primitives::vecs::echo_vec_vec_i32` through the generated binding and assert an empty outer i32 vector crosses the wire and returns as an empty nested vector."
 )]
 #[export]
 pub fn echo_vec_vec_i32(v: Vec<Vec<i32>>) -> Vec<Vec<i32>> {
@@ -291,12 +281,7 @@ pub fn echo_vec_vec_i32(v: Vec<Vec<i32>>) -> Vec<Vec<i32>> {
 #[demo_bench_macros::demo_case(
     "primitives.vecs.nested_bool.should_roundtrip_values",
     justification = "Ensure a nested boolean vector crosses the wire and returns unchanged.",
-    directions = "Call `primitives::vecs::echo_vec_vec_bool` through the generated binding and assert a nested boolean vector crosses the wire and returns unchanged.",
-    exclude(
-        python,
-        reason = ExclusionReason::ImplementationGap,
-        details = "Python is experimental; its lowerer does not currently handle nested Vec<T> shapes. Include this case when nested vectors are implemented for Python."
-    )
+    directions = "Call `primitives::vecs::echo_vec_vec_bool` through the generated binding and assert a nested boolean vector crosses the wire and returns unchanged."
 )]
 #[export]
 pub fn echo_vec_vec_bool(v: Vec<Vec<bool>>) -> Vec<Vec<bool>> {
@@ -307,11 +292,6 @@ pub fn echo_vec_vec_bool(v: Vec<Vec<bool>>) -> Vec<Vec<bool>> {
     "primitives.vecs.nested_isize.should_roundtrip_values",
     justification = "Ensure a nested isize vector crosses the wire and returns unchanged.",
     directions = "Call `primitives::vecs::echo_vec_vec_isize` through the generated binding and assert a nested isize vector crosses the wire and returns unchanged.",
-    exclude(
-        python,
-        reason = ExclusionReason::ImplementationGap,
-        details = "Python is experimental; its lowerer does not currently handle nested Vec<T> shapes. Include this case when nested vectors are implemented for Python."
-    ),
     exclude(
         typescript,
         reason = ExclusionReason::ImplementationGap,
@@ -328,11 +308,6 @@ pub fn echo_vec_vec_isize(v: Vec<Vec<isize>>) -> Vec<Vec<isize>> {
     justification = "Ensure a nested usize vector crosses the wire and returns unchanged.",
     directions = "Call `primitives::vecs::echo_vec_vec_usize` through the generated binding and assert a nested usize vector crosses the wire and returns unchanged.",
     exclude(
-        python,
-        reason = ExclusionReason::ImplementationGap,
-        details = "Python is experimental; its lowerer does not currently handle nested Vec<T> shapes. Include this case when nested vectors are implemented for Python."
-    ),
-    exclude(
         typescript,
         reason = ExclusionReason::ImplementationGap,
         details = "#203: TypeScript nested Vec<Vec<usize>> lowering passes plain Number values to BigInt setters in the generated writer. Include this case when the nested usize writer coerces elements to BigInt."
@@ -346,12 +321,7 @@ pub fn echo_vec_vec_usize(v: Vec<Vec<usize>>) -> Vec<Vec<usize>> {
 #[demo_bench_macros::demo_case(
     "primitives.vecs.nested_string.should_roundtrip_utf8_values",
     justification = "Ensure a nested string vector with UTF-8 values crosses the wire and returns unchanged.",
-    directions = "Call `primitives::vecs::echo_vec_vec_string` through the generated binding and assert a nested string vector with UTF-8 values crosses the wire and returns unchanged.",
-    exclude(
-        python,
-        reason = ExclusionReason::ImplementationGap,
-        details = "Python is experimental; its lowerer does not currently handle nested Vec<T> shapes. Include this case when nested vectors are implemented for Python."
-    )
+    directions = "Call `primitives::vecs::echo_vec_vec_string` through the generated binding and assert a nested string vector with UTF-8 values crosses the wire and returns unchanged."
 )]
 #[export]
 pub fn echo_vec_vec_string(v: Vec<Vec<String>>) -> Vec<Vec<String>> {
@@ -361,22 +331,12 @@ pub fn echo_vec_vec_string(v: Vec<Vec<String>>) -> Vec<Vec<String>> {
 #[demo_bench_macros::demo_case(
     "primitives.vecs.nested_i32.should_flatten_values",
     justification = "Ensure a nested i32 vector crosses the wire and returns as a flattened i32 vector.",
-    directions = "Call `primitives::vecs::flatten_vec_vec_i32` through the generated binding and assert a nested i32 vector crosses the wire and returns as a flattened i32 vector.",
-    exclude(
-        python,
-        reason = ExclusionReason::ImplementationGap,
-        details = "Python is experimental; its lowerer does not currently handle nested Vec<T> shapes. Include this case when nested vectors are implemented for Python."
-    )
+    directions = "Call `primitives::vecs::flatten_vec_vec_i32` through the generated binding and assert a nested i32 vector crosses the wire and returns as a flattened i32 vector."
 )]
 #[demo_bench_macros::demo_case(
     "primitives.vecs.nested_i32.should_flatten_empty",
     justification = "Ensure an empty nested i32 vector crosses the wire and returns as an empty i32 vector.",
-    directions = "Call `primitives::vecs::flatten_vec_vec_i32` through the generated binding and assert an empty nested i32 vector crosses the wire and returns as an empty i32 vector.",
-    exclude(
-        python,
-        reason = ExclusionReason::ImplementationGap,
-        details = "Python is experimental; its lowerer does not currently handle nested Vec<T> shapes. Include this case when nested vectors are implemented for Python."
-    )
+    directions = "Call `primitives::vecs::flatten_vec_vec_i32` through the generated binding and assert an empty nested i32 vector crosses the wire and returns as an empty i32 vector."
 )]
 #[export]
 pub fn flatten_vec_vec_i32(v: Vec<Vec<i32>>) -> Vec<i32> {

--- a/examples/platforms/python/tests/primitives/test_vecs.py
+++ b/examples/platforms/python/tests/primitives/test_vecs.py
@@ -76,6 +76,30 @@ class PrimitiveVecsTests(DemoTestCase):
         self.demo_case("case:primitives.vecs.string.should_report_utf8_byte_lengths")
         self.assertEqual(demo.vec_string_lengths(["hi", "café"]), [2, 5])
 
+    def test_nested_vecs(self) -> None:
+        self.demo_case("case:primitives.vecs.nested_i32.should_roundtrip_values")
+        self.assertEqual(demo.echo_vec_vec_i32([[1, 2], [], [-3]]), [[1, 2], [], [-3]])
+        self.demo_case("case:primitives.vecs.nested_i32.should_roundtrip_empty_outer")
+        self.assertEqual(demo.echo_vec_vec_i32([]), [])
+        self.demo_case("case:primitives.vecs.nested_bool.should_roundtrip_values")
+        self.assertEqual(
+            demo.echo_vec_vec_bool([[True, False], [], [False]]),
+            [[True, False], [], [False]],
+        )
+        self.demo_case("case:primitives.vecs.nested_isize.should_roundtrip_values")
+        self.assertEqual(demo.echo_vec_vec_isize([[-2, 0, 5], []]), [[-2, 0, 5], []])
+        self.demo_case("case:primitives.vecs.nested_usize.should_roundtrip_values")
+        self.assertEqual(demo.echo_vec_vec_usize([[0, 2, 4], []]), [[0, 2, 4], []])
+        self.demo_case("case:primitives.vecs.nested_string.should_roundtrip_utf8_values")
+        self.assertEqual(
+            demo.echo_vec_vec_string([["hello", "café"], [], ["world"]]),
+            [["hello", "café"], [], ["world"]],
+        )
+        self.demo_case("case:primitives.vecs.nested_i32.should_flatten_values")
+        self.assertEqual(demo.flatten_vec_vec_i32([[1, 2], [], [3]]), [1, 2, 3])
+        self.demo_case("case:primitives.vecs.nested_i32.should_flatten_empty")
+        self.assertEqual(demo.flatten_vec_vec_i32([]), [])
+
     def test_make_range(self) -> None:
         self.demo_case("case:primitives.vecs.i32.should_make_range")
         self.assertEqual(demo.make_range(0, 5), [0, 1, 2, 3, 4])


### PR DESCRIPTION
This fixes Python nested vector encoding.

The generated Python writer already used the shared codec IR for nested `Vec<T>` values, but sequence length expressions were rendered without the current codec value in scope. That meant an inner vector could be encoded with `len(self)` instead of `len(__boltffi_value_0)`, and record fields could become `len(self.tags.tags)` instead of `len(self.tags)`.

The fix makes Python operation rendering carry the current sequence value while rendering a sequence length op. When the IR says `self` inside that op, the Python backend now reads it as the value currently being encoded.

This keeps the existing shared `WritePlan` walker in charge of traversal. The backend still only renders operation leaves, so it does not add another recursive walk over `CodecNode`.

The demo now enables Python coverage for nested vectors, including nested integers, booleans, sized integers, strings, empty outer vectors, and flattening a nested integer vector.