### PR TITLE
fix(kotlin): qualify kotlin.Int/kotlin.Double when a data-enum variant shadows them

### DIFF
--- a/boltffi_backend/src/target/kotlin/render/enumeration.rs
+++ b/boltffi_backend/src/target/kotlin/render/enumeration.rs
@@ -56,15 +56,56 @@ const KOTLIN_SHADOWABLE_PRIMITIVES: &[&str] = &[
     "Double",
 ];
 
-fn qualify_if_shadowed(ty: TypeName, variant_names: &[String]) -> TypeName {
-    let name = ty.to_string();
-    if KOTLIN_SHADOWABLE_PRIMITIVES.contains(&name.as_str())
-        && variant_names.iter().any(|variant| variant == &name)
-    {
-        TypeName::new(format!("kotlin.{name}"))
-    } else {
-        ty
+fn shadowed_primitive_names(enum_name: &TypeName, variant_names: &[String]) -> Vec<String> {
+    let enum_name = enum_name.to_string();
+    KOTLIN_SHADOWABLE_PRIMITIVES
+        .iter()
+        .filter(|primitive| {
+            enum_name == **primitive || variant_names.iter().any(|variant| variant == *primitive)
+        })
+        .map(|primitive| (*primitive).to_string())
+        .collect()
+}
+
+fn qualify_shadowed(ty: TypeName, shadowed: &[String]) -> TypeName {
+    if shadowed.is_empty() {
+        return ty;
     }
+    let spelling = ty.to_string();
+    let mut result = String::with_capacity(spelling.len());
+    let mut token = String::new();
+    let mut preceding = None;
+    for ch in spelling.chars() {
+        if ch.is_alphanumeric() || ch == '_' {
+            token.push(ch);
+        } else {
+            flush_token(&mut result, &mut token, preceding, shadowed);
+            result.push(ch);
+            preceding = Some(ch);
+        }
+    }
+    flush_token(&mut result, &mut token, preceding, shadowed);
+    if result == spelling {
+        ty
+    } else {
+        TypeName::new(result)
+    }
+}
+
+fn flush_token(
+    result: &mut String,
+    token: &mut String,
+    preceding: Option<char>,
+    shadowed: &[String],
+) {
+    if token.is_empty() {
+        return;
+    }
+    if preceding != Some('.') && shadowed.iter().any(|name| name == token) {
+        result.push_str("kotlin.");
+    }
+    result.push_str(token);
+    token.clear();
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -356,49 +397,50 @@ impl Enumeration {
                     .map(|name| name.to_string())
             })
             .collect::<Result<Vec<_>>>()?;
-        let wire_size_type = qualify_if_shadowed(TypeName::int(), &variant_names);
+        let shadowed = shadowed_primitive_names(&name, &variant_names);
+        let wire_size_type = qualify_shadowed(TypeName::int(), &shadowed);
+        let requalify = |calls: Vec<ExportedCall>| {
+            calls
+                .into_iter()
+                .map(|call| call.requalify_types(&|ty| qualify_shadowed(ty, &shadowed)))
+                .collect::<Vec<_>>()
+        };
         Ok(Self {
-            name,
-            error,
             body: Body::Data {
                 variants: enumeration
                     .variants()
                     .iter()
                     .map(|variant| {
-                        DataVariant::from_declaration(
-                            variant,
-                            host,
-                            context,
-                            package,
-                            &variant_names,
-                        )
+                        DataVariant::from_declaration(variant, host, context, package, &shadowed)
                     })
                     .collect::<Result<Vec<_>>>()?,
                 wire_size_type,
             },
-            initializers: Self::initializer_calls(
+            initializers: requalify(Self::initializer_calls(
                 enumeration.initializers(),
                 bridge,
                 host,
                 context,
                 package,
-            )?,
-            static_methods: Self::methods(
+            )?),
+            static_methods: requalify(Self::methods(
                 enumeration.methods(),
                 None,
                 bridge,
                 host,
                 context,
                 package,
-            )?,
-            instance_methods: Self::methods(
+            )?),
+            instance_methods: requalify(Self::methods(
                 enumeration.methods(),
                 Some(receiver),
                 bridge,
                 host,
                 context,
                 package,
-            )?,
+            )?),
+            name,
+            error,
         })
     }
 
@@ -575,12 +617,11 @@ impl DataVariant {
         host: &KotlinHost,
         context: &RenderContext<Native>,
         package: Option<&KotlinPackage>,
-        variant_names: &[String],
+        shadowed: &[String],
     ) -> Result<Self> {
         let name = Name::new(variant.name()).variant()?;
         let tag = Self::tag_expression(variant.tag())?;
-        let fields =
-            Self::payload_fields(variant.payload(), host, context, package, variant_names)?;
+        let fields = Self::payload_fields(variant.payload(), host, context, package, shadowed)?;
         let read = Self::read_expression(name.clone(), &fields);
         let size = fields
             .iter()
@@ -606,7 +647,7 @@ impl DataVariant {
         host: &KotlinHost,
         context: &RenderContext<Native>,
         package: Option<&KotlinPackage>,
-        variant_names: &[String],
+        shadowed: &[String],
     ) -> Result<Vec<EncodedField>> {
         let reader = Identifier::parse("reader")?;
         let writer = Identifier::parse("writer")?;
@@ -636,7 +677,7 @@ impl DataVariant {
                 })
                 .map(|field| {
                     field.map(|field| {
-                        let qualified = qualify_if_shadowed(field.ty().clone(), variant_names);
+                        let qualified = qualify_shadowed(field.ty().clone(), shadowed);
                         field.requalified(qualified)
                     })
                 })

--- a/boltffi_backend/src/target/kotlin/render/enumeration.rs
+++ b/boltffi_backend/src/target/kotlin/render/enumeration.rs
@@ -47,7 +47,24 @@ enum Body {
     },
     Data {
         variants: Vec<DataVariant>,
+        wire_size_type: TypeName,
     },
+}
+
+const KOTLIN_SHADOWABLE_PRIMITIVES: &[&str] = &[
+    "Boolean", "Byte", "UByte", "Short", "UShort", "Int", "UInt", "Long", "ULong", "Float",
+    "Double",
+];
+
+fn qualify_if_shadowed(ty: TypeName, variant_names: &[String]) -> TypeName {
+    let name = ty.to_string();
+    if KOTLIN_SHADOWABLE_PRIMITIVES.contains(&name.as_str())
+        && variant_names.iter().any(|variant| variant == &name)
+    {
+        TypeName::new(format!("kotlin.{name}"))
+    } else {
+        ty
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -157,8 +174,15 @@ impl Enumeration {
 
     pub fn data_variants(&self) -> &[DataVariant] {
         match &self.body {
-            Body::Data { variants } => variants,
+            Body::Data { variants, .. } => variants,
             Body::CStyle { .. } => &[],
+        }
+    }
+
+    pub fn wire_size_type(&self) -> TypeName {
+        match &self.body {
+            Body::Data { wire_size_type, .. } => wire_size_type.clone(),
+            Body::CStyle { .. } => TypeName::int(),
         }
     }
 
@@ -323,6 +347,16 @@ impl Enumeration {
             )?),
             writeback: Some(name.clone()),
         };
+        let variant_names = enumeration
+            .variants()
+            .iter()
+            .map(|variant| {
+                Name::new(variant.name())
+                    .variant()
+                    .map(|name| name.to_string())
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let wire_size_type = qualify_if_shadowed(TypeName::int(), &variant_names);
         Ok(Self {
             name,
             error,
@@ -330,8 +364,17 @@ impl Enumeration {
                 variants: enumeration
                     .variants()
                     .iter()
-                    .map(|variant| DataVariant::from_declaration(variant, host, context, package))
+                    .map(|variant| {
+                        DataVariant::from_declaration(
+                            variant,
+                            host,
+                            context,
+                            package,
+                            &variant_names,
+                        )
+                    })
                     .collect::<Result<Vec<_>>>()?,
+                wire_size_type,
             },
             initializers: Self::initializer_calls(
                 enumeration.initializers(),
@@ -532,10 +575,12 @@ impl DataVariant {
         host: &KotlinHost,
         context: &RenderContext<Native>,
         package: Option<&KotlinPackage>,
+        variant_names: &[String],
     ) -> Result<Self> {
         let name = Name::new(variant.name()).variant()?;
         let tag = Self::tag_expression(variant.tag())?;
-        let fields = Self::payload_fields(variant.payload(), host, context, package)?;
+        let fields =
+            Self::payload_fields(variant.payload(), host, context, package, variant_names)?;
         let read = Self::read_expression(name.clone(), &fields);
         let size = fields
             .iter()
@@ -561,6 +606,7 @@ impl DataVariant {
         host: &KotlinHost,
         context: &RenderContext<Native>,
         package: Option<&KotlinPackage>,
+        variant_names: &[String],
     ) -> Result<Vec<EncodedField>> {
         let reader = Identifier::parse("reader")?;
         let writer = Identifier::parse("writer")?;
@@ -587,6 +633,12 @@ impl DataVariant {
                         &writer,
                         current.clone(),
                     ),
+                })
+                .map(|field| {
+                    field.map(|field| {
+                        let qualified = qualify_if_shadowed(field.ty().clone(), variant_names);
+                        field.requalified(qualified)
+                    })
                 })
                 .collect(),
             _ => Err(KotlinHost::unsupported("unknown data enum payload")),

--- a/boltffi_backend/src/target/kotlin/render/field.rs
+++ b/boltffi_backend/src/target/kotlin/render/field.rs
@@ -100,6 +100,11 @@ impl EncodedField {
         &self.ty
     }
 
+    pub(crate) fn requalified(mut self, ty: TypeName) -> Self {
+        self.ty = ty;
+        self
+    }
+
     pub fn read(&self) -> &Expression {
         &self.read
     }

--- a/boltffi_backend/src/target/kotlin/render/function.rs
+++ b/boltffi_backend/src/target/kotlin/render/function.rs
@@ -483,6 +483,15 @@ impl ReceiverCarrier {
 }
 
 impl ExportedCall {
+    pub(crate) fn requalify_types(mut self, requalify: &dyn Fn(TypeName) -> TypeName) -> Self {
+        self.returns = self.returns.take().map(requalify);
+        for parameter in &mut self.parameters {
+            let ty = requalify(parameter.signature.ty().clone());
+            parameter.signature = signature::Parameter::new(parameter.signature.name().clone(), ty);
+        }
+        self
+    }
+
     pub fn name(&self) -> &Identifier {
         &self.name
     }

--- a/boltffi_backend/templates/target/kotlin/enumeration.kt
+++ b/boltffi_backend/templates/target/kotlin/enumeration.kt
@@ -165,7 +165,7 @@ enum class {{ enumeration.name() }}(val value: {{ value_type }}) {
 {%- endif %}
 {%- else if enumeration.data() %}
 sealed class {{ enumeration.name() }}{% if enumeration.error() %} : Exception(){% endif %} {
-    internal abstract fun wireSize(): Int
+    internal abstract fun wireSize(): {{ enumeration.wire_size_type() }}
 
     internal abstract fun writeTo(writer: WireWriter)
 
@@ -183,7 +183,7 @@ sealed class {{ enumeration.name() }}{% if enumeration.error() %} : Exception(){
 {% for variant in enumeration.data_variants() %}
 {%- if variant.unit() %}
     object {{ variant.name() }} : {{ enumeration.name() }}() {
-        internal override fun wireSize(): Int {
+        internal override fun wireSize(): {{ enumeration.wire_size_type() }} {
             return {{ variant.size() }}
         }
 
@@ -197,7 +197,7 @@ sealed class {{ enumeration.name() }}{% if enumeration.error() %} : Exception(){
         val {{ field.name() }}: {{ field.ty() }}{% if !loop.last %},{% endif %}
 {%- endfor %}
     ) : {{ enumeration.name() }}() {
-        internal override fun wireSize(): Int {
+        internal override fun wireSize(): {{ enumeration.wire_size_type() }} {
             return {{ variant.size() }}
         }
 

--- a/boltffi_backend/tests/fixtures/source/enums/primitive_shadow.rs
+++ b/boltffi_backend/tests/fixtures/source/enums/primitive_shadow.rs
@@ -1,0 +1,7 @@
+#[data]
+pub enum PrimitiveValue {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Double(f64),
+}

--- a/boltffi_backend/tests/fixtures/source/enums/primitive_shadow.rs
+++ b/boltffi_backend/tests/fixtures/source/enums/primitive_shadow.rs
@@ -4,4 +4,22 @@ pub enum PrimitiveValue {
     Bool(bool),
     Int(i64),
     Double(f64),
+    MaybeDouble(Option<f64>),
+    Doubles(Vec<f64>),
+}
+
+#[data(impl)]
+impl PrimitiveValue {
+    pub fn new(value: i32) -> Self {
+        PrimitiveValue::Int(i64::from(value))
+    }
+
+    pub fn scaled(&self, factor: i32) -> i32 {
+        factor
+    }
+}
+
+#[data]
+pub enum Int {
+    Value(i64),
 }

--- a/boltffi_backend/tests/kotlin/exports.rs
+++ b/boltffi_backend/tests/kotlin/exports.rs
@@ -120,6 +120,11 @@ fn kotlin_target_qualifies_shadowed_data_enum_payloads() {
 }
 
 #[test]
+fn kotlin_target_qualifies_kotlin_primitive_names_shadowed_by_a_sibling_variant() {
+    insta::assert_snapshot!(rendered_fixture("enums/primitive_shadow"));
+}
+
+#[test]
 fn kotlin_target_renders_result_values_through_shared_codec() {
     insta::assert_snapshot!(rendered_fixture("exports/result_values"));
 }

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_qualifies_kotlin_primitive_names_shadowed_by_a_sibling_variant.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_qualifies_kotlin_primitive_names_shadowed_by_a_sibling_variant.snap
@@ -1,0 +1,91 @@
+---
+source: boltffi_backend/tests/kotlin/exports.rs
+assertion_line: 124
+expression: "rendered_fixture(\"enums/primitive_shadow\")"
+---
+===== com/boltffi/demo/Demo.kt =====
+@file:OptIn(kotlin.ExperimentalUnsignedTypes::class)
+
+package com.boltffi.demo
+
+sealed class PrimitiveValue {
+    internal abstract fun wireSize(): kotlin.Int
+
+    internal abstract fun writeTo(writer: WireWriter)
+
+    internal fun toByteArray(): ByteArray {
+        val buffer = WireWriterPool.acquire(wireSize())
+        val writer = buffer.writer
+        try {
+            writeTo(writer)
+            return buffer.bytes()
+        } finally {
+            buffer.close()
+        }
+    }
+
+
+    object Null : PrimitiveValue() {
+        internal override fun wireSize(): kotlin.Int {
+            return 4
+        }
+
+        internal override fun writeTo(writer: WireWriter) {
+            writer.writeU32(0.toUInt())
+        }
+    }
+    data class Bool(
+        val field0: Boolean
+    ) : PrimitiveValue() {
+        internal override fun wireSize(): kotlin.Int {
+            return 4 + 1
+        }
+
+        internal override fun writeTo(writer: WireWriter) {
+            writer.writeU32(1.toUInt())
+            writer.writeBool(this.field0)
+        }
+    }
+    data class Int(
+        val field0: Long
+    ) : PrimitiveValue() {
+        internal override fun wireSize(): kotlin.Int {
+            return 4 + 8
+        }
+
+        internal override fun writeTo(writer: WireWriter) {
+            writer.writeU32(2.toUInt())
+            writer.writeI64(this.field0)
+        }
+    }
+    data class Double(
+        val field0: kotlin.Double
+    ) : PrimitiveValue() {
+        internal override fun wireSize(): kotlin.Int {
+            return 4 + 8
+        }
+
+        internal override fun writeTo(writer: WireWriter) {
+            writer.writeU32(3.toUInt())
+            writer.writeF64(this.field0)
+        }
+    }
+
+    companion object {
+        internal fun fromReader(reader: WireReader): PrimitiveValue {
+            val tag = reader.readU32()
+            return when (tag) {
+                0.toUInt() -> Null
+                1.toUInt() -> Bool(reader.readBool())
+                2.toUInt() -> Int(reader.readI64())
+                3.toUInt() -> Double(reader.readF64())
+                else -> throw IllegalArgumentException("unknown PrimitiveValue tag: $tag")
+            }
+        }
+
+        internal fun fromByteArray(bytes: ByteArray): PrimitiveValue {
+            val reader = WireReader(bytes)
+            return fromReader(reader)
+        }
+    }
+}

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_qualifies_kotlin_primitive_names_shadowed_by_a_sibling_variant.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_qualifies_kotlin_primitive_names_shadowed_by_a_sibling_variant.snap
@@ -1,12 +1,17 @@
 ---
 source: boltffi_backend/tests/kotlin/exports.rs
-assertion_line: 124
 expression: "rendered_fixture(\"enums/primitive_shadow\")"
 ---
 ===== com/boltffi/demo/Demo.kt =====
 @file:OptIn(kotlin.ExperimentalUnsignedTypes::class)
 
 package com.boltffi.demo
+@Suppress("FunctionName")
+private object Native {
+    @JvmStatic external fun boltffi_init_enum_demo_primitive_value_new(value: Int): ByteArray?
+    @JvmStatic external fun boltffi_method_enum_demo_primitive_value_scaled(`receiver`: java.nio.ByteBuffer, __boltffi_receiver_len: Int, factor: Int): Int
+}
+
 
 sealed class PrimitiveValue {
     internal abstract fun wireSize(): kotlin.Int
@@ -70,6 +75,30 @@ sealed class PrimitiveValue {
             writer.writeF64(this.field0)
         }
     }
+    data class MaybeDouble(
+        val field0: kotlin.Double?
+    ) : PrimitiveValue() {
+        internal override fun wireSize(): kotlin.Int {
+            return 4 + 1 + (this.field0?.let { __boltffi_value_0 -> 8 } ?: 0)
+        }
+
+        internal override fun writeTo(writer: WireWriter) {
+            writer.writeU32(4.toUInt())
+            writer.writeOptionalValue(this.field0, { writer, __boltffi_value_0 -> writer.writeF64(__boltffi_value_0) })
+        }
+    }
+    data class Doubles(
+        val field0: DoubleArray
+    ) : PrimitiveValue() {
+        internal override fun wireSize(): kotlin.Int {
+            return 4 + 4 + this.field0.size * 8
+        }
+
+        internal override fun writeTo(writer: WireWriter) {
+            writer.writeU32(5.toUInt())
+            writer.writeDoubleArray(this.field0)
+        }
+    }
 
     companion object {
         internal fun fromReader(reader: WireReader): PrimitiveValue {
@@ -79,11 +108,77 @@ sealed class PrimitiveValue {
                 1.toUInt() -> Bool(reader.readBool())
                 2.toUInt() -> Int(reader.readI64())
                 3.toUInt() -> Double(reader.readF64())
+                4.toUInt() -> MaybeDouble(reader.readOptionalValue({ reader -> reader.readF64() }))
+                5.toUInt() -> Doubles(reader.readDoubleArray())
                 else -> throw IllegalArgumentException("unknown PrimitiveValue tag: $tag")
             }
         }
 
         internal fun fromByteArray(bytes: ByteArray): PrimitiveValue {
+            val reader = WireReader(bytes)
+            return fromReader(reader)
+        }
+
+        fun new(value: kotlin.Int): com.boltffi.demo.PrimitiveValue {
+            val __boltffi_result = Native.boltffi_init_enum_demo_primitive_value_new(value) ?: throw IllegalStateException("null buffer returned")
+            val __boltffi_reader = WireReader(__boltffi_result)
+            return com.boltffi.demo.PrimitiveValue.fromReader(__boltffi_reader)
+        }
+    }
+
+    fun scaled(factor: kotlin.Int): kotlin.Int {
+        val __boltffi_primitiveValue_wire = WireWriterPool.acquire(this.wireSize())
+        val __boltffi_primitiveValue_writer = __boltffi_primitiveValue_wire.writer
+        this.writeTo(__boltffi_primitiveValue_writer)
+        try {
+            return Native.boltffi_method_enum_demo_primitive_value_scaled(__boltffi_primitiveValue_wire.directBuffer(), __boltffi_primitiveValue_wire.size(), factor)
+        } finally {
+            __boltffi_primitiveValue_wire.close()
+        }
+    }
+}
+
+
+sealed class Int {
+    internal abstract fun wireSize(): kotlin.Int
+
+    internal abstract fun writeTo(writer: WireWriter)
+
+    internal fun toByteArray(): ByteArray {
+        val buffer = WireWriterPool.acquire(wireSize())
+        val writer = buffer.writer
+        try {
+            writeTo(writer)
+            return buffer.bytes()
+        } finally {
+            buffer.close()
+        }
+    }
+
+
+    data class Value(
+        val field0: Long
+    ) : Int() {
+        internal override fun wireSize(): kotlin.Int {
+            return 4 + 8
+        }
+
+        internal override fun writeTo(writer: WireWriter) {
+            writer.writeU32(0.toUInt())
+            writer.writeI64(this.field0)
+        }
+    }
+
+    companion object {
+        internal fun fromReader(reader: WireReader): Int {
+            val tag = reader.readU32()
+            return when (tag) {
+                0.toUInt() -> Value(reader.readI64())
+                else -> throw IllegalArgumentException("unknown Int tag: $tag")
+            }
+        }
+
+        internal fun fromByteArray(bytes: ByteArray): Int {
             val reader = WireReader(bytes)
             return fromReader(reader)
         }


### PR DESCRIPTION
A data enum with a variant named `Int` or `Double` (a JSON-ish value union is exactly this shape) generates a Kotlin sealed class that doesn't compile:

```rust
#[data]
pub enum ParseValue {
    Int(i64),
    Double(f64),
    // ...
}
```

```text
error: return type mismatch: expected 'ParseValue.Int', actual 'Int'.
error: argument type mismatch: actual type is 'ParseValue.Double', but 'Double' was expected.
```

Kotlin resolves bare type names inside a nested class against the enclosing class's members before `kotlin.*`, so the sibling variant shadows the primitive in every `wireSize(): Int` and in the `Double` variant's own field.

Fix: qualify to `kotlin.Int`/`kotlin.Double` when a sibling variant shadows the name.
