### PR TITLE
fix: lower Result<Class, E> returns as object handle, not wire-encoded record

### DIFF
--- a/boltffi_macros/src/exports/methods.rs
+++ b/boltffi_macros/src/exports/methods.rs
@@ -1911,6 +1911,224 @@ mod tests {
     }
 
     #[test]
+    fn instance_method_returning_result_of_exported_class_does_not_wire_encode() {
+        // Regression: `Result<Class, E>` returns must not lower to a
+        // whole-Result `wire_encode`, which would require the class type
+        // to implement `WireEncode`/`WireDecode`. The class is a handle,
+        // not a wire value, so the success payload must cross as an
+        // object handle and the error must cross via the last-error
+        // channel — mirroring the factory-constructor fallible path.
+        let impl_block = parse_impl(
+            r#"
+            impl Map {
+                pub fn try_make_marker(&self, value: i32) -> Result<Marker, String> {
+                    if value < 0 {
+                        Err("negative".to_string())
+                    } else {
+                        Ok(Marker)
+                    }
+                }
+            }
+            "#,
+        );
+        let method = impl_block
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::ImplItem::Fn(method) => Some(method),
+                _ => None,
+            })
+            .expect("instance method should exist");
+        let type_name = impl_type_name(&impl_block).expect("impl type name should resolve");
+
+        let generated = generate_sync_method_export(
+            MethodCallable::new(method),
+            &type_name,
+            "Map",
+            &class_return_lowering(),
+            callback_registry(),
+        )
+        .expect("instance export should be generated")
+        .to_string();
+
+        // The bug: the whole Result was wire-encoded, emitting
+        // `FfiBuf :: wire_encode (& result)` which fails to compile
+        // because `Marker` (a class) does not implement WireEncode /
+        // WireDecode.
+        assert!(
+            !generated.contains("FfiBuf :: wire_encode"),
+            "Result<Class, E> must not wire-encode the whole Result; got:\n{generated}"
+        );
+        // The success payload must cross as an object handle.
+        assert!(
+            generated.contains("Box :: into_raw (Box :: new (value))"),
+            "Result<Class, E> Ok payload must become an object handle; got:\n{generated}"
+        );
+        // The error must cross via the last-error channel.
+        assert!(
+            generated.contains("set_last_error"),
+            "Result<Class, E> Err payload must use set_last_error; got:\n{generated}"
+        );
+    }
+
+    #[test]
+    fn instance_method_returning_result_of_self_does_not_wire_encode() {
+        // `Result<Self, E>` on an instance method (not a factory
+        // constructor) must lower the same way as `Result<Class, E>`:
+        // handle out + last-error, never whole-Result wire_encode.
+        let impl_block = parse_impl(
+            r#"
+            impl Map {
+                pub fn try_clone(&self) -> Result<Self, String> {
+                    Ok(Map)
+                }
+            }
+            "#,
+        );
+        let method = impl_block
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::ImplItem::Fn(method) => Some(method),
+                _ => None,
+            })
+            .expect("instance method should exist");
+        let type_name = impl_type_name(&impl_block).expect("impl type name should resolve");
+
+        let generated = generate_sync_method_export(
+            MethodCallable::new(method),
+            &type_name,
+            "Map",
+            &self_return_lowering(),
+            callback_registry(),
+        )
+        .expect("instance export should be generated")
+        .to_string();
+
+        assert!(
+            !generated.contains("FfiBuf :: wire_encode"),
+            "Result<Self, E> must not wire-encode the whole Result; got:\n{generated}"
+        );
+        assert!(
+            generated.contains("Box :: into_raw (Box :: new (value))"),
+            "Result<Self, E> Ok payload must become an object handle; got:\n{generated}"
+        );
+        assert!(
+            generated.contains("set_last_error"),
+            "Result<Self, E> Err payload must use set_last_error; got:\n{generated}"
+        );
+    }
+
+    #[test]
+    fn static_method_returning_result_of_exported_class_does_not_wire_encode() {
+        // A static (non-constructor) method returning
+        // `Result<OtherClass, E>` must also avoid whole-Result
+        // wire_encode and route through handle + last-error.
+        let impl_block = parse_impl(
+            r#"
+            impl Map {
+                pub fn borrow_marker(id: i32) -> Result<Marker, String> {
+                    if id < 0 {
+                        Err("bad id".to_string())
+                    } else {
+                        Ok(Marker)
+                    }
+                }
+            }
+            "#,
+        );
+        let method = impl_block
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::ImplItem::Fn(method) => Some(method),
+                _ => None,
+            })
+            .expect("static method should exist");
+        let type_name = impl_type_name(&impl_block).expect("impl type name should resolve");
+
+        let generated = generate_sync_method_export(
+            MethodCallable::new(method),
+            &type_name,
+            "Map",
+            &class_return_lowering(),
+            callback_registry(),
+        )
+        .expect("static export should be generated")
+        .to_string();
+
+        assert!(
+            !generated.contains("FfiBuf :: wire_encode"),
+            "static Result<Class, E> must not wire-encode the whole Result; got:\n{generated}"
+        );
+        assert!(
+            generated.contains("Box :: into_raw (Box :: new (value))"),
+            "static Result<Class, E> Ok payload must become an object handle; got:\n{generated}"
+        );
+        assert!(
+            generated.contains("set_last_error"),
+            "static Result<Class, E> Err payload must use set_last_error; got:\n{generated}"
+        );
+    }
+
+    #[test]
+    fn instance_method_returning_result_of_record_still_wire_encodes() {
+        // Regression guard: `Result<Record, E>` must keep wire-encoding
+        // the whole Result, because records implement WireEncode /
+        // WireDecode. Only class/Self payloads are object handles and
+        // must bypass the wire path. `UserProfile` is a #[data] record
+        // (WireEncoded), not a class, so this must NOT lower to an
+        // object handle.
+        let impl_block = parse_impl(
+            r#"
+            impl Service {
+                pub fn fetch_profile(&self, id: i32) -> Result<UserProfile, String> {
+                    if id < 0 {
+                        Err("bad id".to_string())
+                    } else {
+                        Ok(UserProfile)
+                    }
+                }
+            }
+            "#,
+        );
+        let method = impl_block
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::ImplItem::Fn(method) => Some(method),
+                _ => None,
+            })
+            .expect("instance method should exist");
+        let type_name = impl_type_name(&impl_block).expect("impl type name should resolve");
+
+        let generated = generate_sync_method_export(
+            MethodCallable::new(method),
+            &type_name,
+            "Service",
+            &return_lowering(),
+            callback_registry(),
+        )
+        .expect("instance export should be generated")
+        .to_string();
+
+        // Records cross as wire-encoded values, so the whole Result
+        // must be wire-encoded — the opposite of the class case.
+        assert!(
+            generated.contains("FfiBuf :: wire_encode"),
+            "Result<Record, E> must wire-encode the whole Result; got:\n{generated}"
+        );
+        assert!(
+            !generated.contains("Box :: into_raw"),
+            "Result<Record, E> must not lower to an object handle; got:\n{generated}"
+        );
+        assert!(
+            !generated.contains("set_last_error"),
+            "Result<Record, E> must not use the last-error handle path; got:\n{generated}"
+        );
+    }
+
+    #[test]
     fn instance_method_returning_self_lowers_to_object_handle() {
         let impl_block = parse_impl(
             r#"

--- a/boltffi_macros/src/lowering/returns/lower.rs
+++ b/boltffi_macros/src/lowering/returns/lower.rs
@@ -242,6 +242,16 @@ impl ObjectHandleReturn {
                     None => ::core::ptr::null_mut(),
                 }
             }
+        } else if self.is_fallible() {
+            quote! {
+                match #value {
+                    Ok(value) => Box::into_raw(Box::new(value)),
+                    Err(error) => {
+                        ::boltffi::__private::set_last_error(format!("{error:?}"));
+                        ::core::ptr::null_mut()
+                    }
+                }
+            }
         } else {
             quote! {
                 Box::into_raw(Box::new(#value))

--- a/boltffi_macros/src/lowering/returns/model.rs
+++ b/boltffi_macros/src/lowering/returns/model.rs
@@ -119,6 +119,9 @@ pub struct ReturnLoweringContext<'a> {
 pub struct ObjectHandleReturn {
     pointee: Type,
     nullable: bool,
+    /// `Result<Class, E>` / `Result<Self, E>`: the Ok payload becomes a
+    /// handle and the Err payload crosses via the last-error channel.
+    fallible: bool,
 }
 
 impl ObjectHandleReturn {
@@ -126,6 +129,7 @@ impl ObjectHandleReturn {
         Self {
             pointee,
             nullable: false,
+            fallible: false,
         }
     }
 
@@ -133,6 +137,15 @@ impl ObjectHandleReturn {
         Self {
             pointee,
             nullable: true,
+            fallible: false,
+        }
+    }
+
+    fn fallible(pointee: Type) -> Self {
+        Self {
+            pointee,
+            nullable: false,
+            fallible: true,
         }
     }
 
@@ -142,6 +155,10 @@ impl ObjectHandleReturn {
 
     pub fn is_nullable(&self) -> bool {
         self.nullable
+    }
+
+    pub fn is_fallible(&self) -> bool {
+        self.fallible
     }
 }
 
@@ -192,6 +209,9 @@ impl<'a> ReturnLoweringContext<'a> {
             Some(StandardContainer::Option(inner_type)) => self
                 .object_handle_pointee(inner_type)
                 .map(ObjectHandleReturn::nullable),
+            Some(StandardContainer::Result { ok, .. }) => self
+                .object_handle_pointee(ok)
+                .map(ObjectHandleReturn::fallible),
             _ => self
                 .object_handle_pointee(rust_type)
                 .map(ObjectHandleReturn::required),
@@ -229,17 +249,22 @@ impl<'a> ReturnLoweringContext<'a> {
 
     pub fn lower_type(&self, rust_type: &Type) -> ResolvedReturn {
         let value_strategy = classify_value_return_strategy(rust_type, self);
-        let return_contract = ReturnContract::new(value_strategy, ErrorReturnStrategy::None);
         if matches!(value_strategy, ValueReturnStrategy::ObjectHandle)
             && let Some(object_handle) = self.object_handle_return(rust_type)
         {
+            let error_strategy = if object_handle.is_fallible() {
+                ErrorReturnStrategy::StatusCode
+            } else {
+                ErrorReturnStrategy::None
+            };
             return ResolvedReturn::with_object_handle(
                 rust_type.clone(),
-                return_contract,
+                ReturnContract::new(value_strategy, error_strategy),
                 object_handle,
             );
         }
 
+        let return_contract = ReturnContract::new(value_strategy, ErrorReturnStrategy::None);
         ResolvedReturn::new(rust_type.clone(), return_contract)
     }
 }

--- a/boltffi_tests/build.rs
+++ b/boltffi_tests/build.rs
@@ -2352,6 +2352,14 @@ static int boltffi_tests_check_streams(void) {
         boltffi_release_class_boltffi_tests_results_fallible_service(service);
         return 734;
     }
+    uint64_t counter_handle = 0;
+    FfiBuf_u8 counter_error = boltffi_method_class_boltffi_tests_results_fallible_service_try_make_counter(service, 7, &counter_handle);
+    int counter_err_empty = boltffi_tests_check_empty_buf(counter_error, 738);
+    if (counter_err_empty != 0 || counter_handle == 0) {
+        boltffi_release_class_boltffi_tests_results_fallible_service(service);
+        return 740;
+    }
+    boltffi_release_class_boltffi_tests_classes_test_counter(counter_handle);
     RustFutureHandle async_service = boltffi_method_class_boltffi_tests_results_fallible_service_async_get_value(service, 4);
     boltffi_async_method_class_boltffi_tests_results_fallible_service_async_get_value_poll(async_service, 0, boltffi_tests_async_noop);
     FfiStatus async_service_status = FFI_STATUS_INTERNAL_ERROR;

--- a/boltffi_tests/src/results.rs
+++ b/boltffi_tests/src/results.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use boltffi::*;
 
+use crate::TestCounter;
 use crate::{FixtureMessageRecord, FixtureRect, FixtureShape, FixtureStatus};
 
 struct YieldOnce(bool);
@@ -182,6 +183,18 @@ impl FallibleService {
             1 => Err(FixtureError::NotFound),
             _ if key < 0 => Ok(None),
             _ => Ok(Some(key * 4)),
+        }
+    }
+
+    /// Returns a fresh `TestCounter` class handle, or an error when the
+    /// requested initial value is negative. Exercises the
+    /// `Result<Class, Error>` return shape where the success payload must
+    /// lower as a class handle, not as an encoded record.
+    pub fn try_make_counter(&self, initial: i32) -> Result<TestCounter, FixtureError> {
+        if initial < 0 {
+            Err(FixtureError::InvalidInput)
+        } else {
+            Ok(TestCounter::new(initial))
         }
     }
 }

--- a/boltffi_tests/tests/class_ffi.rs
+++ b/boltffi_tests/tests/class_ffi.rs
@@ -107,6 +107,22 @@ fn get_fallible_service_value(handle: u64, key: i32) -> Result<i32, FixtureError
     decode_out_result(&error, value)
 }
 
+fn try_make_counter(handle: u64, initial: i32) -> Result<u64, FixtureError> {
+    let mut counter_handle: u64 = 0;
+    let error = unsafe {
+        boltffi_method_class_boltffi_tests_results_fallible_service_try_make_counter(
+            handle,
+            initial,
+            &mut counter_handle,
+        )
+    };
+    if error.is_empty() {
+        Ok(counter_handle)
+    } else {
+        Err(decode_buf(&error))
+    }
+}
+
 fn add_marker(map: u64, id: i32) -> u64 {
     with_encoded(&FixtureMarkerOptions { id }, |ptr, len| unsafe {
         boltffi_method_class_boltffi_tests_classes_fixture_map_add_marker(map, ptr, len)
@@ -1769,6 +1785,35 @@ mod fallible_service_ffi {
         };
         let result: Option<i32> = decode_buf(&buf);
         assert_eq!(result, None);
+        unsafe { boltffi_release_class_boltffi_tests_results_fallible_service(handle) };
+    }
+
+    #[test]
+    fn try_make_counter_positive_returns_class_handle() {
+        let handle = boltffi_init_class_boltffi_tests_results_fallible_service_new();
+
+        let result = try_make_counter(handle, 7);
+        let counter_handle = result.expect("positive initial should yield a counter handle");
+        assert_ne!(counter_handle, 0);
+
+        // The returned handle is a live TestCounter; its get() should
+        // echo the initial value we passed through the Result payload.
+        let value =
+            unsafe { boltffi_method_class_boltffi_tests_classes_test_counter_get(counter_handle) };
+        assert_eq!(value, 7);
+
+        unsafe {
+            boltffi_release_class_boltffi_tests_classes_test_counter(counter_handle);
+            boltffi_release_class_boltffi_tests_results_fallible_service(handle);
+        }
+    }
+
+    #[test]
+    fn try_make_counter_negative_returns_invalid_input_error() {
+        let handle = boltffi_init_class_boltffi_tests_results_fallible_service_new();
+
+        let result = try_make_counter(handle, -1);
+        assert_eq!(result, Err(FixtureError::InvalidInput));
 
         unsafe { boltffi_release_class_boltffi_tests_results_fallible_service(handle) };
     }


### PR DESCRIPTION
## Problem

A return type of `Result<Class, Error>` (or `Result<Self, Error>`) on an instance method, static method, or free function was misclassified by the legacy macro lowering path as a wire-encoded buffer. The generated code emitted `FfiBuf::wire_encode(&result)` on the *whole* `Result<Class, Error>`, which requires `Class: WireEncode`/`WireDecode`. A class is an object handle, not a wire value — so this produced a trait-bound compile error:

> `the trait bound \`Class: WireDecode\` is not satisfied`

This is the "treats Class as a record, not a class reference" symptom. Factory constructors (`Result<Self, E>`) already had a special-case bypass, but regular returns did not.

## Root cause

`ReturnLoweringContext::object_handle_return` only recognized bare `Class` and `Option<Class>`, not `Result<Class, E>` / `Result<Self, E>`. So `classify_value_return_strategy` fell through to the `StandardContainer::Result` branch and picked `WireEncoded`.

## Fix (`boltffi_macros/src/lowering/returns/`)

- **`model.rs` — `object_handle_return`**: now matches `StandardContainer::Result { ok, .. }` and, when `ok` is a class/Self pointee, returns `ObjectHandleReturn::fallible(...)`. When `ok` is a record/data type, `object_handle_pointee` returns `None`, so `Result<Record, E>` still falls through to wire encoding — the correct path, since records implement `WireEncode`/`WireDecode`.
- **`model.rs` — `ObjectHandleReturn`**: gained a `fallible: bool` field (`is_fallible()` accessor). `lower_type` sets `ErrorReturnStrategy::StatusCode` when fallible.
- **`lower.rs` — `raw_pointer_expression`**: when `is_fallible()`, emits `match { Ok(value) => Box::into_raw(...), Err(error) => { set_last_error(...); null_mut() } }` — mirroring the existing factory-constructor fallible path. Instance methods, static methods, and free functions all route object-handle returns through this one helper, so all three call sites are fixed.

`classify_value_return_strategy` needed no change: `object_handle_return(rust_type)` is checked first, so `Result<Class, E>` now resolves to `ObjectHandle` before reaching the `StandardContainer::Result` branch.

## Tests

### Unit tests (`boltffi_macros/src/exports/methods.rs`)
4 new tests:
- `instance_method_returning_result_of_exported_class_does_not_wire_encode` — **reproduces the bug** (fails before the fix, passes after): asserts no `wire_encode`, Ok payload becomes `Box::into_raw(Box::new(value))`, Err uses `set_last_error`.
- `instance_method_returning_result_of_self_does_not_wire_encode` — `Result<Self, E>` on an instance method (non-constructor).
- `static_method_returning_result_of_exported_class_does_not_wire_encode` — static `Result<OtherClass, E>`.
- `instance_method_returning_result_of_record_still_wire_encodes` — **regression guard**: `Result<UserProfile, String>` (a `#[data]` record, not a class) must still wire-encode the whole Result and must NOT lower to an object handle or use `set_last_error`.

### Integration tests (`boltffi_tests/`)
- Added `FallibleService::try_make_counter(&self, i32) -> Result<TestCounter, FixtureError>` — a class ok + `#[error]` enum err, matching the `Result<Image, DemoError>` shape from the bug report.
- C-harness call in `build.rs` exercising the success path.
- Two FFI-level tests in `class_ffi.rs`:
  - `try_make_counter_positive_returns_class_handle`: success returns a live `TestCounter` handle whose `get()` echoes the initial value (7).
  - `try_make_counter_negative_returns_invalid_input_error`: negative initial returns `FixtureError::InvalidInput`.

## Verification

- `boltffi_macros`: 263 passed (2 pre-existing wasm32-target-not-installed failures, unrelated).
- `boltffi_tests`: 258 passed (including existing `Result<Record, E>` tests `try_rect`/`try_message` in `crossing_behavior.rs`, confirming no regression).
- `boltffi_binding` (327) and `boltffi_core` (218): no regressions.
- `just fmt-check` and `just lint` (workspace clippy `-D warnings`): clean.