### PR TITLE
Enforce strict KMP support admission

### DIFF
--- a/BOLTFFI_TOML_SPEC.md
+++ b/BOLTFFI_TOML_SPEC.md
@@ -240,6 +240,10 @@ Generates a Kotlin Multiplatform module with `commonMain` declarations and JVM/A
   - Default: same as `[targets.android.kotlin].package`
 - `module_name` (string, optional): Kotlin source/module class name.
   - Default: same as `[targets.android.kotlin].module_name`
+- `preview_prune_unsupported` (bool): Experimental diagnostic mode that omits unsupported KMP APIs instead of failing generation.
+  - Default: `false`
+  - When `false`, any unsupported exported API for the selected KMP platform matrix fails generation.
+  - When `true`, unsupported APIs are omitted, `boltffi-kmp-support.json` records the admitted and pruned surface, and `boltffi pack kmp` may package the pruned module only when the generated report matches the effective config.
 
 Desktop JVM native resources for `boltffi pack kmp` use `[targets.java.jvm].host_targets`.
 `targets.java.jvm.enabled` does not need to be true for KMP packaging to read this shared JVM

--- a/boltffi_bindgen/src/render/kmp/mod.rs
+++ b/boltffi_bindgen/src/render/kmp/mod.rs
@@ -5,29 +5,122 @@ use crate::ir::definitions::{EnumRepr, VariantPayload};
 use crate::ir::{self, AbiContract, FfiContract};
 use crate::render::jni::{JniEmitter, JniLowerer, JvmBindingStyle};
 use crate::render::kotlin::{KotlinEmitter, KotlinLowerer, KotlinOptions, NamingConvention};
+use serde::{Deserialize, Serialize};
 
 const KMP_COMMON_RUNTIME_TYPE_NAMES: &[&str] = &["FfiException", "BoltFFIResult"];
 
