### PR TITLE
fix(jni): emit the callback-parameter helper for callback-handle parameters

### DIFF
--- a/boltffi_backend/src/bridge/jni/contract/parameter/native.rs
+++ b/boltffi_backend/src/bridge/jni/contract/parameter/native.rs
@@ -122,6 +122,11 @@ impl NativeParameter {
         }
     }
 
+    /// Returns whether this parameter supplies a callback handle.
+    pub fn is_callback(&self) -> bool {
+        matches!(self.kind, NativeParameterKind::Callback(_))
+    }
+
     /// Returns whether this parameter supplies a C poll continuation.
     pub fn is_continuation(&self) -> bool {
         matches!(self.kind, NativeParameterKind::Continuation(_))

--- a/boltffi_backend/src/bridge/jni/template/method/view.rs
+++ b/boltffi_backend/src/bridge/jni/template/method/view.rs
@@ -46,6 +46,7 @@ pub struct NativeMethodView {
     pub checks_completion_status: bool,
     pub checks_error_buffer: bool,
     pub success_out: Option<SuccessOutReturn>,
+    pub uses_callback_parameters: bool,
     pub uses_continuations: bool,
     pub has_error_label: bool,
 }
@@ -96,6 +97,10 @@ impl NativeMethodView {
             checks_completion_status: method.checks_completion_status(),
             checks_error_buffer: method.checks_error_buffer(),
             success_out: method.success_out().cloned(),
+            uses_callback_parameters: method
+                .parameters()
+                .iter()
+                .any(|parameter| parameter.is_callback()),
             uses_continuations: method
                 .parameters()
                 .iter()

--- a/boltffi_backend/src/bridge/jni/template/source/features/method.rs
+++ b/boltffi_backend/src/bridge/jni/template/source/features/method.rs
@@ -19,6 +19,7 @@ pub struct MethodFeatures {
     pub uses_record_arrays: bool,
     pub uses_direct_buffers: bool,
     pub uses_exceptions: bool,
+    pub uses_callback_parameters: bool,
     pub returns_callback_handles: bool,
 }
 
@@ -46,6 +47,7 @@ impl MethodFeatures {
                     || !method.direct_buffers.is_empty()
                     || !method.record_buffers.is_empty()
             }),
+            uses_callback_parameters: methods.iter().any(|method| method.uses_callback_parameters),
             returns_callback_handles: methods.iter().any(|method| method.returns_callback),
         }
     }

--- a/boltffi_backend/src/bridge/jni/template/source/features/source.rs
+++ b/boltffi_backend/src/bridge/jni/template/source/features/source.rs
@@ -105,6 +105,7 @@ impl SourceFeatures {
                 || !success_out_writers.is_empty()
                 || streams.returns_direct_batches
                 || methods.uses_exceptions
+                || methods.uses_callback_parameters
                 || uses_direct_buffers,
             uses_continuations: methods.uses_continuations,
             uses_lifecycle: methods.uses_continuations
@@ -114,7 +115,8 @@ impl SourceFeatures {
                 || callbacks.has_handle_methods
                 || callbacks.returns_callback_handles
                 || closures.returns_callback_handles
-                || methods.returns_callback_handles,
+                || methods.returns_callback_handles
+                || methods.uses_callback_parameters,
             uses_closure_handles,
         }
     }

--- a/boltffi_backend/tests/fixtures/source/callback/constructor_callback_parameter.rs
+++ b/boltffi_backend/tests/fixtures/source/callback/constructor_callback_parameter.rs
@@ -1,0 +1,19 @@
+use std::sync::Arc;
+
+#[export]
+pub trait Notifier {
+    fn notify(&self, code: u32);
+}
+
+pub struct Engine;
+
+#[export]
+impl Engine {
+    pub fn new(notifier: Arc<dyn Notifier>) -> Self {
+        Self
+    }
+
+    pub fn ping(&self) -> u32 {
+        1
+    }
+}

