### PR TITLE
fix(jni): emit bare return for EncodedError async complete methods

### DIFF
--- a/boltffi_backend/templates/bridge/jni/method/call.c
+++ b/boltffi_backend/templates/bridge/jni/method/call.c
@@ -31,6 +31,8 @@
 {%- else %}
     return boltffi_jni_record_to_byte_array(env, &__boltffi_result, (uintptr_t)sizeof(__boltffi_result));
 {%- endif %}
+{%- else if method.checks_error_buffer && method.success_out.is_none() %}
+    return;
 {%- else %}
     return {{ method.return_value }};
 {%- endif %}

--- a/boltffi_backend/tests/fixtures/source/exports/async_complete_return_shapes.rs
+++ b/boltffi_backend/tests/fixtures/source/exports/async_complete_return_shapes.rs
@@ -17,3 +17,18 @@ pub async fn load_name() -> String {
 pub async fn load_point() -> Point {
     Point { x: 1, y: 2 }
 }
+
+#[error]
+pub enum SaveError {
+    Failed,
+}
+
+#[export]
+pub async fn save() -> Result<(), SaveError> {
+    Ok(())
+}
+
+#[export]
+pub async fn save_checked(value: i32) -> Result<i32, SaveError> {
+    Ok(value)
+}

--- a/boltffi_backend/tests/jni/snapshots/jni__native_methods__jni_bridge_renders_async_complete_return_shapes.snap
+++ b/boltffi_backend/tests/jni/snapshots/jni__native_methods__jni_bridge_renders_async_complete_return_shapes.snap
@@ -8,6 +8,8 @@ typedef struct {
     int32_t x;
     int32_t y;
 } ___Point;
+typedef int32_t ___SaveError;
+#define SAVE_ERROR_FAILED ((___SaveError)0)
 RustFutureHandle boltffi_function_demo_refresh(void);
 void boltffi_async_function_demo_refresh_poll(RustFutureHandle handle, uint64_t callback_data, void (*callback)(uint64_t, int8_t));
 void boltffi_async_function_demo_refresh_complete(RustFutureHandle handle, FfiStatus *out_status);
@@ -26,6 +28,18 @@ ___Point boltffi_async_function_demo_load_point_complete(RustFutureHandle handle
 FfiBuf_u8 boltffi_async_function_demo_load_point_panic_message(RustFutureHandle handle);
 void boltffi_async_function_demo_load_point_cancel(RustFutureHandle handle);
 void boltffi_async_function_demo_load_point_free(RustFutureHandle handle);
+RustFutureHandle boltffi_function_demo_save(void);
+void boltffi_async_function_demo_save_poll(RustFutureHandle handle, uint64_t callback_data, void (*callback)(uint64_t, int8_t));
+FfiBuf_u8 boltffi_async_function_demo_save_complete(RustFutureHandle handle, FfiStatus *out_status);
+FfiBuf_u8 boltffi_async_function_demo_save_panic_message(RustFutureHandle handle);
+void boltffi_async_function_demo_save_cancel(RustFutureHandle handle);
+void boltffi_async_function_demo_save_free(RustFutureHandle handle);
+RustFutureHandle boltffi_function_demo_save_checked(int32_t value);
+void boltffi_async_function_demo_save_checked_poll(RustFutureHandle handle, uint64_t callback_data, void (*callback)(uint64_t, int8_t));
+FfiBuf_u8 boltffi_async_function_demo_save_checked_complete(RustFutureHandle handle, FfiStatus *out_status, int32_t *return_out);
+FfiBuf_u8 boltffi_async_function_demo_save_checked_panic_message(RustFutureHandle handle);
+void boltffi_async_function_demo_save_checked_cancel(RustFutureHandle handle);
+void boltffi_async_function_demo_save_checked_free(RustFutureHandle handle);
 
 ===== jni/jni_glue.c =====
 <jni source includes>
@@ -33,6 +47,7 @@ void boltffi_async_function_demo_load_point_free(RustFutureHandle handle);
 <jni continuation helper>
 <jni exception helpers>
 <jni status helper>
+<jni error-buffer helper>
 <jni byte-array helpers>
 <jni record helpers>
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
@@ -245,6 +260,135 @@ JNIEXPORT void JNICALL Java_com_boltffi_demo_Native_boltffi_1async_1function_1de
 
     (void)env;
     boltffi_async_function_demo_load_point_free((RustFutureHandle)handle);
+
+    return;
+}
+
+JNIEXPORT jlong JNICALL Java_com_boltffi_demo_Native_boltffi_1function_1demo_1save(JNIEnv *env, jclass cls) {
+    (void)cls;
+
+    (void)env;
+    RustFutureHandle __boltffi_result = boltffi_function_demo_save();
+
+    return (jlong)__boltffi_result;
+}
+
+JNIEXPORT void JNICALL Java_com_boltffi_demo_Native_boltffi_1async_1function_1demo_1save_1poll(JNIEnv *env, jclass cls, jlong handle, jlong callback_data) {
+    (void)cls;
+
+    (void)env;
+    boltffi_async_function_demo_save_poll((RustFutureHandle)handle, callback_data, boltffi_jni_continuation_callback);
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_com_boltffi_demo_Native_boltffi_1async_1function_1demo_1save_1complete(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+
+    FfiStatus __boltffi_status = (FfiStatus){0};
+
+    FfiBuf_u8 __boltffi_result = boltffi_async_function_demo_save_complete((RustFutureHandle)handle, &__boltffi_status);
+
+    if (__boltffi_result.ptr != NULL || __boltffi_result.len != 0) {
+        boltffi_jni_throw_error_buffer(env, __boltffi_result);
+        return;
+    }
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_com_boltffi_demo_Native_boltffi_1async_1function_1demo_1save_1panic_1message(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_async_function_demo_save_panic_message((RustFutureHandle)handle);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT void JNICALL Java_com_boltffi_demo_Native_boltffi_1async_1function_1demo_1save_1cancel(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+
+    (void)env;
+    boltffi_async_function_demo_save_cancel((RustFutureHandle)handle);
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_com_boltffi_demo_Native_boltffi_1async_1function_1demo_1save_1free(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+
+    (void)env;
+    boltffi_async_function_demo_save_free((RustFutureHandle)handle);
+
+    return;
+}
+
+JNIEXPORT jlong JNICALL Java_com_boltffi_demo_Native_boltffi_1function_1demo_1save_1checked(JNIEnv *env, jclass cls, jint value) {
+    (void)cls;
+
+    (void)env;
+    RustFutureHandle __boltffi_result = boltffi_function_demo_save_checked(value);
+
+    return (jlong)__boltffi_result;
+}
+
+JNIEXPORT void JNICALL Java_com_boltffi_demo_Native_boltffi_1async_1function_1demo_1save_1checked_1poll(JNIEnv *env, jclass cls, jlong handle, jlong callback_data) {
+    (void)cls;
+
+    (void)env;
+    boltffi_async_function_demo_save_checked_poll((RustFutureHandle)handle, callback_data, boltffi_jni_continuation_callback);
+
+    return;
+}
+
+JNIEXPORT jint JNICALL Java_com_boltffi_demo_Native_boltffi_1async_1function_1demo_1save_1checked_1complete(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+
+    int32_t __boltffi_return = (int32_t){0};
+    FfiStatus __boltffi_status = (FfiStatus){0};
+
+    FfiBuf_u8 __boltffi_result = boltffi_async_function_demo_save_checked_complete((RustFutureHandle)handle, &__boltffi_status, &__boltffi_return);
+
+    if (__boltffi_result.ptr != NULL || __boltffi_result.len != 0) {
+        boltffi_jni_throw_error_buffer(env, __boltffi_result);
+        return 0;
+    }
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return 0;
+    }
+
+    return (jint)__boltffi_return;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_com_boltffi_demo_Native_boltffi_1async_1function_1demo_1save_1checked_1panic_1message(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_async_function_demo_save_checked_panic_message((RustFutureHandle)handle);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT void JNICALL Java_com_boltffi_demo_Native_boltffi_1async_1function_1demo_1save_1checked_1cancel(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+
+    (void)env;
+    boltffi_async_function_demo_save_checked_cancel((RustFutureHandle)handle);
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_com_boltffi_demo_Native_boltffi_1async_1function_1demo_1save_1checked_1free(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+
+    (void)env;
+    boltffi_async_function_demo_save_checked_free((RustFutureHandle)handle);
 
     return;
 }

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_async_complete_return_shapes.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_async_complete_return_shapes.snap
@@ -28,6 +28,18 @@ private object Native {
     @JvmStatic external fun boltffi_async_function_demo_load_point_cancel(handle: Long): Unit
     @JvmStatic external fun boltffi_async_function_demo_load_point_free(handle: Long): Unit
     @JvmStatic external fun boltffi_async_function_demo_load_point_panic_message(handle: Long): ByteArray?
+    @JvmStatic external fun boltffi_function_demo_save(): Long
+    @JvmStatic external fun boltffi_async_function_demo_save_poll(handle: Long, callback_data: Long): Unit
+    @JvmStatic external fun boltffi_async_function_demo_save_complete(handle: Long): Unit
+    @JvmStatic external fun boltffi_async_function_demo_save_cancel(handle: Long): Unit
+    @JvmStatic external fun boltffi_async_function_demo_save_free(handle: Long): Unit
+    @JvmStatic external fun boltffi_async_function_demo_save_panic_message(handle: Long): ByteArray?
+    @JvmStatic external fun boltffi_function_demo_save_checked(value: Int): Long
+    @JvmStatic external fun boltffi_async_function_demo_save_checked_poll(handle: Long, callback_data: Long): Unit
+    @JvmStatic external fun boltffi_async_function_demo_save_checked_complete(handle: Long): Int
+    @JvmStatic external fun boltffi_async_function_demo_save_checked_cancel(handle: Long): Unit
+    @JvmStatic external fun boltffi_async_function_demo_save_checked_free(handle: Long): Unit
+    @JvmStatic external fun boltffi_async_function_demo_save_checked_panic_message(handle: Long): ByteArray?
 
     @JvmStatic fun boltffiFutureContinuationCallback(handle: Long, pollResult: Byte) {
         BoltFfiAsync.resume(handle, pollResult)
@@ -80,6 +92,19 @@ data class Point(
     }
 }
 
+
+sealed class SaveError(val value: Int) : Exception() {
+    object Failed : SaveError(0)
+
+    companion object {
+        fun fromValue(value: Int): SaveError =
+            when (value) {
+                0 -> Failed
+                else -> throw IllegalArgumentException("unknown SaveError value: $value")
+            }
+    }
+}
+
 suspend fun refresh() {
     boltffiCallAsync(
         createFuture = {
@@ -122,5 +147,33 @@ suspend fun loadPoint(): Point {
         },
         free = { future -> Native.boltffi_async_function_demo_load_point_free(future) },
         cancel = { future -> Native.boltffi_async_function_demo_load_point_cancel(future) },
+    )
+}
+
+suspend fun save() {
+    boltffiCallAsync(
+        createFuture = {
+            Native.boltffi_function_demo_save()
+        },
+        poll = { future, contHandle -> Native.boltffi_async_function_demo_save_poll(future, contHandle) },
+        complete = { future ->
+            try { Native.boltffi_async_function_demo_save_complete(future) } catch (__boltffi_error: BoltFfiErrorBufferException) { run { val __boltffi_error_reader = WireReader(__boltffi_error.bytes); throw SaveError.fromValue(__boltffi_error_reader.readI32()) } }
+        },
+        free = { future -> Native.boltffi_async_function_demo_save_free(future) },
+        cancel = { future -> Native.boltffi_async_function_demo_save_cancel(future) },
+    )
+}
+
+suspend fun saveChecked(value: Int): Int {
+    return boltffiCallAsync(
+        createFuture = {
+            Native.boltffi_function_demo_save_checked(value)
+        },
+        poll = { future, contHandle -> Native.boltffi_async_function_demo_save_checked_poll(future, contHandle) },
+        complete = { future ->
+            try { Native.boltffi_async_function_demo_save_checked_complete(future) } catch (__boltffi_error: BoltFfiErrorBufferException) { run { val __boltffi_error_reader = WireReader(__boltffi_error.bytes); throw SaveError.fromValue(__boltffi_error_reader.readI32()) } }
+        },
+        free = { future -> Native.boltffi_async_function_demo_save_checked_free(future) },
+        cancel = { future -> Native.boltffi_async_function_demo_save_checked_cancel(future) },
     )
 }

--- a/boltffi_backend/tests/snapshots/swift__swift_target_renders_async_complete_return_shapes.snap
+++ b/boltffi_backend/tests/snapshots/swift__swift_target_renders_async_complete_return_shapes.snap
@@ -55,6 +55,18 @@ public struct Point: Hashable, Equatable, Sendable {
     }
 }
 
+public enum SaveError: Int32, Hashable, Sendable, CaseIterable, Error {
+    case failed = 0
+
+    @usableFromInline init(fromC c: Int32) {
+        self = SaveError(rawValue: c)!
+    }
+
+    @usableFromInline var cValue: Int32 {
+        rawValue
+    }
+}
+
 public func refresh() async throws {
     let boltffiFuture = boltffi_function_demo_refresh()
     return try await boltffiAsyncCall(
@@ -103,5 +115,47 @@ public func loadPoint() async throws -> Point {
             throw FfiError(message: "FFI failed in async completion with code \(boltffiStatusCode)")
         }
         return Point(fromC: boltffiResult)
+    }
+}
+
+public func save() async throws {
+    let boltffiFuture = boltffi_function_demo_save()
+    return try await boltffiAsyncCall(
+        futureHandle: boltffiFuture,
+        poll: boltffi_async_function_demo_save_poll,
+        cancel: boltffi_async_function_demo_save_cancel,
+        free: boltffi_async_function_demo_save_free
+    ) { boltffiFuture, boltffiStatus in
+        let boltffiError = boltffi_async_function_demo_save_complete(boltffiFuture, boltffiStatus)
+        if boltffiError.ptr != nil || Int(boltffiError.len) != 0 {
+            defer { boltffi_free_buf(boltffiError) }
+            throw boltffiDecodeOwnedBuf(boltffiError.ptr, Int(boltffiError.len)) { boltffiErrorReader in SaveError(rawValue: boltffiErrorReader.readI32())! }
+        }
+        let boltffiStatusCode = boltffiStatus!.pointee.code
+        guard boltffiStatusCode == 0 else {
+            throw FfiError(message: "FFI failed in async completion with code \(boltffiStatusCode)")
+        }
+    }
+}
+
+public func saveChecked(value: Int32) async throws -> Int32 {
+    let boltffiFuture = boltffi_function_demo_save_checked(value)
+    return try await boltffiAsyncCall(
+        futureHandle: boltffiFuture,
+        poll: boltffi_async_function_demo_save_checked_poll,
+        cancel: boltffi_async_function_demo_save_checked_cancel,
+        free: boltffi_async_function_demo_save_checked_free
+    ) { boltffiFuture, boltffiStatus in
+        var boltffiResult: Int32 = Int32()
+        let boltffiError = boltffi_async_function_demo_save_checked_complete(boltffiFuture, boltffiStatus, &boltffiResult)
+        if boltffiError.ptr != nil || Int(boltffiError.len) != 0 {
+            defer { boltffi_free_buf(boltffiError) }
+            throw boltffiDecodeOwnedBuf(boltffiError.ptr, Int(boltffiError.len)) { boltffiErrorReader in SaveError(rawValue: boltffiErrorReader.readI32())! }
+        }
+        let boltffiStatusCode = boltffiStatus!.pointee.code
+        guard boltffiStatusCode == 0 else {
+            throw FfiError(message: "FFI failed in async completion with code \(boltffiStatusCode)")
+        }
+        return boltffiResult
     }
 }


### PR DESCRIPTION
## Summary
Async functions that return `Result<(), E>` generate JNI glue code declared `void` (since there's no success value to return). The template that generates the completion handler for these functions didn't account for this case, and generated a `return` statement with a value anyway — which doesn't compile. This fix makes that case return nothing, matching the function's actual signature.

## Changes
- Async `#[export]` methods returning `Result<(), E>` (`EncodedError`) emitted an invalid `return __boltffi_result;` in a JNI `void` function
- Scope the async-completion bare-return fallback to `checks_error_buffer && success_out.is_none()` so it applies only to `EncodedError`, not to other no-success-out returns (plain scalar/callback)
- Add `Result<(), E>` / `Result<T, E>` async cases to `async_complete_return_shapes` for JNI/Kotlin/Swift snapshot coverage

## Testing
- `cargo test -p boltffi_backend`
- `cargo fmt --all -- --check`
- `cargo clippy -p boltffi_backend --all-targets -- -D warnings`