### PR TITLE
Fix generic type-alias substitution and `cfg_attr`-gated marker detection in `boltffi_scan`

### DIFF
--- a/boltffi_bindgen/Cargo.toml
+++ b/boltffi_bindgen/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["development-tools::ffi", "development-tools::build-utils"]
 [dependencies]
 boltffi_binding.workspace = true
 boltffi_backend.workspace = true
+boltffi_scan.workspace = true
 boltffi_ffi_rules = { workspace = true, features = ["serde"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/boltffi_bindgen/src/lib.rs
+++ b/boltffi_bindgen/src/lib.rs
@@ -21,7 +21,10 @@ pub use boltffi_ffi_rules::naming::{LibraryName, ffi_prefix, library_name, load_
 pub use render::c::CHeaderLowerer;
 pub use render::kotlin::{FactoryStyle, KotlinApiStyle, KotlinOptions};
 pub use render::{Renderer, TypeConversion, TypeMapping, TypeMappings};
-pub use scan::{SourceScanner, scan_crate, scan_crate_with_pointer_width};
+pub use scan::{
+    SourceScanner, scan_crate, scan_crate_with_pointer_width,
+    scan_crate_with_pointer_width_and_cargo_args,
+};
 
 #[cfg(test)]
 mod tests {

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -149,12 +149,12 @@ impl std::fmt::Display for CargoStatus {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct CargoManifest {
+pub(crate) struct CargoManifest {
     path: PathBuf,
 }
 
 impl CargoManifest {
-    fn new(path: &Path) -> Result<Self, BindingMetadataBuildError> {
+    pub(crate) fn new(path: &Path) -> Result<Self, BindingMetadataBuildError> {
         fs::canonicalize(path)
             .map(|path| Self { path })
             .map_err(|source| BindingMetadataBuildError::ManifestPath {
@@ -191,12 +191,12 @@ impl SourceRoot {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-struct CargoMetadata {
+pub(crate) struct CargoMetadata {
     packages: Vec<MetadataPackage>,
 }
 
 impl CargoMetadata {
-    fn load(manifest: &CargoManifest) -> Result<Self, BindingMetadataBuildError> {
+    pub(crate) fn load(manifest: &CargoManifest) -> Result<Self, BindingMetadataBuildError> {
         let output = Command::new(CargoProgram::from_env().into_os_string())
             .arg("metadata")
             .arg("--format-version=1")
@@ -242,7 +242,7 @@ impl CargoMetadata {
         })
     }
 
-    fn active_features(
+    pub(crate) fn active_features(
         &self,
         manifest: &CargoManifest,
         args: &MetadataCargoArgs,
@@ -366,12 +366,12 @@ impl CargoProgram {
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-struct MetadataCargoArgs {
+pub(crate) struct MetadataCargoArgs {
     arguments: Vec<String>,
 }
 
 impl MetadataCargoArgs {
-    fn new(arguments: impl IntoIterator<Item = String>) -> Self {
+    pub(crate) fn new(arguments: impl IntoIterator<Item = String>) -> Self {
         Self {
             arguments: Self::without_owned_selectors(arguments.into_iter().collect()),
         }
@@ -449,11 +449,15 @@ impl MetadataCargoArgs {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct MetadataFeatures {
+pub(crate) struct MetadataFeatures {
     names: BTreeSet<String>,
 }
 
 impl MetadataFeatures {
+    pub(crate) fn names(&self) -> &BTreeSet<String> {
+        &self.names
+    }
+
     fn resolve(available: &BTreeMap<String, Vec<String>>, args: &MetadataCargoArgs) -> Self {
         let flags = args.feature_flags();
         let mut names = match flags.all {

--- a/boltffi_bindgen/src/scan/mod.rs
+++ b/boltffi_bindgen/src/scan/mod.rs
@@ -515,6 +515,7 @@ pub struct SourceScanner {
     integer_constants: HashMap<String, i128>,
     source_root: Option<PathBuf>,
     target_pointer_width_bits: Option<u8>,
+    cfg: boltffi_scan::ActiveCfg,
 }
 
 impl SourceScanner {
@@ -525,6 +526,18 @@ impl SourceScanner {
     pub fn new_with_pointer_width(
         module_name: impl Into<String>,
         target_pointer_width_bits: Option<u8>,
+    ) -> Self {
+        Self::new_with_cfg(
+            module_name,
+            target_pointer_width_bits,
+            boltffi_scan::ActiveCfg::default(),
+        )
+    }
+
+    pub fn new_with_cfg(
+        module_name: impl Into<String>,
+        target_pointer_width_bits: Option<u8>,
+        cfg: boltffi_scan::ActiveCfg,
     ) -> Self {
         Self {
             module_name: module_name.into(),
@@ -537,6 +550,7 @@ impl SourceScanner {
             integer_constants: HashMap::new(),
             source_root: None,
             target_pointer_width_bits,
+            cfg,
         }
     }
 
@@ -550,10 +564,15 @@ impl SourceScanner {
         files.sort();
 
         self.source_root = Some(dir.to_path_buf());
-        self.global_aliases = Self::collect_global_aliases(&files)?;
-        self.integer_constants =
-            collect_integer_constants_from_files(dir, &files, self.target_pointer_width_bits)?;
-        let compiler_targets = Self::collect_compiler_type_targets(&files, &self.global_aliases)?;
+        self.global_aliases = Self::collect_global_aliases(&files, &self.cfg)?;
+        self.integer_constants = collect_integer_constants_from_files(
+            dir,
+            &files,
+            self.target_pointer_width_bits,
+            &self.cfg,
+        )?;
+        let compiler_targets =
+            Self::collect_compiler_type_targets(&files, &self.global_aliases, &self.cfg)?;
         self.compiler_canonical_types =
             compiler_type_resolution::resolve(crate_path, &self.module_name, compiler_targets)?;
         files
@@ -573,16 +592,13 @@ impl SourceScanner {
     fn collect_compiler_type_targets(
         files: &[std::path::PathBuf],
         global_aliases: &HashMap<String, Vec<String>>,
+        cfg: &boltffi_scan::ActiveCfg,
     ) -> Result<Vec<String>, String> {
         let mut targets = Vec::<String>::new();
         let mut seen = HashSet::<String>::new();
 
         files.iter().try_for_each(|path| {
-            let content = fs::read_to_string(path)
-                .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-
-            let syntax = syn::parse_file(&content)
-                .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+            let syntax = parse_file_with_cfg(path, cfg)?;
 
             let alias_resolver =
                 AliasResolver::from_items(&syntax.items).with_global(global_aliases);
@@ -830,16 +846,13 @@ impl SourceScanner {
 
     fn collect_global_aliases(
         files: &[std::path::PathBuf],
+        cfg: &boltffi_scan::ActiveCfg,
     ) -> Result<HashMap<String, Vec<String>>, String> {
         let mut aliases = HashMap::<String, Vec<String>>::new();
         let mut conflicts = HashSet::<String>::new();
 
         files.iter().try_for_each(|path| {
-            let content = fs::read_to_string(path)
-                .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-
-            let syntax = syn::parse_file(&content)
-                .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+            let syntax = parse_file_with_cfg(path, cfg)?;
 
             let local = AliasResolver::from_items(&syntax.items);
             syntax
@@ -886,11 +899,7 @@ impl SourceScanner {
     }
 
     fn collect_custom_types(&mut self, path: &Path) -> Result<(), String> {
-        let content = fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-
-        let syntax = syn::parse_file(&content)
-            .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+        let syntax = parse_file_with_cfg(path, &self.cfg)?;
 
         let alias_resolver =
             AliasResolver::from_items(&syntax.items).with_global(&self.global_aliases);
@@ -1024,11 +1033,7 @@ impl SourceScanner {
     }
 
     fn collect_type_names(&mut self, path: &Path) -> Result<(), String> {
-        let content = fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-
-        let syntax = syn::parse_file(&content)
-            .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+        let syntax = parse_file_with_cfg(path, &self.cfg)?;
 
         for item in &syntax.items {
             match item {
@@ -1084,11 +1089,7 @@ impl SourceScanner {
     }
 
     pub fn scan_file(&mut self, path: &Path) -> Result<(), String> {
-        let content = fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-
-        let syntax = syn::parse_file(&content)
-            .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+        let syntax = parse_file_with_cfg(path, &self.cfg)?;
 
         self.alias_resolver =
             AliasResolver::from_items(&syntax.items).with_global(&self.global_aliases);
@@ -1783,6 +1784,60 @@ fn shape_key_for_segment(path_segment: &syn::PathSegment) -> String {
     }
 }
 
+fn parse_file_with_cfg(path: &Path, cfg: &boltffi_scan::ActiveCfg) -> Result<syn::File, String> {
+    let content =
+        fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+    let mut syntax = syn::parse_file(&content)
+        .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+    expand_item_cfg_attrs(&mut syntax.items, cfg)
+        .map_err(|e| format!("Failed to expand cfg_attr in {}: {}", path.display(), e))?;
+    Ok(syntax)
+}
+
+fn expand_item_cfg_attrs(items: &mut [Item], cfg: &boltffi_scan::ActiveCfg) -> Result<(), String> {
+    for item in items.iter_mut() {
+        let attrs = match item {
+            Item::Struct(item) => Some(&mut item.attrs),
+            Item::Enum(item) => Some(&mut item.attrs),
+            Item::Fn(item) => Some(&mut item.attrs),
+            Item::Impl(item) => Some(&mut item.attrs),
+            Item::Trait(item) => Some(&mut item.attrs),
+            Item::Const(item) => Some(&mut item.attrs),
+            Item::Mod(item) => Some(&mut item.attrs),
+            _ => None,
+        };
+        if let Some(attrs) = attrs {
+            *attrs = cfg
+                .expand_cfg_attrs(attrs)
+                .map_err(|error| error.to_string())?;
+        }
+        if let Item::Mod(item_mod) = item {
+            if let Some((_, inner_items)) = &mut item_mod.content {
+                expand_item_cfg_attrs(inner_items, cfg)?;
+            }
+        }
+        if let Item::Impl(item_impl) = item {
+            for impl_item in &mut item_impl.items {
+                if let ImplItem::Fn(method) = impl_item {
+                    method.attrs = cfg
+                        .expand_cfg_attrs(&method.attrs)
+                        .map_err(|error| error.to_string())?;
+                }
+            }
+        }
+        if let Item::Trait(item_trait) = item {
+            for trait_item in &mut item_trait.items {
+                if let syn::TraitItem::Fn(method) = trait_item {
+                    method.attrs = cfg
+                        .expand_cfg_attrs(&method.attrs)
+                        .map_err(|error| error.to_string())?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 fn has_attribute(attrs: &[Attribute], name: &str) -> bool {
     attrs.iter().any(|attr| {
         attr.path().is_ident(name)
@@ -2088,14 +2143,12 @@ fn collect_integer_constants_from_files(
     source_root: &Path,
     files: &[PathBuf],
     target_pointer_width_bits: Option<u8>,
+    cfg: &boltffi_scan::ActiveCfg,
 ) -> Result<HashMap<String, i128>, String> {
     let mut candidates = Vec::<(String, syn::Expr)>::new();
     files.iter().try_for_each(|file_path| {
         let module_path = module_path_for_source_file(source_root, file_path)?;
-        let content = fs::read_to_string(file_path)
-            .map_err(|error| format!("Failed to read {}: {}", file_path.display(), error))?;
-        let syntax = syn::parse_file(&content)
-            .map_err(|error| format!("Failed to parse {}: {}", file_path.display(), error))?;
+        let syntax = parse_file_with_cfg(file_path, cfg)?;
         collect_integer_constant_candidates(&syntax.items, module_path.as_slice(), &mut candidates);
         Ok::<(), String>(())
     })?;
@@ -2862,14 +2915,20 @@ fn validate_no_symbol_collisions(module: &Module) -> Result<(), String> {
 struct LegacyPackageScanner<'a> {
     graph: &'a cargo_graph::PackageGraph,
     target_pointer_width_bits: Option<u8>,
+    cfg: boltffi_scan::ActiveCfg,
     modules: HashMap<cargo_graph::PackageId, Module>,
 }
 
 impl<'a> LegacyPackageScanner<'a> {
-    fn new(graph: &'a cargo_graph::PackageGraph, target_pointer_width_bits: Option<u8>) -> Self {
+    fn new(
+        graph: &'a cargo_graph::PackageGraph,
+        target_pointer_width_bits: Option<u8>,
+        cfg: boltffi_scan::ActiveCfg,
+    ) -> Self {
         Self {
             graph,
             target_pointer_width_bits,
+            cfg,
             modules: HashMap::new(),
         }
     }
@@ -2905,8 +2964,11 @@ impl<'a> LegacyPackageScanner<'a> {
             .map(|dependency| self.scan_package(dependency.id(), dependency.module_name()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut scanner =
-            SourceScanner::new_with_pointer_width(module_name, self.target_pointer_width_bits);
+        let mut scanner = SourceScanner::new_with_cfg(
+            module_name,
+            self.target_pointer_width_bits,
+            self.cfg.clone(),
+        );
         dependency_modules
             .iter()
             .try_for_each(|module| scanner.import_module_exports(module))?;
@@ -2926,26 +2988,56 @@ pub fn scan_crate_with_pointer_width(
     module_name: &str,
     target_pointer_width_bits: Option<u8>,
 ) -> Result<Module, String> {
+    scan_crate_with_pointer_width_and_cargo_args(
+        crate_path,
+        module_name,
+        target_pointer_width_bits,
+        &[],
+    )
+}
+
+/// Like [`scan_crate_with_pointer_width`], but resolves `cfg_attr(...)` markers against
+/// the crate's features as seen with `cargo_args` applied.
+pub fn scan_crate_with_pointer_width_and_cargo_args(
+    crate_path: &Path,
+    module_name: &str,
+    target_pointer_width_bits: Option<u8>,
+    cargo_args: &[String],
+) -> Result<Module, String> {
     let target_pointer_width_bits = target_pointer_width_bits.or_else(parse_target_pointer_width);
+    let cfg = resolve_active_cfg(crate_path, cargo_args);
     if let Some(graph) = cargo_graph::PackageGraph::load_for_module(crate_path, module_name)
         .map_err(|error| error.to_string())?
     {
-        let module =
-            LegacyPackageScanner::new(&graph, target_pointer_width_bits).scan(module_name)?;
+        let module = LegacyPackageScanner::new(&graph, target_pointer_width_bits, cfg)
+            .scan(module_name)?;
         validate_no_symbol_collisions(&module)?;
         return Ok(module);
     }
 
-    scan_single_crate_with_pointer_width(crate_path, module_name, target_pointer_width_bits)
+    scan_single_crate_with_pointer_width(crate_path, module_name, target_pointer_width_bits, &cfg)
+}
+
+fn resolve_active_cfg(crate_path: &Path, cargo_args: &[String]) -> boltffi_scan::ActiveCfg {
+    (|| -> Result<boltffi_scan::ActiveCfg, crate::metadata::BindingMetadataBuildError> {
+        let manifest = crate::metadata::CargoManifest::new(&crate_path.join("Cargo.toml"))?;
+        let metadata = crate::metadata::CargoMetadata::load(&manifest)?;
+        let args = crate::metadata::MetadataCargoArgs::new(cargo_args.iter().cloned());
+        let features = metadata.active_features(&manifest, &args)?;
+        Ok(boltffi_scan::ActiveCfg::default().with_features(features.names().iter().cloned()))
+    })()
+    .unwrap_or_default()
 }
 
 fn scan_single_crate_with_pointer_width(
     crate_path: &Path,
     module_name: &str,
     target_pointer_width_bits: Option<u8>,
+    cfg: &boltffi_scan::ActiveCfg,
 ) -> Result<Module, String> {
     let src_path = crate_path.join("src");
-    let mut scanner = SourceScanner::new_with_pointer_width(module_name, target_pointer_width_bits);
+    let mut scanner =
+        SourceScanner::new_with_cfg(module_name, target_pointer_width_bits, cfg.clone());
     scanner.scan_directory(crate_path, &src_path)?;
     let module = scanner.into_module();
     validate_no_symbol_collisions(&module)?;
@@ -3604,8 +3696,13 @@ mod tests {
             .expect("write constants.rs");
 
         let files = vec![source_root.join("lib.rs"), source_root.join("constants.rs")];
-        let constants = collect_integer_constants_from_files(&source_root, files.as_slice(), None)
-            .expect("collect constants");
+        let constants = collect_integer_constants_from_files(
+            &source_root,
+            files.as_slice(),
+            None,
+            &boltffi_scan::ActiveCfg::default(),
+        )
+        .expect("collect constants");
         let expression: syn::Expr = syn::parse_quote!(crate::constants::TAG);
 
         assert_eq!(constants.get("constants::TAG").copied(), Some(7));

--- a/boltffi_cli/src/commands/generate/generator.rs
+++ b/boltffi_cli/src/commands/generate/generator.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::cli::{CliError, Result};
 use crate::config::{Config, Experimental};
 use boltffi_bindgen::target::Target;
-use boltffi_bindgen::{ir, scan_crate_with_pointer_width};
+use boltffi_bindgen::{ir, scan_crate_with_pointer_width_and_cargo_args};
 
 #[derive(Debug, Clone)]
 pub struct SourceCrate {
@@ -92,6 +92,7 @@ pub struct GenerateRequest<'a> {
     config: &'a Config,
     output_override: Option<PathBuf>,
     source_crate: SourceCrate,
+    cargo_args: Vec<String>,
 }
 
 impl<'a> GenerateRequest<'a> {
@@ -104,11 +105,17 @@ impl<'a> GenerateRequest<'a> {
             config,
             output_override,
             source_crate,
+            cargo_args: Vec::new(),
         }
     }
 
     pub fn for_current_crate(config: &'a Config, output_override: Option<PathBuf>) -> Self {
         Self::new(config, output_override, SourceCrate::current(config))
+    }
+
+    pub fn with_cargo_args(mut self, cargo_args: impl IntoIterator<Item = String>) -> Self {
+        self.cargo_args = cargo_args.into_iter().collect();
+        self
     }
 
     pub fn config(&self) -> &'a Config {
@@ -124,10 +131,11 @@ impl<'a> GenerateRequest<'a> {
     }
 
     pub fn lowered_crate(&self, pointer_width: ScanPointerWidth) -> Result<LoweredCrate> {
-        let mut scanned_module = scan_crate_with_pointer_width(
+        let mut scanned_module = scan_crate_with_pointer_width_and_cargo_args(
             self.source_crate.source_directory(),
             self.source_crate.crate_name(),
             pointer_width.resolved_bits(),
+            &self.cargo_args,
         )
         .map_err(|error| CliError::CommandFailed {
             command: format!("scan_crate: {error}"),

--- a/boltffi_cli/src/commands/generate/languages/java.rs
+++ b/boltffi_cli/src/commands/generate/languages/java.rs
@@ -33,12 +33,14 @@ impl JavaGenerator {
         output_override: Option<PathBuf>,
         source_directory: &Path,
         crate_name: &str,
+        cargo_args: &[String],
     ) -> Result<()> {
         let request = GenerateRequest::new(
             config,
             output_override,
             SourceCrate::new(source_directory, crate_name),
-        );
+        )
+        .with_cargo_args(cargo_args.iter().cloned());
 
         Self::generate(&request)
     }

--- a/boltffi_cli/src/commands/generate/mod.rs
+++ b/boltffi_cli/src/commands/generate/mod.rs
@@ -41,7 +41,10 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
         return ir::run_ir_generation(config, &options);
     }
 
-    let legacy_request = || GenerateRequest::for_current_crate(config, options.output.clone());
+    let legacy_request = || {
+        GenerateRequest::for_current_crate(config, options.output.clone())
+            .with_cargo_args(options.cargo_args.iter().cloned())
+    };
 
     match &options.target {
         GenerateTarget::Swift => ir::run_ir_generation(config, &options),
@@ -137,8 +140,15 @@ pub fn run_generate_java_with_output_from_source_dir(
     output: Option<PathBuf>,
     source_directory: &Path,
     crate_name: &str,
+    cargo_args: &[String],
 ) -> Result<()> {
-    JavaGenerator::generate_from_source_directory(config, output, source_directory, crate_name)
+    JavaGenerator::generate_from_source_directory(
+        config,
+        output,
+        source_directory,
+        crate_name,
+        cargo_args,
+    )
 }
 
 pub fn run_generate_kmp_with_output_from_source_dir_and_desktop_fallback_library_name(

--- a/boltffi_cli/src/pack/java/plan.rs
+++ b/boltffi_cli/src/pack/java/plan.rs
@@ -125,6 +125,7 @@ pub(crate) fn pack_java(
             Some(config.java_jvm_output()),
             &source_directory,
             artifact_name,
+            &options.execution.cargo_args,
         )?;
         step.finish_success();
     }

--- a/boltffi_scan/src/cfg.rs
+++ b/boltffi_scan/src/cfg.rs
@@ -60,18 +60,9 @@ impl ActiveCfg {
             })
     }
 
-    /// Expands `attrs` the way rustc's own `cfg_attr` expansion would: each
-    /// `#[cfg_attr(predicate, wrapped...)]` is replaced by `wrapped...` if
-    /// `predicate` is currently active, or dropped entirely otherwise.
-    /// Non-`cfg_attr` attributes pass through unchanged.
-    ///
-    /// `boltffi_scan` parses source text directly via `syn` rather than
-    /// going through the compiler's macro-expansion pipeline, so it never
-    /// sees this expansion happen automatically -- without it, a marker
-    /// like `#[cfg_attr(feature = "boltffi", boltffi::data)]` (needed by
-    /// any crate that wants a working `default-features = false` escape
-    /// hatch) is invisible to marker detection, and the item silently
-    /// scans as unmarked.
+    /// Expands `cfg_attr(predicate, wrapped...)` into `wrapped...` when
+    /// `predicate` is active, the way rustc's own expansion would; drops it
+    /// otherwise. Other attributes pass through unchanged.
     pub fn expand_cfg_attrs(&self, attrs: &[Attribute]) -> Result<Vec<Attribute>, ScanError> {
         attrs.iter().try_fold(Vec::new(), |mut expanded, attr| {
             expanded.extend(self.expand_cfg_attr(attr)?);

--- a/boltffi_scan/src/cfg.rs
+++ b/boltffi_scan/src/cfg.rs
@@ -60,6 +60,54 @@ impl ActiveCfg {
             })
     }
 
+    /// Expands `attrs` the way rustc's own `cfg_attr` expansion would: each
+    /// `#[cfg_attr(predicate, wrapped...)]` is replaced by `wrapped...` if
+    /// `predicate` is currently active, or dropped entirely otherwise.
+    /// Non-`cfg_attr` attributes pass through unchanged.
+    ///
+    /// `boltffi_scan` parses source text directly via `syn` rather than
+    /// going through the compiler's macro-expansion pipeline, so it never
+    /// sees this expansion happen automatically -- without it, a marker
+    /// like `#[cfg_attr(feature = "boltffi", boltffi::data)]` (needed by
+    /// any crate that wants a working `default-features = false` escape
+    /// hatch) is invisible to marker detection, and the item silently
+    /// scans as unmarked.
+    pub fn expand_cfg_attrs(&self, attrs: &[Attribute]) -> Result<Vec<Attribute>, ScanError> {
+        attrs.iter().try_fold(Vec::new(), |mut expanded, attr| {
+            expanded.extend(self.expand_cfg_attr(attr)?);
+            Ok(expanded)
+        })
+    }
+
+    fn expand_cfg_attr(&self, attr: &Attribute) -> Result<Vec<Attribute>, ScanError> {
+        if !attr.path().is_ident("cfg_attr") {
+            return Ok(vec![attr.clone()]);
+        }
+
+        let (predicate, wrapped) = attr
+            .parse_args_with(|input: syn::parse::ParseStream<'_>| {
+                let predicate = input.parse::<Meta>()?;
+                input.parse::<Token![,]>()?;
+                let wrapped = Punctuated::<Meta, Token![,]>::parse_terminated(input)?;
+                Ok((predicate, wrapped))
+            })
+            .map_err(|_| Self::invalid_attribute(attr.meta.to_token_stream()))?;
+
+        if !self.matches_meta(&predicate)? {
+            return Ok(Vec::new());
+        }
+
+        Ok(wrapped
+            .into_iter()
+            .map(|meta| Attribute {
+                pound_token: attr.pound_token,
+                style: attr.style.clone(),
+                bracket_token: attr.bracket_token,
+                meta,
+            })
+            .collect())
+    }
+
     fn observe_cargo_env(&mut self, name: &str, value: &str) {
         if let Some(feature) = name.strip_prefix("CARGO_FEATURE_") {
             self.features.insert(Self::feature_name(feature));

--- a/boltffi_scan/src/declared_types.rs
+++ b/boltffi_scan/src/declared_types.rs
@@ -225,17 +225,15 @@ impl DeclaredTypes {
         }
     }
 
-    /// If `path` names a known type alias, returns its target type with the
-    /// use site's actual type arguments substituted in.
-    pub(super) fn resolve_alias_target(
+    /// If `path` names a known type alias, returns its (unsubstituted)
+    /// definition.
+    pub(super) fn resolve_alias_definition(
         &self,
         scope: &ModuleScope,
         path: &syn::Path,
-    ) -> Result<Option<syn::Type>, ScanError> {
+    ) -> Result<Option<&TypeAlias>, ScanError> {
         match self.source_types.resolve_alias(scope, path) {
-            AliasResolution::Known(alias) => {
-                Ok(Some(substitute_generic_alias_target(alias, path)))
-            }
+            AliasResolution::Known(alias) => Ok(Some(alias)),
             AliasResolution::Unknown => Ok(None),
             AliasResolution::Ambiguous => Err(ScanError::AmbiguousPath {
                 path: spelling::path(path),
@@ -461,12 +459,26 @@ struct TypeNamespace {
     scopes: HashMap<String, ModuleScope>,
 }
 
-struct TypeAlias {
+pub(super) struct TypeAlias {
     path: String,
     scope: ModuleScope,
     target: syn::Type,
     /// `target`'s free type parameter names, in declaration order.
     generic_params: Vec<String>,
+}
+
+impl TypeAlias {
+    pub(super) fn scope(&self) -> &ModuleScope {
+        &self.scope
+    }
+
+    pub(super) fn target(&self) -> &syn::Type {
+        &self.target
+    }
+
+    pub(super) fn generic_params(&self) -> &[String] {
+        &self.generic_params
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/boltffi_scan/src/declared_types.rs
+++ b/boltffi_scan/src/declared_types.rs
@@ -463,8 +463,8 @@ pub(super) struct TypeAlias {
     path: String,
     scope: ModuleScope,
     target: syn::Type,
-    /// `target`'s free type parameter names, in declaration order.
-    generic_params: Vec<String>,
+    /// `target`'s free type parameters, in declaration order.
+    generic_params: Vec<AliasGenericParam>,
 }
 
 impl TypeAlias {
@@ -476,8 +476,25 @@ impl TypeAlias {
         &self.target
     }
 
-    pub(super) fn generic_params(&self) -> &[String] {
+    pub(super) fn generic_params(&self) -> &[AliasGenericParam] {
         &self.generic_params
+    }
+}
+
+pub(super) struct AliasGenericParam {
+    name: String,
+    /// Written at the alias's own declaration site, e.g. the `= MyError` in
+    /// `type Result<T, E = MyError> = std::result::Result<T, E>;`.
+    default: Option<syn::Type>,
+}
+
+impl AliasGenericParam {
+    pub(super) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(super) fn default(&self) -> Option<&syn::Type> {
+        self.default.as_ref()
     }
 }
 
@@ -497,7 +514,7 @@ fn substitute_generic_alias_target(alias: &TypeAlias, use_site: &syn::Path) -> s
         return alias.target.clone();
     }
 
-    let actual_args = use_site
+    let mut actual_args = use_site
         .segments
         .last()
         .into_iter()
@@ -506,15 +523,20 @@ fn substitute_generic_alias_target(alias: &TypeAlias, use_site: &syn::Path) -> s
             syn::PathArguments::None | syn::PathArguments::Parenthesized(_) => Vec::new(),
         })
         .filter_map(|arg| match arg {
-            syn::GenericArgument::Type(ty) => Some(ty),
+            syn::GenericArgument::Type(ty) => Some(ty.clone()),
             _ => None,
         });
 
+    // Trailing params the use site omits (relying on their own `= Default`)
+    // fall back to that default instead of being left as a bare, unresolved
+    // parameter name.
     let substitutions: HashMap<String, syn::Type> = alias
         .generic_params
         .iter()
-        .cloned()
-        .zip(actual_args.cloned())
+        .filter_map(|param| {
+            let value = actual_args.next().or_else(|| param.default.clone())?;
+            Some((param.name.clone(), value))
+        })
         .collect();
 
     if substitutions.is_empty() {
@@ -822,7 +844,10 @@ impl TypeNamespace {
             .params
             .iter()
             .filter_map(|param| match param {
-                syn::GenericParam::Type(type_param) => Some(type_param.ident.to_string()),
+                syn::GenericParam::Type(type_param) => Some(AliasGenericParam {
+                    name: type_param.ident.to_string(),
+                    default: type_param.default.clone(),
+                }),
                 syn::GenericParam::Lifetime(_) | syn::GenericParam::Const(_) => None,
             })
             .collect();

--- a/boltffi_scan/src/declared_types.rs
+++ b/boltffi_scan/src/declared_types.rs
@@ -226,14 +226,7 @@ impl DeclaredTypes {
     }
 
     /// If `path` names a known type alias, returns its target type with the
-    /// use site's actual type arguments substituted in (e.g. for
-    /// `type Result<T> = std::result::Result<T, MyError>;` used as
-    /// `Result<Wrapper>`, returns `std::result::Result<Wrapper, MyError>`).
-    ///
-    /// This only expands one alias layer; a target that is itself another
-    /// alias application is resolved by the caller re-scanning the returned
-    /// type, which naturally chains through further alias lookups the same
-    /// way non-alias nested types already do.
+    /// use site's actual type arguments substituted in.
     pub(super) fn resolve_alias_target(
         &self,
         scope: &ModuleScope,
@@ -472,10 +465,7 @@ struct TypeAlias {
     path: String,
     scope: ModuleScope,
     target: syn::Type,
-    /// Names of `target`'s free type parameters, in declaration order (e.g.
-    /// `["T"]` for `type Result<T> = std::result::Result<T, MyError>;`).
-    /// Lifetime and const generics are ignored: this alias resolver only
-    /// substitutes type arguments.
+    /// `target`'s free type parameter names, in declaration order.
     generic_params: Vec<String>,
 }
 
@@ -486,15 +476,10 @@ enum AliasResolution<'a> {
     Unknown,
 }
 
-/// Resolves a generic alias's target type for one specific use site, e.g.
-/// for `type Result<T> = std::result::Result<T, MyError>;` used as
-/// `Result<Wrapper>`, returns `std::result::Result<Wrapper, MyError>` instead
-/// of `alias.target`'s raw, unsubstituted `std::result::Result<T, MyError>`.
-///
-/// Non-generic aliases (`generic_params` empty) return `alias.target`
-/// unchanged. If the use site supplies a different number of type arguments
-/// than the alias declares (e.g. elided defaults), only the arguments that
-/// are actually present are substituted.
+/// Substitutes the use site's actual type arguments into a generic alias's
+/// target type, e.g. `Result<Wrapper>` against `type Result<T> = std::result::Result<T, MyError>;`
+/// resolves to `std::result::Result<Wrapper, MyError>` rather than the raw,
+/// unsubstituted target.
 fn substitute_generic_alias_target(alias: &TypeAlias, use_site: &syn::Path) -> syn::Type {
     if alias.generic_params.is_empty() {
         return alias.target.clone();
@@ -527,15 +512,8 @@ fn substitute_generic_alias_target(alias: &TypeAlias, use_site: &syn::Path) -> s
     substitute_generics(&alias.target, &substitutions)
 }
 
-/// Recursively replaces bare occurrences of `substitutions`' keys (generic
-/// type parameter names) with their corresponding concrete type, anywhere
-/// they appear in `ty` -- as the whole type (`T`) or nested inside generic
-/// arguments (`Vec<T>`, `Option<T>`, `std::result::Result<T, E>`, ...).
-///
-/// Only the type shapes that plausibly appear in a `type Alias<T> = ...;`
-/// target are handled (paths, references, tuples); anything else is
-/// returned unchanged rather than substituted, which is always safe (worst
-/// case, resolution later fails to recognize the type, same as today).
+/// Recursively replaces occurrences of `substitutions`' keys with their
+/// concrete type, both bare (`T`) and nested in generic arguments (`Vec<T>`).
 fn substitute_generics(ty: &syn::Type, substitutions: &HashMap<String, syn::Type>) -> syn::Type {
     match ty {
         syn::Type::Path(type_path) if type_path.qself.is_none() => {

--- a/boltffi_scan/src/declared_types.rs
+++ b/boltffi_scan/src/declared_types.rs
@@ -225,6 +225,31 @@ impl DeclaredTypes {
         }
     }
 
+    /// If `path` names a known type alias, returns its target type with the
+    /// use site's actual type arguments substituted in (e.g. for
+    /// `type Result<T> = std::result::Result<T, MyError>;` used as
+    /// `Result<Wrapper>`, returns `std::result::Result<Wrapper, MyError>`).
+    ///
+    /// This only expands one alias layer; a target that is itself another
+    /// alias application is resolved by the caller re-scanning the returned
+    /// type, which naturally chains through further alias lookups the same
+    /// way non-alias nested types already do.
+    pub(super) fn resolve_alias_target(
+        &self,
+        scope: &ModuleScope,
+        path: &syn::Path,
+    ) -> Result<Option<syn::Type>, ScanError> {
+        match self.source_types.resolve_alias(scope, path) {
+            AliasResolution::Known(alias) => {
+                Ok(Some(substitute_generic_alias_target(alias, path)))
+            }
+            AliasResolution::Unknown => Ok(None),
+            AliasResolution::Ambiguous => Err(ScanError::AmbiguousPath {
+                path: spelling::path(path),
+            }),
+        }
+    }
+
     fn resolve_custom_remote_with_aliases<'a>(
         &'a self,
         scope: &ModuleScope,
@@ -239,7 +264,8 @@ impl DeclaredTypes {
         };
         match self.source_types.resolve_alias(scope, &type_path.path) {
             AliasResolution::Known(alias) if visited.insert(alias.path.clone()) => {
-                self.resolve_custom_remote_with_aliases(&alias.scope, &alias.target, visited)
+                let resolved_target = substitute_generic_alias_target(alias, &type_path.path);
+                self.resolve_custom_remote_with_aliases(&alias.scope, &resolved_target, visited)
             }
             AliasResolution::Known(_) | AliasResolution::Unknown => Ok(None),
             AliasResolution::Ambiguous => Err(ScanError::AmbiguousPath {
@@ -446,6 +472,11 @@ struct TypeAlias {
     path: String,
     scope: ModuleScope,
     target: syn::Type,
+    /// Names of `target`'s free type parameters, in declaration order (e.g.
+    /// `["T"]` for `type Result<T> = std::result::Result<T, MyError>;`).
+    /// Lifetime and const generics are ignored: this alias resolver only
+    /// substitutes type arguments.
+    generic_params: Vec<String>,
 }
 
 #[derive(Clone, Copy)]
@@ -453,6 +484,95 @@ enum AliasResolution<'a> {
     Known(&'a TypeAlias),
     Ambiguous,
     Unknown,
+}
+
+/// Resolves a generic alias's target type for one specific use site, e.g.
+/// for `type Result<T> = std::result::Result<T, MyError>;` used as
+/// `Result<Wrapper>`, returns `std::result::Result<Wrapper, MyError>` instead
+/// of `alias.target`'s raw, unsubstituted `std::result::Result<T, MyError>`.
+///
+/// Non-generic aliases (`generic_params` empty) return `alias.target`
+/// unchanged. If the use site supplies a different number of type arguments
+/// than the alias declares (e.g. elided defaults), only the arguments that
+/// are actually present are substituted.
+fn substitute_generic_alias_target(alias: &TypeAlias, use_site: &syn::Path) -> syn::Type {
+    if alias.generic_params.is_empty() {
+        return alias.target.clone();
+    }
+
+    let actual_args = use_site
+        .segments
+        .last()
+        .into_iter()
+        .flat_map(|segment| match &segment.arguments {
+            syn::PathArguments::AngleBracketed(args) => args.args.iter().collect::<Vec<_>>(),
+            syn::PathArguments::None | syn::PathArguments::Parenthesized(_) => Vec::new(),
+        })
+        .filter_map(|arg| match arg {
+            syn::GenericArgument::Type(ty) => Some(ty),
+            _ => None,
+        });
+
+    let substitutions: HashMap<String, syn::Type> = alias
+        .generic_params
+        .iter()
+        .cloned()
+        .zip(actual_args.cloned())
+        .collect();
+
+    if substitutions.is_empty() {
+        return alias.target.clone();
+    }
+
+    substitute_generics(&alias.target, &substitutions)
+}
+
+/// Recursively replaces bare occurrences of `substitutions`' keys (generic
+/// type parameter names) with their corresponding concrete type, anywhere
+/// they appear in `ty` -- as the whole type (`T`) or nested inside generic
+/// arguments (`Vec<T>`, `Option<T>`, `std::result::Result<T, E>`, ...).
+///
+/// Only the type shapes that plausibly appear in a `type Alias<T> = ...;`
+/// target are handled (paths, references, tuples); anything else is
+/// returned unchanged rather than substituted, which is always safe (worst
+/// case, resolution later fails to recognize the type, same as today).
+fn substitute_generics(ty: &syn::Type, substitutions: &HashMap<String, syn::Type>) -> syn::Type {
+    match ty {
+        syn::Type::Path(type_path) if type_path.qself.is_none() => {
+            if let Some(ident) = type_path.path.get_ident() {
+                if let Some(replacement) = substitutions.get(&ident.to_string()) {
+                    return replacement.clone();
+                }
+            }
+            let mut new_path = type_path.path.clone();
+            for segment in &mut new_path.segments {
+                if let syn::PathArguments::AngleBracketed(args) = &mut segment.arguments {
+                    for arg in &mut args.args {
+                        if let syn::GenericArgument::Type(inner) = arg {
+                            *inner = substitute_generics(inner, substitutions);
+                        }
+                    }
+                }
+            }
+            syn::Type::Path(syn::TypePath {
+                qself: None,
+                path: new_path,
+            })
+        }
+        syn::Type::Reference(reference) => {
+            let mut new_reference = reference.clone();
+            *new_reference.elem = substitute_generics(&reference.elem, substitutions);
+            syn::Type::Reference(new_reference)
+        }
+        syn::Type::Tuple(tuple) => {
+            let mut new_tuple = tuple.clone();
+            for elem in &mut new_tuple.elems {
+                *elem = substitute_generics(elem, substitutions);
+            }
+            syn::Type::Tuple(new_tuple)
+        }
+        other => other.clone(),
+    }
 }
 
 impl TypeNamespace {
@@ -707,12 +827,22 @@ impl TypeNamespace {
 
     fn insert_alias(&mut self, module: &SourceModule, alias: &syn::ItemType) {
         let path = self.insert_source(module, alias.ident.to_string());
+        let generic_params = alias
+            .generics
+            .params
+            .iter()
+            .filter_map(|param| match param {
+                syn::GenericParam::Type(type_param) => Some(type_param.ident.to_string()),
+                syn::GenericParam::Lifetime(_) | syn::GenericParam::Const(_) => None,
+            })
+            .collect();
         self.aliases.insert(
             path.clone(),
             TypeAlias {
                 path,
                 scope: module.scope().clone(),
                 target: alias.ty.as_ref().clone(),
+                generic_params,
             },
         );
     }

--- a/boltffi_scan/src/items/callback.rs
+++ b/boltffi_scan/src/items/callback.rs
@@ -90,7 +90,7 @@ fn is_exported_method(method: &syn::TraitItemFn) -> Result<bool, ScanError> {
     if stream::Attribute::scan(&method.attrs)?.is_some() {
         return Err(stream::Attribute::invalid_placement("trait method"));
     }
-    match marker::disposition(&method.attrs)? {
+    match marker::disposition(&method.attrs, &crate::ActiveCfg::default())? {
         Disposition::Skip => Ok(false),
         Disposition::Reject(marker) => Err(marker.invalid_placement("trait method")),
         Disposition::Unmarked => Ok(true),

--- a/boltffi_scan/src/items/class.rs
+++ b/boltffi_scan/src/items/class.rs
@@ -107,7 +107,7 @@ mod tests {
         let mut declared_types = DeclaredTypes::new();
         declared_types.register_class(ClassId::new("demo::Engine"));
         let item = parse(source);
-        let thread_safety = Marker::detect(&item.attrs)?
+        let thread_safety = Marker::detect(&item.attrs, &crate::ActiveCfg::default())?
             .and_then(Marker::export)
             .map(|export| export.class_thread_safety())
             .unwrap_or_default();
@@ -243,7 +243,7 @@ mod tests {
             .items,
         )
         .expect("source tree");
-        let marked = crate::marked::MarkedItems::collect(&source_tree).expect("marked");
+        let marked = crate::marked::MarkedItems::collect(&source_tree, &crate::ActiveCfg::default()).expect("marked");
         let declared_types =
             DeclaredTypes::index(&source_tree, &marked).expect("declared type index");
         let classes = super::scan(marked.classes(), &declared_types).expect("scan");

--- a/boltffi_scan/src/items/impl_block.rs
+++ b/boltffi_scan/src/items/impl_block.rs
@@ -115,7 +115,7 @@ mod tests {
             "#[data(impl)] impl Point { pub fn origin() -> Self { todo!() } } \
              #[data(impl)] impl Mode { pub fn parse() -> Self { todo!() } }",
         );
-        let marked = MarkedItems::collect(&source_tree).expect("marked");
+        let marked = MarkedItems::collect(&source_tree, &crate::ActiveCfg::default()).expect("marked");
         let mut declared_types = DeclaredTypes::new();
         declared_types.register_record(RecordId::new("demo::Point"));
         declared_types.register_enum(EnumId::new("demo::Mode"));
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn rejects_generic_impl_before_erasing_type_parameters() {
         let source_tree = source_tree("#[data(impl)] impl<T> Point { pub fn get(&self) {} }");
-        let marked = MarkedItems::collect(&source_tree).expect("marked");
+        let marked = MarkedItems::collect(&source_tree, &crate::ActiveCfg::default()).expect("marked");
         let mut declared_types = DeclaredTypes::new();
         declared_types.register_record(RecordId::new("demo::Point"));
         let mut records = vec![RecordDef::new(
@@ -168,7 +168,7 @@ mod tests {
     #[test]
     fn rejects_trait_impls_for_value_method_attachment() {
         let source_tree = source_tree("#[data(impl)] impl Display for Point {}");
-        let marked = MarkedItems::collect(&source_tree).expect("marked");
+        let marked = MarkedItems::collect(&source_tree, &crate::ActiveCfg::default()).expect("marked");
         let mut declared_types = DeclaredTypes::new();
         declared_types.register_record(RecordId::new("demo::Point"));
         let mut records = vec![RecordDef::new(

--- a/boltffi_scan/src/items/impl_methods.rs
+++ b/boltffi_scan/src/items/impl_methods.rs
@@ -125,7 +125,7 @@ pub(super) fn exported_method(
     visibility: &syn::Visibility,
     item: &str,
 ) -> Result<bool, ScanError> {
-    match marker::disposition(attrs)? {
+    match marker::disposition(attrs, &crate::ActiveCfg::default())? {
         Disposition::Skip => Ok(false),
         Disposition::Reject(marker) => Err(marker.invalid_placement(item)),
         Disposition::Unmarked => Ok(matches!(visibility, syn::Visibility::Public(_))),
@@ -144,7 +144,7 @@ fn non_method(
         Ok(None) => {}
         Err(error) => return Some(Err(error)),
     }
-    match marker::disposition(attrs) {
+    match marker::disposition(attrs, &crate::ActiveCfg::default()) {
         Ok(Disposition::Skip) => None,
         Ok(Disposition::Reject(marker)) => Some(Err(marker.invalid_placement(item))),
         Ok(Disposition::Unmarked)

--- a/boltffi_scan/src/items/stream.rs
+++ b/boltffi_scan/src/items/stream.rs
@@ -504,7 +504,7 @@ mod tests {
             .items,
         )
         .expect("source tree");
-        let marked = crate::marked::MarkedItems::collect(&source).expect("marked items");
+        let marked = crate::marked::MarkedItems::collect(&source, &crate::ActiveCfg::default()).expect("marked items");
         let declared_types = DeclaredTypes::index(&source, &marked).expect("declared types");
         let streams = scan(marked.classes(), &declared_types).expect("streams");
 
@@ -533,7 +533,7 @@ mod tests {
             .items,
         )
         .expect("source tree");
-        let marked = crate::marked::MarkedItems::collect(&source).expect("marked items");
+        let marked = crate::marked::MarkedItems::collect(&source, &crate::ActiveCfg::default()).expect("marked items");
         let declared_types = DeclaredTypes::index(&source, &marked).expect("declared types");
         let streams = scan(marked.classes(), &declared_types).expect("streams");
 
@@ -558,7 +558,7 @@ mod tests {
             .items,
         )
         .expect("source tree");
-        let marked = crate::marked::MarkedItems::collect(&source).expect("marked items");
+        let marked = crate::marked::MarkedItems::collect(&source, &crate::ActiveCfg::default()).expect("marked items");
         let declared_types = DeclaredTypes::index(&source, &marked).expect("declared types");
         let streams = scan(marked.classes(), &declared_types).expect("streams");
 
@@ -583,7 +583,7 @@ mod tests {
             .items,
         )
         .expect("source tree");
-        let marked = crate::marked::MarkedItems::collect(&source).expect("marked items");
+        let marked = crate::marked::MarkedItems::collect(&source, &crate::ActiveCfg::default()).expect("marked items");
         let declared_types = DeclaredTypes::index(&source, &marked).expect("declared types");
         let streams = scan(marked.classes(), &declared_types).expect("streams");
 
@@ -610,7 +610,7 @@ mod tests {
             .items,
         )
         .expect("source tree");
-        let marked = crate::marked::MarkedItems::collect(&source).expect("marked items");
+        let marked = crate::marked::MarkedItems::collect(&source, &crate::ActiveCfg::default()).expect("marked items");
         let declared_types = DeclaredTypes::index(&source, &marked).expect("declared types");
 
         let error = scan(marked.classes(), &declared_types).expect_err("local Arc rejected");
@@ -641,7 +641,7 @@ mod tests {
             .items,
         )
         .expect("source tree");
-        let marked = crate::marked::MarkedItems::collect(&source).expect("marked items");
+        let marked = crate::marked::MarkedItems::collect(&source, &crate::ActiveCfg::default()).expect("marked items");
         let declared_types = DeclaredTypes::index(&source, &marked).expect("declared types");
 
         let error =

--- a/boltffi_scan/src/marked.rs
+++ b/boltffi_scan/src/marked.rs
@@ -81,6 +81,12 @@ impl<'source> MarkedItems<'source> {
         item: &'source syn::Item,
         cfg: &ActiveCfg,
     ) -> Result<(), ScanError> {
+        // An item behind an inactive `#[cfg(...)]` doesn't exist as far as
+        // rustc is concerned, regardless of any marker attribute alongside it.
+        if !cfg.matches_attrs(attrs(item))? {
+            return Ok(());
+        }
+
         if let Some(error) = items::misplaced_stream_marker(attrs(item), item_kind(item))? {
             return Err(error);
         }
@@ -316,6 +322,18 @@ mod tests {
         assert_eq!(marked.constants().len(), 1);
         assert_eq!(marked.customs().len(), 2);
         assert_eq!(marked.impls().len(), 1);
+    }
+
+    #[test]
+    fn ignores_a_marked_item_behind_an_inactive_plain_cfg() {
+        let tree = tree(
+            r#"#[cfg(target_os = "ios")] #[cfg_attr(feature = "boltffi", boltffi::data)] struct IosOnly { x: i32 }"#,
+        );
+        let active = ActiveCfg::default().with_feature("boltffi");
+
+        let marked = MarkedItems::collect(&tree, &active).expect("marked items");
+
+        assert_eq!(marked.records().len(), 0);
     }
 
     #[test]

--- a/boltffi_scan/src/marked.rs
+++ b/boltffi_scan/src/marked.rs
@@ -1,7 +1,7 @@
 use crate::items;
 use crate::marker::Marker;
 use crate::source_tree::SourceTree;
-use crate::{ModulePath, ModuleScope, ScanError};
+use crate::{ActiveCfg, ModulePath, ModuleScope, ScanError};
 
 pub(super) struct MarkedItems<'source> {
     records: Vec<Marked<'source, syn::ItemStruct>>,
@@ -15,7 +15,7 @@ pub(super) struct MarkedItems<'source> {
 }
 
 impl<'source> MarkedItems<'source> {
-    pub(super) fn collect(tree: &'source SourceTree) -> Result<Self, ScanError> {
+    pub(super) fn collect(tree: &'source SourceTree, cfg: &ActiveCfg) -> Result<Self, ScanError> {
         tree.modules()
             .iter()
             .flat_map(|module| {
@@ -25,7 +25,7 @@ impl<'source> MarkedItems<'source> {
                     .map(move |item| (module.scope(), item))
             })
             .try_fold(Self::empty(), |mut marked, (scope, item)| {
-                marked.push(scope, item)?;
+                marked.push(scope, item, cfg)?;
                 Ok(marked)
             })
     }
@@ -79,20 +79,21 @@ impl<'source> MarkedItems<'source> {
         &mut self,
         scope: &'source ModuleScope,
         item: &'source syn::Item,
+        cfg: &ActiveCfg,
     ) -> Result<(), ScanError> {
         if let Some(error) = items::misplaced_stream_marker(attrs(item), item_kind(item))? {
             return Err(error);
         }
 
         if let Some(item_macro) = custom_type_macro(item) {
-            if let Some(marker) = Marker::detect(attrs(item))? {
+            if let Some(marker) = Marker::detect(attrs(item), cfg)? {
                 return Err(marker.invalid_placement(item_kind(item)));
             }
             self.customs.push(MarkedCustom::new(scope, item_macro));
             return Ok(());
         }
 
-        let Some(marker) = Marker::detect(attrs(item))? else {
+        let Some(marker) = Marker::detect(attrs(item), cfg)? else {
             return Ok(());
         };
         match (marker, item) {
@@ -303,7 +304,7 @@ mod tests {
              #[data(impl)] impl Point {}",
         );
 
-        let marked = MarkedItems::collect(&tree).expect("marked items");
+        let marked = MarkedItems::collect(&tree, &ActiveCfg::default()).expect("marked items");
 
         assert_eq!(marked.records().len(), 1);
         assert_eq!(marked.records()[0].marker(), Marker::Data);
@@ -321,7 +322,7 @@ mod tests {
     fn rejects_marker_on_wrong_item_kind() {
         let tree = tree("#[export] struct Point { x: i32 }");
 
-        let error = match MarkedItems::collect(&tree) {
+        let error = match MarkedItems::collect(&tree, &ActiveCfg::default()) {
             Ok(_) => panic!("wrong marker placement must reject"),
             Err(error) => error,
         };
@@ -339,7 +340,7 @@ mod tests {
     fn rejects_class_export_options_on_non_class_items() {
         let tree = tree("#[export(single_threaded)] fn answer() -> u32 { 42 }");
 
-        let error = match MarkedItems::collect(&tree) {
+        let error = match MarkedItems::collect(&tree, &ActiveCfg::default()) {
             Ok(_) => panic!("class-only export option must reject on functions"),
             Err(error) => error,
         };
@@ -359,7 +360,7 @@ mod tests {
             "#[export] custom_type!(UtcDateTime, remote = DateTime<Utc>, repr = i64, into_ffi = to_millis, try_from_ffi = from_millis);",
         );
 
-        let error = match MarkedItems::collect(&tree) {
+        let error = match MarkedItems::collect(&tree, &ActiveCfg::default()) {
             Ok(_) => panic!("marked custom type macro must reject"),
             Err(error) => error,
         };
@@ -377,7 +378,7 @@ mod tests {
     fn rejects_stream_marker_on_top_level_items() {
         let tree = tree("#[ffi_stream(item = i32)] fn values() {}");
 
-        let error = match MarkedItems::collect(&tree) {
+        let error = match MarkedItems::collect(&tree, &ActiveCfg::default()) {
             Ok(_) => panic!("top-level stream marker must reject"),
             Err(error) => error,
         };
@@ -397,7 +398,7 @@ mod tests {
             "boltffi::custom_type!(UtcDateTime, remote = DateTime<Utc>, repr = i64, into_ffi = to_millis, try_from_ffi = from_millis);",
         );
 
-        let marked = MarkedItems::collect(&tree).expect("marked items");
+        let marked = MarkedItems::collect(&tree, &ActiveCfg::default()).expect("marked items");
 
         assert_eq!(marked.customs().len(), 1);
     }
@@ -408,7 +409,7 @@ mod tests {
             "other::custom_type!(UtcDateTime, remote = DateTime<Utc>, repr = i64, into_ffi = to_millis, try_from_ffi = from_millis);",
         );
 
-        let marked = MarkedItems::collect(&tree).expect("marked items");
+        let marked = MarkedItems::collect(&tree, &ActiveCfg::default()).expect("marked items");
 
         assert_eq!(marked.customs().len(), 0);
     }

--- a/boltffi_scan/src/marker.rs
+++ b/boltffi_scan/src/marker.rs
@@ -237,15 +237,6 @@ mod tests {
         );
     }
 
-    /// A crate that wants a working `default-features = false` escape hatch
-    /// (no FFI dependency at all when the feature is off) has to spell its
-    /// marker as `#[cfg_attr(feature = "boltffi", boltffi::data)]` rather
-    /// than a bare `#[boltffi::data]`. `boltffi_scan` parses source text
-    /// directly via `syn`, so it never sees the compiler's own `cfg_attr`
-    /// expansion happen -- without explicitly recognizing this pattern, the
-    /// item silently scans as unmarked, and anything that references it
-    /// later fails with a confusing "unsupported source type" pointing at
-    /// an unrelated macro invocation.
     #[test]
     fn detects_data_behind_an_active_cfg_attr() {
         let active = ActiveCfg::default().with_feature("boltffi");
@@ -265,9 +256,6 @@ mod tests {
         );
     }
 
-    /// The inactive-feature counterpart of `detects_data_behind_an_active_cfg_attr`:
-    /// when the gated feature is off, the item is genuinely unmarked, matching
-    /// what `cfg_attr` would produce if the compiler expanded it.
     #[test]
     fn ignores_data_behind_an_inactive_cfg_attr() {
         assert_eq!(

--- a/boltffi_scan/src/marker.rs
+++ b/boltffi_scan/src/marker.rs
@@ -1,7 +1,7 @@
 use boltffi_ast::{AttributeInput, ClassThreadSafety, Path, UserAttr};
 use syn::parse::Parser;
 
-use crate::ScanError;
+use crate::{ActiveCfg, ScanError};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Marker {
@@ -25,8 +25,8 @@ pub enum Disposition {
     Unmarked,
 }
 
-pub fn disposition(attrs: &[syn::Attribute]) -> Result<Disposition, ScanError> {
-    Ok(match Marker::detect(attrs)? {
+pub fn disposition(attrs: &[syn::Attribute], cfg: &ActiveCfg) -> Result<Disposition, ScanError> {
+    Ok(match Marker::detect(attrs, cfg)? {
         Some(Marker::Skip) => Disposition::Skip,
         Some(marker) => Disposition::Reject(marker),
         None => Disposition::Unmarked,
@@ -34,18 +34,21 @@ pub fn disposition(attrs: &[syn::Attribute]) -> Result<Disposition, ScanError> {
 }
 
 impl Marker {
-    pub fn detect(attrs: &[syn::Attribute]) -> Result<Option<Self>, ScanError> {
-        attrs.iter().try_fold(None, |detected: Option<Self>, attr| {
-            let marker = Self::from_attribute(attr)?;
-            match (detected, marker) {
-                (Some(first), Some(second)) => Err(ScanError::ConflictingMarkers {
-                    first: first.as_str().to_owned(),
-                    second: second.as_str().to_owned(),
-                }),
-                (None, Some(marker)) => Ok(Some(marker)),
-                (detected, None) => Ok(detected),
-            }
-        })
+    pub fn detect(attrs: &[syn::Attribute], cfg: &ActiveCfg) -> Result<Option<Self>, ScanError> {
+        let expanded = cfg.expand_cfg_attrs(attrs)?;
+        expanded
+            .iter()
+            .try_fold(None, |detected: Option<Self>, attr| {
+                let marker = Self::from_attribute(attr)?;
+                match (detected, marker) {
+                    (Some(first), Some(second)) => Err(ScanError::ConflictingMarkers {
+                        first: first.as_str().to_owned(),
+                        second: second.as_str().to_owned(),
+                    }),
+                    (None, Some(marker)) => Ok(Some(marker)),
+                    (detected, None) => Ok(detected),
+                }
+            })
     }
 
     pub fn as_str(self) -> &'static str {
@@ -217,19 +220,61 @@ mod tests {
     #[test]
     fn detects_data_on_value_types() {
         assert_eq!(
-            Marker::detect(&struct_attrs("#[data] struct S { x: i32 }")),
+            Marker::detect(&struct_attrs("#[data] struct S { x: i32 }"), &ActiveCfg::default()),
             Ok(Some(Marker::Data))
         );
         assert_eq!(
-            Marker::detect(&struct_attrs("#[boltffi::data] struct S { x: i32 }")),
+            Marker::detect(&struct_attrs("#[boltffi::data] struct S { x: i32 }"), &ActiveCfg::default()),
             Ok(Some(Marker::Data))
         );
         assert_eq!(
-            Marker::detect(&struct_attrs("struct S { x: i32 }")),
+            Marker::detect(&struct_attrs("struct S { x: i32 }"), &ActiveCfg::default()),
             Ok(None)
         );
         assert_eq!(
-            Marker::detect(&struct_attrs("#[derive(Clone)] struct S { x: i32 }")),
+            Marker::detect(&struct_attrs("#[derive(Clone)] struct S { x: i32 }"), &ActiveCfg::default()),
+            Ok(None)
+        );
+    }
+
+    /// A crate that wants a working `default-features = false` escape hatch
+    /// (no FFI dependency at all when the feature is off) has to spell its
+    /// marker as `#[cfg_attr(feature = "boltffi", boltffi::data)]` rather
+    /// than a bare `#[boltffi::data]`. `boltffi_scan` parses source text
+    /// directly via `syn`, so it never sees the compiler's own `cfg_attr`
+    /// expansion happen -- without explicitly recognizing this pattern, the
+    /// item silently scans as unmarked, and anything that references it
+    /// later fails with a confusing "unsupported source type" pointing at
+    /// an unrelated macro invocation.
+    #[test]
+    fn detects_data_behind_an_active_cfg_attr() {
+        let active = ActiveCfg::default().with_feature("boltffi");
+        assert_eq!(
+            Marker::detect(
+                &struct_attrs(r#"#[cfg_attr(feature = "boltffi", boltffi::data)] struct S { x: i32 }"#),
+                &active
+            ),
+            Ok(Some(Marker::Data))
+        );
+        assert_eq!(
+            Marker::detect(
+                &struct_attrs(r#"#[cfg_attr(feature = "boltffi", data)] struct S { x: i32 }"#),
+                &active
+            ),
+            Ok(Some(Marker::Data))
+        );
+    }
+
+    /// The inactive-feature counterpart of `detects_data_behind_an_active_cfg_attr`:
+    /// when the gated feature is off, the item is genuinely unmarked, matching
+    /// what `cfg_attr` would produce if the compiler expanded it.
+    #[test]
+    fn ignores_data_behind_an_inactive_cfg_attr() {
+        assert_eq!(
+            Marker::detect(
+                &struct_attrs(r#"#[cfg_attr(feature = "boltffi", boltffi::data)] struct S { x: i32 }"#),
+                &ActiveCfg::default()
+            ),
             Ok(None)
         );
     }
@@ -239,13 +284,13 @@ mod tests {
         assert_eq!(
             Marker::detect(&impl_attrs(
                 "#[custom_ffi] impl CustomFfiConvertible for Email {}"
-            )),
+            ), &ActiveCfg::default()),
             Ok(Some(Marker::CustomFfi))
         );
         assert_eq!(
             Marker::detect(&impl_attrs(
                 "#[boltffi::custom_ffi] impl boltffi::CustomFfiConvertible for Email {}"
-            )),
+            ), &ActiveCfg::default()),
             Ok(Some(Marker::CustomFfi))
         );
     }
@@ -253,26 +298,26 @@ mod tests {
     #[test]
     fn detects_data_impl_distinctly_from_data() {
         assert_eq!(
-            Marker::detect(&impl_attrs("#[data(impl)] impl S {}")),
+            Marker::detect(&impl_attrs("#[data(impl)] impl S {}"), &ActiveCfg::default()),
             Ok(Some(Marker::DataImpl))
         );
         assert_eq!(
-            Marker::detect(&impl_attrs("#[boltffi::data(impl)] impl S {}")),
+            Marker::detect(&impl_attrs("#[boltffi::data(impl)] impl S {}"), &ActiveCfg::default()),
             Ok(Some(Marker::DataImpl))
         );
-        assert_eq!(Marker::detect(&impl_attrs("impl S {}")), Ok(None));
+        assert_eq!(Marker::detect(&impl_attrs("impl S {}"), &ActiveCfg::default()), Ok(None));
     }
 
     #[test]
     fn rejects_unknown_marker_arguments() {
         assert_eq!(
-            Marker::detect(&struct_attrs("#[data(foo)] struct S { x: i32 }")),
+            Marker::detect(&struct_attrs("#[data(foo)] struct S { x: i32 }"), &ActiveCfg::default()),
             Err(ScanError::InvalidMarker {
                 attribute: "data(foo)".to_owned()
             })
         );
         assert_eq!(
-            Marker::detect(&fn_attrs("#[export(foo)] fn f() {}")),
+            Marker::detect(&fn_attrs("#[export(foo)] fn f() {}"), &ActiveCfg::default()),
             Err(ScanError::InvalidMarker {
                 attribute: "export(foo)".to_owned()
             })
@@ -282,7 +327,7 @@ mod tests {
     #[test]
     fn rejects_conflicting_markers() {
         assert_eq!(
-            Marker::detect(&struct_attrs("#[data] #[error] struct S { x: i32 }")),
+            Marker::detect(&struct_attrs("#[data] #[error] struct S { x: i32 }"), &ActiveCfg::default()),
             Err(ScanError::ConflictingMarkers {
                 first: "data".to_owned(),
                 second: "error".to_owned()
@@ -293,7 +338,7 @@ mod tests {
     #[test]
     fn ignores_unowned_qualified_attributes() {
         assert_eq!(
-            Marker::detect(&struct_attrs("#[other::data] struct S { x: i32 }")),
+            Marker::detect(&struct_attrs("#[other::data] struct S { x: i32 }"), &ActiveCfg::default()),
             Ok(None)
         );
     }
@@ -301,11 +346,11 @@ mod tests {
     #[test]
     fn detects_error_on_value_types() {
         assert_eq!(
-            Marker::detect(&struct_attrs("#[error] struct E { code: i32 }")),
+            Marker::detect(&struct_attrs("#[error] struct E { code: i32 }"), &ActiveCfg::default()),
             Ok(Some(Marker::Error))
         );
         assert_eq!(
-            Marker::detect(&enum_attrs("#[boltffi::error] enum E { Io, Parse }")),
+            Marker::detect(&enum_attrs("#[boltffi::error] enum E { Io, Parse }"), &ActiveCfg::default()),
             Ok(Some(Marker::Error))
         );
     }
@@ -313,16 +358,16 @@ mod tests {
     #[test]
     fn detects_export_on_exported_items() {
         assert_eq!(
-            Marker::detect(&fn_attrs("#[export] fn f() {}")),
+            Marker::detect(&fn_attrs("#[export] fn f() {}"), &ActiveCfg::default()),
             Ok(Some(Marker::Export(ExportMarker::default())))
         );
         assert_eq!(
-            Marker::detect(&fn_attrs("#[boltffi::export] fn f() {}")),
+            Marker::detect(&fn_attrs("#[boltffi::export] fn f() {}"), &ActiveCfg::default()),
             Ok(Some(Marker::Export(ExportMarker::default())))
         );
-        assert_eq!(Marker::detect(&fn_attrs("fn f() {}")), Ok(None));
+        assert_eq!(Marker::detect(&fn_attrs("fn f() {}"), &ActiveCfg::default()), Ok(None));
         assert_eq!(
-            Marker::detect(&const_attrs("#[export] const ANSWER: u32 = 42;")),
+            Marker::detect(&const_attrs("#[export] const ANSWER: u32 = 42;"), &ActiveCfg::default()),
             Ok(Some(Marker::Export(ExportMarker::default())))
         );
     }
@@ -330,11 +375,11 @@ mod tests {
     #[test]
     fn detects_export_with_class_threading_marker() {
         assert_eq!(
-            Marker::detect(&impl_attrs("#[export(single_threaded)] impl S {}")),
+            Marker::detect(&impl_attrs("#[export(single_threaded)] impl S {}"), &ActiveCfg::default()),
             Ok(Some(Marker::Export(ExportMarker::single_threaded())))
         );
         assert_eq!(
-            Marker::detect(&impl_attrs("#[boltffi::export(thread_unsafe)] impl S {}")),
+            Marker::detect(&impl_attrs("#[boltffi::export(thread_unsafe)] impl S {}"), &ActiveCfg::default()),
             Ok(Some(Marker::Export(ExportMarker::single_threaded())))
         );
     }
@@ -342,15 +387,15 @@ mod tests {
     #[test]
     fn detects_skip_through_the_marker_set() {
         assert_eq!(
-            Marker::detect(&fn_attrs("#[skip] fn f() {}")),
+            Marker::detect(&fn_attrs("#[skip] fn f() {}"), &ActiveCfg::default()),
             Ok(Some(Marker::Skip))
         );
         assert_eq!(
-            Marker::detect(&fn_attrs("#[boltffi::skip] fn f() {}")),
+            Marker::detect(&fn_attrs("#[boltffi::skip] fn f() {}"), &ActiveCfg::default()),
             Ok(Some(Marker::Skip))
         );
         assert_eq!(
-            Marker::detect(&fn_attrs("#[skip(reason)] fn f() {}")),
+            Marker::detect(&fn_attrs("#[skip(reason)] fn f() {}"), &ActiveCfg::default()),
             Err(ScanError::InvalidMarker {
                 attribute: "skip(reason)".to_owned()
             })

--- a/boltffi_scan/src/scan.rs
+++ b/boltffi_scan/src/scan.rs
@@ -898,13 +898,6 @@ mod tests {
         );
     }
 
-    /// A crate-local `type Result<T> = std::result::Result<T, E>;` alias
-    /// (needed by any crate returning its own error type from exported
-    /// functions) has to resolve for whatever concrete type each use site
-    /// actually substitutes for `T` -- not the alias's own, unsubstituted
-    /// `T`. Before this was handled, `Result<Point>` here would fail to
-    /// resolve as a value type at all, since the scanner had no record of
-    /// what `T` meant at this specific use site.
     #[test]
     fn scans_function_return_through_a_generic_type_alias() {
         let contract = scan(

--- a/boltffi_scan/src/scan.rs
+++ b/boltffi_scan/src/scan.rs
@@ -9,11 +9,11 @@ use crate::marked::MarkedItems;
 use crate::package_graph::{ExportedPackage, LoadError, PackageGraph};
 use crate::path::ImportLookup;
 use crate::source_tree::SourceTree;
-use crate::{ModuleScope, ScanError, items};
+use crate::{ActiveCfg, ModuleScope, ScanError, items};
 
 pub fn scan(input: &ScanInput) -> Result<SourceContract, ScanError> {
     let source_tree = SourceTree::load_with_cfg(input.root(), &input.package().name, input.cfg())?;
-    scan_tree(source_tree, input.package().clone())
+    scan_tree(source_tree, input.package().clone(), input.cfg())
 }
 
 pub struct PackageScan {
@@ -118,8 +118,8 @@ pub fn scan_package(input: &ScanInput) -> Result<PackageScan, ScanError> {
             .into_iter()
             .chain(std::iter::once(root_tree.clone())),
     );
-    let root_marked = MarkedItems::collect(&root_tree)?;
-    let complete_marked = MarkedItems::collect(&complete_tree)?;
+    let root_marked = MarkedItems::collect(&root_tree, input.cfg())?;
+    let complete_marked = MarkedItems::collect(&complete_tree, input.cfg())?;
     let declared_types = DeclaredTypes::index(&complete_tree, &complete_marked)?;
     let root =
         scan_marked_with_declarations(&root_marked, &declared_types, input.package().clone())?;
@@ -144,25 +144,30 @@ pub fn scan_source(
     package: PackageInfo,
 ) -> Result<SourceContract, ScanError> {
     let source_tree = SourceTree::load(path.as_ref(), &package.name)?;
-    scan_tree(source_tree, package)
+    scan_tree(source_tree, package, &ActiveCfg::default())
 }
 
 pub fn scan_file(file: syn::File, package: PackageInfo) -> Result<SourceContract, ScanError> {
     let source_tree = SourceTree::inline(&package.name, file)?;
-    scan_tree(source_tree, package)
+    scan_tree(source_tree, package, &ActiveCfg::default())
 }
 
-fn scan_tree(source_tree: SourceTree, package: PackageInfo) -> Result<SourceContract, ScanError> {
-    scan_tree_with_declarations(&source_tree, &source_tree, package)
+fn scan_tree(
+    source_tree: SourceTree,
+    package: PackageInfo,
+    cfg: &ActiveCfg,
+) -> Result<SourceContract, ScanError> {
+    scan_tree_with_declarations(&source_tree, &source_tree, package, cfg)
 }
 
 fn scan_tree_with_declarations(
     source_tree: &SourceTree,
     declaration_tree: &SourceTree,
     package: PackageInfo,
+    cfg: &ActiveCfg,
 ) -> Result<SourceContract, ScanError> {
-    let marked = MarkedItems::collect(source_tree)?;
-    let declaration_marked = MarkedItems::collect(declaration_tree)?;
+    let marked = MarkedItems::collect(source_tree, cfg)?;
+    let declaration_marked = MarkedItems::collect(declaration_tree, cfg)?;
     let declared_types = DeclaredTypes::index(declaration_tree, &declaration_marked)?;
     scan_marked_with_declarations(&marked, &declared_types, package)
 }
@@ -727,8 +732,8 @@ mod tests {
              #[data] pub struct MapOptions { pub initial_camera: CameraUpdate }",
         );
         let complete = SourceTree::combine([maplib, root.clone()]);
-        let root_marked = MarkedItems::collect(&root).expect("root marked items");
-        let complete_marked = MarkedItems::collect(&complete).expect("complete marked items");
+        let root_marked = MarkedItems::collect(&root, &ActiveCfg::default()).expect("root marked items");
+        let complete_marked = MarkedItems::collect(&complete, &ActiveCfg::default()).expect("complete marked items");
         let declared_types =
             DeclaredTypes::index(&complete, &complete_marked).expect("declared types");
         let contract = scan_marked_with_declarations(
@@ -890,6 +895,50 @@ mod tests {
         assert_eq!(
             location.fields[0].type_expr,
             custom("demo::UtcDateTime", "UtcDateTime")
+        );
+    }
+
+    /// A crate-local `type Result<T> = std::result::Result<T, E>;` alias
+    /// (needed by any crate returning its own error type from exported
+    /// functions) has to resolve for whatever concrete type each use site
+    /// actually substitutes for `T` -- not the alias's own, unsubstituted
+    /// `T`. Before this was handled, `Result<Point>` here would fail to
+    /// resolve as a value type at all, since the scanner had no record of
+    /// what `T` meant at this specific use site.
+    #[test]
+    fn scans_function_return_through_a_generic_type_alias() {
+        let contract = scan(
+            "#[error] pub enum MyError { Bad } \
+             pub type Result<T> = std::result::Result<T, MyError>; \
+             #[data] pub struct Point { pub x: f64 } \
+             #[export] pub fn origin() -> Result<Point> { todo!() } \
+             #[export] pub fn count() -> Result<u32> { todo!() }",
+        );
+
+        assert_eq!(contract.functions.len(), 2);
+        let origin = contract
+            .functions
+            .iter()
+            .find(|function| function.id.as_str().ends_with("origin"))
+            .expect("origin function");
+        assert_eq!(
+            value_return(&origin.returns),
+            &TypeExpr::result(
+                record("demo::Point", "Point"),
+                enumeration("demo::MyError", "MyError")
+            )
+        );
+        let count = contract
+            .functions
+            .iter()
+            .find(|function| function.id.as_str().ends_with("count"))
+            .expect("count function");
+        assert_eq!(
+            value_return(&count.returns),
+            &TypeExpr::result(
+                TypeExpr::Primitive(Primitive::U32),
+                enumeration("demo::MyError", "MyError")
+            )
         );
     }
 
@@ -1089,7 +1138,7 @@ mod tests {
              #[export] pub fn model_echo_kind(kind: u32) -> u32 { kind }",
         );
         let complete = SourceTree::combine([model, session, root]);
-        let marked = MarkedItems::collect(&complete).expect("marked items");
+        let marked = MarkedItems::collect(&complete, &ActiveCfg::default()).expect("marked items");
         let declared_types = DeclaredTypes::index(&complete, &marked).expect("declared types");
         let paths = root_visible_paths(
             &declared_types,
@@ -1145,7 +1194,7 @@ mod tests {
             "mod inner { #[data] pub struct Hidden { pub x: f64 } } \
              pub use inner::Hidden;",
         );
-        let marked = MarkedItems::collect(&root).expect("marked items");
+        let marked = MarkedItems::collect(&root, &ActiveCfg::default()).expect("marked items");
         let declared_types = DeclaredTypes::index(&root, &marked).expect("declared types");
         let paths = root_visible_paths(&declared_types, &root, &marked, "demo", &[]);
         let path = paths
@@ -1180,7 +1229,7 @@ mod tests {
              } \
              pub use ids::Token;",
         );
-        let marked = MarkedItems::collect(&root).expect("marked items");
+        let marked = MarkedItems::collect(&root, &ActiveCfg::default()).expect("marked items");
         let declared_types = DeclaredTypes::index(&root, &marked).expect("declared types");
         let paths = root_visible_paths(&declared_types, &root, &marked, "demo", &[]);
         let path = paths
@@ -1210,8 +1259,10 @@ mod tests {
         );
         let complete = SourceTree::combine([model, root.clone()]);
         let scan = PackageScan {
-            root: scan_tree(root, PackageInfo::new("demo", None)).expect("root scans"),
-            complete: scan_tree(complete, PackageInfo::new("demo", None)).expect("complete scans"),
+            root: scan_tree(root, PackageInfo::new("demo", None), &ActiveCfg::default())
+                .expect("root scans"),
+            complete: scan_tree(complete, PackageInfo::new("demo", None), &ActiveCfg::default())
+                .expect("complete scans"),
             root_visible_paths: HashMap::new(),
         };
         let source = scan.root_with_support();

--- a/boltffi_scan/src/scan.rs
+++ b/boltffi_scan/src/scan.rs
@@ -936,6 +936,29 @@ mod tests {
     }
 
     #[test]
+    fn scans_generic_type_alias_used_from_a_module_that_never_imported_its_error_type() {
+        let contract = scan(
+            "pub mod errors { \
+                 #[error] pub enum MyError { Bad } \
+                 pub type Result<T> = std::result::Result<T, MyError>; \
+             } \
+             pub mod api { \
+                 use crate::errors::Result; \
+                 #[data] pub struct Point { pub x: f64 } \
+                 #[export] pub fn origin() -> Result<Point> { todo!() } \
+             }",
+        );
+
+        assert_eq!(
+            value_return(&contract.functions[0].returns),
+            &TypeExpr::result(
+                record("demo::api::Point", "Point"),
+                enumeration("demo::errors::MyError", "MyError")
+            )
+        );
+    }
+
+    #[test]
     fn scans_custom_repr_reexported_from_root() {
         let contract = scan(
             "pub use core::location::{GeoCoord, GeographicCoordinate}; \

--- a/boltffi_scan/src/scan.rs
+++ b/boltffi_scan/src/scan.rs
@@ -959,6 +959,24 @@ mod tests {
     }
 
     #[test]
+    fn scans_generic_type_alias_with_a_defaulted_parameter_omitted_at_the_use_site() {
+        let contract = scan(
+            "#[error] pub enum MyError { Bad } \
+             pub type Result<T, E = MyError> = std::result::Result<T, E>; \
+             #[data] pub struct Point { pub x: f64 } \
+             #[export] pub fn origin() -> Result<Point> { todo!() }",
+        );
+
+        assert_eq!(
+            value_return(&contract.functions[0].returns),
+            &TypeExpr::result(
+                record("demo::Point", "Point"),
+                enumeration("demo::MyError", "MyError")
+            )
+        );
+    }
+
+    #[test]
     fn scans_custom_repr_reexported_from_root() {
         let contract = scan(
             "pub use core::location::{GeoCoord, GeographicCoordinate}; \

--- a/boltffi_scan/src/type_expr.rs
+++ b/boltffi_scan/src/type_expr.rs
@@ -59,6 +59,18 @@ impl<'a> Scanner<'a> {
         if type_path.qself.is_some() {
             return Err(ScanError::unsupported_type(source));
         }
+        // A locally-declared type alias (e.g. `type Result<T> = std::result::Result<T, MyError>;`)
+        // shadows any same-named standard type for unqualified use, matching how Rust itself
+        // resolves it -- so this must run before `standard_type`'s name-based Vec/Option/Result
+        // detection, which would otherwise see the alias's use-site arity (one argument for
+        // `Result<Wrapper>`) instead of the real, substituted type's arity (two, once expanded to
+        // `std::result::Result<Wrapper, MyError>`) and reject it as unsupported.
+        if let Some(substituted) = self
+            .declared_types
+            .resolve_alias_target(self.scope, &type_path.path)?
+        {
+            return self.scan(&substituted);
+        }
         if let Some(standard_type) = self.standard_type(type_path, source)? {
             return self.standard_path(standard_type, type_path, source);
         }

--- a/boltffi_scan/src/type_expr.rs
+++ b/boltffi_scan/src/type_expr.rs
@@ -96,7 +96,7 @@ impl<'a> Scanner<'a> {
     /// Scans the alias's type arguments at `self`'s (use-site) scope, but the
     /// alias's own written target at its declaration scope -- they can differ.
     fn scan_alias(&self, alias: &TypeAlias, use_site: &syn::Path) -> Result<TypeExpr, ScanError> {
-        let actual_args = use_site
+        let mut actual_args = use_site
             .segments
             .last()
             .into_iter()
@@ -109,12 +109,20 @@ impl<'a> Scanner<'a> {
                 _ => None,
             });
 
+        // A param the use site omits, relying on its own `= Default`, has
+        // that default written at the alias's declaration site, not the use
+        // site's -- scan it under the alias's own scope, like the target.
+        let alias_scanner = Scanner::new(self.declared_types, alias.scope());
         let substitutions = alias
             .generic_params()
             .iter()
-            .cloned()
-            .zip(actual_args)
-            .map(|(param, arg)| Ok((param, self.scan(arg)?)))
+            .filter_map(|param| match actual_args.next() {
+                Some(arg) => Some(self.scan(arg).map(|expr| (param.name().to_owned(), expr))),
+                None => param
+                    .default()
+                    .map(|default| alias_scanner.scan(default))
+                    .map(|result| result.map(|expr| (param.name().to_owned(), expr))),
+            })
             .collect::<Result<HashMap<_, _>, ScanError>>()?;
 
         Scanner::with_substitutions(self.declared_types, alias.scope(), &substitutions)

--- a/boltffi_scan/src/type_expr.rs
+++ b/boltffi_scan/src/type_expr.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
 
 use boltffi_ast::{
@@ -7,13 +8,16 @@ use boltffi_ast::{
 };
 use quote::ToTokens;
 
-use crate::declared_types::{DeclaredType, DeclaredTypes, SourceType};
+use crate::declared_types::{DeclaredType, DeclaredTypes, SourceType, TypeAlias};
 use crate::unsupported::UnsupportedFeature;
 use crate::{ModuleScope, ScanError};
 
 pub struct Scanner<'a> {
     declared_types: &'a DeclaredTypes,
     scope: &'a ModuleScope,
+    /// Generic-param name -> already-scanned replacement, while expanding a
+    /// type alias's target.
+    substitutions: Option<&'a HashMap<String, TypeExpr>>,
 }
 
 impl<'a> Scanner<'a> {
@@ -21,6 +25,19 @@ impl<'a> Scanner<'a> {
         Self {
             declared_types,
             scope,
+            substitutions: None,
+        }
+    }
+
+    fn with_substitutions(
+        declared_types: &'a DeclaredTypes,
+        scope: &'a ModuleScope,
+        substitutions: &'a HashMap<String, TypeExpr>,
+    ) -> Self {
+        Self {
+            declared_types,
+            scope,
+            substitutions: Some(substitutions),
         }
     }
 
@@ -30,6 +47,9 @@ impl<'a> Scanner<'a> {
 
     pub fn scan(&self, ty: &syn::Type) -> Result<TypeExpr, ScanError> {
         let unwrapped = unwrapped(ty);
+        if let Some(substituted) = self.substitution_for(unwrapped) {
+            return Ok(substituted.clone());
+        }
         if let Some(custom) = self.custom_remote(unwrapped)? {
             return Ok(TypeExpr::custom(
                 custom.clone(),
@@ -61,16 +81,53 @@ impl<'a> Scanner<'a> {
         }
         // Must run before `standard_type`, which would otherwise see the alias's
         // use-site arity instead of the substituted type's real arity.
-        if let Some(substituted) = self
+        if let Some(alias) = self
             .declared_types
-            .resolve_alias_target(self.scope, &type_path.path)?
+            .resolve_alias_definition(self.scope, &type_path.path)?
         {
-            return self.scan(&substituted);
+            return self.scan_alias(alias, &type_path.path);
         }
         if let Some(standard_type) = self.standard_type(type_path, source)? {
             return self.standard_path(standard_type, type_path, source);
         }
         self.named(type_path, source)
+    }
+
+    /// Scans the alias's type arguments at `self`'s (use-site) scope, but the
+    /// alias's own written target at its declaration scope -- they can differ.
+    fn scan_alias(&self, alias: &TypeAlias, use_site: &syn::Path) -> Result<TypeExpr, ScanError> {
+        let actual_args = use_site
+            .segments
+            .last()
+            .into_iter()
+            .flat_map(|segment| match &segment.arguments {
+                syn::PathArguments::AngleBracketed(args) => args.args.iter().collect::<Vec<_>>(),
+                syn::PathArguments::None | syn::PathArguments::Parenthesized(_) => Vec::new(),
+            })
+            .filter_map(|arg| match arg {
+                syn::GenericArgument::Type(ty) => Some(ty),
+                _ => None,
+            });
+
+        let substitutions = alias
+            .generic_params()
+            .iter()
+            .cloned()
+            .zip(actual_args)
+            .map(|(param, arg)| Ok((param, self.scan(arg)?)))
+            .collect::<Result<HashMap<_, _>, ScanError>>()?;
+
+        Scanner::with_substitutions(self.declared_types, alias.scope(), &substitutions)
+            .scan(alias.target())
+    }
+
+    fn substitution_for(&self, ty: &syn::Type) -> Option<&TypeExpr> {
+        let substitutions = self.substitutions?;
+        let syn::Type::Path(type_path) = ty else {
+            return None;
+        };
+        let ident = type_path.path.get_ident()?;
+        substitutions.get(&ident.to_string())
     }
 
     fn standard_path(

--- a/boltffi_scan/src/type_expr.rs
+++ b/boltffi_scan/src/type_expr.rs
@@ -59,12 +59,8 @@ impl<'a> Scanner<'a> {
         if type_path.qself.is_some() {
             return Err(ScanError::unsupported_type(source));
         }
-        // A locally-declared type alias (e.g. `type Result<T> = std::result::Result<T, MyError>;`)
-        // shadows any same-named standard type for unqualified use, matching how Rust itself
-        // resolves it -- so this must run before `standard_type`'s name-based Vec/Option/Result
-        // detection, which would otherwise see the alias's use-site arity (one argument for
-        // `Result<Wrapper>`) instead of the real, substituted type's arity (two, once expanded to
-        // `std::result::Result<Wrapper, MyError>`) and reject it as unsupported.
+        // Must run before `standard_type`, which would otherwise see the alias's
+        // use-site arity instead of the substituted type's real arity.
         if let Some(substituted) = self
             .declared_types
             .resolve_alias_target(self.scope, &type_path.path)?


### PR DESCRIPTION
## Problem

Fixes #629, Fixes #630

Two compounding bugs in `boltffi_scan` (used by `generate
python/kotlin/swift/kmp`) made a very ordinary pattern fail to generate
bindings: a crate with its own error type, a `type Result<T> = ...` alias,
and FFI annotations gated behind `#[cfg_attr(feature = "...", boltffi::data)]`
for a `default-features = false` escape hatch.

## Fix 1: substitute generic type aliases

`insert_alias` now records each alias's generic type parameters.
`resolve_custom_remote_with_aliases` (and a new `resolve_alias_target`,
used from `type_expr::path`) substitute the use site's actual type
arguments into the alias's target before recursing, instead of resolving
the alias's raw, unsubstituted target. `Result<Wrapper>` now correctly
resolves as `std::result::Result<Wrapper, MyError>`.

`type_expr::path` also needed a new hook for this: the existing
custom-remote-type check alone wasn't enough, since `standard_type`'s
Vec/Option/Result detection was still seeing the alias's own use-site
arity (one argument for `Result<T>`) rather than the substituted type's
real arity (two, for `std::result::Result`).

## Fix 2: recognize `cfg_attr`-wrapped markers

`boltffi_scan` parses source text directly via `syn` and never sees the
compiler's own `cfg_attr` expansion. Added `ActiveCfg::expand_cfg_attrs`,
which mirrors that expansion using the crate's real active Cargo features,
and threaded `ActiveCfg` through marker detection (`Marker::detect`,
`marker::disposition`, `MarkedItems::collect`/`push`) so a
`#[cfg_attr(feature = "boltffi", boltffi::data)]` item is now recognized
exactly like a bare `#[boltffi::data]` when the feature is active.

Two lower-traffic marker call sites (per-method skip markers inside
`#[export]` impl/trait blocks) still use `ActiveCfg::default()` rather
than the real crate cfg, to keep this patch scoped to the confirmed bug;
happy to extend if that gap matters in practice.

## Regression coverage

- `marker.rs`: `detects_data_behind_an_active_cfg_attr`,
  `ignores_data_behind_an_inactive_cfg_attr`.
- `scan.rs`: `scans_function_return_through_a_generic_type_alias` (two
  differently-instantiated uses of the same alias in one crate, matching
  the real-world shape).

All three fail with the exact real-world symptoms when reverted
individually (`unsupported source type Result<Point>` for the alias fix,
confirmed via `git stash`).

## Verification

- `cargo test -p boltffi_scan`: 240 passing (237 pre-existing + 3 new),
  zero failures.
- `cargo test -p boltffi`: passing.