### PR TITLE
Add KMP IR admission planning

### DIFF
--- a/KMP_SUPPORT_ROADMAP.md
+++ b/KMP_SUPPORT_ROADMAP.md
@@ -1,0 +1,418 @@
+# Kotlin Multiplatform Support Roadmap
+
+## Executive Decision
+
+Restart the KMP implementation around a Python-style architecture:
+
+- Render pipeline: `plan -> lower -> emit`
+- Packaging pipeline: `plan -> layout -> build/stage/package`
+- Strict support contract: every API emitted into `commonMain` must compile and run on every selected KMP target.
+
+The current KMP branch contains useful lessons, tests, naming helpers, target mapping, Gradle snippets, and JVM/Android delegation ideas. It should not be kept as the owner of the new design. In particular, the Apple path should be deleted or quarantined until it can be rebuilt around explicit capability admission and real Kotlin/Native actuals.
+
+## Why Reset
+
+The current KMP path grew through several PRs:
+
+- Apple cinterop scaffolding
+- Native data/function actuals
+- Native class and handle support
+- Sync callback parameters
+- Class-member support pruning
+- Support-surface refactoring
+
+That work proved important details, but it also left the implementation with the wrong shape. Today `boltffi_bindgen/src/render/kmp/mod.rs` mixes support admission, common API rendering, JVM/Android actuals, Apple actuals, Gradle files, cinterop files, JNI reuse, source filtering, and tests. `boltffi_bindgen/src/render/kmp/apple.rs` then carries a large inline Kotlin/Native runtime and still emits `NotImplementedError` paths for unsupported shapes. `boltffi_cli/src/pack/kmp.rs` packages Android and JVM resources but does not stage or link Apple static libraries.
+
+By contrast, the newer Python backend is cleaner:
+
+- `boltffi_bindgen/src/render/python/plan` defines the target model.
+- `boltffi_bindgen/src/render/python/lower` maps `FfiContract` and `AbiContract` into that model and validates collisions.
+- `boltffi_bindgen/src/render/python/emit` writes source files from the model.
+- `boltffi_cli/src/pack/python` splits packaging into `plan.rs`, `layout.rs`, `build.rs`, and `wheel.rs`.
+
+KMP should follow that pattern.
+
+## Non-Negotiable Invariants
+
+1. No admitted API may compile to a runtime `NotImplementedError`.
+2. `commonMain` is the intersection of the selected platform capabilities.
+3. Platform admission happens before emission, not inside Apple/JVM rendering helpers.
+4. Apple KMP uses an explicit fixed-width ABI input, not an implicit flexible ABI.
+5. Packaging owns native library staging and linking; source generation should not guess at build outputs.
+6. Unsupported APIs fail with a clear diagnostic by default. If preview pruning remains useful, it should be an explicit opt-in that writes a support report.
+7. JVM/Android should delegate to the existing Kotlin/JNI backend instead of copying JNI logic.
+
+## Target Architecture
+
+### Bindgen Layout
+
+Create a real KMP backend boundary:
+
+```text
+boltffi_bindgen/src/render/kmp/
+  mod.rs
+  plan/
+    mod.rs
+    module.rs
+    platform.rs
+    support.rs
+    gradle.rs
+  lower/
+    mod.rs
+    lowerer.rs
+    admission.rs
+    common.rs
+    jvm.rs
+    android.rs
+    apple.rs
+  emit/
+    mod.rs
+    output.rs
+    common.rs
+    jvm.rs
+    android.rs
+    apple.rs
+    gradle.rs
+    cinterop.rs
+  apple/
+    mod.rs
+    runtime.rs
+    codec.rs
+    calls.rs
+    handles.rs
+    callbacks.rs
+```
+
+`mod.rs` should be a thin public facade. It should expose types similar to `PythonLowerer`, `PythonEmitter`, and output-file structs.
+
+Suggested core structs:
+
+- `KmpModule`: full generated module plan.
+- `KmpCommonModule`: declarations emitted to `commonMain`.
+- `KmpPlatformModule`: actuals and runtime needs for one source set.
+- `KmpCapability`: platform-supported feature set.
+- `KmpSupportReport`: admitted, rejected, and pruned API records with reasons.
+- `KmpGradleModule`: Gradle targets, source sets, dependencies, cinterop inputs.
+
+### CLI Packaging Layout
+
+Split `boltffi_cli/src/pack/kmp.rs` into a package:
+
+```text
+boltffi_cli/src/pack/kmp/
+  mod.rs
+  plan.rs
+  layout.rs
+  generate.rs
+  jvm.rs
+  android.rs
+  apple.rs
+```
+
+Suggested core structs:
+
+- `KmpPackagingPlan`: selected source crate, artifact names, build profile, Cargo args, JVM host matrix, Android targets, Apple targets, and generation source directory.
+- `KmpPackageLayout`: `commonMain`, `jvmMain`, `androidMain`, `appleMain`, `nativeInterop`, Android `jniLibs`, JVM native resources, Apple static library staging, support-report path, and safety checks.
+- `KmpAppleNativeLibraryPlan`: maps Rust targets to Kotlin/Native targets and staged static libraries.
+
+## Milestones
+
+### M0: Decision And Reset
+
+Goal: remove the ambiguous half-supported Apple state.
+
+Work:
+
+- Decide whether to delete current `render/kmp/apple.rs` outright or move it behind a quarantined reference module outside the production path.
+- Replace current KMP docs that promise runtime throws for unsupported Apple shapes.
+- Write the support contract in `BOLTFFI_TOML_SPEC.md` and user docs.
+- Add a failing/diagnostic test proving admitted APIs cannot emit `NotImplementedError`.
+
+Exit criteria:
+
+- Production KMP generation has no Apple fallback actuals.
+- Unsupported APIs produce diagnostics or explicit preview-pruning records.
+- The old branch work is classified into "reuse", "reference only", and "delete".
+
+Verification:
+
+- `rg "NotImplementedError|NativeRuntimeNotImplemented" boltffi_bindgen/src/render/kmp` returns no production emission path for admitted APIs.
+- Unit tests cover the strict admission contract.
+
+### M1: Architecture Foundation
+
+Goal: introduce the Python-like structure without expanding behavior.
+
+Work:
+
+- Add `KmpModule`, platform module, output-file, support-report, and Gradle plan structs.
+- Move admission decisions into `lower/admission.rs`.
+- Move emission into `emit/*`.
+- Add `KmpPackagingPlan` and `KmpPackageLayout`.
+- Keep JVM/Android behavior equivalent, or intentionally mark the previous behavior as preview-only until M2.
+
+Exit criteria:
+
+- KMP has a small facade similar to Python.
+- Lowering can be unit-tested without rendering strings.
+- Packaging paths are calculated by `layout.rs`, not scattered through orchestration.
+
+Verification:
+
+- Snapshot tests for generated file lists.
+- Plan-level tests for capability intersection and diagnostics.
+- Existing KMP JVM/Android snapshots pass or are replaced by equivalent plan-level tests.
+
+### M2: JVM And Android Parity
+
+Goal: rebuild the useful part first, cut production JVM/Android KMP over to the new architecture, and remove the old production KMP path.
+
+Work:
+
+- Generate `commonMain`, `jvmMain`, and `androidMain`.
+- Delegate JVM/Android implementation to existing Kotlin/JNI lowerers and emitters.
+- Keep common-to-JVM conversion plans explicit.
+- Keep Android `jniLibs` packaging through the existing Android packager.
+- Keep JVM native resources through the existing JVM packager.
+- Delete the old monolithic `KMPEmitter` production flow after JVM/Android parity is proven.
+- Delete the old single-file `pack/kmp.rs` shape after the new `pack/kmp/*` orchestration owns JVM/Android packaging.
+- Retain only migrated helpers, snippets, and tests with clear ownership in the new modules.
+
+Exit criteria:
+
+- `boltffi generate kmp --experimental` creates a Gradle KMP module for JVM/Android.
+- `boltffi pack kmp --experimental` builds/stages Android and JVM native resources.
+- No KMP-specific duplicate JNI implementation exists.
+- The old KMP renderer/packer is no longer reachable as a fallback production path.
+
+Verification:
+
+- Generated KMP project compiles.
+- JVM smoke tests run against `jvmMain`.
+- Android assemble/package verifies `src/androidMain/jniLibs`.
+- Regression tests compare public KMP API shape to existing Kotlin API where appropriate.
+- `rg "KMPEmitter|boltffiNativeRuntimeNotImplemented|NotImplementedError" boltffi_bindgen/src/render/kmp boltffi_cli/src/pack/kmp*` confirms no legacy production path remains for admitted APIs.
+
+### M3: Apple Native MVP
+
+Goal: support real Kotlin/Native Apple actuals for sync value APIs, including packaging.
+
+MVP capability set:
+
+- Primitive scalar parameters and returns
+- Strings
+- Records
+- C-style enums
+- Data enums
+- `Vec<T>` for supported element types
+- `Option<T>` for supported value types
+- `Result<Ok, Err>` where both sides are supported value types
+- Sync free functions and sync value-type constructors/methods only
+
+Work:
+
+- Lower Apple from an explicit fixed 64-bit ABI.
+- Generate cinterop `.def` files with headers, compiler options, static libraries, and library paths.
+- Stage Rust Apple static libraries under KMP-owned paths per Kotlin/Native target.
+- Generate target-specific Gradle cinterop config.
+- Generate Apple actuals only for admitted APIs.
+- Add macOS and iOS simulator smoke tests before device-only support.
+
+Exit criteria:
+
+- `macosArm64` and `iosSimulatorArm64` compile and link.
+- A smoke test calls Rust through Kotlin/Native on macOS and iOS simulator.
+- There are no generated fallback actuals for admitted Apple APIs.
+
+Verification:
+
+- `boltffi pack kmp --experimental --release` builds Apple static archives and stages them.
+- Gradle cinterop tasks succeed.
+- `macosArm64Test` or equivalent native smoke test passes.
+- iOS simulator smoke test passes on macOS CI.
+
+Reference:
+
+- Kotlin/Native `.def` files support `headers`, `compilerOpts`, `linkerOpts`, `staticLibraries`, and `libraryPaths`: https://kotlinlang.org/docs/native-definition-file.html
+
+### M4: Classes, Handles, And Lifetimes
+
+Goal: make object APIs safe and deterministic on all selected KMP targets.
+
+Work:
+
+- Add handle return and nullable handle return support.
+- Add constructors, named factories, static methods, and instance methods.
+- Define close semantics in common API: `AutoCloseable` for JVM/Android and `Closeable` or common-compatible equivalent for KMP.
+- Model ownership, borrowed handles, double-close, close-during-call, and cross-thread behavior.
+- Decide whether single-threaded classes are excluded from KMP or guarded by target-specific diagnostics.
+
+Exit criteria:
+
+- Class APIs have the same common surface on JVM/Android/Apple.
+- Apple handle lifetime rules are encoded in the plan and tests.
+- No unsafe lifetime behavior is hidden in emission helpers.
+
+Verification:
+
+- Constructor matrix tests.
+- Static and instance method tests.
+- Optional handle return tests.
+- Double-close and close-after-move tests.
+- Thread-safety tests for thread-safe and non-thread-safe class markers.
+
+### M5: Callbacks, Async, And Streams
+
+Goal: complete the runtime-heavy API families once ownership is stable.
+
+Work:
+
+- Add sync callbacks and closure callback ownership.
+- Add async callbacks after sync callback `StableRef` ownership is proven.
+- Add coroutine bridge for async Rust calls.
+- Add cancellation and completion handling.
+- Add streams as Kotlin `Flow` or a documented stream abstraction.
+- Align callback and async error propagation across JVM/Android/Apple.
+
+Exit criteria:
+
+- Callback, async, cancellation, and stream APIs work on JVM/Android/Apple.
+- Runtime resources are released deterministically.
+- Backpressure/cancellation behavior is documented and tested.
+
+Verification:
+
+- Callback lifetime tests.
+- Callback error propagation tests.
+- Async success, failure, and cancellation tests.
+- Stream subscribe, next, cancellation, and drop tests.
+- Stress tests for callback-after-owner-drop and cancellation races.
+
+### M6: Packaging And Distribution
+
+Goal: make generated KMP modules usable outside the repo.
+
+Work:
+
+- Define Gradle plugin versions and dependency policy.
+- Add Maven publication support or a documented local module consumption path.
+- Add stable artifact layout for Android, JVM desktop, and Apple.
+- Add debug symbol policy for Android/JVM/Apple KMP outputs.
+- Decide whether KMP consumes Apple static libraries directly or also offers an xcframework-adjacent distribution mode.
+- Add stale-output cleanup for every staged native target.
+
+Exit criteria:
+
+- A clean checkout can generate, pack, publish locally, and consume the KMP module from another Gradle project.
+- Native artifact layout is documented and stable.
+- Symbols/debug outputs are predictable.
+
+Verification:
+
+- `publishToMavenLocal` or equivalent local publication sample.
+- External consumer sample builds without referencing repo-internal paths.
+- Stale output tests for target removal.
+- Release-like build verifies symbol stripping/debug symbol behavior where supported.
+
+### M7: Demo, CI, And Docs
+
+Goal: make KMP first-class and keep it from regressing.
+
+Work:
+
+- Add `examples/platforms/kmp`.
+- Add a KMP overlay config for the demo crate.
+- Port representative tests from Swift, Kotlin/JVM, and Python demos.
+- Add CI stages gradually:
+  - Generate-only
+  - JVM test
+  - Android assemble
+  - macOS native test
+  - iOS simulator smoke
+- Update public docs only after each capability is real.
+
+Exit criteria:
+
+- KMP is covered in CI across JVM, Android, macOS, and iOS simulator.
+- Public docs describe real support, not planned behavior.
+- The support report is part of developer diagnostics.
+
+Verification:
+
+- Full demo matrix passes on CI.
+- Docs examples are exercised by scripts or smoke tests.
+- `boltffi pack all --experimental` has clear KMP behavior.
+
+## Proposed PR Slices
+
+1. Reset docs and support contract.
+2. Introduce KMP plan/lower/emit skeleton and support report.
+3. Move packaging to `pack/kmp/*` with no feature expansion.
+4. Rebuild JVM/Android KMP generation and packaging.
+5. Add Apple target/layout planning and static library staging.
+6. Add Apple sync value actuals.
+7. Add Apple classes/handles.
+8. Add callbacks.
+9. Add async and streams.
+10. Add publication/demo/CI/docs hardening.
+
+## Salvage Plan
+
+Reuse:
+
+- Target enums and Apple target selection logic from `target.rs` and current KMP generator.
+- JVM/Android delegation concept.
+- Existing Android and JVM packagers.
+- Naming helpers where they match generated Kotlin conventions.
+- Tests that describe desired support decisions.
+
+Reference only:
+
+- Apple runtime snippets in `render/kmp/apple.rs`.
+- cinterop Gradle snippets.
+- Support-surface pruning tests.
+
+Delete or replace:
+
+- Production Apple fallback actuals.
+- Inline support pruning inside string emitters.
+- Monolithic `KMPEmitter::emit` orchestration.
+- Any behavior where unsupported APIs compile and throw at runtime.
+
+## Key Product Decisions
+
+1. Should unsupported APIs fail generation by default?
+
+   Recommendation: yes. Add explicit preview pruning only if needed for demo iteration.
+
+2. Should KMP support be enabled from `[targets.apple]`, `[targets.android]`, and `[targets.java.jvm]`, or should KMP have its own platform matrix?
+
+   Recommendation: KMP should have its own platform matrix that can default from existing target configs. Reusing existing configs silently makes it too easy to accidentally widen the KMP common surface.
+
+3. Should Apple KMP use static libraries through cinterop or consume an xcframework?
+
+   Recommendation: start with staged static libraries through cinterop for the MVP. Revisit xcframework-adjacent distribution in M6 if consumer packaging requires it.
+
+4. Should `pack kmp --no-build` be supported?
+
+   Recommendation: not until layouts and stale-output cleanup are stable. A later implementation can validate all expected staged native artifacts before reusing them.
+
+## Risk Register
+
+- Apple cinterop/linking risk: static library paths and target-specific `.def` files must be deterministic and relocatable.
+- ABI mismatch risk: Apple must use fixed 64-bit ABI consistently from lowerer to header to actuals.
+- Common-surface risk: platform-specific gaps can leak into `commonMain` unless admission is centralized.
+- Runtime ownership risk: callbacks, async, streams, and handles need explicit lifetime models before emission.
+- Test matrix cost: iOS simulator and Android tests will be slower; phase CI in after each capability stabilizes.
+- Documentation risk: public docs should lag implementation until the smoke tests exist.
+
+## Success Definition
+
+KMP is fully supported when a user can:
+
+1. Enable KMP for JVM, Android, macOS, and iOS simulator/device.
+2. Run `boltffi pack kmp --experimental --release`.
+3. Consume the generated Gradle module from a separate project.
+4. Call the same supported API surface from JVM, Android, and Apple Kotlin/Native.
+5. Get generation-time diagnostics for unsupported APIs instead of runtime surprises.
+6. Rely on CI-covered demos for primitives, records, enums, results, classes, callbacks, async, and streams.