+/// Relative path of the generated KMP support metadata file.
+pub const KMP_SUPPORT_REPORT_FILE: &str = "boltffi-kmp-support.json";
+
+/// Schema version for `boltffi-kmp-support.json`.
+pub const KMP_SUPPORT_REPORT_SCHEMA_VERSION: u32 = 1;
+
+/// Platform matrix currently emitted by the production KMP generator.
+pub const KMP_SELECTED_PLATFORMS: &[&str] = &["jvm", "android"];
+
 #[derive(Debug, Clone)]
 pub struct KMPOptions {
+    /// Kotlin package used for common and platform source sets.
     pub package_name: String,
+    /// Kotlin source/module class name.
     pub module_name: String,
+    /// Android minimum SDK written into the generated Gradle module.
     pub min_sdk: u32,
+    /// Options forwarded to the delegated Kotlin/JNI generator.
     pub kotlin_options: KotlinOptions,
+    /// Effective support policy for unsupported KMP declarations.
+    pub support_policy: KmpSupportPolicy,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KMPOutputFile {
+    /// Path relative to the generated KMP module root.
     pub relative_path: PathBuf,
+    /// Complete file contents.
     pub contents: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KMPOutput {
+    /// Files emitted under the generated KMP module root.
     pub files: Vec<KMPOutputFile>,
+    /// Parsed support report also written to [`KMP_SUPPORT_REPORT_FILE`].
+    pub support_report: KmpSupportReport,
 }
 
 pub struct KMPEmitter;
+
+/// Controls how KMP generation handles exported APIs outside the supported
+/// commonMain surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KmpSupportPolicy {
+    /// Unsupported APIs fail generation before source files are emitted.
+    Strict,
+    /// Unsupported APIs are omitted and recorded in the support report.
+    PreviewPruneUnsupported,
+}
+
+impl KmpSupportPolicy {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Strict => "strict",
+            Self::PreviewPruneUnsupported => "preview_prune_unsupported",
+        }
+    }
+}
+
+/// Generated metadata describing the effective KMP support policy and surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KmpSupportReport {
+    /// Version of the JSON report schema.
+    pub schema_version: u32,
+    /// Effective policy used when the module was generated.
+    pub mode: KmpSupportPolicy,
+    /// KMP platforms that the generated commonMain surface was checked against.
+    pub selected_platforms: Vec<String>,
+    /// Kotlin package used in generated common/platform sources.
+    pub package_name: String,
+    /// Kotlin source/module class name used in generated files.
+    pub module_name: String,
+    /// Android minimum SDK used in the generated Gradle module.
+    pub min_sdk: u32,
+    /// APIs emitted into the generated KMP module.
+    pub admitted_apis: Vec<KmpSupportApi>,
+    /// APIs rejected in strict mode or pruned in preview mode.
+    pub rejected_apis: Vec<KmpSupportApi>,
+    /// Version of `boltffi_bindgen` that generated the report.
+    pub generator_version: String,
+}
+
+/// One API entry in a generated KMP support report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KmpSupportApi {
+    /// API kind, such as `function`, `record`, or `class`.
+    pub kind: String,
+    /// Stable display name for the API.
+    pub name: String,
+    /// Rejection or pruning reason. Admitted APIs leave this empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum KMPError {
+    #[error(
+        "unsupported KMP APIs in {mode} mode: {apis}. Set targets.kotlin_multiplatform.preview_prune_unsupported = true to emit a pruned diagnostic surface"
+    )]
+    UnsupportedApis {
+        /// Effective support mode used for the failed generation.
+        mode: &'static str,
+        /// Short human-readable summary of rejected APIs.
+        apis: String,
+        /// Full support report for diagnostics and tests.
+        report: Box<KmpSupportReport>,
+    },
+    #[error("serialize KMP support report: {0}")]
+    SupportReport(#[from] serde_json::Error),
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum KmpActualBackend {
@@ -144,18 +237,39 @@ impl KMPEmitter {
         package_name.split('.').collect()
     }
 
-    pub fn emit(contract: &FfiContract, abi: &AbiContract, options: KMPOptions) -> KMPOutput {
+    pub fn emit(
+        contract: &FfiContract,
+        abi: &AbiContract,
+        options: KMPOptions,
+    ) -> Result<KMPOutput, KMPError> {
         let KMPOptions {
             package_name,
             module_name,
             min_sdk,
             kotlin_options,
+            support_policy,
         } = options;
         let internal_package = format!("{package_name}.jvm");
         let common_package_path = Self::package_path(&package_name);
         let internal_package_path = Self::package_path(&internal_package);
         let platform_adapters = Self::default_platform_adapters();
         let support = KmpSurfaceSupport::for_contract(contract);
+        let support_report = build_support_report(
+            contract,
+            &support,
+            &package_name,
+            &module_name,
+            min_sdk,
+            support_policy,
+        );
+
+        if support_policy == KmpSupportPolicy::Strict && !support_report.rejected_apis.is_empty() {
+            return Err(KMPError::UnsupportedApis {
+                mode: support_policy.label(),
+                apis: summarize_rejected_apis(&support_report),
+                report: Box::new(support_report),
+            });
+        }
 
         let rendered = Self::render_surfaces_with_support(
             contract,
@@ -202,6 +316,10 @@ impl KMPEmitter {
                 relative_path: common_dir.join(format!("{module_name}.kt")),
                 contents: rendered.common,
             },
+            KMPOutputFile {
+                relative_path: PathBuf::from(KMP_SUPPORT_REPORT_FILE),
+                contents: format!("{}\n", serde_json::to_string_pretty(&support_report)?),
+            },
         ];
 
         rendered.platform_actuals.into_iter().for_each(|actual| {
@@ -241,7 +359,10 @@ impl KMPEmitter {
                 });
             });
 
-        KMPOutput { files }
+        Ok(KMPOutput {
+            files,
+            support_report,
+        })
     }
 
     fn default_platform_adapters() -> Vec<KmpPlatformAdapter> {
@@ -306,8 +427,6 @@ impl KMPEmitter {
         common_sections.push(format!("package {package_name}"));
         common_sections.push(Self::render_common_result_runtime());
 
-        let mut unsupported = Vec::new();
-
         contract
             .catalog
             .all_custom_types()
@@ -332,17 +451,8 @@ impl KMPEmitter {
         contract.functions.iter().for_each(|function| {
             if function_supported(function, contract, support) {
                 common_sections.push(Self::render_common_function(function));
-            } else {
-                unsupported.push(function.id.as_str().to_string());
             }
         });
-
-        if !unsupported.is_empty() {
-            common_sections.push(format!(
-                "// Unsupported in the initial KMP generator slice: {}",
-                unsupported.join(", ")
-            ));
-        }
 
         join_kotlin_sections(common_sections)
     }
@@ -904,6 +1014,307 @@ fn kdoc_block(doc: &Option<String>) -> String {
             result
         })
         .unwrap_or_default()
+}
+
+fn build_support_report(
+    contract: &ir::FfiContract,
+    support: &KmpSurfaceSupport,
+    package_name: &str,
+    module_name: &str,
+    min_sdk: u32,
+    mode: KmpSupportPolicy,
+) -> KmpSupportReport {
+    let mut admitted_apis = Vec::new();
+    let mut rejected_apis = Vec::new();
+
+    contract.catalog.all_custom_types().for_each(|custom| {
+        if support.custom_types.contains(custom.id.as_str()) {
+            admitted_apis.push(support_api("custom_type", custom.id.as_str(), None));
+        } else {
+            rejected_apis.push(support_api(
+                "custom_type",
+                custom.id.as_str(),
+                Some(custom_type_rejection_reason(custom, support)),
+            ));
+        }
+    });
+
+    contract.catalog.all_records().for_each(|record| {
+        if support.records.contains(record.id.as_str()) {
+            admitted_apis.push(support_api("record", record.id.as_str(), None));
+        } else {
+            rejected_apis.push(support_api(
+                "record",
+                record.id.as_str(),
+                Some(record_rejection_reason(record, contract, support)),
+            ));
+        }
+        push_record_member_rejections(record, &mut rejected_apis);
+    });
+
+    contract.catalog.all_enums().for_each(|enumeration| {
+        if support.enums.contains(enumeration.id.as_str()) {
+            admitted_apis.push(support_api("enum", enumeration.id.as_str(), None));
+        } else {
+            rejected_apis.push(support_api(
+                "enum",
+                enumeration.id.as_str(),
+                Some(enum_rejection_reason(enumeration, contract, support)),
+            ));
+        }
+        push_enum_member_rejections(enumeration, &mut rejected_apis);
+    });
+
+    contract.catalog.all_classes().for_each(|class| {
+        rejected_apis.push(support_api(
+            "class",
+            class.id.as_str(),
+            Some("class APIs are not supported by the current KMP generator".to_string()),
+        ));
+    });
+
+    contract.catalog.all_callbacks().for_each(|callback| {
+        rejected_apis.push(support_api(
+            "callback",
+            callback.id.as_str(),
+            Some("callback APIs are not supported by the current KMP generator".to_string()),
+        ));
+    });
+
+    contract.functions.iter().for_each(|function| {
+        if function_supported(function, contract, support) {
+            admitted_apis.push(support_api("function", function.id.as_str(), None));
+        } else {
+            rejected_apis.push(support_api(
+                "function",
+                function.id.as_str(),
+                Some(function_rejection_reason(function, support)),
+            ));
+        }
+    });
+
+    KmpSupportReport {
+        schema_version: KMP_SUPPORT_REPORT_SCHEMA_VERSION,
+        mode,
+        selected_platforms: KMP_SELECTED_PLATFORMS
+            .iter()
+            .map(|platform| (*platform).to_string())
+            .collect(),
+        package_name: package_name.to_string(),
+        module_name: module_name.to_string(),
+        min_sdk,
+        admitted_apis,
+        rejected_apis,
+        generator_version: env!("CARGO_PKG_VERSION").to_string(),
+    }
+}
+
+fn support_api(kind: &str, name: &str, reason: Option<String>) -> KmpSupportApi {
+    KmpSupportApi {
+        kind: kind.to_string(),
+        name: name.to_string(),
+        reason,
+    }
+}
+
+fn push_record_member_rejections(
+    record: &ir::definitions::RecordDef,
+    rejected_apis: &mut Vec<KmpSupportApi>,
+) {
+    record
+        .constructors
+        .iter()
+        .enumerate()
+        .for_each(|(index, _)| {
+            rejected_apis.push(support_api(
+                "record_constructor",
+                &format!("{}#{index}", record.id.as_str()),
+                Some(
+                    "value-type constructors are not supported by the current KMP generator"
+                        .to_string(),
+                ),
+            ));
+        });
+    record.methods.iter().for_each(|method| {
+        rejected_apis.push(support_api(
+            "record_method",
+            &format!("{}.{}", record.id.as_str(), method.id.as_str()),
+            Some("value-type methods are not supported by the current KMP generator".to_string()),
+        ));
+    });
+}
+
+fn push_enum_member_rejections(
+    enumeration: &ir::definitions::EnumDef,
+    rejected_apis: &mut Vec<KmpSupportApi>,
+) {
+    enumeration
+        .constructors
+        .iter()
+        .enumerate()
+        .for_each(|(index, _)| {
+            rejected_apis.push(support_api(
+                "enum_constructor",
+                &format!("{}#{index}", enumeration.id.as_str()),
+                Some(
+                    "value-type constructors are not supported by the current KMP generator"
+                        .to_string(),
+                ),
+            ));
+        });
+    enumeration.methods.iter().for_each(|method| {
+        rejected_apis.push(support_api(
+            "enum_method",
+            &format!("{}.{}", enumeration.id.as_str(), method.id.as_str()),
+            Some("value-type methods are not supported by the current KMP generator".to_string()),
+        ));
+    });
+}
+
+fn summarize_rejected_apis(report: &KmpSupportReport) -> String {
+    report
+        .rejected_apis
+        .iter()
+        .take(5)
+        .map(|api| format!("{} {}", api.kind, api.name))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn custom_type_rejection_reason(
+    custom: &ir::definitions::CustomTypeDef,
+    support: &KmpSurfaceSupport,
+) -> String {
+    if has_reserved_common_runtime_type_name(custom.id.as_str()) {
+        return "name conflicts with KMP common runtime support type".to_string();
+    }
+
+    type_rejection_reason(&custom.repr, support).unwrap_or_else(|| {
+        "custom type is not admitted by the current KMP capability set".to_string()
+    })
+}
+
+fn record_rejection_reason(
+    record: &ir::definitions::RecordDef,
+    contract: &ir::FfiContract,
+    support: &KmpSurfaceSupport,
+) -> String {
+    if has_reserved_common_runtime_type_name(record.id.as_str()) {
+        return "name conflicts with KMP common runtime support type".to_string();
+    }
+
+    if error_record_has_incompatible_message_field(record, contract) {
+        return "error record has a message field that cannot override kotlin.Throwable.message"
+            .to_string();
+    }
+
+    record
+        .fields
+        .iter()
+        .find_map(|field| {
+            type_rejection_reason(&field.type_expr, support)
+                .map(|reason| format!("field {}: {reason}", field.name.as_str()))
+        })
+        .unwrap_or_else(|| "record is not admitted by the current KMP capability set".to_string())
+}
+
+fn enum_rejection_reason(
+    enumeration: &ir::definitions::EnumDef,
+    contract: &ir::FfiContract,
+    support: &KmpSurfaceSupport,
+) -> String {
+    if has_reserved_common_runtime_type_name(enumeration.id.as_str()) {
+        return "name conflicts with KMP common runtime support type".to_string();
+    }
+
+    if error_enum_has_incompatible_message_field(enumeration, contract) {
+        return "error enum has a message field that cannot override kotlin.Throwable.message"
+            .to_string();
+    }
+
+    enum_variants(enumeration)
+        .iter()
+        .find_map(|variant| {
+            enum_variant_fields(&variant.payload)
+                .iter()
+                .find_map(|field| {
+                    type_rejection_reason(&field.type_expr, support).map(|reason| {
+                        format!(
+                            "variant {} field {}: {reason}",
+                            variant.name,
+                            field.kotlin_name()
+                        )
+                    })
+                })
+        })
+        .unwrap_or_else(|| "enum is not admitted by the current KMP capability set".to_string())
+}
+
+fn function_rejection_reason(
+    function: &ir::definitions::FunctionDef,
+    support: &KmpSurfaceSupport,
+) -> String {
+    if let Some(reason) = return_rejection_reason(&function.returns, support) {
+        return format!("return type: {reason}");
+    }
+
+    function
+        .params
+        .iter()
+        .find_map(|param| {
+            type_rejection_reason(&param.type_expr, support)
+                .map(|reason| format!("parameter {}: {reason}", param.name.as_str()))
+        })
+        .unwrap_or_else(|| "function is not admitted by the current KMP capability set".to_string())
+}
+
+fn return_rejection_reason(
+    returns: &ir::definitions::ReturnDef,
+    support: &KmpSurfaceSupport,
+) -> Option<String> {
+    match returns {
+        ir::definitions::ReturnDef::Void => None,
+        ir::definitions::ReturnDef::Value(ty) => type_rejection_reason(ty, support),
+        ir::definitions::ReturnDef::Result { ok, err } => type_rejection_reason(ok, support)
+            .map(|reason| format!("result ok: {reason}"))
+            .or_else(|| {
+                type_rejection_reason(err, support).map(|reason| format!("result err: {reason}"))
+            }),
+    }
+}
+
+fn type_rejection_reason(ty: &ir::types::TypeExpr, support: &KmpSurfaceSupport) -> Option<String> {
+    match ty {
+        ir::types::TypeExpr::Void
+        | ir::types::TypeExpr::Primitive(_)
+        | ir::types::TypeExpr::String => None,
+        ir::types::TypeExpr::Vec(inner) => {
+            type_rejection_reason(inner, support).map(|reason| format!("Vec element: {reason}"))
+        }
+        ir::types::TypeExpr::Option(inner) => {
+            type_rejection_reason(inner, support).map(|reason| format!("Option inner: {reason}"))
+        }
+        ir::types::TypeExpr::Result { ok, err } => type_rejection_reason(ok, support)
+            .map(|reason| format!("Result ok: {reason}"))
+            .or_else(|| {
+                type_rejection_reason(err, support).map(|reason| format!("Result err: {reason}"))
+            }),
+        ir::types::TypeExpr::Record(id) => (!support.records.contains(id.as_str()))
+            .then(|| format!("record {} is not admitted", id.as_str())),
+        ir::types::TypeExpr::Enum(id) => (!support.enums.contains(id.as_str()))
+            .then(|| format!("enum {} is not admitted", id.as_str())),
+        ir::types::TypeExpr::Custom(id) => (!support.custom_types.contains(id.as_str()))
+            .then(|| format!("custom type {} is not admitted", id.as_str())),
+        ir::types::TypeExpr::Builtin(id) => {
+            Some(format!("builtin type {} is not supported", id.as_str()))
+        }
+        ir::types::TypeExpr::Callback(id) => {
+            Some(format!("callback type {} is not supported", id.as_str()))
+        }
+        ir::types::TypeExpr::Handle(id) => {
+            Some(format!("handle type {} is not supported", id.as_str()))
+        }
+    }
 }
 
 fn filter_contract_for_kmp_surface(
@@ -1685,6 +2096,28 @@ mod tests {
         }
     }
 
+    fn default_constructor() -> ir::definitions::ConstructorDef {
+        ir::definitions::ConstructorDef::Default {
+            params: Vec::new(),
+            is_fallible: false,
+            is_optional: false,
+            doc: None,
+            deprecated: None,
+        }
+    }
+
+    fn sync_method(id: &str) -> ir::definitions::MethodDef {
+        ir::definitions::MethodDef {
+            id: id.into(),
+            receiver: ir::definitions::Receiver::RefSelf,
+            params: Vec::new(),
+            returns: ir::definitions::ReturnDef::Void,
+            execution_kind: boltffi_ffi_rules::callable::ExecutionKind::Sync,
+            doc: None,
+            deprecated: None,
+        }
+    }
+
     fn custom_type(id: &str, repr: ir::types::TypeExpr) -> ir::definitions::CustomTypeDef {
         ir::definitions::CustomTypeDef {
             id: id.into(),
@@ -1771,7 +2204,7 @@ mod tests {
         assert!(!common.contains("data class FfiException("));
         assert!(!common.contains("typealias BoltFFIResult"));
         assert!(!common.contains("expect fun load"));
-        assert!(common.contains("Unsupported in the initial KMP generator slice: load"));
+        assert!(!common.contains("Unsupported in the initial KMP generator slice"));
         assert_eq!(internal_contract.catalog.all_records().count(), 0);
         assert_eq!(internal_contract.catalog.all_custom_types().count(), 0);
         assert!(internal_contract.functions.is_empty());
@@ -1958,7 +2391,114 @@ mod tests {
         assert_eq!(direct, "data class ServiceError(val message: Int)");
         assert!(!common.contains("data class ServiceError("));
         assert!(!common.contains("expect fun load"));
-        assert!(common.contains("Unsupported in the initial KMP generator slice: load"));
+        assert!(!common.contains("Unsupported in the initial KMP generator slice"));
+    }
+
+    #[test]
+    fn emit_rejects_unsupported_kmp_surface_in_strict_mode() {
+        let mut contract = empty_contract();
+        let mut record = error_record("ServiceError");
+        record.fields = vec![field(
+            "message",
+            ir::types::TypeExpr::Primitive(ir::types::PrimitiveType::I32),
+        )];
+        contract.catalog.insert_record(record);
+        contract.functions.push(sync_function(
+            "load",
+            ir::definitions::ReturnDef::Result {
+                ok: ir::types::TypeExpr::String,
+                err: ir::types::TypeExpr::Record("ServiceError".into()),
+            },
+        ));
+        let abi = ir::Lowerer::new(&contract).to_abi_contract();
+
+        let error = KMPEmitter::emit(
+            &contract,
+            &abi,
+            KMPOptions {
+                package_name: "com.example.demo".to_string(),
+                module_name: "Demo".to_string(),
+                min_sdk: 23,
+                support_policy: KmpSupportPolicy::Strict,
+                kotlin_options: KotlinOptions::default(),
+            },
+        )
+        .expect_err("strict mode should reject unsupported KMP APIs");
+
+        match error {
+            KMPError::UnsupportedApis { report, .. } => {
+                assert_eq!(report.mode, KmpSupportPolicy::Strict);
+                assert!(
+                    report
+                        .rejected_apis
+                        .iter()
+                        .any(|api| api.kind == "function" && api.name == "load")
+                );
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn support_report_lists_members_when_parent_type_is_rejected() {
+        let mut contract = empty_contract();
+        let mut record = empty_record();
+        record.id = "BadRecord".into();
+        record.fields = vec![field(
+            "callback",
+            ir::types::TypeExpr::Callback("Listener".into()),
+        )];
+        record.constructors = vec![default_constructor()];
+        record.methods = vec![sync_method("describe")];
+        contract.catalog.insert_record(record);
+
+        let enumeration = ir::definitions::EnumDef {
+            id: "BadEnum".into(),
+            repr: EnumRepr::Data {
+                tag_type: ir::types::PrimitiveType::I32,
+                variants: vec![ir::definitions::DataVariant {
+                    name: "WithCallback".into(),
+                    discriminant: 0,
+                    payload: VariantPayload::Tuple(vec![ir::types::TypeExpr::Callback(
+                        "Listener".into(),
+                    )]),
+                    doc: None,
+                }],
+            },
+            is_error: false,
+            constructors: vec![default_constructor()],
+            methods: vec![sync_method("code")],
+            doc: None,
+            deprecated: None,
+        };
+        contract.catalog.insert_enum(enumeration);
+
+        let support = KmpSurfaceSupport::for_contract(&contract);
+        let report = build_support_report(
+            &contract,
+            &support,
+            "com.example.demo",
+            "Demo",
+            23,
+            KmpSupportPolicy::PreviewPruneUnsupported,
+        );
+
+        for (kind, name) in [
+            ("record", "BadRecord"),
+            ("record_constructor", "BadRecord#0"),
+            ("record_method", "BadRecord.describe"),
+            ("enum", "BadEnum"),
+            ("enum_constructor", "BadEnum#0"),
+            ("enum_method", "BadEnum.code"),
+        ] {
+            assert!(
+                report
+                    .rejected_apis
+                    .iter()
+                    .any(|api| api.kind == kind && api.name == name),
+                "missing rejected API {kind} {name}"
+            );
+        }
     }
 
     #[test]
@@ -1986,8 +2526,27 @@ mod tests {
                 package_name: "com.example.demo".to_string(),
                 module_name: "Demo".to_string(),
                 min_sdk: 23,
+                support_policy: KmpSupportPolicy::PreviewPruneUnsupported,
                 kotlin_options: KotlinOptions::default(),
             },
+        )
+        .expect("preview pruning should emit supported KMP subset");
+        assert_eq!(
+            output.support_report.mode,
+            KmpSupportPolicy::PreviewPruneUnsupported
+        );
+        assert!(
+            output
+                .support_report
+                .rejected_apis
+                .iter()
+                .any(|api| api.kind == "function" && api.name == "load")
+        );
+        assert!(
+            output
+                .files
+                .iter()
+                .any(|file| file.relative_path.as_path() == Path::new(KMP_SUPPORT_REPORT_FILE))
         );
         let common = output
             .files
@@ -2014,9 +2573,9 @@ mod tests {
         assert!(!common.contents.contains("data class ServiceError("));
         assert!(!common.contents.contains("expect fun load"));
         assert!(
-            common
+            !common
                 .contents
-                .contains("Unsupported in the initial KMP generator slice: load")
+                .contains("Unsupported in the initial KMP generator slice")
         );
         assert!(!internal_jvm.contents.contains("data class ServiceError("));
         assert!(!internal_jvm.contents.contains("fun load("));
@@ -2106,9 +2665,11 @@ mod tests {
                 package_name: "com.example.demo".to_string(),
                 module_name: "Demo".to_string(),
                 min_sdk: 23,
+                support_policy: KmpSupportPolicy::Strict,
                 kotlin_options: KotlinOptions::default(),
             },
-        );
+        )
+        .expect("strict mode should emit fully supported KMP surface");
         let common = output
             .files
             .iter()
@@ -2180,7 +2741,7 @@ mod tests {
         assert!(!direct.contains("override val message: Int"));
         assert!(!common.contains("sealed class DomainError"));
         assert!(!common.contains("expect fun load"));
-        assert!(common.contains("Unsupported in the initial KMP generator slice: load"));
+        assert!(!common.contains("Unsupported in the initial KMP generator slice"));
     }
 
     #[test]
@@ -2300,9 +2861,11 @@ mod tests {
                 package_name: "com.example.demo".to_string(),
                 module_name: "Demo".to_string(),
                 min_sdk: 23,
+                support_policy: KmpSupportPolicy::Strict,
                 kotlin_options: KotlinOptions::default(),
             },
-        );
+        )
+        .expect("strict mode should emit fully supported KMP surface");
         let common = output
             .files
             .iter()

--- a/boltffi_cli/src/commands/generate/languages/kmp.rs
+++ b/boltffi_cli/src/commands/generate/languages/kmp.rs
@@ -1,7 +1,10 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use boltffi_bindgen::KotlinOptions;
-use boltffi_bindgen::render::kmp::{KMPEmitter, KMPOptions};
+use boltffi_bindgen::render::kmp::{
+    KMP_SUPPORT_REPORT_FILE, KMPEmitter, KMPOptions, KmpSupportPolicy,
+};
 use boltffi_bindgen::render::kotlin::{
     FactoryStyle as BindgenFactoryStyle, KotlinApiStyle, KotlinDesktopLoader,
 };
@@ -12,6 +15,17 @@ use crate::cli::{CliError, Result};
 use crate::commands::generate::generator::SourceCrate;
 use crate::commands::generate::generator::{GenerateRequest, LanguageGenerator, ScanPointerWidth};
 use crate::config::KotlinFactoryStyle as ConfigKotlinFactoryStyle;
+
+const KMP_MANAGED_GENERATED_PATHS: &[&str] = &[
+    "settings.gradle.kts",
+    "build.gradle.kts",
+    KMP_SUPPORT_REPORT_FILE,
+    "src/commonMain/kotlin",
+    "src/jvmMain/kotlin",
+    "src/androidMain/kotlin",
+    "src/jvmMain/c",
+    "src/androidMain/c",
+];
 
 pub struct KMPGenerator;
 
@@ -82,6 +96,18 @@ impl KMPGenerator {
 
         let lowered_crate = request.lowered_crate(ScanPointerWidth::Flexible)?;
         let module_name = request.config().kotlin_multiplatform_module_name();
+        let support_policy = if request
+            .config()
+            .kotlin_multiplatform_preview_prune_unsupported()
+        {
+            eprintln!(
+                "warning: KMP preview pruning is enabled; unsupported APIs will be omitted and recorded in {}",
+                output_directory.join(KMP_SUPPORT_REPORT_FILE).display()
+            );
+            KmpSupportPolicy::PreviewPruneUnsupported
+        } else {
+            KmpSupportPolicy::Strict
+        };
         let kmp_output = KMPEmitter::emit(
             &lowered_crate.ffi_contract,
             &lowered_crate.abi_contract,
@@ -89,13 +115,20 @@ impl KMPGenerator {
                 package_name: request.config().kotlin_multiplatform_package(),
                 module_name: module_name.clone(),
                 min_sdk: request.config().android_min_sdk(),
+                support_policy,
                 kotlin_options: Self::kotlin_options(
                     request,
                     &module_name,
                     desktop_fallback_library_name,
                 ),
             },
-        );
+        )
+        .map_err(|error| CliError::CommandFailed {
+            command: format!("generate kmp: {error}"),
+            status: None,
+        })?;
+
+        prepare_kmp_output_directory(request, &output_directory)?;
 
         kmp_output.files.iter().try_for_each(|output_file| {
             let output_path = output_directory.join(&output_file.relative_path);
@@ -109,10 +142,89 @@ impl KMPGenerator {
     }
 }
 
+fn prepare_kmp_output_directory(
+    request: &GenerateRequest<'_>,
+    output_directory: &Path,
+) -> Result<()> {
+    request.ensure_output_directory(output_directory)?;
+    remove_stale_kmp_generated_paths(output_directory)
+}
+
+fn remove_stale_kmp_generated_paths(output_directory: &Path) -> Result<()> {
+    KMP_MANAGED_GENERATED_PATHS
+        .iter()
+        .map(|relative_path| output_directory.join(relative_path))
+        .try_for_each(remove_stale_generated_path)
+}
+
+fn remove_stale_generated_path(path: PathBuf) -> Result<()> {
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => {
+            return Err(CliError::ReadFailed { path, source });
+        }
+    };
+
+    if metadata.is_dir() {
+        fs::remove_dir_all(&path).map_err(|source| CliError::WriteFailed { path, source })
+    } else {
+        fs::remove_file(&path).map_err(|source| CliError::WriteFailed { path, source })
+    }
+}
+
 impl LanguageGenerator for KMPGenerator {
     const TARGET: Target = Target::KotlinMultiplatform;
 
     fn generate(request: &GenerateRequest<'_>) -> Result<()> {
         Self::generate_with_desktop_fallback_library_name(request, None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::remove_stale_kmp_generated_paths;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+
+        std::env::temp_dir().join(format!("{prefix}-{unique_suffix}"))
+    }
+
+    #[test]
+    fn stale_kmp_generated_cleanup_preserves_packaged_native_outputs() {
+        let output_directory = unique_temp_dir("boltffi-kmp-generated-cleanup-test");
+        let stale_common = output_directory.join("src/commonMain/kotlin/com/old/Old.kt");
+        let stale_jvm_c = output_directory.join("src/jvmMain/c/jni_glue.c");
+        let native_resource = output_directory.join("src/jvmMain/resources/native/current/lib.so");
+        let android_jnilib = output_directory.join("src/androidMain/jniLibs/arm64-v8a/libdemo.so");
+
+        for path in [
+            &stale_common,
+            &stale_jvm_c,
+            &native_resource,
+            &android_jnilib,
+        ] {
+            fs::create_dir_all(path.parent().expect("test path has parent"))
+                .expect("create test directory");
+            fs::write(path, []).expect("write test file");
+        }
+        fs::write(output_directory.join("build.gradle.kts"), []).expect("write stale gradle file");
+
+        remove_stale_kmp_generated_paths(&output_directory).expect("cleanup should succeed");
+
+        assert!(!stale_common.exists());
+        assert!(!stale_jvm_c.exists());
+        assert!(!output_directory.join("build.gradle.kts").exists());
+        assert!(native_resource.exists());
+        assert!(android_jnilib.exists());
+
+        fs::remove_dir_all(output_directory).expect("cleanup temp output");
     }
 }

--- a/boltffi_cli/src/commands/generate/mod.rs
+++ b/boltffi_cli/src/commands/generate/mod.rs
@@ -197,6 +197,10 @@ mod tests {
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    use boltffi_bindgen::render::kmp::{
+        KMP_SUPPORT_REPORT_FILE, KmpSupportPolicy, KmpSupportReport,
+    };
+
     use super::generator::{GenerateRequest, LanguageGenerator, SourceCrate};
     use super::languages::{KMPGenerator, KotlinGenerator};
     use crate::config::Config;
@@ -300,6 +304,15 @@ package = "com.boltffi.demo"
     #[test]
     fn kotlin_multiplatform_generate_writes_kmp_sources() {
         let output_directory = unique_temp_dir("boltffi-kmp-generate-test");
+        let stale_common_path = output_directory.join("src/commonMain/kotlin/com/old/Stale.kt");
+        let staged_native_path =
+            output_directory.join("src/jvmMain/resources/native/current/libdemo.so");
+        fs::create_dir_all(stale_common_path.parent().expect("stale path has parent"))
+            .expect("create stale source directory");
+        fs::write(&stale_common_path, "package com.old\n").expect("write stale source");
+        fs::create_dir_all(staged_native_path.parent().expect("native path has parent"))
+            .expect("create native resource directory");
+        fs::write(&staged_native_path, []).expect("write native resource");
         let config = parse_config(
             r#"
 experimental = ["kotlin_multiplatform"]
@@ -311,6 +324,7 @@ version = "0.1.0"
 [targets.kotlin_multiplatform]
 enabled = true
 package = "com.boltffi.demo"
+preview_prune_unsupported = true
 
 [targets.android.kotlin.type_mappings]
 Email = { type = "java.net.URI", conversion = "url_string" }
@@ -336,6 +350,7 @@ Email = { type = "java.net.URI", conversion = "url_string" }
         let jni_glue_path = output_directory.join("src/jvmMain/c/jni_glue.c");
         let build_gradle_path = output_directory.join("build.gradle.kts");
         let settings_gradle_path = output_directory.join("settings.gradle.kts");
+        let support_report_path = output_directory.join(KMP_SUPPORT_REPORT_FILE);
 
         let common = fs::read_to_string(&common_path).expect("common source should be readable");
         let jvm_actual =
@@ -349,6 +364,10 @@ Email = { type = "java.net.URI", conversion = "url_string" }
             fs::read_to_string(&build_gradle_path).expect("gradle file should be readable");
         let settings_gradle =
             fs::read_to_string(&settings_gradle_path).expect("settings file should be readable");
+        let support_report: KmpSupportReport = serde_json::from_str(
+            &fs::read_to_string(&support_report_path).expect("support report should be readable"),
+        )
+        .expect("support report should be valid JSON");
 
         assert!(common.contains("package com.boltffi.demo"));
         assert!(common.contains("typealias Email = String"));
@@ -369,7 +388,12 @@ Email = { type = "java.net.URI", conversion = "url_string" }
         assert!(
             common.contains("expect fun resultToString(v: BoltFFIResult<Int, String>): String")
         );
-        assert!(common.contains("Unsupported in the initial KMP generator slice"));
+        assert!(!common.contains("Unsupported in the initial KMP generator slice"));
+        assert_eq!(
+            support_report.mode,
+            KmpSupportPolicy::PreviewPruneUnsupported
+        );
+        assert!(!support_report.rejected_apis.is_empty());
         assert!(jvm_actual.contains("actual fun echoBytes"));
         assert!(jvm_actual.contains("actual fun checkedDivide(a: Int, b: Int): Int"));
         assert!(jvm_actual.contains("catch (err: com.boltffi.demo.jvm.MathError)"));
@@ -397,8 +421,47 @@ Email = { type = "java.net.URI", conversion = "url_string" }
         assert!(settings_gradle.contains("pluginManagement"));
         assert!(settings_gradle.contains("gradlePluginPortal()"));
         assert!(settings_gradle.contains("RepositoriesMode.FAIL_ON_PROJECT_REPOS"));
+        assert!(!stale_common_path.exists());
+        assert!(staged_native_path.exists());
 
         fs::remove_dir_all(output_directory).expect("cleanup generated output");
+    }
+
+    #[test]
+    fn kotlin_multiplatform_generate_fails_unsupported_surface_by_default() {
+        let output_directory = unique_temp_dir("boltffi-kmp-strict-generate-test");
+        let config = parse_config(
+            r#"
+experimental = ["kotlin_multiplatform"]
+
+[package]
+name = "demo"
+version = "0.1.0"
+
+[targets.kotlin_multiplatform]
+enabled = true
+package = "com.boltffi.demo"
+"#,
+        );
+
+        let error =
+            KMPGenerator::generate_from_source_directory_with_desktop_fallback_library_name(
+                &config,
+                Some(output_directory.clone()),
+                &demo_source_directory(),
+                "demo",
+                None,
+            )
+            .expect_err("strict KMP generation should reject unsupported demo APIs");
+
+        assert!(
+            matches!(error, crate::cli::CliError::CommandFailed { command, status: None }
+                if command.contains("unsupported KMP APIs in strict mode"))
+        );
+
+        if output_directory.exists() {
+            fs::remove_dir_all(output_directory).expect("cleanup generated output");
+        }
     }
 
     #[test]
@@ -419,6 +482,7 @@ library_name = "configured-library"
 enabled = true
 package = "com.boltffi.demo"
 module_name = "Demo"
+preview_prune_unsupported = true
 "#,
         );
 

--- a/boltffi_cli/src/config/mod.rs
+++ b/boltffi_cli/src/config/mod.rs
@@ -669,6 +669,11 @@ impl Config {
         self.targets.kotlin_multiplatform.output.clone()
     }
 
+    /// Returns whether KMP generation may emit a pruned diagnostic surface.
+    pub fn kotlin_multiplatform_preview_prune_unsupported(&self) -> bool {
+        self.targets.kotlin_multiplatform.preview_prune_unsupported
+    }
+
     pub fn kotlin_multiplatform_package(&self) -> String {
         self.targets
             .kotlin_multiplatform
@@ -2157,6 +2162,21 @@ module_name = "AndroidBindings"
         );
 
         assert_eq!(config.kotlin_multiplatform_module_name(), "AndroidBindings");
+    }
+
+    #[test]
+    fn kotlin_multiplatform_preview_prune_unsupported_defaults_to_false() {
+        let config = parse_config(
+            r#"
+[package]
+name = "mylib"
+
+[targets.kotlin_multiplatform]
+enabled = true
+"#,
+        );
+
+        assert!(!config.kotlin_multiplatform_preview_prune_unsupported());
     }
 
     #[test]

--- a/boltffi_cli/src/config/targets/kmp.rs
+++ b/boltffi_cli/src/config/targets/kmp.rs
@@ -8,6 +8,11 @@ pub struct KotlinMultiplatformConfig {
     pub output: PathBuf,
     #[serde(default)]
     pub enabled: bool,
+    /// Allows KMP generation to omit unsupported declarations instead of
+    /// failing. This is intentionally explicit because it changes the public
+    /// API shape of the generated commonMain surface.
+    #[serde(default)]
+    pub preview_prune_unsupported: bool,
     pub package: Option<String>,
     pub module_name: Option<String>,
 }
@@ -17,6 +22,7 @@ impl Default for KotlinMultiplatformConfig {
         Self {
             output: default_kotlin_multiplatform_output(),
             enabled: false,
+            preview_prune_unsupported: false,
             package: None,
             module_name: None,
         }

--- a/boltffi_cli/src/pack/kmp.rs
+++ b/boltffi_cli/src/pack/kmp.rs
@@ -1,5 +1,10 @@
+use std::fs;
 use std::path::PathBuf;
 
+use boltffi_bindgen::render::kmp::{
+    KMP_SELECTED_PLATFORMS, KMP_SUPPORT_REPORT_FILE, KMP_SUPPORT_REPORT_SCHEMA_VERSION,
+    KmpSupportPolicy, KmpSupportReport,
+};
 use boltffi_bindgen::target::Target;
 
 use crate::cli::{CliError, Result};
@@ -85,6 +90,7 @@ pub(crate) fn pack_kmp(
         step.finish_success();
     }
 
+    verify_kmp_support_metadata(config)?;
     package_kmp_android_libraries(config, &options, reporter)?;
 
     let kmp_jvm_layout = kmp_jvm_native_layout(config, source_crate_name);
@@ -118,6 +124,103 @@ pub(crate) fn pack_kmp(
 
     reporter.finish();
     Ok(())
+}
+
+fn verify_kmp_support_metadata(config: &Config) -> Result<()> {
+    let path = kmp_support_report_path(config);
+    let contents = fs::read_to_string(&path).map_err(|source| {
+        if source.kind() == std::io::ErrorKind::NotFound {
+            CliError::FileNotFound(path.clone())
+        } else {
+            CliError::ReadFailed {
+                path: path.clone(),
+                source,
+            }
+        }
+    })?;
+    let report = serde_json::from_str::<KmpSupportReport>(&contents).map_err(|source| {
+        CliError::CommandFailed {
+            command: format!("read {}: {source}", path.display()),
+            status: None,
+        }
+    })?;
+
+    validate_kmp_support_report(config, &report)
+}
+
+fn validate_kmp_support_report(config: &Config, report: &KmpSupportReport) -> Result<()> {
+    if report.schema_version != KMP_SUPPORT_REPORT_SCHEMA_VERSION {
+        return Err(kmp_support_metadata_error(format!(
+            "expected schema_version {}, found {}",
+            KMP_SUPPORT_REPORT_SCHEMA_VERSION, report.schema_version
+        )));
+    }
+
+    let expected_policy = kmp_support_policy(config);
+    if report.mode != expected_policy {
+        return Err(kmp_support_metadata_error(format!(
+            "expected mode {:?}, found {:?}",
+            expected_policy, report.mode
+        )));
+    }
+
+    let expected_platforms = KMP_SELECTED_PLATFORMS
+        .iter()
+        .map(|platform| (*platform).to_string())
+        .collect::<Vec<_>>();
+    if report.selected_platforms != expected_platforms {
+        return Err(kmp_support_metadata_error(format!(
+            "expected selected_platforms {:?}, found {:?}",
+            expected_platforms, report.selected_platforms
+        )));
+    }
+
+    let expected_package = config.kotlin_multiplatform_package();
+    if report.package_name != expected_package {
+        return Err(kmp_support_metadata_error(format!(
+            "expected package_name {}, found {}",
+            expected_package, report.package_name
+        )));
+    }
+
+    let expected_module = config.kotlin_multiplatform_module_name();
+    if report.module_name != expected_module {
+        return Err(kmp_support_metadata_error(format!(
+            "expected module_name {}, found {}",
+            expected_module, report.module_name
+        )));
+    }
+
+    let expected_min_sdk = config.android_min_sdk();
+    if report.min_sdk != expected_min_sdk {
+        return Err(kmp_support_metadata_error(format!(
+            "expected min_sdk {}, found {}",
+            expected_min_sdk, report.min_sdk
+        )));
+    }
+
+    if report.mode == KmpSupportPolicy::Strict && !report.rejected_apis.is_empty() {
+        return Err(kmp_support_metadata_error(
+            "strict support report contains rejected APIs".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn kmp_support_policy(config: &Config) -> KmpSupportPolicy {
+    if config.kotlin_multiplatform_preview_prune_unsupported() {
+        KmpSupportPolicy::PreviewPruneUnsupported
+    } else {
+        KmpSupportPolicy::Strict
+    }
+}
+
+fn kmp_support_metadata_error(reason: String) -> CliError {
+    CliError::CommandFailed {
+        command: format!("KMP support metadata mismatch: {reason}"),
+        status: None,
+    }
 }
 
 fn ensure_kmp_packaging_enabled(config: &Config, experimental_flag: bool) -> Result<()> {
@@ -222,6 +325,12 @@ fn kmp_jvm_native_resource_root(config: &Config) -> PathBuf {
         .join("src/jvmMain/resources/native")
 }
 
+fn kmp_support_report_path(config: &Config) -> PathBuf {
+    config
+        .kotlin_multiplatform_output()
+        .join(KMP_SUPPORT_REPORT_FILE)
+}
+
 fn kmp_jvm_native_layout(config: &Config, header_name: &str) -> JvmNativePackageLayout {
     JvmNativePackageLayout {
         jni_dir: kmp_jvm_jni_dir(config),
@@ -238,16 +347,53 @@ fn kmp_jvm_native_layout(config: &Config, header_name: &str) -> JvmNativePackage
 mod tests {
     use super::{
         ensure_kmp_no_build_supported, ensure_kmp_packaging_enabled, kmp_jvm_jni_dir,
-        kmp_jvm_native_layout, kmp_jvm_native_resource_root,
+        kmp_jvm_native_layout, kmp_jvm_native_resource_root, kmp_support_report_path,
+        validate_kmp_support_report, verify_kmp_support_metadata,
     };
     use crate::cli::CliError;
     use crate::config::Config;
+    use boltffi_bindgen::render::kmp::{
+        KMP_SELECTED_PLATFORMS, KMP_SUPPORT_REPORT_SCHEMA_VERSION, KmpSupportApi, KmpSupportPolicy,
+        KmpSupportReport,
+    };
+    use std::fs;
     use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn parse_config(input: &str) -> Config {
         let parsed: Config = toml::from_str(input).expect("toml parse failed");
         parsed.validate().expect("config validation failed");
         parsed
+    }
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+
+        std::env::temp_dir().join(format!("{prefix}-{unique_suffix}"))
+    }
+
+    fn support_report(config: &Config, mode: KmpSupportPolicy) -> KmpSupportReport {
+        KmpSupportReport {
+            schema_version: KMP_SUPPORT_REPORT_SCHEMA_VERSION,
+            mode,
+            selected_platforms: KMP_SELECTED_PLATFORMS
+                .iter()
+                .map(|platform| (*platform).to_string())
+                .collect(),
+            package_name: config.kotlin_multiplatform_package(),
+            module_name: config.kotlin_multiplatform_module_name(),
+            min_sdk: config.android_min_sdk(),
+            admitted_apis: vec![KmpSupportApi {
+                kind: "function".to_string(),
+                name: "ping".to_string(),
+                reason: None,
+            }],
+            rejected_apis: Vec::new(),
+            generator_version: "test".to_string(),
+        }
     }
 
     #[test]
@@ -354,6 +500,114 @@ enabled = true
         assert!(layout.flat_output_root.is_none());
         assert!(!layout.strip_symbols);
         assert!(!layout.debug_symbols_enabled);
+    }
+
+    #[test]
+    fn kmp_support_metadata_accepts_matching_strict_report() {
+        let config = parse_config(
+            r#"
+experimental = ["kotlin_multiplatform"]
+
+[package]
+name = "demo"
+
+[targets.kotlin_multiplatform]
+enabled = true
+output = "dist/kmp"
+package = "com.example.demo"
+module_name = "Demo"
+"#,
+        );
+        let report = support_report(&config, KmpSupportPolicy::Strict);
+
+        validate_kmp_support_report(&config, &report).expect("strict report should match config");
+    }
+
+    #[test]
+    fn kmp_support_metadata_accepts_matching_preview_report() {
+        let config = parse_config(
+            r#"
+experimental = ["kotlin_multiplatform"]
+
+[package]
+name = "demo"
+
+[targets.kotlin_multiplatform]
+enabled = true
+output = "dist/kmp"
+package = "com.example.demo"
+module_name = "Demo"
+preview_prune_unsupported = true
+"#,
+        );
+        let mut report = support_report(&config, KmpSupportPolicy::PreviewPruneUnsupported);
+        report.rejected_apis.push(KmpSupportApi {
+            kind: "class".to_string(),
+            name: "Service".to_string(),
+            reason: Some("class APIs are not supported".to_string()),
+        });
+
+        validate_kmp_support_report(&config, &report).expect("preview report should match config");
+    }
+
+    #[test]
+    fn kmp_support_metadata_rejects_preview_report_when_config_is_strict() {
+        let config = parse_config(
+            r#"
+experimental = ["kotlin_multiplatform"]
+
+[package]
+name = "demo"
+
+[targets.kotlin_multiplatform]
+enabled = true
+output = "dist/kmp"
+package = "com.example.demo"
+module_name = "Demo"
+"#,
+        );
+        let report = support_report(&config, KmpSupportPolicy::PreviewPruneUnsupported);
+
+        let error = validate_kmp_support_report(&config, &report)
+            .expect_err("preview report should not package under strict config");
+
+        assert!(
+            matches!(error, CliError::CommandFailed { command, status: None }
+                if command.contains("KMP support metadata mismatch")
+                    && command.contains("expected mode Strict"))
+        );
+    }
+
+    #[test]
+    fn kmp_support_metadata_rejects_missing_report_file() {
+        let output_directory = unique_temp_dir("boltffi-kmp-missing-support-report-test");
+        let config = parse_config(&format!(
+            r#"
+experimental = ["kotlin_multiplatform"]
+
+[package]
+name = "demo"
+
+[targets.kotlin_multiplatform]
+enabled = true
+output = "{}"
+package = "com.example.demo"
+module_name = "Demo"
+"#,
+            output_directory.display()
+        ));
+
+        let error = verify_kmp_support_metadata(&config)
+            .expect_err("missing support report should fail packaging");
+
+        assert!(matches!(
+            error,
+            CliError::FileNotFound(path) if path == kmp_support_report_path(&config)
+        ));
+
+        if output_directory.exists() {
+            fs::remove_dir_all(output_directory).expect("cleanup generated output");
+        }
     }
 
     #[test]

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -446,9 +446,13 @@ enabled = true
 output = "dist/kotlin-multiplatform"
 package = "com.mycompany.mylib"
 module_name = "MyLib"
+# Experimental diagnostic mode. Default is false.
+preview_prune_unsupported = false
 ```
 
 Generated output is a Kotlin Multiplatform Gradle module with `commonMain` declarations and `jvmMain`/`androidMain` actuals backed by the existing Kotlin/JNI generator. Kotlin/Native `cinterop` actuals for iOS/macOS are not generated yet.
+
+KMP generation is strict by default. Unsupported exported APIs fail generation so `commonMain` never silently exposes a partial contract. Setting `preview_prune_unsupported = true` omits unsupported APIs, writes `boltffi-kmp-support.json`, and marks the generated module as pruned for diagnostic iteration.
 
 If `package` or `module_name` is omitted, BoltFFI reuses the corresponding Android Kotlin defaults.
 

--- a/docs/src/content/docs/packaging.mdx
+++ b/docs/src/content/docs/packaging.mdx
@@ -397,6 +397,8 @@ boltffi pack kmp --experimental --release
 
 This generates the KMP sources, builds Android `jniLibs`, and writes JVM desktop native resources to `dist/kotlin-multiplatform/src/jvmMain/resources/native/<host-target>/`.
 
+`pack kmp` verifies `boltffi-kmp-support.json` before packaging. The report must match the current KMP package, module, min SDK, selected platforms, and pruning policy. A module generated with `preview_prune_unsupported = true` cannot be packaged under strict config.
+
 KMP reuses the Java JVM host matrix:
 
 ```toml


### PR DESCRIPTION
Fail KMP generation by default when unsupported APIs are present, add
explicit preview pruning via config, emit boltffi-kmp-support.json, and
make pack kmp verify the generated support metadata before packaging.
