### PR TITLE
Emit fun interface for single-method Kotlin callbacks

### DIFF
--- a/boltffi_backend/src/target/kotlin/render/callback.rs
+++ b/boltffi_backend/src/target/kotlin/render/callback.rs
@@ -268,6 +268,13 @@ impl Callback {
         &self.methods
     }
 
+    /// Kotlin permits the `fun` modifier only on interfaces with exactly one
+    /// abstract method; a `fun interface` gains SAM conversion, so callers can
+    /// pass a lambda instead of an `object :` expression.
+    pub fn fun_interface(&self) -> bool {
+        self.methods.len() == 1
+    }
+
     pub fn handle_methods(&self) -> &[HandleMethod] {
         &self.handle_methods
     }

--- a/boltffi_backend/templates/target/kotlin/callback.kt
+++ b/boltffi_backend/templates/target/kotlin/callback.kt
@@ -1,4 +1,4 @@
-interface {{ callback.name() }} {
+{% if callback.fun_interface() %}fun {% endif %}interface {{ callback.name() }} {
 {%- for method in callback.methods() %}
     {% if method.asynchronous() %}suspend {% endif %}fun {{ method.name() }}({% for parameter in method.public_parameters() %}{{ parameter.name() }}: {{ parameter.ty() }}{% if !loop.last %}, {% endif %}{% endfor %}){% if let Some(return_type) = method.public_return() %}: {{ return_type }}{% endif %}
 {%- endfor %}

--- a/boltffi_backend/tests/kotlin/callback.rs
+++ b/boltffi_backend/tests/kotlin/callback.rs
@@ -73,7 +73,21 @@ fn kotlin_target_renders_nullable_callback_handle_returns() {
 
 #[test]
 fn kotlin_target_renders_async_callback_return_shapes() {
-    insta::assert_snapshot!(rendered_fixture("callback/async_callback_return_shapes"));
+    let rendered = rendered_fixture("callback/async_callback_return_shapes");
+
+    assert!(rendered.contains("\ninterface Listener {"));
+    assert!(!rendered.contains("fun interface"));
+
+    insta::assert_snapshot!(rendered);
+}
+
+#[test]
+fn kotlin_target_renders_single_method_callbacks_as_fun_interfaces() {
+    let rendered = rendered_fixture("callback/async_callback_string_return");
+
+    assert!(rendered.contains("fun interface Listener {"));
+
+    insta::assert_snapshot!(rendered);
 }
 
 #[test]

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_async_callback_handle_returns.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_async_callback_handle_returns.snap
@@ -22,7 +22,7 @@ private object Native {
     }
 }
 
-interface Child {
+fun interface Child {
     fun onValue(value: UInt): UInt
 }
 
@@ -70,7 +70,7 @@ object ChildBridge {
     }
 }
 
-interface Sibling {
+fun interface Sibling {
     fun onName(name: String)
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_async_callback_return_shapes.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_async_callback_return_shapes.snap
@@ -1,6 +1,6 @@
 ---
 source: boltffi_backend/tests/kotlin/callback.rs
-expression: "rendered_fixture(\"callback/async_callback_return_shapes\")"
+expression: rendered
 ---
 ===== com/boltffi/demo/Demo.kt =====
 @file:OptIn(kotlin.ExperimentalUnsignedTypes::class)

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_encoded_parameters.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_encoded_parameters.snap
@@ -7,7 +7,7 @@ expression: "rendered_fixture(\"callback/callback_byte_slice_parameter\")"
 
 package com.boltffi.demo
 
-interface Listener {
+fun interface Listener {
     fun onName(name: String)
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_encoded_payloads.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_encoded_payloads.snap
@@ -7,7 +7,7 @@ expression: "rendered_fixture(\"callback/callback_encoded_return\")"
 
 package com.boltffi.demo
 
-interface Listener {
+fun interface Listener {
     fun name(): String
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_encoded_result_returns.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_encoded_result_returns.snap
@@ -11,7 +11,7 @@ private object Native {
     @JvmStatic external fun boltffi_success_bytes(returnOut: Long, value: ByteArray): Unit
 }
 
-interface MessageMapper {
+fun interface MessageMapper {
     fun mapMessage(key: Int): String
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_enum_parameters.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_enum_parameters.snap
@@ -22,7 +22,7 @@ enum class Status(val value: Byte) {
     }
 }
 
-interface StatusMapper {
+fun interface StatusMapper {
     fun mapStatus(status: Status): Status
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_handle_parameters.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_handle_parameters.snap
@@ -11,7 +11,7 @@ private object Native {
     @JvmStatic external fun boltffi_function_demo_install(listener: Long): Unit
 }
 
-interface Listener {
+fun interface Listener {
     fun onValue(value: UInt): UInt
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_optional_scalar_returns.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_optional_scalar_returns.snap
@@ -7,7 +7,7 @@ expression: "rendered_fixture(\"callback/callback_optional_scalar_return\")"
 
 package com.boltffi.demo
 
-interface Listener {
+fun interface Listener {
     fun next(): UInt?
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_record_parameters.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_record_parameters.snap
@@ -52,7 +52,7 @@ data class Point(
     }
 }
 
-interface Listener {
+fun interface Listener {
     fun onPoint(point: Point)
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_result_returns.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_result_returns.snap
@@ -11,7 +11,7 @@ private object Native {
     @JvmStatic external fun boltffi_success_i32(returnOut: Long, value: Int): Unit
 }
 
-interface StatusMapper {
+fun interface StatusMapper {
     fun mapStatus(status: Int): Int
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_vectors.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_callback_vectors.snap
@@ -7,7 +7,7 @@ expression: "rendered_fixture(\"callback/callback_direct_vector_parameter\")"
 
 package com.boltffi.demo
 
-interface Listener {
+fun interface Listener {
     fun process(values: IntArray): IntArray
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_nullable_callback_handle_returns.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_nullable_callback_handle_returns.snap
@@ -15,7 +15,7 @@ private object Native {
     @JvmStatic external fun boltffi_callback_handle_release(handle: Long): Unit
 }
 
-interface Listener {
+fun interface Listener {
     fun onValue(value: UInt): UInt
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_single_method_callbacks_as_fun_interfaces.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__callback__kotlin_target_renders_single_method_callbacks_as_fun_interfaces.snap
@@ -1,0 +1,79 @@
+---
+source: boltffi_backend/tests/kotlin/callback.rs
+expression: rendered
+---
+===== com/boltffi/demo/Demo.kt =====
+@file:OptIn(kotlin.ExperimentalUnsignedTypes::class)
+
+package com.boltffi.demo
+
+import kotlinx.coroutines.launch
+@Suppress("FunctionName")
+private object Native {
+    @JvmStatic external fun boltffi_async_callback_complete_Bytes(callback: Long, context: Long, result: ByteArray): Unit
+    @JvmStatic external fun boltffi_async_callback_complete_Bytes_failure(callback: Long, context: Long): Unit
+    @JvmStatic external fun boltffi_async_callback_complete_Bytes_error(callback: Long, context: Long, result: ByteArray): Unit
+
+    @JvmStatic fun boltffiFutureContinuationCallback(handle: Long, pollResult: Byte) {
+        BoltFfiAsync.resume(handle, pollResult)
+    }
+}
+
+fun interface Listener {
+    suspend fun load(key: UInt): String
+}
+
+private object ListenerMap {
+    private val map = java.util.concurrent.ConcurrentHashMap<Long, Listener>()
+    private val counter = java.util.concurrent.atomic.AtomicLong(1L)
+
+    fun insert(value: Listener): Long {
+        val handle = counter.getAndAdd(2L)
+        map[handle] = value
+        return handle
+    }
+
+    fun get(handle: Long): Listener? = map[handle]
+
+    fun remove(handle: Long): Listener? = map.remove(handle)
+
+    fun clone(handle: Long): Long {
+        val value = map[handle] ?: return 0L
+        return insert(value)
+    }
+}
+
+object ListenerCallbacks {
+    @JvmStatic
+    fun free(handle: Long) {
+        ListenerMap.remove(handle)
+    }
+
+    @JvmStatic
+    fun clone(handle: Long): Long {
+        return ListenerMap.clone(handle)
+    }
+
+    @JvmStatic
+    fun load(handle: Long, key: Int, callbackToken: Long, callbackContext: Long) {
+        val impl = ListenerMap.get(handle) ?: error("ListenerMap: invalid handle $handle")
+        boltffiLaunchCallback {
+            try {
+                val __boltffi_result = impl.load(key.toUInt())
+                val __boltffi_load_wire = WireWriterPool.acquire(4 + Utf8Codec.maxBytes(__boltffi_result))
+                val __boltffi_load_writer = __boltffi_load_wire.writer
+                __boltffi_load_writer.writeString(__boltffi_result)
+                Native.boltffi_async_callback_complete_Bytes(callbackToken, callbackContext, __boltffi_load_wire.bytes())
+                __boltffi_load_wire.close()
+            } catch (throwable: Throwable) {
+                Native.boltffi_async_callback_complete_Bytes_failure(callbackToken, callbackContext)
+            }
+        }
+    }
+}
+
+object ListenerBridge {
+    fun create(value: Listener): Long {
+        return ListenerMap.insert(value)
+    }
+}

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_closure_handle_returns.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_closure_handle_returns.snap
@@ -37,7 +37,7 @@ private object ClosureToBoxDemoListenerCallbacks {
     }
 }
 
-interface Listener {
+fun interface Listener {
     fun onValue(value: UInt): UInt
 }
 


### PR DESCRIPTION
## Summary

A capability trait with a single method currently renders as a plain Kotlin `interface`, which Kotlin cannot SAM-convert — every implementation site has to spell out an `object :` expression:

```kotlin
// before
store.install(object : Listener {
    override fun onValue(value: UInt): UInt = value + 1u
})

// after
store.install(Listener { value -> value + 1u })
```

This PR emits `fun interface` when a callback has exactly one abstract method. Multi-method callbacks keep rendering as plain interfaces.

## Fix

- `boltffi_backend/templates/target/kotlin/callback.kt`: the interface header becomes `{% if callback.fun_interface() %}fun {% endif %}interface …`.
- `boltffi_backend/src/target/kotlin/render/callback.rs`: adds the `fun_interface()` predicate on `Callback` — true when `methods.len() == 1`, mirroring the language rule (Kotlin permits the `fun` modifier only on interfaces with exactly one abstract method).

The closure template in the same directory already emits `fun interface` for the identical shape (`templates/target/kotlin/closure.kt`); this applies that existing pattern to callbacks.

## Suspend callbacks are included

The predicate is "exactly one abstract method", not "one *sync* method": a single-method async callback renders as `fun interface Listener { suspend fun load(key: UInt): String }`. Suspend members in `fun` interfaces are legal since Kotlin 1.6, well below the versions this repo pins (Kotlin example: 2.0.21; KMP template: 2.3.21), and suspend callbacks are arguably where lambdas help most. Verified by compiling the rendered snapshot output (see below).

Adding `fun` is source- and binary-compatible for existing implementers (`object :` expressions and implementing classes are unaffected). If a callback later grows a second method, the modifier comes off again — lambda call sites then break, but any second abstract method already breaks `object :` implementers the same way, so this does not add a new evolution hazard.

---

Authored with AI assistance (Claude Fable); reviewed and validated manually.