--- a/boltffi_backend/src/target/kmp/host.rs
+++ b/boltffi_backend/src/target/kmp/host.rs
@@ -4,41 +4,83 @@ use boltffi_binding::{
 };
 
 use crate::core::{
-    BindingCapability, BridgeCapability, CapabilityRequirements, Emitted, Error, GeneratedOutput,
-    HostCapabilities, RenderContext, RenderedDeclaration, Result, Target, contract::sealed, host,
+    BindingCapability, BridgeCapability, CapabilityRequirements, DeclarationLabel, Diagnostic,
+    Emitted, GeneratedOutput, HostCapabilities, RenderContext, RenderedDeclaration, Result, Target,
+    contract::sealed, host,
 };
 
-use super::{KmpBridge, KmpBridgeContract, Syntax};
+use super::{
+    KmpBridge, KmpBridgeContract, KmpPlatform, KmpSupportMode, Syntax,
+    lower::{KmpLowerer, KmpLoweringOptions, admission::KmpAdmission},
+};
 
-const M1A_ADMISSION_REASON: &str =
-    "KMP IR backend skeleton rejects exported APIs until M1b admission is implemented";
-
-/// Kotlin Multiplatform host renderer for the IR backend skeleton.
+/// Kotlin Multiplatform host renderer for the IR backend plan.
 ///
