### PR TITLE
Support borrowed direct record parameters

### DIFF
--- a/boltffi_backend/src/bridge/c/function/signature.rs
+++ b/boltffi_backend/src/bridge/c/function/signature.rs
@@ -45,6 +45,8 @@ struct FallibleAsyncCallbackSuccess;
 
 trait EncodedWritebackReceive {
     fn needs_encoded_writeback(self) -> bool;
+    fn needs_mutable_pointer(self) -> bool;
+    fn direct_param_type(self, ty: &DirectValueType, value: Type) -> Type;
 }
 
 /// C ABI projection for the callable body behind a closure handle.
@@ -62,11 +64,31 @@ impl EncodedWritebackReceive for Receive {
     fn needs_encoded_writeback(self) -> bool {
         self == Receive::ByMutRef
     }
+
+    fn needs_mutable_pointer(self) -> bool {
+        self == Receive::ByMutRef
+    }
+
+    fn direct_param_type(self, ty: &DirectValueType, value: Type) -> Type {
+        match (ty, self) {
+            (DirectValueType::Record(_), Receive::ByRef) => Type::ConstPointer(Box::new(value)),
+            (DirectValueType::Record(_), Receive::ByMutRef) => Type::MutPointer(Box::new(value)),
+            _ => value,
+        }
+    }
 }
 
 impl EncodedWritebackReceive for () {
     fn needs_encoded_writeback(self) -> bool {
         false
+    }
+
+    fn needs_mutable_pointer(self) -> bool {
+        false
+    }
+
+    fn direct_param_type(self, _: &DirectValueType, value: Type) -> Type {
+        value
     }
 }
 
