### PR TITLE
Fix lost wake signal in Swift stream drain loop

### DIFF
--- a/boltffi_backend/templates/target/swift/stream.swift
+++ b/boltffi_backend/templates/target/swift/stream.swift
@@ -280,22 +280,24 @@ private final class BoltFFIStreamContext<Item>: BoltFFIStreamPollContext, @unche
             finalizeIfIdle()
             return
         }
-        defer {
-            _ = withUnsafeMutablePointer(to: &processing) { atomicCompareExchange($0, 1, 0) }
-            finalizeIfIdle()
+        let reschedule = processPoll(result)
+        _ = withUnsafeMutablePointer(to: &processing) { atomicCompareExchange($0, 1, 0) }
+        finalizeIfIdle()
+        if reschedule {
+            schedulePoll()
         }
+    }
+
+    private func processPoll(_ result: Int8) -> Bool {
         guard withUnsafeMutablePointer(to: &lifecycle, { atomicCompareExchange($0, 0, 0) }) else {
-            return
+            return false
         }
         drain()
         if result == BoltFFIStreamPollResult.closed.rawValue {
             requestTermination()
-            return
+            return false
         }
-        guard withUnsafeMutablePointer(to: &lifecycle, { atomicCompareExchange($0, 0, 0) }) else {
-            return
-        }
-        schedulePoll()
+        return withUnsafeMutablePointer(to: &lifecycle) { atomicCompareExchange($0, 0, 0) }
     }
 
     private func drain() {

--- a/boltffi_backend/tests/snapshots/swift__swift_target_renders_stream_runtime.snap
+++ b/boltffi_backend/tests/snapshots/swift__swift_target_renders_stream_runtime.snap
@@ -1,0 +1,522 @@
+---
+source: boltffi_backend/tests/swift.rs
+expression: "rendered_swift_runtime(SourceFixture::one(\"stream/protocol_functions\"))"
+---
+===== DemoFFI.swift =====
+private func boltffiReadDirectStreamBatch<Element, Item>(
+    subscription: UInt64,
+    batchSize: UInt,
+    popBatch: (UInt64, UnsafeMutablePointer<Element>?, UInt) -> UInt,
+    mapItems: (UnsafeBufferPointer<Element>) -> [Item]
+) -> [Item] {
+    if batchSize == 0 {
+        return []
+    }
+    let items = UnsafeMutablePointer<Element>.allocate(capacity: Int(batchSize))
+    defer { items.deallocate() }
+    let count = popBatch(subscription, items, batchSize)
+    if count == 0 {
+        return []
+    }
+    return mapItems(UnsafeBufferPointer(start: items, count: Int(count)))
+}
+
+private class BoltFFIStreamPollContext: @unchecked Sendable {
+    func handlePoll(_ result: Int8) {
+        preconditionFailure("invalid BoltFFI stream poll context")
+    }
+}
+
+private let boltffiStreamPollCallback: @convention(c) (UInt64, Int8) -> Void = { data, result in
+    Unmanaged<BoltFFIStreamPollContext>.fromOpaque(UnsafeRawPointer(bitPattern: UInt(data))!).takeRetainedValue().handlePoll(result)
+}
+
+private final class BoltFFIStreamContext<Item>: BoltFFIStreamPollContext, @unchecked Sendable {
+    private let subscription: UInt64
+    private let batchSize: UInt
+    private let readBatch: (UInt64, UInt) -> [Item]
+    private let poll: (UInt64, UInt64, StreamContinuationCallback?) -> Void
+    private let unsubscribe: (UInt64) -> Void
+    private let free: (UInt64) -> Void
+    private let atomicCompareExchange: (UnsafeMutablePointer<UInt8>?, UInt8, UInt8) -> Bool
+    private let yieldItem: (Item) -> Void
+    private let finish: () -> Void
+    private var lifecycle = UInt8(0)
+    private var processing = UInt8(0)
+
+    init(
+        subscription: UInt64,
+        batchSize: UInt,
+        readBatch: @escaping (UInt64, UInt) -> [Item],
+        poll: @escaping (UInt64, UInt64, StreamContinuationCallback?) -> Void,
+        unsubscribe: @escaping (UInt64) -> Void,
+        free: @escaping (UInt64) -> Void,
+        atomicCompareExchange: @escaping (UnsafeMutablePointer<UInt8>?, UInt8, UInt8) -> Bool,
+        yieldItem: @escaping (Item) -> Void,
+        finish: @escaping () -> Void
+    ) {
+        self.subscription = subscription
+        self.batchSize = batchSize
+        self.readBatch = readBatch
+        self.poll = poll
+        self.unsubscribe = unsubscribe
+        self.free = free
+        self.atomicCompareExchange = atomicCompareExchange
+        self.yieldItem = yieldItem
+        self.finish = finish
+    }
+
+    func start() {
+        registerPoll()
+    }
+
+    func requestTermination() {
+        let started = withUnsafeMutablePointer(to: &lifecycle) {
+            atomicCompareExchange($0, 0, 1)
+        }
+        if started {
+            unsubscribe(subscription)
+            _ = withUnsafeMutablePointer(to: &lifecycle) {
+                atomicCompareExchange($0, 1, 2)
+            }
+        }
+        finalizeIfIdle()
+    }
+
+    private func registerPoll() {
+        guard withUnsafeMutablePointer(to: &lifecycle, { atomicCompareExchange($0, 0, 0) }) else {
+            finalizeIfIdle()
+            return
+        }
+        let data = UInt64(UInt(bitPattern: Unmanaged.passRetained(self).toOpaque()))
+        poll(subscription, data, boltffiStreamPollCallback)
+    }
+
+    override func handlePoll(_ result: Int8) {
+        guard withUnsafeMutablePointer(to: &processing, { atomicCompareExchange($0, 0, 1) }) else {
+            finalizeIfIdle()
+            return
+        }
+        let reschedule = processPoll(result)
+        _ = withUnsafeMutablePointer(to: &processing) { atomicCompareExchange($0, 1, 0) }
+        finalizeIfIdle()
+        if reschedule {
+            schedulePoll()
+        }
+    }
+
+    private func processPoll(_ result: Int8) -> Bool {
+        guard withUnsafeMutablePointer(to: &lifecycle, { atomicCompareExchange($0, 0, 0) }) else {
+            return false
+        }
+        drain()
+        if result == BoltFFIStreamPollResult.closed.rawValue {
+            requestTermination()
+            return false
+        }
+        return withUnsafeMutablePointer(to: &lifecycle) { atomicCompareExchange($0, 0, 0) }
+    }
+
+    private func drain() {
+        while true {
+            let items = readBatch(subscription, batchSize)
+            if items.isEmpty {
+                return
+            }
+            for item in items {
+                yieldItem(item)
+            }
+        }
+    }
+
+    private func schedulePoll() {
+        _Concurrency.Task { [self] in
+            await _Concurrency.Task.yield()
+            registerPoll()
+        }
+    }
+
+    private func finalizeIfIdle() {
+        guard withUnsafeMutablePointer(to: &processing, { atomicCompareExchange($0, 0, 0) }) else {
+            return
+        }
+        guard withUnsafeMutablePointer(to: &lifecycle, { atomicCompareExchange($0, 2, 3) }) else {
+            return
+        }
+        free(subscription)
+        finish()
+    }
+}
+
+@usableFromInline struct WireReader {
+    @usableFromInline let data: Data
+    @usableFromInline var position: Int
+
+    @inlinable init(data: Data, position: Int = 0) {
+        self.data = data
+        self.position = position
+    }
+
+    @inlinable init(ptr: UnsafePointer<UInt8>, len: Int) {
+        self.data = Data(bytes: ptr, count: len)
+        self.position = 0
+    }
+
+    @inlinable mutating func readU8() -> UInt8 {
+        let value = data[position]
+        position += 1
+        return value
+    }
+
+    @inlinable mutating func readI8() -> Int8 {
+        Int8(bitPattern: readU8())
+    }
+
+    @inlinable mutating func readU16() -> UInt16 {
+        let value = data.withUnsafeBytes { buffer in
+            buffer.loadUnaligned(fromByteOffset: position, as: UInt16.self)
+        }
+        position += 2
+        return UInt16(littleEndian: value)
+    }
+
+    @inlinable mutating func readI16() -> Int16 {
+        Int16(bitPattern: readU16())
+    }
+
+    @inlinable mutating func readU32() -> UInt32 {
+        let value = data.withUnsafeBytes { buffer in
+            buffer.loadUnaligned(fromByteOffset: position, as: UInt32.self)
+        }
+        position += 4
+        return UInt32(littleEndian: value)
+    }
+
+    @inlinable mutating func readI32() -> Int32 {
+        Int32(bitPattern: readU32())
+    }
+
+    @inlinable mutating func readU64() -> UInt64 {
+        let value = data.withUnsafeBytes { buffer in
+            buffer.loadUnaligned(fromByteOffset: position, as: UInt64.self)
+        }
+        position += 8
+        return UInt64(littleEndian: value)
+    }
+
+    @inlinable mutating func readI64() -> Int64 {
+        Int64(bitPattern: readU64())
+    }
+
+    @inlinable mutating func readF32() -> Float {
+        Float(bitPattern: readU32())
+    }
+
+    @inlinable mutating func readF64() -> Double {
+        Double(bitPattern: readU64())
+    }
+
+    @inlinable mutating func readBool() -> Bool {
+        readU8() != 0
+    }
+
+    @inlinable mutating func readString() -> String {
+        let length = Int(readU32())
+        guard length > 0 else { return "" }
+        let start = position
+        position += length
+        return data.withUnsafeBytes { bytes in
+            let pointer = bytes.baseAddress!.advanced(by: start).assumingMemoryBound(to: UInt8.self)
+            let buffer = UnsafeBufferPointer(start: pointer, count: length)
+            return String(decoding: buffer, as: UTF8.self)
+        }
+    }
+
+    @inlinable mutating func readBytes() -> Data {
+        let length = Int(readU32())
+        guard length > 0 else { return Data() }
+        let start = position
+        position += length
+        return Data(data[start..<(start + length)])
+    }
+
+    @inlinable mutating func readDuration() -> TimeInterval {
+        let seconds = readU64()
+        let nanoseconds = readU32()
+        return Double(seconds) + (Double(nanoseconds) / 1.0e9)
+    }
+
+    @inlinable mutating func readTimestamp() -> Date {
+        let seconds = readI64()
+        let nanoseconds = readU32()
+        let delta = Double(seconds) + (Double(nanoseconds) / 1.0e9)
+        return Date(timeIntervalSince1970: delta)
+    }
+
+    @inlinable mutating func readUuid() -> UUID {
+        let hi = readU64()
+        let lo = readU64()
+        var uuid: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        var hiBe = hi.bigEndian
+        var loBe = lo.bigEndian
+        withUnsafeMutableBytes(of: &uuid) { uuidBytes in
+            Swift.withUnsafeBytes(of: &hiBe) { uuidBytes[0..<8].copyBytes(from: $0) }
+            Swift.withUnsafeBytes(of: &loBe) { uuidBytes[8..<16].copyBytes(from: $0) }
+        }
+        return UUID(uuid: uuid)
+    }
+
+    @inlinable mutating func readUrl() -> URL {
+        guard let url = URL(string: readString()) else { fatalError("Invalid URL") }
+        return url
+    }
+
+    @inlinable mutating func readOptional<T>(_ body: (inout WireReader) -> T) -> T? {
+        switch readU8() {
+        case 0:
+            return nil
+        case 1:
+            return body(&self)
+        default:
+            fatalError("Invalid optional wire tag")
+        }
+    }
+
+    @inlinable mutating func readSequence<T>(_ body: (inout WireReader) -> T) -> [T] {
+        let count = Int(readU32())
+        guard count > 0 else { return [] }
+        var result = [T]()
+        result.reserveCapacity(count)
+        for _ in 0..<count {
+            result.append(body(&self))
+        }
+        return result
+    }
+
+    @inlinable mutating func readArray<T>(_ body: (inout WireReader) -> T) -> [T] {
+        readSequence(body)
+    }
+
+    @inlinable mutating func readResult<Success, Failure: Swift.Error>(
+        _ success: (inout WireReader) -> Success,
+        _ failure: (inout WireReader) -> Failure
+    ) -> Swift.Result<Success, Failure> {
+        switch readU8() {
+        case 0:
+            return .success(success(&self))
+        case 1:
+            return .failure(failure(&self))
+        default:
+            fatalError("Invalid result wire tag")
+        }
+    }
+
+    @inlinable mutating func readMap<K: Hashable, V>(
+        _ key: (inout WireReader) -> K,
+        _ value: (inout WireReader) -> V
+    ) -> [K: V] {
+        let count = Int(readU32())
+        var result = [K: V]()
+        result.reserveCapacity(count)
+        for _ in 0..<count {
+            let decodedKey = key(&self)
+            let decodedValue = value(&self)
+            if result.updateValue(decodedValue, forKey: decodedKey) != nil {
+                fatalError("Duplicate map key")
+            }
+        }
+        return result
+    }
+}
+
+@usableFromInline struct WireWriter {
+    @usableFromInline var data: Data
+
+    @inlinable init(capacity: Int = 64) {
+        self.data = Data(capacity: capacity)
+    }
+
+    @inlinable mutating func writeU8(_ value: UInt8) {
+        data.append(value)
+    }
+
+    @inlinable mutating func writeI8(_ value: Int8) {
+        writeU8(UInt8(bitPattern: value))
+    }
+
+    @inlinable mutating func writeU16(_ value: UInt16) {
+        var value = value.littleEndian
+        Swift.withUnsafeBytes(of: &value) { bytes in
+            data.append(contentsOf: bytes)
+        }
+    }
+
+    @inlinable mutating func writeI16(_ value: Int16) {
+        writeU16(UInt16(bitPattern: value))
+    }
+
+    @inlinable mutating func writeU32(_ value: UInt32) {
+        var value = value.littleEndian
+        Swift.withUnsafeBytes(of: &value) { bytes in
+            data.append(contentsOf: bytes)
+        }
+    }
+
+    @inlinable mutating func writeI32(_ value: Int32) {
+        writeU32(UInt32(bitPattern: value))
+    }
+
+    @inlinable mutating func writeU64(_ value: UInt64) {
+        var value = value.littleEndian
+        Swift.withUnsafeBytes(of: &value) { bytes in
+            data.append(contentsOf: bytes)
+        }
+    }
+
+    @inlinable mutating func writeI64(_ value: Int64) {
+        writeU64(UInt64(bitPattern: value))
+    }
+
+    @inlinable mutating func writeF32(_ value: Float) {
+        writeU32(value.bitPattern)
+    }
+
+    @inlinable mutating func writeF64(_ value: Double) {
+        writeU64(value.bitPattern)
+    }
+
+    @inlinable mutating func writeBool(_ value: Bool) {
+        writeU8(value ? 1 : 0)
+    }
+
+    @inlinable mutating func writeString(_ value: String) {
+        var value = value
+        value.withUTF8 { utf8 in
+            writeU32(UInt32(utf8.count))
+            data.append(contentsOf: utf8)
+        }
+    }
+
+    @inlinable mutating func writeBytes(_ value: Data) {
+        writeU32(UInt32(value.count))
+        data.append(contentsOf: value)
+    }
+
+    @inlinable mutating func writeDuration(_ value: TimeInterval) {
+        if value.rounded(.down) > Double(Int64.max) { fatalError("Duration overflow") }
+        if value < 0 { fatalError("Invalid duration") }
+        let seconds = UInt64(value)
+        let nanoseconds = UInt32((value - Double(seconds)) * 1.0e9)
+        writeU64(seconds)
+        writeU32(nanoseconds)
+    }
+
+    @inlinable mutating func writeTimestamp(_ value: Date) {
+        let delta = value.timeIntervalSince1970
+        let secondsDouble = delta.rounded(.down)
+        if secondsDouble < Double(Int64.min) || secondsDouble > Double(Int64.max) { fatalError("Timestamp overflow") }
+        let seconds = Int64(secondsDouble)
+        let nanoseconds = UInt32((delta - secondsDouble) * 1.0e9)
+        writeI64(seconds)
+        writeU32(nanoseconds)
+    }
+
+    @inlinable mutating func writeUuid(_ value: UUID) {
+        var uuid = value.uuid
+        let (hi, lo) = Swift.withUnsafeBytes(of: &uuid) { raw -> (UInt64, UInt64) in
+            let hiBe = raw.loadUnaligned(fromByteOffset: 0, as: UInt64.self)
+            let loBe = raw.loadUnaligned(fromByteOffset: 8, as: UInt64.self)
+            return (UInt64(bigEndian: hiBe), UInt64(bigEndian: loBe))
+        }
+        writeU64(hi)
+        writeU64(lo)
+    }
+
+    @inlinable mutating func writeUrl(_ value: URL) {
+        writeString(value.absoluteString)
+    }
+
+    @inlinable mutating func writeOptional<T>(_ value: T?, _ body: (inout WireWriter, T) -> Void) {
+        switch value {
+        case .some(let value):
+            writeU8(1)
+            body(&self, value)
+        case .none:
+            writeU8(0)
+        }
+    }
+
+    @inlinable mutating func writeSequence<T>(_ value: [T], _ body: (inout WireWriter, T) -> Void) {
+        writeU32(UInt32(value.count))
+        for item in value {
+            body(&self, item)
+        }
+    }
+
+    @inlinable mutating func writeArray<T>(_ value: [T], _ body: (inout WireWriter, T) -> Void) {
+        writeSequence(value, body)
+    }
+
+    @inlinable mutating func writeResult<Success, Failure: Swift.Error>(
+        _ value: Swift.Result<Success, Failure>,
+        _ success: (inout WireWriter, Success) -> Void,
+        _ failure: (inout WireWriter, Failure) -> Void
+    ) {
+        switch value {
+        case .success(let value):
+            writeU8(0)
+            success(&self, value)
+        case .failure(let value):
+            writeU8(1)
+            failure(&self, value)
+        }
+    }
+
+    @inlinable mutating func writeMap<K: Hashable, V>(
+        _ value: [K: V],
+        _ key: (inout WireWriter, K) -> Void,
+        _ writeValue: (inout WireWriter, V) -> Void
+    ) {
+        writeU32(UInt32(value.count))
+        for entry in value {
+            key(&self, entry.key)
+            writeValue(&self, entry.value)
+        }
+    }
+
+    @inlinable func finalize() -> Data {
+        data
+    }
+}
+
+@inlinable func boltffiDecodeOwnedBuf<T>(
+    _ pointer: UnsafePointer<UInt8>?,
+    _ length: Int,
+    _ decode: (inout WireReader) -> T
+) -> T {
+    var reader = WireReader(ptr: pointer!, len: length)
+    return decode(&reader)
+}
+
+@inlinable func boltffiEncode(_ body: (inout WireWriter) -> Void) -> [UInt8] {
+    var writer = WireWriter()
+    body(&writer)
+    return [UInt8](writer.finalize())
+}
+
+@inline(__always)
+private func boltffiReadWireStreamBatch<Item>(
+    subscription: UInt64,
+    batchSize: UInt,
+    popBatch: (UInt64, UInt) -> FfiBuf_u8,
+    freeBuf: (FfiBuf_u8) -> Void,
+    decodeItems: (inout WireReader) -> [Item]
+) -> [Item] {
+    let buffer = popBatch(subscription, batchSize)
+    defer { freeBuf(buffer) }
+    guard buffer.len > 0, let pointer = buffer.ptr else {
+        return []
+    }
+    var reader = WireReader(ptr: pointer, len: Int(buffer.len))
+    return decodeItems(&reader)
+}

--- a/boltffi_backend/tests/swift.rs
+++ b/boltffi_backend/tests/swift.rs
@@ -222,6 +222,13 @@ fn swift_target_renders_stream_protocols() {
 }
 
 #[test]
+fn swift_target_renders_stream_runtime() {
+    insta::assert_snapshot!(rendered_swift_runtime(SourceFixture::one(
+        "stream/protocol_functions"
+    )));
+}
+
+#[test]
 fn swift_target_renders_callback_handle_parameters() {
     insta::assert_snapshot!(rendered_partial_fixture(
         "callback/foreign_callback_parameter"


### PR DESCRIPTION
## Summary

`BoltFFIStreamContext.handlePoll` re-registered the next poll via `schedulePoll()` while still holding the `processing` flag (the `defer` cleared it afterwards). The Rust side fires the poll callback synchronously when items are already buffered, so a callback landing in that window hit the `processing` CAS-failure guard, which discarded the `Ready` signal without re-registering. The handshake is then dead — the continuation slot was consumed, nothing re-parks it, and later pushes only latch a `Waked` state nobody collects — so the stream stalls permanently with items stuck in the ring buffer. Async and callback delivery modes are affected; batch mode never parks and is immune. The window is tens of nanoseconds, so the failure is rare, but it is silent, unrecoverable, and reachable from any producer thread with no consumer-side misuse.

Kotlin and Java are not affected: their runtimes clear `processing` *before* re-registering the poll. This PR makes Swift follow the same ordering.

## Fix

Drain work moves into a `processPoll` helper (mirroring the Java runtime), and `schedulePoll()` runs only after `processing` is cleared:

```swift
override func handlePoll(_ result: Int8) {
    guard withUnsafeMutablePointer(to: &processing, { atomicCompareExchange($0, 0, 1) }) else {
        finalizeIfIdle()
        return
    }
    let reschedule = processPoll(result)
    _ = withUnsafeMutablePointer(to: &processing) { atomicCompareExchange($0, 1, 0) }
    finalizeIfIdle()
    if reschedule {
        schedulePoll()
    }
}

private func processPoll(_ result: Int8) -> Bool {
    guard withUnsafeMutablePointer(to: &lifecycle, { atomicCompareExchange($0, 0, 0) }) else {
        return false
    }
    drain()
    if result == BoltFFIStreamPollResult.closed.rawValue {
        requestTermination()
        return false
    }
    return withUnsafeMutablePointer(to: &lifecycle) { atomicCompareExchange($0, 0, 0) }
}
```

Since only one poll is ever outstanding, re-registering strictly after the clear makes the CAS-failure branch unreachable defensive code — its role in Kotlin and Java. Termination is unchanged: if `requestTermination()` races in before `schedulePoll()`, `registerPoll()`'s lifecycle guard still prevents any use of the freed subscription. The `defer` was dropped because `schedulePoll()` must run after the clear (a defer cannot order code after itself); none of the closures can throw, so nothing is lost.

## Verification

There is no XCTest regression test: `BoltFFIStreamContext` is private to the generated file and the window cannot be forced from the public API — a stress test passes with and without the fix (0 natural hits in ~7M pushes). Instead, a new snapshot test (`swift_target_renders_stream_runtime`) locks in the corrected runtime ordering; the runtime section previously had no snapshot coverage.

The fix itself was validated with a standalone harness linking the real `boltffi_core::EventSubscription` against the generated Swift runtime verbatim, forcing the race deterministically through injection points the generated code already exposes (an `atomicCompareExchange` wrapper delaying the `processing` clear to simulate preemption, plus a push from `readBatch` on empty ring so the re-registered poll sync-fires):

| Runtime variant | Deterministic trials |
| --- | --- |
| Current template | **10/10 permanent stalls** — signal discarded, revival push never delivered |
| This fix | **0/10 stalls** — all items delivered, 0 discard-branch hits |

Stress on the fixed runtime: 16 trials × 50k pushes, 8 workers + 8 load threads — 0 stalls, 0 out-of-order deliveries. Repo checks: `cargo test -p boltffi_backend`, `fmt-check`, `clippy`, and the full apple platform verification (pack + 87 swift tests + xcodebuild smokes) all pass. Demo bindings regenerated (`DemoBoltFFI.swift` is untracked generated output, so it shows no PR diff).

---

Made with help of Claude Fable and my own time and effort