### PR TITLE
fix: accept a precompiled WebAssembly.Module source in instantiateBoltFFI

### DIFF
--- a/boltffi_backend/src/target/typescript/mod.rs
+++ b/boltffi_backend/src/target/typescript/mod.rs
@@ -647,6 +647,24 @@ mod tests {
     }
 
     #[test]
+    fn browser_init_accepts_a_precompiled_wasm_module_source() {
+        let output = TypeScriptHost::new("demo")
+            .expect("host constructs")
+            .into_target()
+            .render(&bindings())
+            .expect("target renders");
+
+        let browser = output
+            .files()
+            .iter()
+            .find(|file| file.path().as_path().ends_with("demo.ts"))
+            .expect("browser module");
+        assert!(browser.contents().contains(
+            "export default async function init(source: BufferSource | Response | WebAssembly.Module): Promise<void>"
+        ));
+    }
+
+    #[test]
     fn renders_primitive_functions_through_the_wasm_surface() {
         let output = TypeScriptHost::new("demo")
             .expect("host constructs")

--- a/boltffi_backend/templates/target/typescript/browser.ts
+++ b/boltffi_backend/templates/target/typescript/browser.ts
@@ -10,7 +10,7 @@ const _callbackImports: Record<string, WebAssembly.ImportValue> = {};
 {% endfor %}
 {{ closure_adapters }}
 
-export default async function init(source: BufferSource | Response): Promise<void> {
+export default async function init(source: BufferSource | Response | WebAssembly.Module): Promise<void> {
   _module = await instantiateBoltFFI(source, WASM_ABI_VERSION, { env: _callbackImports });
   _exports = _module.exports;
 {{ constant_initializers }}

--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -1437,18 +1437,10 @@ function createImportModuleProxy(moduleName: string): Record<string, WebAssembly
 }
 
 export async function instantiateBoltFFI(
-  source: BufferSource | Response,
+  source: BufferSource | Response | WebAssembly.Module,
   expectedVersion: number,
   imports?: BoltFFIImports
 ): Promise<BoltFFIModule> {
-  let wasmSource: BufferSource;
-
-  if (source instanceof Response) {
-    wasmSource = await source.arrayBuffer();
-  } else {
-    wasmSource = source;
-  }
-
   const asyncManager = new AsyncFutureManager();
   const streamManager = new StreamPollManager();
 
@@ -1462,7 +1454,13 @@ export async function instantiateBoltFFI(
     __wbindgen_externref_xform__: createImportModuleProxy("__wbindgen_externref_xform__"),
   };
 
-  const { instance } = await WebAssembly.instantiate(wasmSource, importObject);
+  let instance: WebAssembly.Instance;
+  if (source instanceof WebAssembly.Module) {
+    instance = await WebAssembly.instantiate(source, importObject);
+  } else {
+    const wasmSource = source instanceof Response ? await source.arrayBuffer() : source;
+    ({ instance } = await WebAssembly.instantiate(wasmSource, importObject));
+  }
   const module = new BoltFFIModule(instance, asyncManager, streamManager);
 
   const actualVersion = module.exports.boltffi_wasm_abi_version();

--- a/runtime/typescript/test/runtime.test.ts
+++ b/runtime/typescript/test/runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { AsyncFutureManager, BoltFFIModule } from "../src/module.js";
+import { AsyncFutureManager, BoltFFIModule, instantiateBoltFFI } from "../src/module.js";
 import { CallbackRegistry } from "../src/callback.js";
 import { StreamPollManager, StreamPollResult, StreamSession } from "../src/stream.js";
 import {
@@ -687,5 +687,41 @@ describe("CallbackRegistry", () => {
     expect(registry.get(handle)).toBe(callback);
     registry.release(handle);
     expect(() => registry.get(handle)).toThrow("Transform callback handle");
+  });
+});
+
+// Minimal module: 1-page memory, boltffi_wasm_abi_version() -> 7, boltffi_wasm_return_slot_addr() -> 0.
+const MINIMAL_BOLTFFI_WASM = new Uint8Array([
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, 0x03,
+  0x03, 0x02, 0x00, 0x00, 0x05, 0x03, 0x01, 0x00, 0x01, 0x07, 0x45, 0x03, 0x06, 0x6d, 0x65, 0x6d,
+  0x6f, 0x72, 0x79, 0x02, 0x00, 0x18, 0x62, 0x6f, 0x6c, 0x74, 0x66, 0x66, 0x69, 0x5f, 0x77, 0x61,
+  0x73, 0x6d, 0x5f, 0x61, 0x62, 0x69, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x00, 0x00,
+  0x1d, 0x62, 0x6f, 0x6c, 0x74, 0x66, 0x66, 0x69, 0x5f, 0x77, 0x61, 0x73, 0x6d, 0x5f, 0x72, 0x65,
+  0x74, 0x75, 0x72, 0x6e, 0x5f, 0x73, 0x6c, 0x6f, 0x74, 0x5f, 0x61, 0x64, 0x64, 0x72, 0x00, 0x01,
+  0x0a, 0x0b, 0x02, 0x04, 0x00, 0x41, 0x07, 0x0b, 0x04, 0x00, 0x41, 0x00, 0x0b,
+]);
+
+describe("instantiateBoltFFI", () => {
+  it("accepts an ArrayBuffer source", async () => {
+    const mod = await instantiateBoltFFI(MINIMAL_BOLTFFI_WASM.buffer, 7);
+    expect(mod.exports.boltffi_wasm_abi_version()).toBe(7);
+  });
+
+  it("accepts a Response source", async () => {
+    const response = new Response(MINIMAL_BOLTFFI_WASM);
+    const mod = await instantiateBoltFFI(response, 7);
+    expect(mod.exports.boltffi_wasm_abi_version()).toBe(7);
+  });
+
+  it("accepts an already-compiled WebAssembly.Module source", async () => {
+    const precompiled = await WebAssembly.compile(MINIMAL_BOLTFFI_WASM);
+    const mod = await instantiateBoltFFI(precompiled, 7);
+    expect(mod.exports.boltffi_wasm_abi_version()).toBe(7);
+  });
+
+  it("throws a clear ABI mismatch error rather than silently continuing", async () => {
+    await expect(instantiateBoltFFI(MINIMAL_BOLTFFI_WASM.buffer, 99)).rejects.toThrow(
+      "BoltFFI ABI version mismatch: expected 99, got 7"
+    );
   });
 });


### PR DESCRIPTION
On Cloudflare Workers the only way to get a bundled `.wasm` asset is the ES-module import, which hands you an already-compiled `WebAssembly.Module` - there's no filesystem to read raw bytes from. Feeding that to the runtime crashes:

```ts
import wasmModule from "./my_crate_bg.wasm"; // WebAssembly.Module, not bytes

const mod = await instantiateBoltFFI(wasmModule, EXPECTED_ABI_VERSION);
// TypeError: Cannot read properties of undefined (reading 'exports')
```

`WebAssembly.instantiate` resolves an `Instance` directly for a `Module` (only the BufferSource/Response overload resolves `{ module, instance }`), so the `{ instance }` destructure comes back undefined.

This widens the source type to include `WebAssembly.Module` and branches on it. Added tests for the three source shapes plus the ABI-mismatch path.