--- a/boltffi_backend/tests/jni/callback.rs
+++ b/boltffi_backend/tests/jni/callback.rs
@@ -29,7 +29,21 @@ fn jni_bridge_indexes_callback_registrations_by_source_id() {
 
 #[test]
 fn jni_bridge_renders_callback_handle_parameters() {
-    insta::assert_snapshot!(rendered_fixture("callback/foreign_callback_parameter"));
+    let rendered = rendered_fixture("callback/foreign_callback_parameter");
+
+    assert!(rendered.contains("static BoltFFICallbackHandle boltffi_jni_callback_parameter"));
+
+    insta::assert_snapshot!(rendered);
+}
+
+#[test]
+fn jni_bridge_renders_constructor_callback_parameters() {
+    let rendered = rendered_fixture("callback/constructor_callback_parameter");
+
+    assert!(rendered.contains("boltffi_jni_callback_parameter((uint64_t)notifier"));
+    assert!(rendered.contains("static BoltFFICallbackHandle boltffi_jni_callback_parameter"));
+
+    insta::assert_snapshot!(rendered);
 }
 
 #[test]

--- a/boltffi_backend/tests/jni/snapshots/jni__callback__jni_bridge_caches_android_callback_threads_with_local_frames.snap
+++ b/boltffi_backend/tests/jni/snapshots/jni__callback__jni_bridge_caches_android_callback_threads_with_local_frames.snap
@@ -18,6 +18,91 @@ FfiStatus boltffi_function_demo_install(BoltFFICallbackHandle listener);
 <jni thread runtime>
 <jni exception helpers>
 <jni status helper>
+typedef struct {
+    void (*free)(uint64_t handle);
+    uint64_t (*clone)(uint64_t handle);
+} BoltFFICallbackVTablePrefix;
+
+static const BoltFFICallbackVTablePrefix *boltffi_jni_callback_vtable_prefix(const BoltFFICallbackHandle *callback) {
+    return callback == NULL ? NULL : (const BoltFFICallbackVTablePrefix *)callback->vtable;
+}
+
+static void boltffi_jni_release_callback_value(BoltFFICallbackHandle callback) {
+    const BoltFFICallbackVTablePrefix *vtable = boltffi_jni_callback_vtable_prefix(&callback);
+    if (callback.handle != 0 && vtable != NULL && vtable->free != NULL) {
+        vtable->free(callback.handle);
+    }
+}
+
+static jlong boltffi_jni_callback_handle_new_owned(JNIEnv *env, BoltFFICallbackHandle callback) {
+    if (callback.handle == 0 || callback.vtable == NULL) {
+        return 0;
+    }
+    BoltFFICallbackHandle *stored_callback = (BoltFFICallbackHandle *)malloc(sizeof(BoltFFICallbackHandle));
+    if (stored_callback == NULL) {
+        boltffi_jni_release_callback_value(callback);
+        boltffi_jni_throw_runtime(env, "failed to allocate BoltFFI callback handle");
+        return 0;
+    }
+    *stored_callback = callback;
+    return (jlong)(uintptr_t)stored_callback;
+}
+
+static BoltFFICallbackHandle *boltffi_jni_callback_handle_ref(jlong handle) {
+    return handle == 0 ? NULL : (BoltFFICallbackHandle *)(uintptr_t)handle;
+}
+
+typedef BoltFFICallbackHandle (*BoltFFICallbackCreate)(uint64_t handle);
+
+static BoltFFICallbackHandle boltffi_jni_callback_parameter(uint64_t handle, BoltFFICallbackCreate create) {
+    if ((handle & 1u) != 0u) {
+        return create(handle);
+    }
+    const BoltFFICallbackHandle *stored_callback = boltffi_jni_callback_handle_ref((jlong)handle);
+    const BoltFFICallbackVTablePrefix *vtable = boltffi_jni_callback_vtable_prefix(stored_callback);
+    if (stored_callback == NULL || stored_callback->handle == 0 || vtable == NULL || vtable->clone == NULL) {
+        return (BoltFFICallbackHandle){0};
+    }
+    return (BoltFFICallbackHandle){
+        .handle = vtable->clone(stored_callback->handle),
+        .vtable = stored_callback->vtable,
+    };
+}
+
+static void boltffi_jni_callback_handle_release(BoltFFICallbackHandle *callback) {
+    if (callback == NULL) {
+        return;
+    }
+    boltffi_jni_release_callback_value(*callback);
+    free(callback);
+}
+
+static jlong boltffi_jni_callback_handle_clone(JNIEnv *env, const BoltFFICallbackHandle *callback) {
+    const BoltFFICallbackVTablePrefix *vtable = boltffi_jni_callback_vtable_prefix(callback);
+    if (callback == NULL || callback->handle == 0 || vtable == NULL || vtable->clone == NULL) {
+        return 0;
+    }
+    BoltFFICallbackHandle cloned_callback = {
+        .handle = vtable->clone(callback->handle),
+        .vtable = callback->vtable,
+    };
+    if (cloned_callback.handle == 0) {
+        return 0;
+    }
+    return boltffi_jni_callback_handle_new_owned(env, cloned_callback);
+}
+
+JNIEXPORT jlong JNICALL Java_com_boltffi_demo_Native_boltffi_1callback_1handle_1clone(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+    return boltffi_jni_callback_handle_clone(env, boltffi_jni_callback_handle_ref(handle));
+}
+
+JNIEXPORT void JNICALL Java_com_boltffi_demo_Native_boltffi_1callback_1handle_1release(JNIEnv *env, jclass cls, jlong handle) {
+    (void)env;
+    (void)cls;
+    boltffi_jni_callback_handle_release(boltffi_jni_callback_handle_ref(handle));
+}
+
 static jclass g____ListenerVTable_class = NULL;
 static jmethodID g____ListenerVTable_free_method = NULL;
 static jmethodID g____ListenerVTable_clone_method = NULL;

--- a/boltffi_backend/tests/jni/snapshots/jni__callback__jni_bridge_renders_constructor_callback_parameters.snap
+++ b/boltffi_backend/tests/jni/snapshots/jni__callback__jni_bridge_renders_constructor_callback_parameters.snap
@@ -7,17 +7,18 @@ expression: rendered
 typedef struct {
     void (*free)(uint64_t);
     uint64_t (*clone)(uint64_t);
-    uint32_t (*on_value)(uint64_t, uint32_t);
-} ___ListenerVTable;
-void boltffi_register_callback_demo_listener(const ___ListenerVTable *vtable);
-BoltFFICallbackHandle boltffi_create_callback_demo_listener(uint64_t handle);
-FfiStatus boltffi_function_demo_install(BoltFFICallbackHandle listener);
+    void (*notify)(uint64_t, uint32_t);
+} ___NotifierVTable;
+void boltffi_register_callback_demo_notifier(const ___NotifierVTable *vtable);
+BoltFFICallbackHandle boltffi_create_callback_demo_notifier(uint64_t handle);
+void boltffi_release_class_demo_engine(uint64_t handle);
+uint64_t boltffi_init_class_demo_engine_new(BoltFFICallbackHandle notifier);
+uint32_t boltffi_method_class_demo_engine_ping(uint64_t receiver);
 
 ===== jni/jni_glue.c =====
 <jni source includes>
 <jni thread runtime>
 <jni exception helpers>
