### PR TITLE
fix(kotlin): close if-body when desktop_loader is 'none'

### DIFF
--- a/boltffi_backend/templates/target/kotlin/module.kt
+++ b/boltffi_backend/templates/target/kotlin/module.kt
@@ -31,6 +31,8 @@ private object Native {
         } else {
             System.loadLibrary(desktopFallbackLibrary)
         }
+{%- else %}
+        }
 {%- endif %}
     }
 {%- if native_libraries.bundled_desktop_loader() %}

--- a/boltffi_backend/tests/kotlin/exports.rs
+++ b/boltffi_backend/tests/kotlin/exports.rs
@@ -1,6 +1,8 @@
 use boltffi_backend::{
     Error,
-    target::kotlin::{KotlinApiStyle, KotlinCustomMapping, KotlinFactoryStyle, KotlinHost},
+    target::kotlin::{
+        KotlinApiStyle, KotlinCustomMapping, KotlinDesktopLoader, KotlinFactoryStyle, KotlinHost,
+    },
 };
 
 use super::{
@@ -16,6 +18,27 @@ fn kotlin_target_renders_primitive_function_stack() {
 #[test]
 fn kotlin_target_renders_shared_runtime_support() {
     insta::assert_snapshot!(rendered_fixture_with_runtime("exports/primitive_functions"));
+}
+
+#[test]
+fn kotlin_target_closes_native_loader_if_body_when_desktop_loader_is_none() {
+    let host = KotlinHost::new("com.boltffi.demo", "Demo")
+        .expect("Kotlin host")
+        .desktop_loader(KotlinDesktopLoader::None);
+
+    let files = files_with_host(&fixture("exports/primitive_functions"), host);
+    let (_, contents) = files
+        .iter()
+        .find(|(path, _)| path.ends_with(".kt"))
+        .expect("Kotlin target should render a Kotlin source file");
+
+    let open_braces = contents.matches('{').count();
+    let close_braces = contents.matches('}').count();
+    assert_eq!(
+        open_braces, close_braces,
+        "unbalanced braces ({open_braces} open, {close_braces} close) when desktop_loader is \
+         none:\n{contents}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The Kotlin `module.kt` template's native-library loader block only closed the `if (isAndroidRuntime)` body inside its `bundled_desktop_loader()` and `system_desktop_loader()` branches. When a host configures `desktop_loader = 'none'`, neither branch fires, so the closing brace is never emitted — leaving every declaration after it trapped inside an unclosed block and producing invalid Kotlin. This change adds the missing branch so the body is always closed regardless of which desktop loader is configured.

## Changes

- Add an `{%- else %}` branch to `module.kt` that emits the closing `}` for the `if` body when no desktop loader is configured.
- Add `kotlin_target_closes_native_loader_if_body_when_desktop_loader_is_none`, a brace-balance regression test rendering with `KotlinDesktopLoader::None`.

## Testing

- `cargo test -p boltffi_backend kotlin_target_closes_native_loader_if_body_when_desktop_loader_is_none`