@@ -143,27 +165,34 @@ where
 {
     type Output = Result<Vec<Parameter>>;
 
-    fn direct(&mut self, ty: &'plan DirectValueType, _: D::Receive) -> Self::Output {
+    fn direct(&mut self, ty: &'plan DirectValueType, receive: D::Receive) -> Self::Output {
+        let value = self.signature.names.direct_value(ty)?;
         Ok(vec![Parameter::new(
             self.name.as_str(),
-            self.signature.names.direct_value(ty)?,
+            receive.direct_param_type(ty, value),
         )?])
     }
 
     fn encoded(
         &mut self,
-        _: &'plan TypeRef,
+        ty: &'plan TypeRef,
         _: &'plan D::Codec,
         shape: native::BufferShape,
         receive: D::Receive,
     ) -> Self::Output {
         match shape {
             native::BufferShape::Slice => {
-                let mut parameters = vec![
-                    Parameter::byte_pointer(&self.name)?,
-                    Parameter::byte_length(&self.name)?,
-                ];
-                if receive.needs_encoded_writeback() {
+                // Only the in-place `&mut [u8]` case (no writeback out-param) takes a
+                // mutable input pointer. Other `&mut` encoded params (e.g. `&mut [u64]`,
+                // `&mut <record>`) keep a const input pointer plus an encoded writeback
+                // out-param, matching the Rust extern and host renderers.
+                let pointer = if receive.needs_mutable_pointer() && matches!(ty, TypeRef::Bytes) {
+                    Parameter::mutable_byte_pointer(&self.name)?
+                } else {
+                    Parameter::byte_pointer(&self.name)?
+                };
+                let mut parameters = vec![pointer, Parameter::byte_length(&self.name)?];
+                if receive.needs_encoded_writeback() && !matches!(ty, TypeRef::Bytes) {
                     parameters.push(Parameter::encoded_writeback(&self.name)?);
                 }
                 Ok(parameters)

--- a/boltffi_backend/src/bridge/c/mod.rs
+++ b/boltffi_backend/src/bridge/c/mod.rs
@@ -47,7 +47,7 @@ mod tests {
 
     use crate::core::bridge::BridgeBackend;
 
-    use super::{CBridge, ParameterGroup, Type};
+    use super::{CBridge, Identifier, ParameterGroup, Type};
 
     fn bindings(source: &str) -> boltffi_binding::Bindings<Native> {
         let file = syn::parse_str(source).expect("valid source fixture");
@@ -238,6 +238,23 @@ mod tests {
     }
 
     #[test]
+    fn c_header_renders_mutable_encoded_parameter_pointer() {
+        let header = header(
+            r#"
+            #[export]
+            pub fn fill(out: &mut [u8]) -> u32 { out.len() as u32 }
+            "#,
+        );
+
+        assert!(
+            header.contains(
+                "uint32_t boltffi_function_demo_fill(uint8_t *out_ptr, uintptr_t out_len);"
+            ),
+            "{header}"
+        );
+    }
+
+    #[test]
     fn c_contract_groups_closure_parameter_triples() {
         let contract = contract(
             r#"
@@ -416,6 +433,82 @@ mod tests {
         assert_eq!(bytes.name(), "name");
         assert_eq!(function.parameter(bytes.pointer()).name(), "name_ptr");
         assert_eq!(function.parameter(bytes.length()).name(), "name_len");
+    }
+
+    #[test]
+    fn c_contract_direct_record_params_are_receive_aware() {
+        let contract = contract(
+            r#"
+            #[repr(C)]
+            #[data]
+            pub struct Point {
+                pub x: f64,
+                pub y: f64,
+            }
+
+            #[export]
+            pub fn distance(point: &Point) -> f64 {
+                0.0
+            }
+
+            #[export]
+            pub fn scale(point: &mut Point, factor: f64) {
+                point.x *= factor;
+            }
+
+            #[export]
+            pub fn echo(point: Point) -> Point {
+                point
+            }
+            "#,
+        );
+        let distance = contract
+            .functions()
+            .iter()
+            .find(|function| function.name() == "boltffi_function_demo_distance")
+            .expect("shared direct record parameter function");
+        let scale = contract
+            .functions()
+            .iter()
+            .find(|function| function.name() == "boltffi_function_demo_scale")
+            .expect("mutable direct record parameter function");
+        let echo = contract
+            .functions()
+            .iter()
+            .find(|function| function.name() == "boltffi_function_demo_echo")
+            .expect("by-value direct record parameter function");
+
+        let [ParameterGroup::Value(distance_point)] = distance.parameter_groups() else {
+            panic!("expected one direct-record parameter");
+        };
+        let [
+            ParameterGroup::Value(scale_point),
+            ParameterGroup::Value(scale_factor),
+        ] = scale.parameter_groups()
+        else {
+            panic!("expected direct-record pointer and scalar parameter");
+        };
+        let [ParameterGroup::Value(echo_point)] = echo.parameter_groups() else {
+            panic!("expected one direct-record parameter");
+        };
+
+        assert_eq!(
+            distance.parameter(*distance_point).ty(),
+            &Type::ConstPointer(Box::new(Type::DirectRecord(
+                Identifier::parse("___Point").expect("identifier")
+            )))
+        );
+        assert_eq!(
+            scale.parameter(*scale_point).ty(),
+            &Type::MutPointer(Box::new(Type::DirectRecord(
+                Identifier::parse("___Point").expect("identifier")
+            )))
+        );
+        assert_eq!(scale.parameter(*scale_factor).name(), "factor");
+        assert_eq!(
+            echo.parameter(*echo_point).ty(),
+            &Type::DirectRecord(Identifier::parse("___Point").expect("identifier"))
+        );
     }
 
     #[test]

--- a/boltffi_backend/src/bridge/c/parameter/mod.rs
+++ b/boltffi_backend/src/bridge/c/parameter/mod.rs
@@ -80,9 +80,18 @@ impl Parameter {
 
     /// Creates the pointer half of a borrowed byte-slice C ABI parameter group.
     pub fn byte_pointer(name: &str) -> Result<Self> {
+        Self::byte_pointer_with_type(name, Type::ConstPointer(Box::new(Type::Uint8)))
+    }
+
+    /// Creates the pointer half of a mutable byte-slice C ABI parameter group.
+    pub fn mutable_byte_pointer(name: &str) -> Result<Self> {
+        Self::byte_pointer_with_type(name, Type::MutPointer(Box::new(Type::Uint8)))
+    }
+
+    fn byte_pointer_with_type(name: &str, ty: Type) -> Result<Self> {
         Self::with_role(
             format!("{name}_ptr"),
-            Type::ConstPointer(Box::new(Type::Uint8)),
+            ty,
             ParameterRole::BytePointer(Identifier::escape(name)?),
         )
     }

--- a/boltffi_backend/src/bridge/jni/contract/parameter/build.rs
+++ b/boltffi_backend/src/bridge/jni/contract/parameter/build.rs
@@ -97,3 +97,59 @@ impl NativeParameter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::bridge::c::{Function, Identifier, Parameter, Type};
+
+    use super::*;
+
+    fn point_type() -> Type {
+        Type::DirectRecord(Identifier::parse("___Point").expect("record identifier"))
+    }
+
+    fn native_parameters_for(point: Type) -> Vec<NativeParameter> {
+        let function = Function::new(
+            "boltffi_function_demo_distance",
+            vec![Parameter::new("point", point).expect("parameter")],
+            Type::Float64,
+        )
+        .expect("function");
+        NativeParameter::from_c_function(&function, &[], &[]).expect("jni parameters")
+    }
+
+    #[test]
+    fn borrowed_direct_record_parameter_remains_record_shaped_for_jni() {
+        let params = native_parameters_for(Type::ConstPointer(Box::new(point_type())));
+
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0].ty().to_string(), "jbyteArray");
+        assert!(
+            params[0].record().is_some(),
+            "borrowed direct records must stay record-shaped instead of falling through to jlong"
+        );
+    }
+
+    #[test]
+    fn borrowed_direct_record_jni_call_argument_addresses_local_copy() {
+        let params = native_parameters_for(Type::ConstPointer(Box::new(point_type())));
+        let arguments = params[0]
+            .c_arguments()
+            .expect("record parameter call arguments");
+
+        assert_eq!(arguments.len(), 1);
+        assert_eq!(arguments[0].to_string(), "&__boltffi_point_value");
+    }
+
+    #[test]
+    fn by_value_direct_record_jni_call_argument_stays_local_value() {
+        let params = native_parameters_for(point_type());
+        let arguments = params[0]
+            .c_arguments()
+            .expect("record parameter call arguments");
+
+        assert_eq!(params[0].ty().to_string(), "jbyteArray");
+        assert_eq!(arguments.len(), 1);
+        assert_eq!(arguments[0].to_string(), "__boltffi_point_value");
+    }
+}

--- a/boltffi_backend/src/bridge/jni/contract/parameter/native.rs
+++ b/boltffi_backend/src/bridge/jni/contract/parameter/native.rs
@@ -85,13 +85,11 @@ impl NativeParameter {
             }))
             .collect()),
             NativeParameterKind::DirectVector(parameter) => Ok(parameter.c_arguments()),
-            NativeParameterKind::Record(parameter) => Ok(std::iter::once(Expression::identifier(
-                parameter.local().clone(),
-            ))
-            .chain(parameter.writeback().map(|writeback| {
-                Expression::address_of(Expression::identifier(writeback.local().clone()))
-            }))
-            .collect()),
+            NativeParameterKind::Record(parameter) => Ok(std::iter::once(parameter.c_argument())
+                .chain(parameter.writeback().map(|writeback| {
+                    Expression::address_of(Expression::identifier(writeback.local().clone()))
+                }))
+                .collect()),
             NativeParameterKind::Callback(parameter) => Ok(vec![parameter.c_argument()]),
             NativeParameterKind::Closure(parameter) => Ok(parameter.c_arguments()),
             NativeParameterKind::Continuation(parameter) => parameter.c_arguments(),

--- a/boltffi_backend/src/bridge/jni/contract/record/parameter.rs
+++ b/boltffi_backend/src/bridge/jni/contract/record/parameter.rs
@@ -10,7 +10,7 @@
 //! of deciding record mutability from the source type.
 
 use crate::{
-    bridge::c::{self, Identifier},
+    bridge::c::{self, Expression, Identifier},
     core::{Error, Result},
 };
 
@@ -42,6 +42,11 @@ impl RecordParameter {
     /// Returns the local C record value passed to the C bridge.
     pub fn local(&self) -> &Identifier {
         &self.local
+    }
+
+    /// Returns the expression passed to the C bridge function.
+    pub fn c_argument(&self) -> Expression {
+        self.value.c_argument(self.local.clone())
     }
 
     /// Returns the mutation writeback contract when the C bridge expects one.

--- a/boltffi_backend/src/bridge/jni/contract/record/value.rs
+++ b/boltffi_backend/src/bridge/jni/contract/record/value.rs
@@ -9,13 +9,20 @@
 //! callback arguments. It never looks into record fields; it only carries the ABI
 //! value shape already chosen by the C bridge.
 
-use crate::bridge::c::{self, Identifier, TypeFragment};
+use crate::bridge::c::{self, Expression, Identifier, TypeFragment};
 
 /// Direct record value carried through JNI as a fixed-size byte array.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub struct RecordValue {
     c_type: Identifier,
+    passing: RecordPassing,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum RecordPassing {
+    Value,
+    Pointer,
 }
 
 impl RecordValue {
@@ -29,12 +36,29 @@ impl RecordValue {
         TypeFragment::new(self.c_type.to_string())
     }
 
+    /// Returns the C bridge call expression for this record value.
+    pub fn c_argument(&self, local: Identifier) -> Expression {
+        let local = Expression::identifier(local);
+        match self.passing {
+            RecordPassing::Value => local,
+            RecordPassing::Pointer => Expression::address_of(local),
+        }
+    }
+
     /// Creates a direct-record JNI value from a C ABI type.
     pub fn from_c_type(ty: &c::Type) -> Option<Self> {
         match ty {
             c::Type::DirectRecord(c_type) => Some(Self {
                 c_type: c_type.clone(),
+                passing: RecordPassing::Value,
             }),
+            c::Type::ConstPointer(inner) | c::Type::MutPointer(inner) => match inner.as_ref() {
+                c::Type::DirectRecord(c_type) => Some(Self {
+                    c_type: c_type.clone(),
+                    passing: RecordPassing::Pointer,
+                }),
+                _ => None,
+            },
             _ => None,
         }
     }

--- a/boltffi_backend/src/target/python/cpython/mod.rs
+++ b/boltffi_backend/src/target/python/cpython/mod.rs
@@ -513,6 +513,41 @@ mod tests {
     }
 
     #[test]
+    fn python_target_renders_borrowed_direct_record_param_as_addressed_local() {
+        let output = target()
+            .render(&bindings(
+                r#"
+                #[repr(C)]
+                #[data]
+                pub struct Point {
+                    pub x: f64,
+                    pub y: f64,
+                }
+
+                #[export]
+                pub fn distance(point: &Point) -> f64 {
+                    point.x
+                }
+                "#,
+            ))
+            .expect("Python target should render borrowed direct record params");
+        let extension = extension(&output);
+        let stub = file(&output, "demo/__init__.pyi");
+
+        assert!(extension.contains("___Point point;"));
+        assert!(extension.contains("boltffi_python_parse_point(args[0], &point)"));
+        assert!(
+            extension.contains("boltffi_python_boltffi_function_demo_distance(&point)"),
+            "borrowed direct records should stay Python record-shaped and pass an addressed local to the pointer-shaped C ABI\n{extension}"
+        );
+        assert!(
+            !extension.contains("boltffi_python_boltffi_function_demo_distance(point)"),
+            "borrowed direct records must not keep passing the local by value after the C ABI becomes pointer-shaped\n{extension}"
+        );
+        assert!(stub.contains("def distance(point: Point) -> float: ..."));
+    }
+
+    #[test]
     fn python_target_renders_direct_record_vector_function_wrapper() {
         let output = target()
             .render(&bindings(

--- a/boltffi_backend/src/target/python/cpython/render/argument/mod.rs
+++ b/boltffi_backend/src/target/python/cpython/render/argument/mod.rs
@@ -127,7 +127,7 @@ impl Conversion {
 
     pub fn call_args(&self) -> Result<Vec<c::Expression>> {
         match &self.kind {
-            Kind::Direct(_) => Ok(vec![c::Expression::identifier(self.name.clone())]),
+            Kind::Direct(direct) => Ok(vec![direct.call_arg(self.name.clone())]),
             Kind::Buffered(buffered) => buffered.call_args(),
             Kind::Closure(closure) => closure
                 .call_args()
@@ -366,10 +366,11 @@ impl Conversion {
         }
     }
 
-    fn from_direct_slot(
+    fn from_direct_slot_with_passing(
         index: usize,
         name: Identifier,
         direct: direct::NativeSlot,
+        passing: DirectPassing,
     ) -> Result<Self> {
         Ok(Self {
             index,
@@ -377,6 +378,7 @@ impl Conversion {
             kind: Kind::Direct(Direct {
                 c_type: direct.c_type().clone(),
                 parser: direct.parser().clone(),
+                passing,
             }),
             primitive: direct.primitive(),
         })
@@ -398,6 +400,7 @@ impl Conversion {
             kind: Kind::Direct(Direct {
                 c_type: carrier.c_type()?,
                 parser: carrier.parser()?,
+                passing: DirectPassing::Value,
             }),
             primitive: Some(carrier),
         })
@@ -418,6 +421,7 @@ impl Conversion {
             kind: Kind::Direct(Direct {
                 c_type: TypeFragment::anonymous(&Type::CallbackHandle(callback))?,
                 parser: symbols.parser(presence).clone(),
+                passing: DirectPassing::Value,
             }),
             primitive: None,
         })
@@ -467,7 +471,11 @@ impl Conversion {
         Ok(Self {
             index,
             name,
-            kind: Kind::Direct(Direct { c_type, parser }),
+            kind: Kind::Direct(Direct {
+                c_type,
+                parser,
+                passing: DirectPassing::Value,
+            }),
             primitive: None,
         })
     }
@@ -519,11 +527,18 @@ struct ParameterConversion<'render> {
 impl<'render> ParameterConversion<'render> {
     fn direct_type(&self, ty: &DirectValueType, receive: Receive) -> Result<Conversion> {
         match receive {
-            Receive::ByValue | Receive::ByRef => Conversion::from_direct_slot(
-                self.index,
-                self.name.clone(),
-                direct::NativeSlot::from_direct_value(ty, self.bridge, self.context)?,
-            ),
+            Receive::ByValue | Receive::ByRef => {
+                let passing = match (ty, receive) {
+                    (DirectValueType::Record(_), Receive::ByRef) => DirectPassing::Address,
+                    _ => DirectPassing::Value,
+                };
+                Conversion::from_direct_slot_with_passing(
+                    self.index,
+                    self.name.clone(),
+                    direct::NativeSlot::from_direct_value(ty, self.bridge, self.context)?,
+                    passing,
+                )
+            }
             _ => Err(Error::UnsupportedTarget {
                 target: "python",
                 shape: "borrowed direct parameter",
@@ -636,6 +651,23 @@ enum Kind {
 struct Direct {
     c_type: c::TypeFragment,
     parser: Identifier,
+    passing: DirectPassing,
+}
+
+#[derive(Clone, Copy)]
+enum DirectPassing {
+    Value,
+    Address,
+}
+
+impl Direct {
+    fn call_arg(&self, name: Identifier) -> c::Expression {
+        let value = c::Expression::identifier(name);
+        match self.passing {
+            DirectPassing::Value => value,
+            DirectPassing::Address => c::Expression::address_of(value),
+        }
+    }
 }
 
 enum EitherIter<Left, Right> {

--- a/boltffi_bindgen/src/ir/contract.rs
+++ b/boltffi_bindgen/src/ir/contract.rs
@@ -11,7 +11,7 @@ use crate::ir::types::BuiltinDef;
 ///
 /// Records, enums, classes, callbacks, free functions. What the crate exports.
 /// Nothing here knows about wire encoding or parameter passing. That happens
-/// when [`Lowerer`](crate::ir::Lowerer) turns this into an [`AbiContract`].
+/// when [`Lowerer`](crate::ir::Lowerer) turns this into an [`AbiContract`](crate::ir::abi::AbiContract).
 #[derive(Debug, Clone)]
 pub struct FfiContract {
     pub package: PackageInfo,

--- a/boltffi_bindgen/src/render/mod.rs
+++ b/boltffi_bindgen/src/render/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Each backend is split into three parts:
 //!
-//! - A **lowerer** that walks the [`AbiContract`] and maps each [`AbiCall`],
-//!   [`AbiRecord`], [`AbiEnum`], and [`AbiStream`] into language-specific plan
+//! - A **lowerer** that walks the [`AbiContract`] and maps each `AbiCall`,
+//!   `AbiRecord`, `AbiEnum`, and `AbiStream` into language-specific plan
 //!   structs. These plan structs carry everything a template needs to render:
 //!   type names, method signatures, wire read/write expressions, native
 //!   function declarations.

--- a/boltffi_binding/src/ir/decl.rs
+++ b/boltffi_binding/src/ir/decl.rs
@@ -19,7 +19,7 @@ use crate::{
 /// FFI decision already made.
 ///
 /// Generic over `S: Surface` because every variant transitively contains
-/// at least one [`CallableDecl`], and callable shapes diverge by target.
+/// at least one callable declaration, and callable shapes diverge by target.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(bound(
     serialize = "S::BufferShape: Serialize, S::HandleCarrier: Serialize, S::AsyncProtocol: Serialize, S::CallbackProtocol: Serialize",
@@ -1413,7 +1413,7 @@ impl DataVariantPayload {
 /// A free function exported across the boundary.
 ///
 /// Carries the binding name, the native symbol foreign code links
-/// against, and the [`CallableDecl`] that describes how the call
+/// against, and the callable declaration that describes how the call
 /// actually crosses.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(bound(

--- a/boltffi_binding/src/ir/surface.rs
+++ b/boltffi_binding/src/ir/surface.rs
@@ -344,7 +344,7 @@ pub mod native {
     /// `free_slot` is invoked when Rust drops the foreign
     /// implementation. `clone_slot` is invoked when Rust duplicates the
     /// handle. Each method on the trait occupies its own slot named on
-    /// the corresponding [`MethodDecl`].
+    /// the corresponding method declaration.
     #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
     pub struct CallbackVTable {
         free_slot: VTableSlot,

--- a/boltffi_core/src/passable/sequence.rs
+++ b/boltffi_core/src/passable/sequence.rs
@@ -2,7 +2,7 @@ use crate::types::FfiBuf;
 
 /// Packs and unpacks `Vec<Self>` using the ABI representation chosen for `Self`.
 ///
-/// This trait models sequence transport separately from [`Passable`], which only
+/// This trait models sequence transport separately from [`crate::Passable`], which only
 /// describes the ABI form of a single value.
 pub trait VecTransport: Sized {
     /// Packs an owned vector into an FFI-owned byte buffer.

--- a/boltffi_macros/src/experimental/expansion/mod.rs
+++ b/boltffi_macros/src/experimental/expansion/mod.rs
@@ -1732,6 +1732,19 @@ mod tests {
         source
     }
 
+    fn mutable_byte_vec_param_contract() -> SourceContract {
+        let mut function =
+            FunctionDef::new(FunctionId::new("demo::grow"), CanonicalName::single("grow"));
+        let mut parameter = parameter("bytes", byte_vec());
+        parameter.passing = ParameterPassing::RefMut;
+        function.parameters = vec![parameter];
+        function.returns = ReturnDef::Void;
+
+        let mut source = SourceContract::new(PackageInfo::new("demo", None));
+        source.functions.push(function);
+        source
+    }
+
     fn encoded_record_param_contract() -> SourceContract {
         let mut function = FunctionDef::new(
             FunctionId::new("demo::name_score"),
@@ -2669,6 +2682,27 @@ mod tests {
         assert!(matches!(
             error,
             Error::UnsupportedExpansion("encoded tuple arity")
+        ));
+    }
+
+    #[test]
+    fn native_mutable_byte_vec_param_expansion_rejects_unsupported_growable_param() {
+        let source = mutable_byte_vec_param_contract();
+        let lowered = lower_with_declarations::<Native>(&source).expect("lowered bindings");
+        let expansion = Expansion::new(&lowered);
+        let syntax = syn::parse_quote! {
+            pub fn grow(bytes: &mut Vec<u8>) {}
+        };
+
+        let error = expand_function(&expansion, &source.functions[0], syntax)
+            .expect_err("`&mut Vec<u8>` params must reject");
+
+        assert!(matches!(
+            error,
+            Error::UnsupportedExpansion(
+                "`&mut Vec<u8>` parameters are not supported; \
+                 use `&mut [u8]` for in-place mutation or return `Vec<u8>`"
+            )
         ));
     }
 
@@ -4650,12 +4684,17 @@ mod tests {
                 #[cfg(not(target_arch = "wasm32"))]
                 #[unsafe(no_mangle)]
                 pub unsafe extern "C" fn boltffi_function_demo_shift(
-                    point: <Point as ::boltffi::__private::Passable>::In
+                    point: *mut <Point as ::boltffi::__private::Passable>::In
                 ) -> f64 {
-                    let mut point: Point = unsafe {
-                        <Point as ::boltffi::__private::Passable>::unpack(point)
-                    };
-                    shift(&mut point)
+                    if point.is_null() {
+                        ::boltffi::__private::set_last_error(format!(
+                            "{}: null direct record pointer",
+                            stringify!(point)
+                        ));
+                        return <f64 as ::core::default::Default>::default();
+                    }
+                    let point: &mut Point = unsafe { &mut *(point as *mut Point) };
+                    shift(point)
                 }
             }
             .to_string()

--- a/boltffi_macros/src/experimental/rust_api/ty.rs
+++ b/boltffi_macros/src/experimental/rust_api/ty.rs
@@ -115,6 +115,12 @@ impl DecodeTarget {
         &self.source
     }
 
+    /// Returns true when the source type is a slice (`&mut [u8]`), as opposed to an owned
+    /// collection (`&mut Vec<u8>`). Used to select direct mutable-slice ABI vs wire-decode.
+    pub fn is_slice_source(&self) -> bool {
+        matches!(&self.source, TypeExpr::Slice(_))
+    }
+
     pub fn incoming_encoded_type(&self) -> IncomingEncodedType {
         IncomingEncodedType::new(&self.source)
     }

--- a/boltffi_macros/src/experimental/surface/mod.rs
+++ b/boltffi_macros/src/experimental/surface/mod.rs
@@ -51,6 +51,9 @@ pub trait RenderSurface:
     /// Crossing used for direct record parameters.
     const DIRECT_RECORD_PARAMS: DirectRecordCrossing;
 
+    /// Whether borrowed direct record parameters use typed native pointers.
+    const BORROWED_DIRECT_RECORD_PARAMS: bool;
+
     /// Returns the `cfg` attribute applied to generated wrapper items for this surface.
     fn cfg_attr() -> TokenStream;
 }
@@ -76,6 +79,7 @@ pub enum DirectRecordCrossing {
 impl RenderSurface for Native {
     const SCALAR_OPTION: ScalarOptionCrossing = ScalarOptionCrossing::WireEncoded;
     const DIRECT_RECORD_PARAMS: DirectRecordCrossing = DirectRecordCrossing::Value;
+    const BORROWED_DIRECT_RECORD_PARAMS: bool = true;
 
     fn cfg_attr() -> TokenStream {
         quote! { #[cfg(not(target_arch = "wasm32"))] }
@@ -85,6 +89,7 @@ impl RenderSurface for Native {
 impl RenderSurface for Wasm32 {
     const SCALAR_OPTION: ScalarOptionCrossing = ScalarOptionCrossing::NanBoxedF64;
     const DIRECT_RECORD_PARAMS: DirectRecordCrossing = DirectRecordCrossing::Pointer;
+    const BORROWED_DIRECT_RECORD_PARAMS: bool = false;
 
     fn cfg_attr() -> TokenStream {
         quote! { #[cfg(target_arch = "wasm32")] }

--- a/boltffi_macros/src/experimental/wrapper/param/direct.rs
+++ b/boltffi_macros/src/experimental/wrapper/param/direct.rs
@@ -70,6 +70,10 @@ where
             DirectValueType::Primitive(primitive) => {
                 PrimitiveParam::new(*primitive, input.receive, input.ident).tokens::<S>()
             }
+            DirectValueType::Record(_) if S::BORROWED_DIRECT_RECORD_PARAMS => {
+                NativeRecordParam::new(input.receive, input.ident, input.rust_type, input.failure)
+                    .tokens()
+            }
             DirectValueType::Record(_) => <Record as Render<S, _>>::render(
                 Record,
                 RecordInput::new(input.receive, input.rust_type, input.ident, input.failure),
@@ -194,6 +198,96 @@ impl PassableParam {
                     <#rust_type as ::boltffi::__private::Passable>::unpack(#ident)
                 };
             }],
+        }
+    }
+}
+
+pub struct NativeRecordParam {
+    receive: Receive,
+    ident: Ident,
+    rust_type: Type,
+    failure: TokenStream,
+}
+
+impl NativeRecordParam {
+    pub fn new(receive: Receive, ident: Ident, rust_type: Type, failure: TokenStream) -> Self {
+        Self {
+            receive,
+            ident,
+            rust_type,
+            failure,
+        }
+    }
+
+    pub fn tokens(self) -> Result<Tokens, Error> {
+        match self.receive {
+            Receive::ByValue => {
+                PassableParam::new(self.receive, self.ident, self.rust_type).tokens()
+            }
+            Receive::ByRef | Receive::ByMutRef => self.pointer_tokens(),
+            _ => Err(Error::UnsupportedExpansion(
+                "unknown direct record receive mode",
+            )),
+        }
+    }
+
+    fn pointer_tokens(self) -> Result<Tokens, Error> {
+        let ident = &self.ident;
+        let _rust_type = &self.rust_type;
+        let ffi_type = self.ffi_type()?;
+        Ok(Tokens {
+            items: Vec::new(),
+            ffi_parameters: vec![quote! { #ident: #ffi_type }],
+            ffi_parameter_types: vec![ffi_type],
+            conversions: vec![self.conversion()?],
+            writebacks: Vec::new(),
+            argument: quote! { #ident },
+        })
+    }
+
+    fn ffi_type(&self) -> Result<TokenStream, Error> {
+        let rust_type = &self.rust_type;
+        match self.receive {
+            Receive::ByRef => {
+                Ok(quote! { *const <#rust_type as ::boltffi::__private::Passable>::In })
+            }
+            Receive::ByMutRef => {
+                Ok(quote! { *mut <#rust_type as ::boltffi::__private::Passable>::In })
+            }
+            _ => Err(Error::UnsupportedExpansion(
+                "unknown borrowed direct record receive mode",
+            )),
+        }
+    }
+
+    fn conversion(&self) -> Result<TokenStream, Error> {
+        let ident = &self.ident;
+        let rust_type = &self.rust_type;
+        let failure = &self.failure;
+        match self.receive {
+            Receive::ByRef => Ok(quote! {
+                if #ident.is_null() {
+                    ::boltffi::__private::set_last_error(format!(
+                        "{}: null direct record pointer",
+                        stringify!(#ident)
+                    ));
+                    #failure
+                }
+                let #ident: &#rust_type = unsafe { &*(#ident as *const #rust_type) };
+            }),
+            Receive::ByMutRef => Ok(quote! {
+                if #ident.is_null() {
+                    ::boltffi::__private::set_last_error(format!(
+                        "{}: null direct record pointer",
+                        stringify!(#ident)
+                    ));
+                    #failure
+                }
+                let #ident: &mut #rust_type = unsafe { &mut *(#ident as *mut #rust_type) };
+            }),
+            _ => Err(Error::UnsupportedExpansion(
+                "unknown borrowed direct record receive mode",
+            )),
         }
     }
 }

--- a/boltffi_macros/src/experimental/wrapper/param/encoded.rs
+++ b/boltffi_macros/src/experimental/wrapper/param/encoded.rs
@@ -23,6 +23,7 @@ pub struct Input<'expansion, 'lowered, S: RenderSurface> {
     failure: TokenStream,
     expansion: &'expansion Expansion<'lowered, S>,
     writeback: bool,
+    mutable_bytes: bool,
 }
 
 impl<'expansion, 'lowered, S: RenderSurface> Input<'expansion, 'lowered, S> {
@@ -42,11 +43,17 @@ impl<'expansion, 'lowered, S: RenderSurface> Input<'expansion, 'lowered, S> {
             failure,
             expansion,
             writeback: false,
+            mutable_bytes: false,
         }
     }
 
     pub fn with_writeback(mut self) -> Self {
         self.writeback = true;
+        self
+    }
+
+    pub fn into_mutable_bytes(mut self) -> Self {
+        self.mutable_bytes = true;
         self
     }
 }
@@ -75,6 +82,7 @@ impl<'expansion, 'lowered> Render<Wasm32, Input<'expansion, 'lowered, Wasm32>> f
             wasm32::BufferShape::Slice => {
                 let mut input = input;
                 input.writeback = false;
+                input.mutable_bytes = false;
                 Slice::new(input).tokens()
             }
             wasm32::BufferShape::Packed => {
@@ -96,6 +104,7 @@ struct Slice<'expansion, 'lowered, S: RenderSurface> {
     failure: TokenStream,
     expansion: &'expansion Expansion<'lowered, S>,
     writeback: bool,
+    mutable_bytes: bool,
 }
 
 impl<'expansion, 'lowered, S: RenderSurface> From<Input<'expansion, 'lowered, S>>
@@ -121,10 +130,24 @@ impl<'expansion, 'lowered, S: RenderSurface> Slice<'expansion, 'lowered, S> {
             failure: input.failure,
             expansion: input.expansion,
             writeback: input.writeback,
+            mutable_bytes: input.mutable_bytes,
         }
     }
 
     fn tokens(self) -> Result<Tokens, Error> {
+        // For mutable byte-slice params (&mut [u8]) in the new direct ABI, bypass wire-decoding
+        // and create a mutable slice directly from the raw pointer.
+        if self.mutable_bytes {
+            return if self.target.is_slice_source() {
+                self.mutable_byte_slice_tokens()
+            } else {
+                Err(Error::UnsupportedExpansion(
+                    "`&mut Vec<u8>` parameters are not supported; \
+                     use `&mut [u8]` for in-place mutation or return `Vec<u8>`",
+                ))
+            };
+        }
+
         let pointer = &self.pointer;
         let length = &self.length;
         let ident = &self.ident;
@@ -155,8 +178,46 @@ impl<'expansion, 'lowered, S: RenderSurface> Slice<'expansion, 'lowered, S> {
         })
     }
 
+    /// Generates tokens for a `&mut [u8]` parameter using direct `from_raw_parts_mut`,
+    /// bypassing wire-decoding. Modifications to the slice are visible to the caller.
+    fn mutable_byte_slice_tokens(self) -> Result<Tokens, Error> {
+        let pointer = &self.pointer;
+        let length = &self.length;
+        let ident = &self.ident;
+        let failure = &self.failure;
+        let conversion = quote! {
+            let #ident: &mut [u8] = if #pointer.is_null() && #length > 0 {
+                ::boltffi::__private::set_last_error(format!(
+                    "{}: null pointer with non-zero length (buf_len={})",
+                    stringify!(#ident),
+                    #length
+                ));
+                #failure
+            } else if #length == 0 {
+                &mut []
+            } else {
+                unsafe { ::core::slice::from_raw_parts_mut(#pointer, #length) }
+            };
+        };
+        Ok(Tokens {
+            items: Vec::new(),
+            ffi_parameters: vec![quote! { #pointer: *mut u8 }, quote! { #length: usize }],
+            ffi_parameter_types: vec![quote! { *mut u8 }, quote! { usize }],
+            conversions: vec![conversion],
+            writebacks: Vec::new(),
+            argument: quote! { #ident },
+        })
+    }
+
     fn pointer_type(&self) -> TokenStream {
-        quote! { *const u8 }
+        // Only the in-place mutable byte slice (`&mut [u8]`) takes a mutable input
+        // pointer. Writeback params read a const input and return results via the
+        // separate out-param, matching the C bridge signature.
+        if self.mutable_bytes {
+            quote! { *mut u8 }
+        } else {
+            quote! { *const u8 }
+        }
     }
 
     fn writeback(&self) -> Result<Writeback, Error> {

--- a/boltffi_macros/src/experimental/wrapper/param/mod.rs
+++ b/boltffi_macros/src/experimental/wrapper/param/mod.rs
@@ -1,4 +1,6 @@
-use boltffi_binding::{DirectValueType, IncomingParam, IntoRust, ParamDecl, ParamPlan, Receive};
+use boltffi_binding::{
+    DirectValueType, IncomingParam, IntoRust, ParamDecl, ParamPlan, Receive, TypeRef,
+};
 use proc_macro2::TokenStream;
 
 use crate::experimental::{
@@ -20,9 +22,18 @@ pub struct Renderer;
 
 pub fn requires_failure_return<S: RenderSurface>(param: &ParamDecl<S, IntoRust>) -> bool {
     match param.payload() {
-        IncomingParam::Value(ParamPlan::Direct { ty, .. }) => {
-            matches!(S::DIRECT_RECORD_PARAMS, DirectRecordCrossing::Pointer)
-                && matches!(ty, DirectValueType::Record(_))
+        IncomingParam::Value(ParamPlan::Direct { ty, receive }) => {
+            // A direct record needs a failure return only when it crosses as a
+            // nullable pointer that the wrapper null-checks:
+            //   * surfaces that pass every direct record by pointer (e.g. wasm)
+            //     null-check all of them, including by-value; or
+            //   * surfaces that only borrow direct records by pointer (native)
+            //     null-check just the borrowed `&T` / `&mut T` cases. By-value
+            //     records there are passed directly and can never be null.
+            matches!(ty, DirectValueType::Record(_))
+                && (matches!(S::DIRECT_RECORD_PARAMS, DirectRecordCrossing::Pointer)
+                    || (S::BORROWED_DIRECT_RECORD_PARAMS
+                        && matches!(receive, Receive::ByRef | Receive::ByMutRef)))
         }
         IncomingParam::Value(ParamPlan::Encoded { .. })
         | IncomingParam::Value(ParamPlan::Handle { .. })
@@ -122,6 +133,7 @@ where
                 codec,
                 shape,
                 receive,
+                ty,
                 ..
             }) => {
                 let encoded_input = encoded::Input::new(
@@ -132,8 +144,9 @@ where
                     input.failure,
                     input.expansion,
                 );
-                let encoded_input = match receive {
-                    Receive::ByMutRef => encoded_input.with_writeback(),
+                let encoded_input = match (receive, ty) {
+                    (Receive::ByMutRef, TypeRef::Bytes) => encoded_input.into_mutable_bytes(),
+                    (Receive::ByMutRef, _) => encoded_input.with_writeback(),
                     _ => encoded_input,
                 };
                 <encoded::Renderer as Render<S, _>>::render(encoded::Renderer, encoded_input)

--- a/boltffi_tests/build.rs
+++ b/boltffi_tests/build.rs
@@ -634,13 +634,7 @@ static int boltffi_tests_check_i32_vec_buf(FfiBuf_u8 buf, const int32_t *expecte
     if (echoed != 0) {
         return echoed;
     }
-    const uint8_t grown_expected[9] = {5, 0, 0, 0, 1, 2, 3, 4, 9};
-    FfiBuf_u8 grown = {0};
-    FfiStatus status = boltffi_function_boltffi_tests_bytes_grow_bytes(data, 8, &grown, 9);
-    if (status.code != FFI_STATUS_OK.code) {
-        return 56;
-    }
-    return boltffi_tests_check_buf(grown, grown_expected, 9, 57);
+    return 0;
 }
 "#
     }
@@ -711,12 +705,15 @@ static int boltffi_tests_check_direct_records(void) {
     if (boltffi_function_boltffi_tests_records_direct_rect_area(rect) != 12.0) {
         return 202;
     }
-    if (boltffi_function_boltffi_tests_records_direct_rect_x(rect) != 1.0) {
+    if (boltffi_function_boltffi_tests_records_direct_rect_x(&rect) != 1.0) {
         return 203;
     }
-    FfiStatus status = boltffi_function_boltffi_tests_records_direct_scale_rect_in_place(rect, 2.0);
+    FfiStatus status = boltffi_function_boltffi_tests_records_direct_scale_rect_in_place(&rect, 2.0);
     if (status.code != FFI_STATUS_OK.code) {
         return 204;
+    }
+    if (rect.width != 6.0 || rect.height != 8.0) {
+        return 205;
     }
     return 0;
 }
@@ -848,7 +845,7 @@ static int boltffi_tests_check_direct_records(void) {
     if (shouted != 0) {
         return shouted;
     }
-    const uint8_t base[8] = {4, 0, 0, 0, 'b', 'a', 's', 'e'};
+    uint8_t base[8] = {4, 0, 0, 0, 'b', 'a', 's', 'e'};
     const uint8_t suffix[6] = {2, 0, 0, 0, ':', 'x'};
     const uint8_t rewritten_expected[10] = {6, 0, 0, 0, 'b', 'a', 's', 'e', ':', 'x'};
     FfiBuf_u8 rewritten = {0};
@@ -863,7 +860,7 @@ static int boltffi_tests_check_direct_records(void) {
 
     fn encoded_records_harness(&self) -> &'static str {
         r#"static int boltffi_tests_check_encoded_records(void) {
-    const uint8_t record[27] = {
+    uint8_t record[27] = {
         3, 0, 0, 0, 'o', 'l', 'd',
         0, 0, 0, 0, 0, 0, 0, 64,
         0, 0, 0, 0, 0, 0, 8, 64,

--- a/boltffi_tests/src/bytes.rs
+++ b/boltffi_tests/src/bytes.rs
@@ -22,8 +22,3 @@ pub fn fill_bytes(out: &mut [u8]) -> u32 {
 pub fn echo_bytes(data: Vec<u8>) -> Vec<u8> {
     data
 }
-
-#[export]
-pub fn grow_bytes(data: &mut Vec<u8>, extra: u8) {
-    data.push(extra);
-}

--- a/boltffi_tests/tests/crossing_behavior.rs
+++ b/boltffi_tests/tests/crossing_behavior.rs
@@ -140,32 +140,13 @@ mod bytes {
     }
 
     #[test]
-    fn mutable_byte_vec_writeback_returns_changed_bytes() {
-        let data = vec![5u8, 6, 7];
-        let mut out = FfiBuf::empty();
-        with_encoded(&data, |ptr, len| {
-            assert_ok(unsafe {
-                boltffi_function_boltffi_tests_bytes_grow_bytes(ptr, len, &mut out, 8)
-            });
-        });
-        assert_eq!(decode_buf::<Vec<u8>>(out), vec![5, 6, 7, 8]);
-    }
-
-    #[test]
-    fn mutable_byte_slice_writeback_returns_changed_bytes_on_current_contract() {
-        let input = vec![0u8; 6];
-        let encoded = encode_buf(&input);
-        let mut out = FfiBuf::empty();
+    fn mutable_byte_slice_writes_into_current_buffer() {
+        let mut input = vec![0u8; 6];
         let written = unsafe {
-            boltffi_function_boltffi_tests_bytes_fill_bytes(
-                encoded.as_ptr(),
-                encoded.len(),
-                &mut out,
-            )
+            boltffi_function_boltffi_tests_bytes_fill_bytes(input.as_mut_ptr(), input.len())
         };
         assert_eq!(written, 6);
-        let filled = decode_buf::<Vec<u8>>(out);
-        assert_eq!(filled, vec![1, 4, 7, 10, 13, 16]);
+        assert_eq!(input, vec![1, 4, 7, 10, 13, 16]);
     }
 }
 
@@ -191,7 +172,11 @@ mod strings {
             |text_ptr, text_len, suffix_ptr, suffix_len| {
                 assert_ok(unsafe {
                     boltffi_function_boltffi_tests_strings_rewrite(
-                        text_ptr, text_len, &mut out, suffix_ptr, suffix_len,
+                        text_ptr as *mut u8,
+                        text_len,
+                        &mut out,
+                        suffix_ptr,
+                        suffix_len,
                     )
                 });
             },
@@ -205,7 +190,7 @@ mod records {
 
     #[test]
     fn direct_record_functions_keep_c_layout_values() {
-        let rect =
+        let mut rect =
             unsafe { boltffi_function_boltffi_tests_records_direct_make_rect(1.0, 2.0, 3.0, 4.0) };
         assert_eq!(
             rect,
@@ -221,12 +206,14 @@ mod records {
             12.0
         );
         assert_eq!(
-            unsafe { boltffi_function_boltffi_tests_records_direct_rect_x(rect) },
+            unsafe { boltffi_function_boltffi_tests_records_direct_rect_x(&rect) },
             1.0
         );
         assert_ok(unsafe {
-            boltffi_function_boltffi_tests_records_direct_scale_rect_in_place(rect, 2.0)
+            boltffi_function_boltffi_tests_records_direct_scale_rect_in_place(&mut rect, 2.0)
         });
+        assert_eq!(rect.width, 6.0);
+        assert_eq!(rect.height, 8.0);
     }
 
     #[test]
@@ -253,7 +240,11 @@ mod records {
             |record_ptr, record_len, label_ptr, label_len| {
                 assert_ok(unsafe {
                     boltffi_function_boltffi_tests_records_encoded_relabel(
-                        record_ptr, record_len, &mut out, label_ptr, label_len,
+                        record_ptr as *mut u8,
+                        record_len,
+                        &mut out,
+                        label_ptr,
+                        label_len,
                     )
                 });
             },


### PR DESCRIPTION
## Summary

This adds the target-agnostic native ABI support needed for borrowed direct record parameters.

Direct/blittable records are now receive-aware in the C bridge:

- `Point` stays a value slot
- `&Point` becomes `const ___Point *`
- `&mut Point` becomes `___Point *`

The generated native Rust wrapper accepts those borrowed record pointers, null-checks them, and borrows the pointee for the duration of the synchronous call. This keeps borrowed direct records on a native pointer path instead of pushing them through `FfiBuf_u8`.

## Scope

This is intentionally only for direct/blittable records. Encoded records with Rust-owned fields like `String`/`Vec` are not made parameter-capable here.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -q -p boltffi_backend c_contract`
- `cargo test -q -p boltffi_macros direct_record --lib`