-<jni status helper>
 typedef struct {
     void (*free)(uint64_t handle);
     uint64_t (*clone)(uint64_t handle);
@@ -103,29 +104,29 @@ JNIEXPORT void JNICALL Java_com_boltffi_demo_Native_boltffi_1callback_1handle_1r
     boltffi_jni_callback_handle_release(boltffi_jni_callback_handle_ref(handle));
 }
 
-static jclass g____ListenerVTable_class = NULL;
-static jmethodID g____ListenerVTable_free_method = NULL;
-static jmethodID g____ListenerVTable_clone_method = NULL;
-static jmethodID g____ListenerVTable_on_value_method = NULL;
+static jclass g____NotifierVTable_class = NULL;
+static jmethodID g____NotifierVTable_free_method = NULL;
+static jmethodID g____NotifierVTable_clone_method = NULL;
+static jmethodID g____NotifierVTable_notify_method = NULL;
 
-static void ___ListenerVTable_free(uint64_t handle) {
+static void ___NotifierVTable_free(uint64_t handle) {
     JNIEnv *env = NULL;
     int attached = 0;
     if (!boltffi_jni_enter(&env, &attached)) {
         return;
     }
-    (*env)->CallStaticVoidMethod(env, g____ListenerVTable_class, g____ListenerVTable_free_method, (jlong)handle);
+    (*env)->CallStaticVoidMethod(env, g____NotifierVTable_class, g____NotifierVTable_free_method, (jlong)handle);
     boltffi_jni_clear_exception(env);
     boltffi_jni_exit(env, attached);
 }
 
-static uint64_t ___ListenerVTable_clone(uint64_t handle) {
+static uint64_t ___NotifierVTable_clone(uint64_t handle) {
     JNIEnv *env = NULL;
     int attached = 0;
     if (!boltffi_jni_enter(&env, &attached)) {
         return 0;
     }
-    jlong result = (*env)->CallStaticLongMethod(env, g____ListenerVTable_class, g____ListenerVTable_clone_method, (jlong)handle);
+    jlong result = (*env)->CallStaticLongMethod(env, g____NotifierVTable_class, g____NotifierVTable_clone_method, (jlong)handle);
     if (boltffi_jni_clear_exception(env)) {
         boltffi_jni_exit(env, attached);
         return 0;
@@ -134,64 +135,64 @@ static uint64_t ___ListenerVTable_clone(uint64_t handle) {
     return (uint64_t)result;
 }
 
-static uint32_t ___ListenerVTable_on_value(uint64_t handle, uint32_t value) {
+static void ___NotifierVTable_notify(uint64_t handle, uint32_t code) {
     JNIEnv *env = NULL;
     int attached = 0;
 
     if (!boltffi_jni_enter(&env, &attached)) {
-        return 0;
+        return;
     }
 
-    uint32_t result = (uint32_t)(*env)->CallStaticIntMethod(env, g____ListenerVTable_class, g____ListenerVTable_on_value_method, (jlong)handle, (jint)value);
+    (*env)->CallStaticVoidMethod(env, g____NotifierVTable_class, g____NotifierVTable_notify_method, (jlong)handle, (jint)code);
     if (boltffi_jni_clear_exception(env)) {
         goto __boltffi_fail;
     }
 
     boltffi_jni_exit(env, attached);
-    return result;
+    return;
 __boltffi_fail:
 
     boltffi_jni_clear_exception(env);
     boltffi_jni_exit(env, attached);
 
-    return 0;
+    return;
 }
 
-static ___ListenerVTable g____ListenerVTable_vtable = {
-    .free = ___ListenerVTable_free,
-    .clone = ___ListenerVTable_clone,
-    .on_value = ___ListenerVTable_on_value,
+static ___NotifierVTable g____NotifierVTable_vtable = {
+    .free = ___NotifierVTable_free,
+    .clone = ___NotifierVTable_clone,
+    .notify = ___NotifierVTable_notify,
 };
 
-static bool boltffi_jni_load____ListenerVTable_callbacks(JNIEnv *env) {
-    if (!boltffi_jni_lookup_global_class_with_diagnostic(env, "com/boltffi/demo/ListenerCallbacks", "com/boltffi/demo/ListenerCallbacks", &g____ListenerVTable_class)) {
+static bool boltffi_jni_load____NotifierVTable_callbacks(JNIEnv *env) {
+    if (!boltffi_jni_lookup_global_class_with_diagnostic(env, "com/boltffi/demo/NotifierCallbacks", "com/boltffi/demo/NotifierCallbacks", &g____NotifierVTable_class)) {
         return false;
     }
-    if (!boltffi_jni_lookup_static_method_with_diagnostic(env, g____ListenerVTable_class, "com/boltffi/demo/ListenerCallbacks", "free", "free", "(J)V", "(J)V", &g____ListenerVTable_free_method)) {
+    if (!boltffi_jni_lookup_static_method_with_diagnostic(env, g____NotifierVTable_class, "com/boltffi/demo/NotifierCallbacks", "free", "free", "(J)V", "(J)V", &g____NotifierVTable_free_method)) {
         goto fail;
     }
-    if (!boltffi_jni_lookup_static_method_with_diagnostic(env, g____ListenerVTable_class, "com/boltffi/demo/ListenerCallbacks", "clone", "clone", "(J)J", "(J)J", &g____ListenerVTable_clone_method)) {
+    if (!boltffi_jni_lookup_static_method_with_diagnostic(env, g____NotifierVTable_class, "com/boltffi/demo/NotifierCallbacks", "clone", "clone", "(J)J", "(J)J", &g____NotifierVTable_clone_method)) {
         goto fail;
     }
-    if (!boltffi_jni_lookup_static_method_with_diagnostic(env, g____ListenerVTable_class, "com/boltffi/demo/ListenerCallbacks", "on_value", "on_value", "(JI)I", "(JI)I", &g____ListenerVTable_on_value_method)) {
+    if (!boltffi_jni_lookup_static_method_with_diagnostic(env, g____NotifierVTable_class, "com/boltffi/demo/NotifierCallbacks", "notify", "notify", "(JI)V", "(JI)V", &g____NotifierVTable_notify_method)) {
         goto fail;
     }
-    boltffi_register_callback_demo_listener(&g____ListenerVTable_vtable);
+    boltffi_register_callback_demo_notifier(&g____NotifierVTable_vtable);
     return true;
 fail:
-    (*env)->DeleteGlobalRef(env, g____ListenerVTable_class);
-    g____ListenerVTable_class = NULL;
+    (*env)->DeleteGlobalRef(env, g____NotifierVTable_class);
+    g____NotifierVTable_class = NULL;
     return false;
 }
 
-static void boltffi_jni_unload____ListenerVTable_callbacks(JNIEnv *env) {
-    if (g____ListenerVTable_class != NULL) {
-        (*env)->DeleteGlobalRef(env, g____ListenerVTable_class);
+static void boltffi_jni_unload____NotifierVTable_callbacks(JNIEnv *env) {
+    if (g____NotifierVTable_class != NULL) {
+        (*env)->DeleteGlobalRef(env, g____NotifierVTable_class);
     }
-    g____ListenerVTable_class = NULL;
-    g____ListenerVTable_free_method = NULL;
-    g____ListenerVTable_clone_method = NULL;
-    g____ListenerVTable_on_value_method = NULL;
+    g____NotifierVTable_class = NULL;
+    g____NotifierVTable_free_method = NULL;
+    g____NotifierVTable_clone_method = NULL;
+    g____NotifierVTable_notify_method = NULL;
 }
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
@@ -205,8 +206,8 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
     if (!boltffi_jni_lookup_global_class_with_diagnostic(env, "com/boltffi/demo/Native", "com/boltffi/demo/Native", &boltffi_jni_native_class)) {
         return JNI_ERR;
     }
-    if (!boltffi_jni_load____ListenerVTable_callbacks(env)) {
-        boltffi_jni_unload____ListenerVTable_callbacks(env);
+    if (!boltffi_jni_load____NotifierVTable_callbacks(env)) {
+        boltffi_jni_unload____NotifierVTable_callbacks(env);
         (*env)->DeleteGlobalRef(env, boltffi_jni_native_class);
         boltffi_jni_native_class = NULL;
         return JNI_ERR;
@@ -219,7 +220,7 @@ JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *vm, void *reserved) {
     (void)reserved;
     JNIEnv *env = NULL;
     if ((*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_6) == JNI_OK) {
-        boltffi_jni_unload____ListenerVTable_callbacks(env);
+        boltffi_jni_unload____NotifierVTable_callbacks(env);
         if (boltffi_jni_native_class != NULL) {
             (*env)->DeleteGlobalRef(env, boltffi_jni_native_class);
         }
@@ -228,15 +229,29 @@ JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *vm, void *reserved) {
     boltffi_jni_native_class = NULL;
 }
 
-JNIEXPORT void JNICALL Java_com_boltffi_demo_Native_boltffi_1function_1demo_1install(JNIEnv *env, jclass cls, jlong listener) {
+JNIEXPORT void JNICALL Java_com_boltffi_demo_Native_boltffi_1release_1class_1demo_1engine(JNIEnv *env, jclass cls, jlong handle) {
     (void)cls;
 
-    FfiStatus __boltffi_status = boltffi_function_demo_install(boltffi_jni_callback_parameter((uint64_t)listener, boltffi_create_callback_demo_listener));
-
-    if (__boltffi_status.code != 0) {
-        boltffi_jni_throw_status(env, __boltffi_status);
-        return;
-    }
+    (void)env;
+    boltffi_release_class_demo_engine(handle);
 
     return;
+}
+
+JNIEXPORT jlong JNICALL Java_com_boltffi_demo_Native_boltffi_1init_1class_1demo_1engine_1new(JNIEnv *env, jclass cls, jlong notifier) {
+    (void)cls;
+
+    (void)env;
+    uint64_t __boltffi_result = boltffi_init_class_demo_engine_new(boltffi_jni_callback_parameter((uint64_t)notifier, boltffi_create_callback_demo_notifier));
+
+    return (jlong)__boltffi_result;
+}
+
+JNIEXPORT jint JNICALL Java_com_boltffi_demo_Native_boltffi_1method_1class_1demo_1engine_1ping(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    uint32_t __boltffi_result = boltffi_method_class_demo_engine_ping(receiver);
+
+    return (jint)__boltffi_result;
 }


### PR DESCRIPTION
## Summary

Since `50ee1836`, every JNI callback-handle parameter resolves through `boltffi_jni_callback_parameter(...)`, but the support-fragment gate still only accounts for callback-handle returns and callback registrations. When a callback trait is only consumed as a parameter, the generated glue calls the helper without ever defining it:

```rust
#[boltffi::export]
pub trait Notifier {
    fn notify(&self, code: u32);
}

#[boltffi::export]
impl Engine {
    pub fn new(notifier: Arc<dyn Notifier>) -> Self { … }
}
```

```
jni_glue.c: error: call to undeclared function 'boltffi_jni_callback_parameter';
            ISO C99 and later do not support implicit function declarations
```

`boltffi pack android` then fails at the glue compile step. The existing `foreign_callback_parameter` snapshot already contained the undefined call.

## Changes

- track callback-handle parameters on `NativeMethodView` and `MethodFeatures`
- include the `bridge/jni/callback.c` fragment (and the exception helpers it references) whenever a native method takes a callback-handle parameter
- add a constructor-only callback-parameter fixture and assert the helper definition is present in both parameter snapshots