-/// M1a wires KMP into the typed backend pipeline but deliberately does not
-/// admit any exported API. Complete coverage generation therefore fails for
-/// non-empty binding surfaces, preserving the strict KMP contract until the
-/// M1b plan/lower/admission layer can decide the supported common surface.
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+/// The host currently lowers to a typed [`super::KmpModule`] plan and emits no
+/// Kotlin strings. Complete coverage rendering remains strict: APIs outside
+/// the selected platform capability intersection produce diagnostics that the
+/// backend driver turns into generation failures.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
-pub struct KmpHost;
+pub struct KmpHost {
+    selected_platforms: Vec<KmpPlatform>,
+}
 
 impl KmpHost {
     /// Creates a KMP host renderer.
-    pub const fn new() -> Self {
-        Self
+    pub fn new() -> Self {
+        Self {
+            selected_platforms: KmpPlatform::default_selected(),
+        }
+    }
+
+    /// Selects the KMP platform matrix checked by admission.
+    pub fn selected_platforms(mut self, platforms: impl Into<Vec<KmpPlatform>>) -> Self {
+        self.selected_platforms = platforms.into();
+        self
     }
 
     /// Creates the backend target stack for this skeletal KMP host.
-    pub const fn into_target(self) -> Target<Self, KmpBridge> {
+    pub fn into_target(self) -> Target<Self, KmpBridge> {
         Target::new(self, KmpBridge)
     }
 
-    fn unsupported(&self, shape: &'static str) -> Result<Emitted> {
-        Err(Error::UnsupportedTarget {
-            target: "kotlin_multiplatform",
-            shape,
-        })
+    fn emit_admitted(
+        &self,
+        declaration: boltffi_binding::DeclarationRef<'_, Native>,
+        bindings: &Bindings<Native>,
+    ) -> Emitted {
+        let label = DeclarationLabel::from_ref(declaration);
+        let records = KmpAdmission::for_bindings(self.selected_platforms.clone(), bindings)
+            .evaluate_declaration(declaration);
+        let diagnostics = records
+            .iter()
+            .filter(|record| !record.is_admitted())
+            .map(|record| Diagnostic::new(admission_message(&label, record)))
+            .collect::<Vec<_>>();
+        if diagnostics.is_empty() {
+            Emitted::primary("")
+        } else {
+            Emitted::primary("").with_diagnostics(diagnostics)
+        }
+    }
+}
+
+fn admission_message(
+    label: &DeclarationLabel,
+    record: &super::lower::admission::KmpAdmissionRecord,
+) -> String {
+    let reason = record.reason().unwrap_or("unsupported");
+    if record.kind() == label.kind() && record.name() == label.name() {
+        reason.to_owned()
+    } else {
+        format!("{} {}: {reason}", record.kind(), record.name())
+    }
+}
+
+impl Default for KmpHost {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -53,14 +95,14 @@ impl host::HostBackend for KmpHost {
 
     fn binding_capabilities(&self) -> HostCapabilities {
         HostCapabilities::new()
-            .in_progress(BindingCapability::Records, M1A_ADMISSION_REASON)
-            .in_progress(BindingCapability::Enums, M1A_ADMISSION_REASON)
-            .in_progress(BindingCapability::Functions, M1A_ADMISSION_REASON)
-            .in_progress(BindingCapability::Classes, M1A_ADMISSION_REASON)
-            .in_progress(BindingCapability::Callbacks, M1A_ADMISSION_REASON)
-            .in_progress(BindingCapability::Streams, M1A_ADMISSION_REASON)
-            .in_progress(BindingCapability::Constants, M1A_ADMISSION_REASON)
-            .in_progress(BindingCapability::CustomTypes, M1A_ADMISSION_REASON)
+            .stable(BindingCapability::Records)
+            .stable(BindingCapability::Enums)
+            .stable(BindingCapability::Functions)
+            .stable(BindingCapability::Classes)
+            .stable(BindingCapability::Callbacks)
+            .stable(BindingCapability::Streams)
+            .stable(BindingCapability::Constants)
+            .stable(BindingCapability::CustomTypes)
     }
 
     fn bridge_capabilities(&self) -> CapabilityRequirements<BridgeCapability> {
@@ -69,84 +111,121 @@ impl host::HostBackend for KmpHost {
 
     fn record(
         &self,
-        _decl: &RecordDecl<Self::Surface>,
+        decl: &RecordDecl<Self::Surface>,
         _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        self.unsupported("record declarations")
+        Ok(self.emit_admitted(
+            boltffi_binding::DeclarationRef::Record(decl),
+            context.bindings(),
+        ))
     }
 
     fn enumeration(
         &self,
-        _decl: &EnumDecl<Self::Surface>,
+        decl: &EnumDecl<Self::Surface>,
         _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        self.unsupported("enum declarations")
+        Ok(self.emit_admitted(
+            boltffi_binding::DeclarationRef::Enum(decl),
+            context.bindings(),
+        ))
     }
 
     fn function(
         &self,
-        _decl: &FunctionDecl<Self::Surface>,
+        decl: &FunctionDecl<Self::Surface>,
         _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        self.unsupported("function declarations")
+        Ok(self.emit_admitted(
+            boltffi_binding::DeclarationRef::Function(decl),
+            context.bindings(),
+        ))
     }
 
     fn class(
         &self,
-        _decl: &ClassDecl<Self::Surface>,
+        decl: &ClassDecl<Self::Surface>,
         _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        self.unsupported("class declarations")
+        Ok(self.emit_admitted(
+            boltffi_binding::DeclarationRef::Class(decl),
+            context.bindings(),
+        ))
     }
 
     fn callback(
         &self,
-        _decl: &CallbackDecl<Self::Surface>,
+        decl: &CallbackDecl<Self::Surface>,
         _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        self.unsupported("callback declarations")
+        Ok(self.emit_admitted(
+            boltffi_binding::DeclarationRef::Callback(decl),
+            context.bindings(),
+        ))
     }
 
     fn stream(
         &self,
-        _decl: &StreamDecl<Self::Surface>,
+        decl: &StreamDecl<Self::Surface>,
         _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        self.unsupported("stream declarations")
+        Ok(self.emit_admitted(
+            boltffi_binding::DeclarationRef::Stream(decl),
+            context.bindings(),
+        ))
     }
 
     fn constant(
         &self,
-        _decl: &ConstantDecl<Self::Surface>,
+        decl: &ConstantDecl<Self::Surface>,
         _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        self.unsupported("constant declarations")
+        Ok(self.emit_admitted(
+            boltffi_binding::DeclarationRef::Constant(decl),
+            context.bindings(),
+        ))
     }
 
     fn custom_type(
         &self,
-        _decl: &CustomTypeDecl,
+        decl: &CustomTypeDecl,
         _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        self.unsupported("custom type declarations")
+        Ok(self.emit_admitted(
+            boltffi_binding::DeclarationRef::CustomType(decl),
+            context.bindings(),
+        ))
     }
 
     fn assemble<'decl>(
         &self,
-        _bindings: &Bindings<Self::Surface>,
+        bindings: &Bindings<Self::Surface>,
         _bridge: &Self::Bridge,
         _context: &RenderContext<Self::Surface>,
-        _declarations: Vec<RenderedDeclaration<'decl, Self::Surface>>,
+        declarations: Vec<RenderedDeclaration<'decl, Self::Surface>>,
     ) -> Result<GeneratedOutput> {
-        Ok(GeneratedOutput::empty())
+        KmpLowerer::new(
+            KmpLoweringOptions::new()
+                .selected_platforms(self.selected_platforms.clone())
+                .support_mode(KmpSupportMode::PreviewPruneUnsupported),
+        )
+        .lower(bindings)
+        .map_err(|error| error.into_backend_error())?;
+        Ok(GeneratedOutput::new(
+            Vec::new(),
+            declarations
+                .iter()
+                .flat_map(|declaration| declaration.emitted().diagnostics().iter().cloned())
+                .collect(),
+        ))
     }
 }
 
@@ -159,8 +238,7 @@ mod tests {
 
     use crate::{
         Error,
-        core::{BindingCapability, CapabilityStatus},
-        target::kmp::KmpHost,
+        target::kmp::{KmpHost, KmpPlatform},
     };
 
     fn bindings(source: &str) -> Bindings<Native> {
@@ -185,8 +263,8 @@ mod tests {
     }
 
     #[test]
-    fn kmp_target_rejects_exported_apis_in_complete_mode() {
-        let error = KmpHost::new()
+    fn kmp_target_renders_admitted_sync_function_without_files() {
+        let output = KmpHost::new()
             .into_target()
             .render(&bindings(
                 r#"
@@ -196,14 +274,116 @@ mod tests {
                 }
                 "#,
             ))
-            .expect_err("KMP IR skeleton should reject exported APIs");
+            .expect("KMP IR plan should admit sync primitive functions for JVM and Android");
+
+        assert!(output.files().is_empty());
+        assert!(output.diagnostics().is_empty());
+        assert!(output.coverage().is_complete());
+    }
+
+    #[test]
+    fn kmp_target_rejects_apis_outside_platform_intersection() {
+        let error = KmpHost::new()
+            .selected_platforms(vec![KmpPlatform::Jvm, KmpPlatform::IosSimulatorArm64])
+            .into_target()
+            .render(&bindings(
+                r#"
+                #[export]
+                pub fn add(left: i32, right: i32) -> i32 {
+                    left + right
+                }
+                "#,
+            ))
+            .expect_err("KMP IR plan should reject APIs not supported by every platform");
 
         match error {
-            Error::BindingCapability {
+            Error::IncompleteCoverage {
                 target: "kotlin_multiplatform",
-                capability: BindingCapability::Functions,
-                status: CapabilityStatus::InProgress { reason },
-            } => assert_eq!(reason, super::M1A_ADMISSION_REASON),
+                reason,
+            } => {
+                assert!(reason.contains("function add"));
+                assert!(reason.contains("synchronous callables on iosSimulatorArm64"));
+            }
+            other => panic!("unexpected KMP IR skeleton error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kmp_target_rejects_empty_platform_matrix() {
+        let error = KmpHost::new()
+            .selected_platforms(Vec::<KmpPlatform>::new())
+            .into_target()
+            .render(&bindings(
+                r#"
+                #[export]
+                pub fn add(left: i32, right: i32) -> i32 {
+                    left + right
+                }
+                "#,
+            ))
+            .expect_err("KMP IR plan should require at least one selected platform");
+
+        match error {
+            Error::IncompleteCoverage {
+                target: "kotlin_multiplatform",
+                reason,
+            } => {
+                assert!(reason.contains("function add"), "{reason}");
+                assert!(reason.contains("no selected KMP platforms"), "{reason}");
+            }
+            other => panic!("unexpected KMP IR skeleton error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kmp_target_rejects_empty_platform_matrix_without_apis() {
+        let error = KmpHost::new()
+            .selected_platforms(Vec::<KmpPlatform>::new())
+            .into_target()
+            .render(&bindings(""))
+            .expect_err("KMP IR plan should require at least one selected platform");
+
+        match error {
+            Error::UnsupportedTarget {
+                target: "kotlin_multiplatform",
+                shape: "invalid KMP platform matrix",
+            } => {}
+            other => panic!("unexpected KMP IR skeleton error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kmp_target_rejects_api_using_custom_type_with_unsupported_representation() {
+        let error = KmpHost::new()
+            .into_target()
+            .render(&bindings(
+                r#"
+                use std::time::Duration;
+
+                custom_type!(
+                    BadDuration,
+                    remote = RemoteDuration,
+                    repr = Duration,
+                    into_ffi = |_value: &RemoteDuration| Duration::from_secs(0),
+                    try_from_ffi = |_value: Duration| Ok(RemoteDuration),
+                );
+
+                #[export]
+                pub fn echo_bad(value: RemoteDuration) -> RemoteDuration {
+                    value
+                }
+                "#,
+            ))
+            .expect_err("KMP IR plan should reject custom type representations it cannot admit");
+
+        match error {
+            Error::IncompleteCoverage {
+                target: "kotlin_multiplatform",
+                reason,
+            } => {
+                assert!(reason.contains("function echo::bad"), "{reason}");
+                assert!(reason.contains("unknown binding shapes on jvm"), "{reason}");
+            }
             other => panic!("unexpected KMP IR skeleton error: {other:?}"),
         }
     }
@@ -214,9 +394,13 @@ mod tests {
             .into_target()
             .render_partial(&bindings(
                 r#"
-                #[export]
-                pub fn add(left: i32, right: i32) -> i32 {
-                    left + right
+                pub struct Engine;
+
+                #[export(single_threaded)]
+                impl Engine {
+                    pub fn new() -> Self {
+                        Engine
+                    }
                 }
                 "#,
             ))
@@ -224,9 +408,70 @@ mod tests {
         let unsupported = output.coverage().unsupported();
 
         assert!(output.files().is_empty());
-        assert_eq!(unsupported.len(), 1);
-        assert_eq!(unsupported[0].declaration().kind(), "function");
-        assert_eq!(unsupported[0].declaration().name(), "add");
-        assert_eq!(unsupported[0].reason(), super::M1A_ADMISSION_REASON);
+        assert_eq!(output.diagnostics().len(), 2);
+        assert!(
+            output
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.message()
+                    == "unsupported classes on jvm, classes on android")
+        );
+        assert!(
+            output
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.message()
+                    == "class initializer engine::new: unsupported classes on jvm, classes on android")
+        );
+        assert_eq!(unsupported.len(), 2);
+        assert_eq!(unsupported[0].declaration().kind(), "class");
+        assert_eq!(unsupported[0].declaration().name(), "engine");
+        assert_eq!(
+            unsupported[0].reason(),
+            "unsupported classes on jvm, classes on android"
+        );
+    }
+
+    #[test]
+    fn kmp_target_reports_every_unsupported_owned_api_in_partial_mode() {
+        let output = KmpHost::new()
+            .into_target()
+            .render_partial(&bindings(
+                r#"
+                #[repr(C)]
+                #[data]
+                pub struct Point {
+                    pub x: i32,
+                }
+
+                #[data(impl)]
+                impl Point {
+                    pub async fn load(&self) -> i32 {
+                        1
+                    }
+
+                    pub async fn save(&self) -> i32 {
+                        2
+                    }
+                }
+                "#,
+            ))
+            .expect("partial KMP IR skeleton should report every unsupported owned API");
+        let unsupported = output.coverage().unsupported();
+        let diagnostics = output.diagnostics();
+
+        assert!(output.files().is_empty());
+        assert_eq!(diagnostics.len(), 2);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message().contains("record method point::load"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message().contains("record method point::save"))
+        );
+        assert_eq!(unsupported.len(), 2);
     }
 }

--- a/boltffi_backend/src/target/kmp/lower/admission.rs
+++ b/boltffi_backend/src/target/kmp/lower/admission.rs
@@ -1,0 +1,806 @@
+//! Capability admission for KMP plans.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use boltffi_binding::{
+    Bindings, CallableDecl, CallbackDecl, ClassDecl, ConstantDecl, ConstantValueDecl,
+    CustomTypeDecl, CustomTypeId, DataVariantPayload, Decl, DeclarationRef, DirectValueType,
+    EnumDecl, EnumId, ErrorChannel, ErrorDecl, ExecutionDecl, ExportedMethodDecl, FunctionDecl,
+    IncomingParam, InitializerDecl, Native, NativeSymbol, ParamPlan, Receive, RecordDecl, RecordId,
+    ReturnPlan, RustBody, TypeRef,
+};
+
+use crate::core::DeclarationLabel;
+
+use super::super::plan::{KmpCapability, KmpCapabilitySet, KmpPlatform, KmpSupportApi};
+
+/// Admission engine for one selected KMP platform matrix.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct KmpAdmission<'bindings> {
+    selected_platforms: Vec<KmpPlatform>,
+    bindings: &'bindings Bindings<Native>,
+    records: BTreeMap<RecordId, &'bindings RecordDecl<Native>>,
+    enumerations: BTreeMap<EnumId, &'bindings EnumDecl<Native>>,
+    custom_types: BTreeMap<CustomTypeId, &'bindings CustomTypeDecl>,
+}
+
+#[derive(Default)]
+struct TypeCapabilityStack {
+    custom_types: BTreeSet<CustomTypeId>,
+    records: BTreeSet<RecordId>,
+    enums: BTreeSet<EnumId>,
+}
+
+impl TypeCapabilityStack {
+    fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<'bindings> KmpAdmission<'bindings> {
+    /// Creates admission for the selected KMP platform matrix and binding graph.
+    pub fn for_bindings(
+        selected_platforms: Vec<KmpPlatform>,
+        bindings: &'bindings Bindings<Native>,
+    ) -> Self {
+        Self {
+            selected_platforms,
+            bindings,
+            records: record_index(bindings),
+            enumerations: enum_index(bindings),
+            custom_types: custom_type_index(bindings),
+        }
+    }
+
+    /// Evaluates all declarations in a binding contract.
+    pub fn evaluate(&self) -> KmpAdmissionReport {
+        self.bindings
+            .decls()
+            .iter()
+            .fold(KmpAdmissionReport::new(), |mut report, decl| {
+                self.evaluate_declaration(DeclarationRef::from(decl))
+                    .into_iter()
+                    .for_each(|record| report.push(record));
+                report
+            })
+    }
+
+    /// Evaluates one declaration and any member APIs it owns.
+    pub fn evaluate_decl(&self, decl: &Decl<Native>) -> Vec<KmpAdmissionRecord> {
+        self.evaluate_declaration(DeclarationRef::from(decl))
+    }
+
+    /// Evaluates one declaration view and any member APIs it owns.
+    pub fn evaluate_declaration(
+        &self,
+        declaration: DeclarationRef<'_, Native>,
+    ) -> Vec<KmpAdmissionRecord> {
+        match declaration {
+            DeclarationRef::Record(record) => self.record(record),
+            DeclarationRef::Enum(enumeration) => self.enumeration(enumeration),
+            DeclarationRef::Function(function) => self.function(function),
+            DeclarationRef::Class(class) => self.class(class),
+            DeclarationRef::Callback(callback) => self.callback(callback),
+            DeclarationRef::Stream(stream) => {
+                let label = DeclarationLabel::from_ref(DeclarationRef::Stream(stream));
+                vec![self.rejected(
+                    label.kind(),
+                    label.name(),
+                    KmpCapabilitySet::from_iter([KmpCapability::Streams]),
+                )]
+            }
+            DeclarationRef::Constant(constant) => self.constant(constant),
+            DeclarationRef::CustomType(custom_type) => {
+                vec![self.admit(
+                    "custom type",
+                    custom_type.name().as_path_string(),
+                    union(
+                        KmpCapabilitySet::from_iter([KmpCapability::CustomTypes]),
+                        self.type_ref_capability_set(custom_type.representation()),
+                    ),
+                )]
+            }
+        }
+    }
+
+    /// Evaluates one declaration as a single API for host render coverage.
+    pub fn evaluate_declaration_only(
+        &self,
+        decl: DeclarationRef<'_, Native>,
+    ) -> KmpAdmissionRecord {
+        let label = DeclarationLabel::from_ref(decl);
+        let required = match decl {
+            DeclarationRef::Record(record) => self.record_declaration_capability_set(record),
+            DeclarationRef::Enum(enumeration) => self.enum_declaration_capability_set(enumeration),
+            DeclarationRef::Function(function) => self.callable_capabilities(function.callable()),
+            DeclarationRef::Class(_) => KmpCapabilitySet::from_iter([KmpCapability::Classes]),
+            DeclarationRef::Callback(_) => KmpCapabilitySet::from_iter([KmpCapability::Callbacks]),
+            DeclarationRef::Stream(_) => KmpCapabilitySet::from_iter([KmpCapability::Streams]),
+            DeclarationRef::Constant(constant) => self.constant_capability_set(constant),
+            DeclarationRef::CustomType(custom_type) => union(
+                KmpCapabilitySet::from_iter([KmpCapability::CustomTypes]),
+                self.type_ref_capability_set(custom_type.representation()),
+            ),
+        };
+        self.admit(label.kind(), label.name(), required)
+    }
+
+    fn record(&self, record: &RecordDecl<Native>) -> Vec<KmpAdmissionRecord> {
+        let owner_record = self.evaluate_declaration_only(DeclarationRef::Record(record));
+        let mut records = vec![owner_record.clone()];
+        match record {
+            RecordDecl::Direct(record) => {
+                records.extend(self.admit_owned_members(
+                    record.name(),
+                    record.initializers(),
+                    record.methods(),
+                    "record initializer",
+                    "record method",
+                    &owner_record,
+                ));
+            }
+            RecordDecl::Encoded(record) => {
+                records.extend(self.admit_owned_members(
+                    record.name(),
+                    record.initializers(),
+                    record.methods(),
+                    "record initializer",
+                    "record method",
+                    &owner_record,
+                ));
+            }
+            _ => {
+                records.push(self.rejected(
+                    "record",
+                    record.name().as_path_string(),
+                    KmpCapabilitySet::from_iter([KmpCapability::UnknownBindingShapes]),
+                ));
+            }
+        }
+        records
+    }
+
+    fn enumeration(&self, enumeration: &EnumDecl<Native>) -> Vec<KmpAdmissionRecord> {
+        let owner_record = self.evaluate_declaration_only(DeclarationRef::Enum(enumeration));
+        let mut records = vec![owner_record.clone()];
+        match enumeration {
+            EnumDecl::CStyle(enumeration) => {
+                records.extend(self.admit_owned_members(
+                    enumeration.name(),
+                    enumeration.initializers(),
+                    enumeration.methods(),
+                    "enum initializer",
+                    "enum method",
+                    &owner_record,
+                ));
+            }
+            EnumDecl::Data(enumeration) => {
+                records.extend(self.admit_owned_members(
+                    enumeration.name(),
+                    enumeration.initializers(),
+                    enumeration.methods(),
+                    "enum initializer",
+                    "enum method",
+                    &owner_record,
+                ));
+            }
+            _ => {
+                records.push(self.rejected(
+                    "enum",
+                    enumeration.name().as_path_string(),
+                    KmpCapabilitySet::from_iter([KmpCapability::UnknownBindingShapes]),
+                ));
+            }
+        }
+        records
+    }
+
+    fn function(&self, function: &FunctionDecl<Native>) -> Vec<KmpAdmissionRecord> {
+        vec![self.admit_callable(
+            "function",
+            function.name().as_path_string(),
+            function.callable(),
+        )]
+    }
+
+    fn class(&self, class: &ClassDecl<Native>) -> Vec<KmpAdmissionRecord> {
+        let mut records = vec![self.rejected(
+            "class",
+            class.name().as_path_string(),
+            KmpCapabilitySet::from_iter([KmpCapability::Classes]),
+        )];
+        records.extend(class.initializers().iter().map(|initializer| {
+            self.rejected(
+                "class initializer",
+                member_name(class.name(), initializer.name()),
+                union(
+                    KmpCapabilitySet::from_iter([KmpCapability::Classes]),
+                    self.callable_capabilities(initializer.callable()),
+                ),
+            )
+        }));
+        records.extend(class.methods().iter().map(|method| {
+            self.rejected(
+                "class method",
+                member_name(class.name(), method.name()),
+                union(
+                    KmpCapabilitySet::from_iter([KmpCapability::Classes]),
+                    self.callable_capabilities(method.callable()),
+                ),
+            )
+        }));
+        records
+    }
+
+    fn callback(&self, callback: &CallbackDecl<Native>) -> Vec<KmpAdmissionRecord> {
+        vec![self.rejected(
+            "callback",
+            callback.name().as_path_string(),
+            KmpCapabilitySet::from_iter([KmpCapability::Callbacks]),
+        )]
+    }
+
+    fn constant(&self, constant: &ConstantDecl<Native>) -> Vec<KmpAdmissionRecord> {
+        vec![self.admit(
+            "constant",
+            constant.name().as_path_string(),
+            self.constant_capability_set(constant),
+        )]
+    }
+
+    fn admit_callable(
+        &self,
+        kind: &'static str,
+        name: String,
+        callable: &CallableDecl<Native, RustBody>,
+    ) -> KmpAdmissionRecord {
+        self.admit(kind, name, self.callable_capabilities(callable))
+    }
+
+    fn admit_owned_members(
+        &self,
+        owner: &boltffi_binding::CanonicalName,
+        initializers: &[InitializerDecl<Native>],
+        methods: &[ExportedMethodDecl<Native, NativeSymbol>],
+        initializer_kind: &'static str,
+        method_kind: &'static str,
+        owner_record: &KmpAdmissionRecord,
+    ) -> Vec<KmpAdmissionRecord> {
+        initializers
+            .iter()
+            .map(|initializer| {
+                self.admit_member_callable(
+                    initializer_kind,
+                    member_name(owner, initializer.name()),
+                    initializer.callable(),
+                    owner_record,
+                )
+            })
+            .chain(methods.iter().map(|method| {
+                self.admit_member_callable(
+                    method_kind,
+                    member_name(owner, method.name()),
+                    method.callable(),
+                    owner_record,
+                )
+            }))
+            .collect()
+    }
+
+    fn admit_member_callable(
+        &self,
+        kind: &'static str,
+        name: String,
+        callable: &CallableDecl<Native, RustBody>,
+        owner_record: &KmpAdmissionRecord,
+    ) -> KmpAdmissionRecord {
+        let required = union(
+            owner_record.required_capabilities().clone(),
+            self.callable_capabilities(callable),
+        );
+        if owner_record.is_admitted() {
+            self.admit(kind, name, required)
+        } else {
+            self.rejected(kind, name, required)
+        }
+    }
+
+    fn admit(
+        &self,
+        kind: &'static str,
+        name: impl Into<String>,
+        required_capabilities: KmpCapabilitySet,
+    ) -> KmpAdmissionRecord {
+        let name = name.into();
+        match unsupported_reason(&self.selected_platforms, &required_capabilities) {
+            Some(reason) => KmpAdmissionRecord::rejected(kind, name, required_capabilities, reason),
+            None => KmpAdmissionRecord::admitted(kind, name, required_capabilities),
+        }
+    }
+
+    fn rejected(
+        &self,
+        kind: &'static str,
+        name: impl Into<String>,
+        required_capabilities: KmpCapabilitySet,
+    ) -> KmpAdmissionRecord {
+        let reason = unsupported_reason(&self.selected_platforms, &required_capabilities)
+            .unwrap_or_else(|| "unsupported by the KMP admission policy".to_owned());
+        KmpAdmissionRecord::rejected(kind, name, required_capabilities, reason)
+    }
+
+    fn callable_capabilities(&self, callable: &CallableDecl<Native, RustBody>) -> KmpCapabilitySet {
+        let execution = match callable.execution() {
+            ExecutionDecl::Synchronous(_) => KmpCapability::SyncCallables,
+            ExecutionDecl::Asynchronous(_) => KmpCapability::AsyncCallables,
+            _ => KmpCapability::UnknownBindingShapes,
+        };
+        let capabilities = std::iter::once(execution)
+            .chain(self.receiver_capabilities(callable.receiver()))
+            .chain(
+                callable
+                    .params()
+                    .iter()
+                    .flat_map(|param| self.param_capabilities(param.payload()).into_iter()),
+            )
+            .chain(self.return_capabilities(callable.returns().plan()))
+            .chain(self.error_capabilities(callable.error()));
+        KmpCapabilitySet::from_iter(capabilities)
+    }
+
+    fn receiver_capabilities(&self, receiver: Option<Receive>) -> Vec<KmpCapability> {
+        match receiver {
+            Some(Receive::ByMutRef) => vec![KmpCapability::MutatingReceivers],
+            Some(Receive::ByValue | Receive::ByRef) | None => Vec::new(),
+            _ => vec![KmpCapability::UnknownBindingShapes],
+        }
+    }
+
+    fn constant_capability_set(&self, constant: &ConstantDecl<Native>) -> KmpCapabilitySet {
+        let required = KmpCapabilitySet::from_iter([KmpCapability::Constants]);
+        match constant.value() {
+            ConstantValueDecl::Inline { ty, .. } => {
+                union(required, self.type_ref_capability_set(ty))
+            }
+            ConstantValueDecl::Accessor { callable, .. } => {
+                union(required, self.callable_capabilities(callable))
+            }
+            _ => union(
+                required,
+                KmpCapabilitySet::from_iter([KmpCapability::UnknownBindingShapes]),
+            ),
+        }
+    }
+
+    fn param_capabilities(&self, payload: &IncomingParam<Native>) -> Vec<KmpCapability> {
+        match payload {
+            IncomingParam::Value(plan) => self.param_plan_capabilities(plan),
+            IncomingParam::Closure(_) => vec![KmpCapability::Callbacks],
+        }
+    }
+
+    fn param_plan_capabilities<D>(&self, plan: &ParamPlan<Native, D>) -> Vec<KmpCapability>
+    where
+        D: boltffi_binding::Direction,
+    {
+        match plan {
+            ParamPlan::Direct { ty, .. } => self.direct_value_capabilities(ty),
+            ParamPlan::Encoded { ty, .. } => self.type_ref_capabilities(ty),
+            ParamPlan::Handle { target, .. } => handle_capability(target),
+            ParamPlan::ScalarOption { .. } => Vec::new(),
+            ParamPlan::DirectVec { element } => match element {
+                boltffi_binding::DirectVectorElementType::Primitive(_) => Vec::new(),
+                boltffi_binding::DirectVectorElementType::Record(_) => {
+                    vec![KmpCapability::DirectRecords]
+                }
+                _ => vec![KmpCapability::UnknownBindingShapes],
+            },
+            _ => vec![KmpCapability::UnknownBindingShapes],
+        }
+    }
+
+    fn return_capabilities(
+        &self,
+        plan: &ReturnPlan<Native, boltffi_binding::OutOfRust>,
+    ) -> Vec<KmpCapability> {
+        match plan {
+            ReturnPlan::Void => Vec::new(),
+            ReturnPlan::DirectViaReturnSlot { ty } | ReturnPlan::DirectViaOutPointer { ty } => {
+                self.direct_value_capabilities(ty)
+            }
+            ReturnPlan::EncodedViaReturnSlot { ty, .. }
+            | ReturnPlan::EncodedViaOutPointer { ty, .. } => self.type_ref_capabilities(ty),
+            ReturnPlan::HandleViaReturnSlot { target, .. }
+            | ReturnPlan::HandleViaOutPointer { target, .. } => handle_capability(target),
+            ReturnPlan::ScalarOptionViaReturnSlot { .. } => Vec::new(),
+            ReturnPlan::DirectVecViaReturnSlot { element } => match element {
+                boltffi_binding::DirectVectorElementType::Primitive(_) => Vec::new(),
+                boltffi_binding::DirectVectorElementType::Record(_) => {
+                    vec![KmpCapability::DirectRecords]
+                }
+                _ => vec![KmpCapability::UnknownBindingShapes],
+            },
+            ReturnPlan::ClosureViaOutPointer(_) => vec![KmpCapability::Callbacks],
+            _ => vec![KmpCapability::UnknownBindingShapes],
+        }
+    }
+
+    fn error_capabilities(
+        &self,
+        error: &ErrorDecl<Native, boltffi_binding::OutOfRust>,
+    ) -> Vec<KmpCapability> {
+        match error.channel() {
+            ErrorChannel::None | ErrorChannel::Status => Vec::new(),
+            ErrorChannel::Encoded { ty, .. } => self.type_ref_capabilities(ty),
+            _ => vec![KmpCapability::UnknownBindingShapes],
+        }
+    }
+
+    fn direct_value_capabilities(&self, ty: &DirectValueType) -> Vec<KmpCapability> {
+        match ty {
+            DirectValueType::Primitive(_) => Vec::new(),
+            DirectValueType::Record(_) => vec![KmpCapability::DirectRecords],
+            DirectValueType::Enum(_) => vec![KmpCapability::CStyleEnums],
+            _ => vec![KmpCapability::UnknownBindingShapes],
+        }
+    }
+
+    fn type_ref_capability_set(&self, ty: &TypeRef) -> KmpCapabilitySet {
+        KmpCapabilitySet::from_iter(self.type_ref_capabilities(ty))
+    }
+
+    fn type_ref_capabilities(&self, ty: &TypeRef) -> Vec<KmpCapability> {
+        self.type_ref_capabilities_inner(ty, &mut TypeCapabilityStack::new())
+    }
+
+    fn type_ref_capabilities_inner(
+        &self,
+        ty: &TypeRef,
+        visiting: &mut TypeCapabilityStack,
+    ) -> Vec<KmpCapability> {
+        match ty {
+            TypeRef::Primitive(_) | TypeRef::String | TypeRef::Bytes => Vec::new(),
+            TypeRef::Record(id) => {
+                let mut capabilities = vec![KmpCapability::EncodedRecords];
+                if !visiting.records.insert(*id) {
+                    return capabilities;
+                }
+                match self.record_declaration(*id) {
+                    Some(record) => {
+                        capabilities.extend(self.record_declaration_capabilities(record, visiting))
+                    }
+                    None => capabilities.push(KmpCapability::UnknownBindingShapes),
+                }
+                visiting.records.remove(id);
+                capabilities
+            }
+            TypeRef::Enum(id) => {
+                let mut capabilities = vec![KmpCapability::DataEnums];
+                if !visiting.enums.insert(*id) {
+                    return capabilities;
+                }
+                match self.enum_declaration(*id) {
+                    Some(enumeration) => capabilities
+                        .extend(self.enum_declaration_capabilities(enumeration, visiting)),
+                    None => capabilities.push(KmpCapability::UnknownBindingShapes),
+                }
+                visiting.enums.remove(id);
+                capabilities
+            }
+            TypeRef::Class(_) => vec![KmpCapability::Classes],
+            TypeRef::Callback(_) => vec![KmpCapability::Callbacks],
+            TypeRef::Custom(id) => {
+                let mut capabilities = vec![KmpCapability::CustomTypes];
+                if !visiting.custom_types.insert(*id) {
+                    capabilities.push(KmpCapability::UnknownBindingShapes);
+                    return capabilities;
+                }
+                match self.custom_type(*id) {
+                    Some(custom_type) => capabilities.extend(
+                        self.type_ref_capabilities_inner(custom_type.representation(), visiting),
+                    ),
+                    None => capabilities.push(KmpCapability::UnknownBindingShapes),
+                }
+                visiting.custom_types.remove(id);
+                capabilities
+            }
+            TypeRef::Optional(inner) | TypeRef::Sequence(inner) => {
+                self.type_ref_capabilities_inner(inner, visiting)
+            }
+            TypeRef::Result { ok, err } => self
+                .type_ref_capabilities_inner(ok, visiting)
+                .into_iter()
+                .chain(self.type_ref_capabilities_inner(err, visiting))
+                .collect(),
+            TypeRef::Builtin(_) => vec![KmpCapability::UnknownBindingShapes],
+            TypeRef::Tuple(items) => std::iter::once(KmpCapability::UnknownBindingShapes)
+                .chain(
+                    items
+                        .iter()
+                        .flat_map(|item| self.type_ref_capabilities_inner(item, visiting)),
+                )
+                .collect(),
+            TypeRef::Map { key, value } => std::iter::once(KmpCapability::UnknownBindingShapes)
+                .chain(self.type_ref_capabilities_inner(key, visiting))
+                .chain(self.type_ref_capabilities_inner(value, visiting))
+                .collect(),
+            _ => vec![KmpCapability::UnknownBindingShapes],
+        }
+    }
+
+    fn record_declaration_capability_set(&self, record: &RecordDecl<Native>) -> KmpCapabilitySet {
+        KmpCapabilitySet::from_iter(
+            self.record_declaration_capabilities(record, &mut TypeCapabilityStack::new()),
+        )
+    }
+
+    fn record_declaration_capabilities(
+        &self,
+        record: &RecordDecl<Native>,
+        visiting: &mut TypeCapabilityStack,
+    ) -> Vec<KmpCapability> {
+        match record {
+            RecordDecl::Direct(_) => vec![KmpCapability::DirectRecords],
+            RecordDecl::Encoded(record) => std::iter::once(KmpCapability::EncodedRecords)
+                .chain(
+                    record
+                        .fields()
+                        .iter()
+                        .flat_map(|field| self.type_ref_capabilities_inner(field.ty(), visiting)),
+                )
+                .collect(),
+            _ => vec![KmpCapability::UnknownBindingShapes],
+        }
+    }
+
+    fn enum_declaration_capability_set(&self, enumeration: &EnumDecl<Native>) -> KmpCapabilitySet {
+        KmpCapabilitySet::from_iter(
+            self.enum_declaration_capabilities(enumeration, &mut TypeCapabilityStack::new()),
+        )
+    }
+
+    fn enum_declaration_capabilities(
+        &self,
+        enumeration: &EnumDecl<Native>,
+        visiting: &mut TypeCapabilityStack,
+    ) -> Vec<KmpCapability> {
+        match enumeration {
+            EnumDecl::CStyle(_) => vec![KmpCapability::CStyleEnums],
+            EnumDecl::Data(enumeration) => std::iter::once(KmpCapability::DataEnums)
+                .chain(enumeration.variants().iter().flat_map(|variant| {
+                    self.data_variant_payload_capabilities_inner(variant.payload(), visiting)
+                }))
+                .collect(),
+            _ => vec![KmpCapability::UnknownBindingShapes],
+        }
+    }
+
+    fn data_variant_payload_capabilities_inner(
+        &self,
+        payload: &DataVariantPayload,
+        visiting: &mut TypeCapabilityStack,
+    ) -> Vec<KmpCapability> {
+        match payload {
+            DataVariantPayload::Unit => Vec::new(),
+            DataVariantPayload::Tuple(fields) | DataVariantPayload::Struct(fields) => fields
+                .iter()
+                .flat_map(|field| self.type_ref_capabilities_inner(field.ty(), visiting))
+                .collect(),
+            _ => vec![KmpCapability::UnknownBindingShapes],
+        }
+    }
+
+    fn record_declaration(&self, id: RecordId) -> Option<&RecordDecl<Native>> {
+        self.records.get(&id).copied()
+    }
+
+    fn enum_declaration(&self, id: EnumId) -> Option<&EnumDecl<Native>> {
+        self.enumerations.get(&id).copied()
+    }
+
+    fn custom_type(&self, id: CustomTypeId) -> Option<&CustomTypeDecl> {
+        self.custom_types.get(&id).copied()
+    }
+}
+
+/// Admission report for all APIs in a binding contract.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct KmpAdmissionReport {
+    records: Vec<KmpAdmissionRecord>,
+}
+
+impl KmpAdmissionReport {
+    /// Creates an empty admission report.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds one admission record.
+    pub fn push(&mut self, record: KmpAdmissionRecord) {
+        self.records.push(record);
+    }
+
+    /// Returns all admission records.
+    pub fn records(&self) -> &[KmpAdmissionRecord] {
+        &self.records
+    }
+
+    /// Returns admitted API records.
+    pub fn admitted(&self) -> Vec<&KmpAdmissionRecord> {
+        self.records
+            .iter()
+            .filter(|record| record.is_admitted())
+            .collect()
+    }
+
+    /// Returns rejected API records.
+    pub fn rejected(&self) -> Vec<&KmpAdmissionRecord> {
+        self.records
+            .iter()
+            .filter(|record| !record.is_admitted())
+            .collect()
+    }
+
+    pub(crate) fn admitted_support_apis(&self) -> Vec<KmpSupportApi> {
+        self.admitted()
+            .into_iter()
+            .map(|record| KmpSupportApi::admitted(record.kind, record.name.clone()))
+            .collect()
+    }
+
+    pub(crate) fn rejected_support_apis(&self) -> Vec<KmpSupportApi> {
+        self.rejected()
+            .into_iter()
+            .map(|record| {
+                KmpSupportApi::rejected(
+                    record.kind,
+                    record.name.clone(),
+                    record.reason.as_deref().unwrap_or("unsupported"),
+                )
+            })
+            .collect()
+    }
+}
+
+/// Admission outcome for one KMP API.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct KmpAdmissionRecord {
+    kind: &'static str,
+    name: String,
+    required_capabilities: KmpCapabilitySet,
+    reason: Option<String>,
+}
+
+impl KmpAdmissionRecord {
+    /// Creates an admitted API record.
+    pub fn admitted(
+        kind: &'static str,
+        name: impl Into<String>,
+        required_capabilities: KmpCapabilitySet,
+    ) -> Self {
+        Self {
+            kind,
+            name: name.into(),
+            required_capabilities,
+            reason: None,
+        }
+    }
+
+    /// Creates a rejected API record.
+    pub fn rejected(
+        kind: &'static str,
+        name: impl Into<String>,
+        required_capabilities: KmpCapabilitySet,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            name: name.into(),
+            required_capabilities,
+            reason: Some(reason.into()),
+        }
+    }
+
+    /// Returns whether the API is admitted.
+    pub fn is_admitted(&self) -> bool {
+        self.reason.is_none()
+    }
+
+    /// Returns the API kind.
+    pub const fn kind(&self) -> &'static str {
+        self.kind
+    }
+
+    /// Returns the API display name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the capabilities this API requires.
+    pub const fn required_capabilities(&self) -> &KmpCapabilitySet {
+        &self.required_capabilities
+    }
+
+    /// Returns the rejection reason, if any.
+    pub fn reason(&self) -> Option<&str> {
+        self.reason.as_deref()
+    }
+}
+
+fn handle_capability(target: &boltffi_binding::HandleTarget) -> Vec<KmpCapability> {
+    match target {
+        boltffi_binding::HandleTarget::Class(_) => vec![KmpCapability::Classes],
+        boltffi_binding::HandleTarget::Callback(_) => vec![KmpCapability::Callbacks],
+        boltffi_binding::HandleTarget::Stream(_) => vec![KmpCapability::Streams],
+        _ => vec![KmpCapability::UnknownBindingShapes],
+    }
+}
+
+fn unsupported_reason(
+    platforms: &[KmpPlatform],
+    required_capabilities: &KmpCapabilitySet,
+) -> Option<String> {
+    if platforms.is_empty() {
+        return Some("no selected KMP platforms".to_owned());
+    }
+
+    let unsupported = platforms
+        .iter()
+        .flat_map(|platform| {
+            let platform_capabilities = platform.capabilities();
+            required_capabilities
+                .iter()
+                .filter(move |capability| !platform_capabilities.contains(*capability))
+                .map(move |capability| format!("{} on {}", capability.label(), platform.label()))
+        })
+        .collect::<Vec<_>>();
+
+    (!unsupported.is_empty()).then(|| format!("unsupported {}", unsupported.join(", ")))
+}
+
+fn union(left: KmpCapabilitySet, right: KmpCapabilitySet) -> KmpCapabilitySet {
+    KmpCapabilitySet::from_iter(left.iter().chain(right.iter()))
+}
+
+fn record_index(bindings: &Bindings<Native>) -> BTreeMap<RecordId, &RecordDecl<Native>> {
+    bindings
+        .decls()
+        .iter()
+        .filter_map(|decl| match decl {
+            Decl::Record(record) => Some((record.id(), record.as_ref())),
+            _ => None,
+        })
+        .collect()
+}
+
+fn enum_index(bindings: &Bindings<Native>) -> BTreeMap<EnumId, &EnumDecl<Native>> {
+    bindings
+        .decls()
+        .iter()
+        .filter_map(|decl| match decl {
+            Decl::Enum(enumeration) => Some((enumeration.id(), enumeration.as_ref())),
+            _ => None,
+        })
+        .collect()
+}
+
+fn custom_type_index(bindings: &Bindings<Native>) -> BTreeMap<CustomTypeId, &CustomTypeDecl> {
+    bindings
+        .decls()
+        .iter()
+        .filter_map(|decl| match decl {
+            Decl::CustomType(custom_type) => Some((custom_type.id(), custom_type.as_ref())),
+            _ => None,
+        })
+        .collect()
+}
+
+fn member_name(
+    owner: &boltffi_binding::CanonicalName,
+    member: &boltffi_binding::CanonicalName,
+) -> String {
+    format!("{}::{}", owner.as_path_string(), member.as_path_string())
+}

--- a/boltffi_backend/src/target/kmp/lower/mod.rs
+++ b/boltffi_backend/src/target/kmp/lower/mod.rs
@@ -1,0 +1,1064 @@
+//! KMP plan lowering and admission.
+
+pub mod admission;
+
+use std::fmt;
+
+use boltffi_binding::{Bindings, Native};
+
+use super::plan::{
+    KmpApiPlan, KmpCommonModule, KmpModule, KmpPlatform, KmpPlatformModule, KmpSupportMode,
+    KmpSupportReport,
+};
+
+/// Options controlling KMP plan lowering.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct KmpLoweringOptions {
+    selected_platforms: Vec<KmpPlatform>,
+    support_mode: KmpSupportMode,
+}
+
+impl Default for KmpLoweringOptions {
+    fn default() -> Self {
+        Self {
+            selected_platforms: KmpPlatform::default_selected(),
+            support_mode: KmpSupportMode::Strict,
+        }
+    }
+}
+
+impl KmpLoweringOptions {
+    /// Creates lowering options using the default JVM and Android platform set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the selected KMP platforms.
+    pub fn selected_platforms(mut self, selected_platforms: impl Into<Vec<KmpPlatform>>) -> Self {
+        self.selected_platforms = selected_platforms.into();
+        self
+    }
+
+    /// Sets the support mode used for unsupported APIs.
+    pub fn support_mode(mut self, support_mode: KmpSupportMode) -> Self {
+        self.support_mode = support_mode;
+        self
+    }
+
+    /// Returns the selected KMP platforms.
+    pub fn platforms(&self) -> &[KmpPlatform] {
+        &self.selected_platforms
+    }
+
+    /// Returns the support mode.
+    pub const fn mode(&self) -> KmpSupportMode {
+        self.support_mode
+    }
+}
+
+/// Lowers classified native bindings into a KMP module plan.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct KmpLowerer {
+    options: KmpLoweringOptions,
+}
+
+impl KmpLowerer {
+    /// Creates a lowerer from options.
+    pub fn new(options: KmpLoweringOptions) -> Self {
+        Self { options }
+    }
+
+    /// Lowers bindings into a KMP module plan.
+    pub fn lower(
+        &self,
+        bindings: &Bindings<Native>,
+    ) -> std::result::Result<KmpModule, KmpLowerError> {
+        let admission = admission::KmpAdmission::for_bindings(
+            self.options.selected_platforms.clone(),
+            bindings,
+        );
+        let admission_report = admission.evaluate();
+        let admitted = admission_report
+            .admitted()
+            .iter()
+            .map(|record| {
+                KmpApiPlan::new(
+                    record.kind(),
+                    record.name(),
+                    record.required_capabilities().clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let support_report = KmpSupportReport::new(
+            self.options.support_mode,
+            self.options.selected_platforms.clone(),
+            admission_report.admitted_support_apis(),
+            admission_report.rejected_support_apis(),
+        );
+
+        if self.options.selected_platforms.is_empty() {
+            return Err(KmpLowerError::InvalidPlatformMatrix {
+                reason: "no selected KMP platforms".to_owned(),
+                report: support_report,
+            });
+        }
+
+        if self.options.support_mode == KmpSupportMode::Strict
+            && !support_report.rejected_apis().is_empty()
+        {
+            return Err(KmpLowerError::UnsupportedApis {
+                report: support_report,
+            });
+        }
+
+        let platforms = self
+            .options
+            .selected_platforms
+            .iter()
+            .map(|platform| KmpPlatformModule::new(*platform, platform.capabilities()))
+            .collect();
+
+        Ok(KmpModule::new(
+            KmpCommonModule::new(admitted),
+            platforms,
+            support_report,
+        ))
+    }
+
+    /// Returns the lowerer options.
+    pub const fn options(&self) -> &KmpLoweringOptions {
+        &self.options
+    }
+}
+
+/// Failure while lowering a KMP module plan.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum KmpLowerError {
+    /// Strict mode rejected at least one API.
+    UnsupportedApis {
+        /// Full support report describing admitted and rejected APIs.
+        report: KmpSupportReport,
+    },
+    /// The selected platform matrix cannot produce a KMP module.
+    InvalidPlatformMatrix {
+        /// Human-readable platform matrix failure.
+        reason: String,
+        /// Support report built with the invalid matrix for diagnostics.
+        report: KmpSupportReport,
+    },
+}
+
+impl KmpLowerError {
+    /// Converts this KMP lowering failure into a backend render error.
+    pub(crate) fn into_backend_error(self) -> crate::Error {
+        match self {
+            Self::UnsupportedApis { .. } => crate::Error::UnsupportedTarget {
+                target: "kotlin_multiplatform",
+                shape: "unsupported KMP APIs",
+            },
+            Self::InvalidPlatformMatrix { .. } => crate::Error::UnsupportedTarget {
+                target: "kotlin_multiplatform",
+                shape: "invalid KMP platform matrix",
+            },
+        }
+    }
+}
+
+impl fmt::Display for KmpLowerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedApis { report } => {
+                write!(
+                    formatter,
+                    "unsupported KMP APIs: {}",
+                    summarize_report(report)
+                )
+            }
+            Self::InvalidPlatformMatrix { reason, report } => {
+                write!(
+                    formatter,
+                    "invalid KMP platform matrix: {reason}: {}",
+                    summarize_report(report)
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for KmpLowerError {}
+
+fn summarize_report(report: &KmpSupportReport) -> String {
+    report
+        .rejected_apis()
+        .iter()
+        .take(4)
+        .map(|api| match api.reason() {
+            Some(reason) => format!("{} {} ({reason})", api.kind(), api.name()),
+            None => format!("{} {}", api.kind(), api.name()),
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Lowers bindings with default strict JVM and Android options.
+pub fn lower(bindings: &Bindings<Native>) -> std::result::Result<KmpModule, KmpLowerError> {
+    KmpLowerer::new(KmpLoweringOptions::new()).lower(bindings)
+}
+
+#[cfg(test)]
+mod tests {
+    use boltffi_ast::PackageInfo;
+    use boltffi_binding::{Bindings, Native, lower as lower_bindings};
+
+    use super::{
+        super::plan::{KmpCapability, KmpPlatform, KmpSupportMode},
+        KmpLowerError, KmpLowerer, KmpLoweringOptions,
+    };
+
+    fn bindings(source: &str) -> Bindings<Native> {
+        let source = boltffi_scan::scan_file(
+            syn::parse_str(source).expect("valid source fixture"),
+            PackageInfo::new("demo", None),
+        )
+        .expect("source should scan");
+        lower_bindings::<Native>(&source).expect("source should lower")
+    }
+
+    fn unsupported_report(error: KmpLowerError) -> super::super::plan::KmpSupportReport {
+        match error {
+            KmpLowerError::UnsupportedApis { report } => report,
+            other => panic!("unexpected KMP lower error: {other:?}"),
+        }
+    }
+
+    fn admitted_api<'module>(
+        module: &'module super::super::plan::KmpModule,
+        kind: &str,
+        name: &str,
+    ) -> &'module super::super::plan::KmpApiPlan {
+        module
+            .common()
+            .apis()
+            .iter()
+            .find(|api| api.kind() == kind && api.name() == name)
+            .expect("admitted API")
+    }
+
+    #[test]
+    fn lowerer_admits_sync_function_for_default_jvm_android_intersection() {
+        let module = super::lower(&bindings(
+            r#"
+            #[export]
+            pub fn add(left: i32, right: i32) -> i32 {
+                left + right
+            }
+            "#,
+        ))
+        .expect("sync primitive function should be admitted for JVM and Android");
+
+        assert_eq!(module.platforms().len(), 2);
+        assert_eq!(module.platforms()[0].platform(), KmpPlatform::Jvm);
+        assert_eq!(module.platforms()[1].platform(), KmpPlatform::Android);
+        assert_eq!(module.common().apis().len(), 1);
+        assert_eq!(module.common().apis()[0].kind(), "function");
+        assert_eq!(module.common().apis()[0].name(), "add");
+        assert_eq!(module.support_report().mode(), KmpSupportMode::Strict);
+        assert_eq!(module.support_report().admitted_apis().len(), 1);
+        assert!(module.support_report().rejected_apis().is_empty());
+    }
+
+    #[test]
+    fn lowerer_rejects_api_missing_from_any_selected_platform() {
+        let error = KmpLowerer::new(
+            KmpLoweringOptions::new()
+                .selected_platforms(vec![KmpPlatform::Jvm, KmpPlatform::IosSimulatorArm64]),
+        )
+        .lower(&bindings(
+            r#"
+            #[export]
+            pub fn add(left: i32, right: i32) -> i32 {
+                left + right
+            }
+            "#,
+        ))
+        .expect_err("iOS simulator is not admitted yet");
+
+        let report = unsupported_report(error);
+        assert_eq!(
+            report.selected_platforms(),
+            &[KmpPlatform::Jvm, KmpPlatform::IosSimulatorArm64]
+        );
+        assert_eq!(report.rejected_apis().len(), 1);
+        assert_eq!(report.rejected_apis()[0].kind(), "function");
+        assert_eq!(report.rejected_apis()[0].name(), "add");
+        assert!(
+            report.rejected_apis()[0]
+                .reason()
+                .expect("rejection reason")
+                .contains("synchronous callables on iosSimulatorArm64")
+        );
+    }
+
+    #[test]
+    fn preview_prune_records_rejected_class_surface_without_common_api() {
+        let module = KmpLowerer::new(
+            KmpLoweringOptions::new().support_mode(KmpSupportMode::PreviewPruneUnsupported),
+        )
+        .lower(&bindings(
+            r#"
+            pub struct Engine;
+
+            #[export(single_threaded)]
+            impl Engine {
+                pub fn new() -> Self {
+                    Engine
+                }
+
+                pub fn version(&self) -> u32 {
+                    1
+                }
+            }
+            "#,
+        ))
+        .expect("preview mode should return a pruned plan");
+
+        let rejected = module.support_report().rejected_apis();
+        assert!(module.common().apis().is_empty());
+        assert_eq!(
+            module.support_report().mode(),
+            KmpSupportMode::PreviewPruneUnsupported
+        );
+        assert!(
+            rejected
+                .iter()
+                .any(|api| api.kind() == "class" && api.name() == "engine")
+        );
+        assert!(
+            rejected
+                .iter()
+                .any(|api| api.kind() == "class initializer" && api.name() == "engine::new")
+        );
+        assert!(
+            rejected
+                .iter()
+                .any(|api| api.kind() == "class method" && api.name() == "engine::version")
+        );
+    }
+
+    #[test]
+    fn strict_lowerer_rejects_unsupported_members_on_admitted_parent() {
+        let error = super::lower(&bindings(
+            r#"
+            #[repr(C)]
+            #[data]
+            pub struct Point {
+                pub x: i32,
+            }
+
+            #[data(impl)]
+            impl Point {
+                pub async fn load(&self) -> i32 {
+                    1
+                }
+            }
+            "#,
+        ))
+        .expect_err("async record methods are outside the M1b KMP capability set");
+
+        let report = unsupported_report(error);
+        assert!(
+            report
+                .admitted_apis()
+                .iter()
+                .any(|api| api.kind() == "record" && api.name() == "point")
+        );
+        assert!(report.rejected_apis().iter().any(|api| {
+            api.kind() == "record method"
+                && api.name() == "point::load"
+                && api
+                    .reason()
+                    .expect("rejection reason")
+                    .contains("asynchronous callables on jvm")
+        }));
+    }
+
+    #[test]
+    fn strict_lowerer_rejects_mutating_record_and_enum_methods() {
+        let error = super::lower(&bindings(
+            r#"
+            #[repr(C)]
+            #[data]
+            pub struct Point {
+                pub x: i32,
+            }
+
+            #[data(impl)]
+            impl Point {
+                pub fn translate(&mut self, dx: i32) {
+                    self.x += dx;
+                }
+            }
+
+            #[data]
+            pub enum Mode {
+                Fast,
+                Slow,
+            }
+
+            #[data(impl)]
+            impl Mode {
+                pub fn flip(&mut self) {
+                    *self = Mode::Slow;
+                }
+            }
+            "#,
+        ))
+        .expect_err("mutating record and enum receivers are outside the M1b KMP capability set");
+
+        let report = unsupported_report(error);
+        assert!(
+            report
+                .admitted_apis()
+                .iter()
+                .any(|api| api.kind() == "record" && api.name() == "point")
+        );
+        assert!(
+            report
+                .admitted_apis()
+                .iter()
+                .any(|api| api.kind() == "enum" && api.name() == "mode")
+        );
+        assert!(report.rejected_apis().iter().any(|api| {
+            api.kind() == "record method"
+                && api.name() == "point::translate"
+                && api
+                    .reason()
+                    .expect("rejection reason")
+                    .contains("mutating receivers on jvm")
+        }));
+        assert!(report.rejected_apis().iter().any(|api| {
+            api.kind() == "enum method"
+                && api.name() == "mode::flip"
+                && api
+                    .reason()
+                    .expect("rejection reason")
+                    .contains("mutating receivers on jvm")
+        }));
+        assert!(
+            !report
+                .admitted_apis()
+                .iter()
+                .any(|api| { matches!(api.name(), "point::translate" | "mode::flip") })
+        );
+    }
+
+    #[test]
+    fn preview_prune_omits_mutating_record_and_enum_methods() {
+        let module = KmpLowerer::new(
+            KmpLoweringOptions::new().support_mode(KmpSupportMode::PreviewPruneUnsupported),
+        )
+        .lower(&bindings(
+            r#"
+            #[repr(C)]
+            #[data]
+            pub struct Point {
+                pub x: i32,
+            }
+
+            #[data(impl)]
+            impl Point {
+                pub fn translate(&mut self, dx: i32) {
+                    self.x += dx;
+                }
+            }
+
+            #[data]
+            pub enum Mode {
+                Fast,
+                Slow,
+            }
+
+            #[data(impl)]
+            impl Mode {
+                pub fn flip(&mut self) {
+                    *self = Mode::Slow;
+                }
+            }
+            "#,
+        ))
+        .expect("preview mode should return a pruned plan");
+
+        assert!(
+            module
+                .common()
+                .apis()
+                .iter()
+                .any(|api| api.kind() == "record" && api.name() == "point")
+        );
+        assert!(
+            module
+                .common()
+                .apis()
+                .iter()
+                .any(|api| api.kind() == "enum" && api.name() == "mode")
+        );
+        assert!(
+            !module
+                .common()
+                .apis()
+                .iter()
+                .any(|api| { matches!(api.name(), "point::translate" | "mode::flip") })
+        );
+        assert!(
+            module
+                .support_report()
+                .rejected_apis()
+                .iter()
+                .any(|api| { api.kind() == "record method" && api.name() == "point::translate" })
+        );
+        assert!(
+            module
+                .support_report()
+                .rejected_apis()
+                .iter()
+                .any(|api| { api.kind() == "enum method" && api.name() == "mode::flip" })
+        );
+    }
+
+    #[test]
+    fn lowerer_records_owner_capabilities_on_admitted_members() {
+        let module = super::lower(&bindings(
+            r#"
+            #[repr(C)]
+            #[data]
+            pub struct Point {
+                pub x: i32,
+            }
+
+            #[data(impl)]
+            impl Point {
+                pub fn stable(&self) -> u32 {
+                    1
+                }
+            }
+
+            #[data]
+            pub enum Mode {
+                Fast,
+                Slow,
+            }
+
+            #[data(impl)]
+            impl Mode {
+                pub fn stable(&self) -> u32 {
+                    1
+                }
+            }
+            "#,
+        ))
+        .expect("supported record and enum methods should be admitted");
+
+        let record_method = admitted_api(&module, "record method", "point::stable");
+        assert!(
+            record_method
+                .required_capabilities()
+                .contains(KmpCapability::DirectRecords)
+        );
+        assert!(
+            record_method
+                .required_capabilities()
+                .contains(KmpCapability::SyncCallables)
+        );
+
+        let enum_method = admitted_api(&module, "enum method", "mode::stable");
+        assert!(
+            enum_method
+                .required_capabilities()
+                .contains(KmpCapability::CStyleEnums)
+        );
+        assert!(
+            enum_method
+                .required_capabilities()
+                .contains(KmpCapability::SyncCallables)
+        );
+    }
+
+    #[test]
+    fn strict_lowerer_rejects_encoded_record_with_unsupported_field_type() {
+        let error = super::lower(&bindings(
+            r#"
+            #[export]
+            pub trait Listener {
+                fn notify(&self);
+            }
+
+            #[data]
+            pub struct BadRecord {
+                pub callback: Box<dyn Listener>,
+            }
+            "#,
+        ))
+        .expect_err("encoded record callback fields are outside the M1b KMP capability set");
+
+        let report = unsupported_report(error);
+        assert!(
+            report.rejected_apis().iter().any(|api| {
+                api.kind() == "record"
+                    && api.name() == "bad::record"
+                    && api
+                        .reason()
+                        .expect("rejection reason")
+                        .contains("callbacks on jvm")
+            }),
+            "{:#?}",
+            report.rejected_apis()
+        );
+    }
+
+    #[test]
+    fn strict_lowerer_rejects_data_enum_with_unsupported_payload_type() {
+        let error = super::lower(&bindings(
+            r#"
+            #[export]
+            pub trait Listener {
+                fn notify(&self);
+            }
+
+            #[data]
+            pub enum BadEnum {
+                WithCallback(Box<dyn Listener>),
+            }
+            "#,
+        ))
+        .expect_err("data enum callback payloads are outside the M1b KMP capability set");
+
+        let report = unsupported_report(error);
+        assert!(
+            report.rejected_apis().iter().any(|api| {
+                api.kind() == "enum"
+                    && api.name() == "bad::enum"
+                    && api
+                        .reason()
+                        .expect("rejection reason")
+                        .contains("callbacks on jvm")
+            }),
+            "{:#?}",
+            report.rejected_apis()
+        );
+    }
+
+    #[test]
+    fn strict_lowerer_rejects_functions_using_rejected_records_and_enums() {
+        let error = super::lower(&bindings(
+            r#"
+            #[export]
+            pub trait Listener {
+                fn notify(&self);
+            }
+
+            #[data]
+            pub struct BadRecord {
+                pub callback: Box<dyn Listener>,
+            }
+
+            #[data]
+            pub enum BadEnum {
+                WithCallback(Box<dyn Listener>),
+            }
+
+            #[export]
+            pub fn use_record(value: BadRecord) -> BadRecord {
+                value
+            }
+
+            #[export]
+            pub fn use_enum(value: BadEnum) -> BadEnum {
+                value
+            }
+            "#,
+        ))
+        .expect_err("dependent APIs must reject when their record or enum type is rejected");
+
+        let report = unsupported_report(error);
+        assert!(report.rejected_apis().iter().any(|api| {
+            api.kind() == "function"
+                && api.name() == "use::record"
+                && api
+                    .reason()
+                    .expect("rejection reason")
+                    .contains("callbacks on jvm")
+        }));
+        assert!(report.rejected_apis().iter().any(|api| {
+            api.kind() == "function"
+                && api.name() == "use::enum"
+                && api
+                    .reason()
+                    .expect("rejection reason")
+                    .contains("callbacks on jvm")
+        }));
+        assert!(!report.admitted_apis().iter().any(|api| {
+            api.kind() == "function" && matches!(api.name(), "use::record" | "use::enum")
+        }));
+    }
+
+    #[test]
+    fn preview_prune_omits_functions_using_rejected_records_and_enums() {
+        let module = KmpLowerer::new(
+            KmpLoweringOptions::new().support_mode(KmpSupportMode::PreviewPruneUnsupported),
+        )
+        .lower(&bindings(
+            r#"
+            #[export]
+            pub trait Listener {
+                fn notify(&self);
+            }
+
+            #[data]
+            pub struct BadRecord {
+                pub callback: Box<dyn Listener>,
+            }
+
+            #[data]
+            pub enum BadEnum {
+                WithCallback(Box<dyn Listener>),
+            }
+
+            #[export]
+            pub fn use_record(value: BadRecord) -> BadRecord {
+                value
+            }
+
+            #[export]
+            pub fn use_enum(value: BadEnum) -> BadEnum {
+                value
+            }
+            "#,
+        ))
+        .expect("preview mode should return a pruned plan");
+
+        assert!(!module.common().apis().iter().any(|api| {
+            api.kind() == "function" && matches!(api.name(), "use::record" | "use::enum")
+        }));
+        assert!(
+            module
+                .support_report()
+                .rejected_apis()
+                .iter()
+                .any(|api| { api.kind() == "function" && api.name() == "use::record" })
+        );
+        assert!(
+            module
+                .support_report()
+                .rejected_apis()
+                .iter()
+                .any(|api| { api.kind() == "function" && api.name() == "use::enum" })
+        );
+    }
+
+    #[test]
+    fn strict_lowerer_cascades_rejected_record_owner_to_members() {
+        let error = super::lower(&bindings(
+            r#"
+            #[export]
+            pub trait Listener {
+                fn notify(&self);
+            }
+
+            #[data]
+            pub struct BadRecord {
+                pub callback: Box<dyn Listener>,
+            }
+
+            #[data(impl)]
+            impl BadRecord {
+                pub fn stable(&self) -> u32 {
+                    1
+                }
+            }
+            "#,
+        ))
+        .expect_err("members of rejected records must be rejected too");
+
+        let report = unsupported_report(error);
+        assert!(report.rejected_apis().iter().any(|api| {
+            api.kind() == "record method"
+                && api.name() == "bad::record::stable"
+                && api
+                    .reason()
+                    .expect("rejection reason")
+                    .contains("callbacks on jvm")
+        }));
+        assert!(
+            !report.admitted_apis().iter().any(|api| {
+                api.kind() == "record method" && api.name() == "bad::record::stable"
+            })
+        );
+    }
+
+    #[test]
+    fn strict_lowerer_cascades_rejected_enum_owner_to_members() {
+        let error = super::lower(&bindings(
+            r#"
+            #[export]
+            pub trait Listener {
+                fn notify(&self);
+            }
+
+            #[data]
+            pub enum BadEnum {
+                WithCallback(Box<dyn Listener>),
+            }
+
+            #[data(impl)]
+            impl BadEnum {
+                pub fn stable(&self) -> u32 {
+                    1
+                }
+            }
+            "#,
+        ))
+        .expect_err("members of rejected enums must be rejected too");
+
+        let report = unsupported_report(error);
+        assert!(report.rejected_apis().iter().any(|api| {
+            api.kind() == "enum method"
+                && api.name() == "bad::enum::stable"
+                && api
+                    .reason()
+                    .expect("rejection reason")
+                    .contains("callbacks on jvm")
+        }));
+        assert!(
+            !report
+                .admitted_apis()
+                .iter()
+                .any(|api| api.kind() == "enum method" && api.name() == "bad::enum::stable")
+        );
+    }
+
+    #[test]
+    fn strict_lowerer_rejects_empty_platform_matrix() {
+        let error = KmpLowerer::new(
+            KmpLoweringOptions::new().selected_platforms(Vec::<KmpPlatform>::new()),
+        )
+        .lower(&bindings(
+            r#"
+            #[export]
+            pub fn add(left: i32, right: i32) -> i32 {
+                left + right
+            }
+            "#,
+        ))
+        .expect_err("KMP planning needs at least one selected platform");
+
+        let KmpLowerError::InvalidPlatformMatrix { reason, report } = error else {
+            panic!("unexpected KMP lower error: {error:?}");
+        };
+        assert!(reason.contains("no selected KMP platforms"));
+        assert_eq!(report.selected_platforms(), &[]);
+        assert!(report.rejected_apis().iter().any(|api| {
+            api.kind() == "function"
+                && api.name() == "add"
+                && api
+                    .reason()
+                    .expect("rejection reason")
+                    .contains("no selected KMP platforms")
+        }));
+    }
+
+    #[test]
+    fn strict_lowerer_rejects_empty_platform_matrix_without_apis() {
+        let error = KmpLowerer::new(
+            KmpLoweringOptions::new().selected_platforms(Vec::<KmpPlatform>::new()),
+        )
+        .lower(&bindings(""))
+        .expect_err("KMP planning needs at least one selected platform even for empty bindings");
+
+        let KmpLowerError::InvalidPlatformMatrix { reason, report } = error else {
+            panic!("unexpected KMP lower error: {error:?}");
+        };
+        assert!(reason.contains("no selected KMP platforms"));
+        assert_eq!(report.selected_platforms(), &[]);
+        assert!(report.rejected_apis().is_empty());
+    }
+
+    #[test]
+    fn strict_lowerer_rejects_inline_constant_using_rejected_enum() {
+        let error = super::lower(&bindings(
+            r#"
+            #[export]
+            pub trait Listener {
+                fn notify(&self);
+            }
+
+            #[data]
+            pub enum BadEnum {
+                Good,
+                WithCallback(Box<dyn Listener>),
+            }
+
+            #[export]
+            pub const DEFAULT_BAD: BadEnum = BadEnum::Good;
+            "#,
+        ))
+        .expect_err("inline constants must reject when their declared type is rejected");
+
+        let KmpLowerError::UnsupportedApis { report } = error else {
+            panic!("unexpected KMP lower error: {error:?}");
+        };
+        assert!(
+            report.rejected_apis().iter().any(|api| {
+                api.kind() == "constant"
+                    && api.name() == "default::bad"
+                    && api
+                        .reason()
+                        .expect("rejection reason")
+                        .contains("callbacks on jvm")
+            }),
+            "{:#?}",
+            report.rejected_apis()
+        );
+        assert!(
+            !report
+                .admitted_apis()
+                .iter()
+                .any(|api| api.kind() == "constant" && api.name() == "default::bad")
+        );
+    }
+
+    #[test]
+    fn preview_prune_omits_inline_constant_using_rejected_enum() {
+        let module = KmpLowerer::new(
+            KmpLoweringOptions::new().support_mode(KmpSupportMode::PreviewPruneUnsupported),
+        )
+        .lower(&bindings(
+            r#"
+            #[export]
+            pub trait Listener {
+                fn notify(&self);
+            }
+
+            #[data]
+            pub enum BadEnum {
+                Good,
+                WithCallback(Box<dyn Listener>),
+            }
+
+            #[export]
+            pub const DEFAULT_BAD: BadEnum = BadEnum::Good;
+            "#,
+        ))
+        .expect("preview mode should return a pruned plan");
+
+        assert!(
+            !module
+                .common()
+                .apis()
+                .iter()
+                .any(|api| { api.kind() == "constant" && api.name() == "default::bad" })
+        );
+        assert!(
+            module
+                .support_report()
+                .rejected_apis()
+                .iter()
+                .any(|api| { api.kind() == "constant" && api.name() == "default::bad" }),
+            "{:#?}",
+            module.support_report().rejected_apis()
+        );
+    }
+
+    #[test]
+    fn strict_lowerer_rejects_unsupported_fallible_error_payload() {
+        let error = super::lower(&bindings(
+            r#"
+            use std::time::Duration;
+
+            #[export]
+            pub fn load() -> Result<String, Duration> {
+                Ok(String::new())
+            }
+            "#,
+        ))
+        .expect_err("builtin error payloads are outside the M1b KMP capability set");
+
+        let report = unsupported_report(error);
+        assert!(report.rejected_apis().iter().any(|api| {
+            api.kind() == "function"
+                && api.name() == "load"
+                && api
+                    .reason()
+                    .expect("rejection reason")
+                    .contains("unknown binding shapes on jvm")
+        }));
+    }
+
+    #[test]
+    fn strict_lowerer_rejects_unmodeled_typeref_families() {
+        let error = super::lower(&bindings(
+            r#"
+            use std::collections::HashMap;
+
+            #[export]
+            pub fn echo_map(value: HashMap<String, String>) -> HashMap<String, String> {
+                value
+            }
+            "#,
+        ))
+        .expect_err("maps are outside the M1b KMP capability set");
+
+        let report = unsupported_report(error);
+        assert!(report.rejected_apis().iter().any(|api| {
+            api.kind() == "function"
+                && api.name() == "echo::map"
+                && api
+                    .reason()
+                    .expect("rejection reason")
+                    .contains("unknown binding shapes on jvm")
+        }));
+    }
+
+    #[test]
+    fn strict_lowerer_rejects_custom_type_with_unsupported_representation() {
+        let error = super::lower(&bindings(
+            r#"
+            use std::time::Duration;
+
+            custom_type!(
+                BadDuration,
+                remote = RemoteDuration,
+                repr = Duration,
+                into_ffi = |_value: &RemoteDuration| Duration::from_secs(0),
+                try_from_ffi = |_value: Duration| Ok(RemoteDuration),
+            );
+
+            #[export]
+            pub fn echo_bad(value: RemoteDuration) -> RemoteDuration {
+                value
+            }
+            "#,
+        ))
+        .expect_err("custom type representations must be admitted too");
+
+        let report = unsupported_report(error);
+        assert!(report.rejected_apis().iter().any(|api| {
+            api.kind() == "custom type"
+                && api.name() == "bad::duration"
+                && api
+                    .reason()
+                    .expect("rejection reason")
+                    .contains("unknown binding shapes on jvm")
+        }));
+        assert!(report.rejected_apis().iter().any(|api| {
+            api.kind() == "function"
+                && api.name() == "echo::bad"
+                && api
+                    .reason()
+                    .expect("rejection reason")
+                    .contains("unknown binding shapes on jvm")
+        }));
+    }
+}

--- a/boltffi_backend/src/target/kmp/mod.rs
+++ b/boltffi_backend/src/target/kmp/mod.rs
@@ -7,8 +7,15 @@
 
 mod bridge;
 mod host;
+pub mod lower;
+pub mod plan;
 mod syntax;
 
 pub use bridge::{KmpBridge, KmpBridgeContract};
 pub use host::KmpHost;
+pub use lower::{KmpLowerError, KmpLowerer, KmpLoweringOptions};
+pub use plan::{
+    KmpApiPlan, KmpCapability, KmpCapabilitySet, KmpCommonModule, KmpModule, KmpPlatform,
+    KmpPlatformModule, KmpSupportApi, KmpSupportMode, KmpSupportReport,
+};
 pub use syntax::Syntax;

--- a/boltffi_backend/src/target/kmp/plan/mod.rs
+++ b/boltffi_backend/src/target/kmp/plan/mod.rs
@@ -1,0 +1,381 @@
+//! Typed Kotlin Multiplatform generation plan.
+
+use std::collections::BTreeSet;
+
+/// Feature required by one generated KMP API.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
+pub enum KmpCapability {
+    /// Direct record declarations.
+    DirectRecords,
+    /// Encoded record declarations.
+    EncodedRecords,
+    /// C-style enum declarations.
+    CStyleEnums,
+    /// Payload-carrying enum declarations.
+    DataEnums,
+    /// Synchronous exported callables.
+    SyncCallables,
+    /// Asynchronous exported callables.
+    AsyncCallables,
+    /// Mutating receiver callables, such as Rust `&mut self` methods.
+    MutatingReceivers,
+    /// Class handle declarations.
+    Classes,
+    /// Callback trait declarations.
+    Callbacks,
+    /// Stream declarations.
+    Streams,
+    /// Constant declarations.
+    Constants,
+    /// Custom type declarations.
+    CustomTypes,
+    /// Future binding shapes this backend does not know how to admit yet.
+    UnknownBindingShapes,
+}
+
+impl KmpCapability {
+    /// Returns a stable diagnostic label for this capability.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::DirectRecords => "direct records",
+            Self::EncodedRecords => "encoded records",
+            Self::CStyleEnums => "c-style enums",
+            Self::DataEnums => "data enums",
+            Self::SyncCallables => "synchronous callables",
+            Self::AsyncCallables => "asynchronous callables",
+            Self::MutatingReceivers => "mutating receivers",
+            Self::Classes => "classes",
+            Self::Callbacks => "callbacks",
+            Self::Streams => "streams",
+            Self::Constants => "constants",
+            Self::CustomTypes => "custom types",
+            Self::UnknownBindingShapes => "unknown binding shapes",
+        }
+    }
+}
+
+/// Set of KMP capabilities supported by a platform or required by an API.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct KmpCapabilitySet {
+    capabilities: BTreeSet<KmpCapability>,
+}
+
+impl KmpCapabilitySet {
+    /// Creates an empty capability set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns whether the set contains the capability.
+    pub fn contains(&self, capability: KmpCapability) -> bool {
+        self.capabilities.contains(&capability)
+    }
+
+    /// Iterates capabilities in deterministic order.
+    pub fn iter(&self) -> impl Iterator<Item = KmpCapability> + '_ {
+        self.capabilities.iter().copied()
+    }
+
+    /// Returns whether this set contains every capability in `required`.
+    pub fn supports_all(&self, required: &Self) -> bool {
+        required.iter().all(|capability| self.contains(capability))
+    }
+}
+
+impl FromIterator<KmpCapability> for KmpCapabilitySet {
+    fn from_iter<T: IntoIterator<Item = KmpCapability>>(capabilities: T) -> Self {
+        Self {
+            capabilities: capabilities.into_iter().collect(),
+        }
+    }
+}
+
+/// KMP platform selected for the generated module.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
+pub enum KmpPlatform {
+    /// Kotlin/JVM target.
+    Jvm,
+    /// Kotlin Android target.
+    Android,
+    /// Kotlin/Native macOS arm64 target.
+    MacosArm64,
+    /// Kotlin/Native iOS simulator arm64 target.
+    IosSimulatorArm64,
+}
+
+impl KmpPlatform {
+    /// Returns the production platforms currently owned by the legacy KMP path.
+    pub fn default_selected() -> Vec<Self> {
+        vec![Self::Jvm, Self::Android]
+    }
+
+    /// Returns the stable platform label written into reports.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Jvm => "jvm",
+            Self::Android => "android",
+            Self::MacosArm64 => "macosArm64",
+            Self::IosSimulatorArm64 => "iosSimulatorArm64",
+        }
+    }
+
+    /// Returns the KMP capabilities this platform can satisfy today.
+    pub fn capabilities(self) -> KmpCapabilitySet {
+        match self {
+            Self::Jvm | Self::Android => KmpCapabilitySet::from_iter([
+                KmpCapability::DirectRecords,
+                KmpCapability::EncodedRecords,
+                KmpCapability::CStyleEnums,
+                KmpCapability::DataEnums,
+                KmpCapability::SyncCallables,
+                KmpCapability::Constants,
+                KmpCapability::CustomTypes,
+            ]),
+            Self::MacosArm64 | Self::IosSimulatorArm64 => KmpCapabilitySet::new(),
+        }
+    }
+}
+
+/// Effective support mode used while planning the KMP module.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum KmpSupportMode {
+    /// Unsupported APIs fail planning.
+    #[default]
+    Strict,
+    /// Unsupported APIs are omitted from the planned common surface.
+    PreviewPruneUnsupported,
+}
+
+impl KmpSupportMode {
+    /// Returns the metadata label for this mode.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Strict => "strict",
+            Self::PreviewPruneUnsupported => "preview_prune_unsupported",
+        }
+    }
+}
+
+/// Complete planned KMP module before string rendering.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct KmpModule {
+    common: KmpCommonModule,
+    platforms: Vec<KmpPlatformModule>,
+    support_report: KmpSupportReport,
+}
+
+impl KmpModule {
+    /// Creates a KMP module plan.
+    pub fn new(
+        common: KmpCommonModule,
+        platforms: Vec<KmpPlatformModule>,
+        support_report: KmpSupportReport,
+    ) -> Self {
+        Self {
+            common,
+            platforms,
+            support_report,
+        }
+    }
+
+    /// Returns the planned common source-set API surface.
+    pub const fn common(&self) -> &KmpCommonModule {
+        &self.common
+    }
+
+    /// Returns the selected platform modules.
+    pub fn platforms(&self) -> &[KmpPlatformModule] {
+        &self.platforms
+    }
+
+    /// Returns the support report for this plan.
+    pub const fn support_report(&self) -> &KmpSupportReport {
+        &self.support_report
+    }
+}
+
+/// Planned declarations emitted to `commonMain`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct KmpCommonModule {
+    apis: Vec<KmpApiPlan>,
+}
+
+impl KmpCommonModule {
+    /// Creates a common module plan from admitted APIs.
+    pub fn new(apis: Vec<KmpApiPlan>) -> Self {
+        Self { apis }
+    }
+
+    /// Returns APIs admitted to `commonMain`.
+    pub fn apis(&self) -> &[KmpApiPlan] {
+        &self.apis
+    }
+}
+
+/// Planned platform source-set module.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct KmpPlatformModule {
+    platform: KmpPlatform,
+    capabilities: KmpCapabilitySet,
+}
+
+impl KmpPlatformModule {
+    /// Creates a platform module plan for one selected KMP platform.
+    pub fn new(platform: KmpPlatform, capabilities: KmpCapabilitySet) -> Self {
+        Self {
+            platform,
+            capabilities,
+        }
+    }
+
+    /// Returns the selected platform.
+    pub const fn platform(&self) -> KmpPlatform {
+        self.platform
+    }
+
+    /// Returns capabilities advertised by the platform.
+    pub const fn capabilities(&self) -> &KmpCapabilitySet {
+        &self.capabilities
+    }
+}
+
+/// One API admitted into the planned common surface.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct KmpApiPlan {
+    kind: &'static str,
+    name: String,
+    required_capabilities: KmpCapabilitySet,
+}
+
+impl KmpApiPlan {
+    /// Creates an admitted API plan.
+    pub fn new(
+        kind: &'static str,
+        name: impl Into<String>,
+        required_capabilities: KmpCapabilitySet,
+    ) -> Self {
+        Self {
+            kind,
+            name: name.into(),
+            required_capabilities,
+        }
+    }
+
+    /// Returns the API kind, such as `function` or `record`.
+    pub const fn kind(&self) -> &'static str {
+        self.kind
+    }
+
+    /// Returns the stable API display name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns capabilities required by this API.
+    pub const fn required_capabilities(&self) -> &KmpCapabilitySet {
+        &self.required_capabilities
+    }
+}
+
+/// Generated support report for a planned KMP module.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct KmpSupportReport {
+    mode: KmpSupportMode,
+    selected_platforms: Vec<KmpPlatform>,
+    admitted_apis: Vec<KmpSupportApi>,
+    rejected_apis: Vec<KmpSupportApi>,
+}
+
+impl KmpSupportReport {
+    /// Creates a KMP support report.
+    pub fn new(
+        mode: KmpSupportMode,
+        selected_platforms: Vec<KmpPlatform>,
+        admitted_apis: Vec<KmpSupportApi>,
+        rejected_apis: Vec<KmpSupportApi>,
+    ) -> Self {
+        Self {
+            mode,
+            selected_platforms,
+            admitted_apis,
+            rejected_apis,
+        }
+    }
+
+    /// Returns the effective support mode.
+    pub const fn mode(&self) -> KmpSupportMode {
+        self.mode
+    }
+
+    /// Returns the selected platform matrix.
+    pub fn selected_platforms(&self) -> &[KmpPlatform] {
+        &self.selected_platforms
+    }
+
+    /// Returns APIs admitted to the planned common surface.
+    pub fn admitted_apis(&self) -> &[KmpSupportApi] {
+        &self.admitted_apis
+    }
+
+    /// Returns APIs rejected in strict mode or pruned in preview mode.
+    pub fn rejected_apis(&self) -> &[KmpSupportApi] {
+        &self.rejected_apis
+    }
+}
+
+/// One support report entry for an admitted or rejected API.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct KmpSupportApi {
+    kind: &'static str,
+    name: String,
+    reason: Option<String>,
+}
+
+impl KmpSupportApi {
+    /// Creates an admitted support report entry.
+    pub fn admitted(kind: &'static str, name: impl Into<String>) -> Self {
+        Self {
+            kind,
+            name: name.into(),
+            reason: None,
+        }
+    }
+
+    /// Creates a rejected support report entry.
+    pub fn rejected(
+        kind: &'static str,
+        name: impl Into<String>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            name: name.into(),
+            reason: Some(reason.into()),
+        }
+    }
+
+    /// Returns the API kind.
+    pub const fn kind(&self) -> &'static str {
+        self.kind
+    }
+
+    /// Returns the stable API display name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the rejection reason, if this API was rejected.
+    pub fn reason(&self) -> Option<&str> {
+        self.reason.as_deref()
+    }
+}


### PR DESCRIPTION
Introduce the KMP plan/lower/admission layer for the IR backend,
including platform capability intersection, strict unsupported-API
rejection, preview pruning support reports, and host integration.

Reject mutating record/enum receivers until KMP semantics are modeled,
and cover strict and preview-prune behavior with regression tests.
