### PR TITLE
fix(csharp): qualify stream emission with the owning class

### DIFF
--- a/boltffi_backend/src/target/csharp/mod.rs
+++ b/boltffi_backend/src/target/csharp/mod.rs
@@ -852,16 +852,16 @@ mod tests {
 
         let source = file(&output, "Demo.cs");
         assert!(source.contains("IAsyncEnumerable<int> Values(this Engine self"));
-        assert!(source.contains("MessagesSubscription Messages(this Engine self)"));
-        assert!(source.contains("TicksCancellable Ticks(this Engine self"));
+        assert!(source.contains("EngineMessagesSubscription Messages(this Engine self)"));
+        assert!(source.contains("EngineTicksCancellable Ticks(this Engine self"));
         assert!(source.contains("EnumeratorCancellation"));
-        assert!(source.contains("NativeValuesPopBatch"));
+        assert!(source.contains("NativeEngineValuesPopBatch"));
         assert!(source.contains("NativeMethods.FreeBuf(buffer);"));
         assert!(source.contains(
             "await foreach (var item in ReadAll(subscription, cancellation.Token)) callback(item);"
         ));
         let callback_subscribe = source
-            .find("ulong subscription = NativeMethods.NativeTicksSubscribe(receiver);")
+            .find("ulong subscription = NativeMethods.NativeEngineTicksSubscribe(receiver);")
             .expect("callback stream should subscribe synchronously");
         let callback_task = source[callback_subscribe..]
             .find("global::System.Threading.Tasks.Task.Run(async () =>")
@@ -870,6 +870,45 @@ mod tests {
         assert!(callback_subscribe < callback_task);
         assert!(
             !source.contains("ReadAll(subscription, cancellation.Token).ConfigureAwait(false)")
+        );
+        assert!(output.diagnostics().is_empty());
+    }
+
+    #[test]
+    fn csharp_target_renders_same_named_streams_per_class() {
+        let bindings = bindings(
+            r#"
+            use boltffi::EventSubscription;
+            use std::sync::Arc;
+
+            pub struct Store;
+            pub struct Draft;
+
+            #[export]
+            impl Store {
+                #[ffi_stream(item = i32)]
+                pub fn snapshots(&self) -> Arc<EventSubscription<i32>> { loop {} }
+            }
+
+            #[export]
+            impl Draft {
+                #[ffi_stream(item = String)]
+                pub fn snapshots(&self) -> Arc<EventSubscription<String>> { loop {} }
+            }
+            "#,
+        );
+        let output = target(CSharpHost::new())
+            .render(&bindings)
+            .expect("streams should render");
+
+        let source = file(&output, "Demo.cs");
+        assert!(source.contains("EntryPoint = \"boltffi_stream_demo_store_snapshots_subscribe\""));
+        assert!(source.contains("EntryPoint = \"boltffi_stream_demo_draft_snapshots_subscribe\""));
+        assert!(source.contains("IAsyncEnumerable<int> Snapshots(this Store self"));
+        assert!(source.contains("IAsyncEnumerable<string> Snapshots(this Draft self"));
+        assert!(
+            source.contains("=> StoreSnapshotsStreamRuntime.ReadAll(self.Handle")
+                && source.contains("=> DraftSnapshotsStreamRuntime.ReadAll(self.Handle")
         );
         assert!(output.diagnostics().is_empty());
     }

--- a/boltffi_backend/src/target/csharp/render/stream.rs
+++ b/boltffi_backend/src/target/csharp/render/stream.rs
@@ -20,6 +20,7 @@ use askama::Template;
 pub(in crate::target::csharp) struct Stream {
     documentation: Documentation,
     name: Identifier,
+    qualified: Identifier,
     owner: Option<TypeFragment>,
     item: StreamItem,
     mode: StreamMode,
@@ -59,22 +60,29 @@ impl Stream {
                     invariant: "stream protocol is missing from the C bridge",
                 })?;
         let name = Name::new(declaration.name()).pascal()?;
+        let owner = declaration
+            .owner()
+            .map(|owner| type_name::class(owner, context))
+            .transpose()?;
+        let qualified = match &owner {
+            Some(owner) => Identifier::parse(format!("{owner}{name}"))?,
+            None => name.clone(),
+        };
         let mut item = declaration
             .item()
             .render_with(&mut StreamItemRenderer { context })?;
-        item.read_batch = item
-            .read_batch
-            .replace("NativeStreamPopBatch", &format!("Native{name}PopBatch"));
+        item.read_batch = item.read_batch.replace(
+            "NativeStreamPopBatch",
+            &format!("Native{qualified}PopBatch"),
+        );
         Ok(Self {
             documentation: Documentation::summary(declaration.meta().doc(), "        "),
-            runtime: Identifier::parse(format!("{name}StreamRuntime"))?,
-            subscription: Identifier::parse(format!("{name}Subscription"))?,
-            cancellable: Identifier::parse(format!("{name}Cancellable"))?,
+            runtime: Identifier::parse(format!("{qualified}StreamRuntime"))?,
+            subscription: Identifier::parse(format!("{qualified}Subscription"))?,
+            cancellable: Identifier::parse(format!("{qualified}Cancellable"))?,
             name,
-            owner: declaration
-                .owner()
-                .map(|owner| type_name::class(owner, context))
-                .transpose()?,
+            qualified,
+            owner,
             item,
             mode: declaration.mode(),
             subscribe: protocol.subscribe().name().to_owned(),
@@ -93,7 +101,7 @@ impl Stream {
             .with_aux(AuxChunk::Helper {
                 id: HelperId::new(CanonicalName::single(format!(
                     "csharp_stream_{}",
-                    self.name
+                    self.qualified
                 ))),
                 text: self.native_source().into(),
             });
@@ -255,19 +263,19 @@ impl Stream {
     }
 
     fn subscribe_method(&self) -> String {
-        format!("Native{}Subscribe", self.name)
+        format!("Native{}Subscribe", self.qualified)
     }
     fn pop_method(&self) -> String {
-        format!("Native{}PopBatch", self.name)
+        format!("Native{}PopBatch", self.qualified)
     }
     fn wait_method(&self) -> String {
-        format!("Native{}Wait", self.name)
+        format!("Native{}Wait", self.qualified)
     }
     fn unsubscribe_method(&self) -> String {
-        format!("Native{}Unsubscribe", self.name)
+        format!("Native{}Unsubscribe", self.qualified)
     }
     fn free_method(&self) -> String {
-        format!("Native{}Free", self.name)
+        format!("Native{}Free", self.qualified)
     }
 
     fn pop_native_source(&self) -> String {

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -3047,7 +3047,7 @@ public static class DemoTest
         Console.WriteLine("Testing streams (batch mode)...");
         using (var bus = new EventBus())
         {
-            using SubscribeValuesBatchSubscription subscription = bus.SubscribeValuesBatch();
+            using EventBusSubscribeValuesBatchSubscription subscription = bus.SubscribeValuesBatch();
 
             bus.EmitValue(100);
             bus.EmitValue(200);
@@ -3067,7 +3067,7 @@ public static class DemoTest
             List<int> received = new List<int>();
             var receivedAll = new global::System.Threading.Tasks.TaskCompletionSource<bool>(
                 global::System.Threading.Tasks.TaskCreationOptions.RunContinuationsAsynchronously);
-            using SubscribeValuesCallbackCancellable subscription = bus.SubscribeValuesCallback(value =>
+            using EventBusSubscribeValuesCallbackCancellable subscription = bus.SubscribeValuesCallback(value =>
             {
                 lock (received)
                 {
@@ -3212,7 +3212,7 @@ public static class DemoTest
     }
 
     private static List<int> CollectBatchStreamItems(
-        SubscribeValuesBatchSubscription stream,
+        EventBusSubscribeValuesBatchSubscription stream,
         int expectedCount,
         string label)
     {


### PR DESCRIPTION
## Summary

The C# backend keys stream emission by the unqualified method name, so two classes with same-named `#[ffi_stream]` methods collapse into one binding family:

```rust
#[boltffi::export]
impl Store { #[ffi_stream(item = i32)] fn snapshots(&self) -> … }

#[boltffi::export]
impl Draft { #[ffi_stream(item = i32)] fn snapshots(&self) -> … }
```

Both streams render a `csharp_stream_Snapshots` helper and an identical `SnapshotsStreamRuntime`; the module assembler dedups by helper id and text, so the draft's `DllImport` block is dropped and both public `Snapshots()` methods route into the store's stream:

```csharp
public static IAsyncEnumerable<int> Snapshots(this Store self, …)
    => SnapshotsStreamRuntime.ReadAll(self.Handle, …);
public static IAsyncEnumerable<int> Snapshots(this Draft self, …)
    => SnapshotsStreamRuntime.ReadAll(self.Handle, …);   // store's subscribe entry point
```

The result compiles, and a subscriber on the second class silently never receives anything. Regression from #654; the pre-IR backend emitted both. Prefixing the derived identifiers with the owning class (`StoreSnapshotsStreamRuntime`, `NativeDraftSnapshotsSubscribe`, `csharp_stream_DraftSnapshots`) keeps the emissions distinct end to end; free-function streams keep the bare name.

## Changes

- Derive stream runtime/subscription/cancellable identifiers, `Native*` method names, and the helper id from `{Owner}{Method}` instead of the method name alone in `boltffi_backend/src/target/csharp/render/stream.rs`.
- Add a test rendering same-named streams on two classes (with distinct item types) and owner-qualify the existing stream assertions.
- Rename the two stream helper types in the C# platform demo to the owner-qualified names.

