### PR TITLE
fix(csharp): qualify Decode calls shadowed by a same-named sibling method

### DIFF
--- a/boltffi_backend/src/target/csharp/mod.rs
+++ b/boltffi_backend/src/target/csharp/mod.rs
@@ -158,7 +158,8 @@ impl host::HostBackend for CSharpHost {
         bridge: &Self::Bridge,
         context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        render::Function::from_declaration(decl, bridge, context)?.render()
+        let namespace = self.namespace_for(context.bindings())?;
+        render::Function::from_declaration(decl, Some(&namespace), bridge, context)?.render()
     }
 
     fn class(
@@ -648,11 +649,13 @@ mod tests {
             "[MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)] [In] bool[] values"
         ));
         assert!(source.contains("return resultReader.ReadRawBoolArray();"));
-        assert!(source.contains("public static Point[] EchoPoints(Point[] values)"));
         assert!(source.contains(
-            "NativeEchoPoints(values, (nuint)(values.Length * Marshal.SizeOf<Point>()))"
+            "public static global::Demo.Point[] EchoPoints(global::Demo.Point[] values)"
         ));
-        assert!(source.contains("return resultReader.ReadRawArray<Point>();"));
+        assert!(source.contains(
+            "NativeEchoPoints(values, (nuint)(values.Length * Marshal.SizeOf<global::Demo.Point>()))"
+        ));
+        assert!(source.contains("return resultReader.ReadRawArray<global::Demo.Point>();"));
         assert!(output.diagnostics().is_empty());
     }
 
@@ -987,9 +990,9 @@ mod tests {
         assert!(source.contains("return boltffiResult;"));
         assert!(source.contains("public static string LoadName(bool valid)"));
         assert!(source.contains("out FfiBuf boltffiResultBuffer"));
-        assert!(
-            source.contains("throw new AppErrorException(AppError.Decode(boltffiErrorReader));")
-        );
+        assert!(source.contains(
+            "throw new global::Demo.AppErrorException(global::Demo.AppError.Decode(boltffiErrorReader));"
+        ));
         assert!(source.contains("return resultReader.ReadString();"));
         assert!(source.contains("public static void Validate(bool valid)"));
         assert!(source.contains("[MarshalAs(UnmanagedType.I1)] out bool boltffiResult"));
@@ -1128,9 +1131,9 @@ mod tests {
         assert!(profile.contains("if (this.Outcome.IsOk)"));
         assert!(profile.contains("public nuint AliasCount()"));
         assert!(profile.contains("this.Encode(boltffiReceiverWriter);"));
-        assert!(profile.contains("public Profile ClearAliases()"));
+        assert!(profile.contains("public global::Demo.Profile ClearAliases()"));
         assert!(profile.contains("out FfiBuf boltffiReceiverOut"));
-        assert!(profile.contains("return Profile.Decode(boltffiReceiverReader);"));
+        assert!(profile.contains("return global::Demo.Profile.Decode(boltffiReceiverReader);"));
 
         let point = file(&output, "Point.cs");
         assert!(point.contains("[StructLayout(LayoutKind.Sequential)]"));
@@ -1138,9 +1141,11 @@ mod tests {
         assert!(point.contains("writer.WriteI32(this.X);"));
 
         let module = file(&output, "Demo.cs");
-        assert!(module.contains("public static Profile EchoProfile(Profile profile)"));
+        assert!(module.contains(
+            "public static global::Demo.Profile EchoProfile(global::Demo.Profile profile)"
+        ));
         assert!(module.contains("profile.Encode(profileWriter);"));
-        assert!(module.contains("return Profile.Decode(resultReader);"));
+        assert!(module.contains("return global::Demo.Profile.Decode(resultReader);"));
         assert!(output.diagnostics().is_empty());
     }
 
@@ -1185,9 +1190,11 @@ mod tests {
         assert!(shape.contains("return global::Demo.Shape.Decode(boltffiReceiverReader);"));
 
         let module = file(&output, "Demo.cs");
-        assert!(module.contains("public static Shape EchoShape(Shape shape)"));
+        assert!(
+            module.contains("public static global::Demo.Shape EchoShape(global::Demo.Shape shape)")
+        );
         assert!(module.contains("shape.Encode(shapeWriter);"));
-        assert!(module.contains("return Shape.Decode(resultReader);"));
+        assert!(module.contains("return global::Demo.Shape.Decode(resultReader);"));
         assert!(output.diagnostics().is_empty());
     }
 
@@ -1295,7 +1302,7 @@ mod tests {
 
         let module = file(&output, "Demo.cs");
         assert!(module.contains(
-            "/// Echoes a profile.\n        /// </summary>\n        public static Profile EchoProfile"
+            "/// Echoes a profile.\n        /// </summary>\n        public static global::Demo.Profile EchoProfile"
         ));
         assert!(module.contains(
             "/// The default answer.\n        /// </summary>\n        public const uint Answer = 42U;"
@@ -1436,10 +1443,18 @@ mod tests {
         }
         "###);
         let module = file(&output, "Demo.cs");
-        assert!(module.contains("public static Point EchoPoint(Point point)"));
-        assert!(module.contains("internal static extern Point NativeEchoPoint(Point point);"));
-        assert!(module.contains("public static Mode EchoMode(Mode mode)"));
-        assert!(module.contains("internal static extern Mode NativeEchoMode(Mode mode);"));
+        assert!(
+            module.contains("public static global::Demo.Point EchoPoint(global::Demo.Point point)")
+        );
+        assert!(module.contains(
+            "internal static extern global::Demo.Point NativeEchoPoint(global::Demo.Point point);"
+        ));
+        assert!(
+            module.contains("public static global::Demo.Mode EchoMode(global::Demo.Mode mode)")
+        );
+        assert!(module.contains(
+            "internal static extern global::Demo.Mode NativeEchoMode(global::Demo.Mode mode);"
+        ));
     }
 
     #[test]
@@ -1485,21 +1500,21 @@ mod tests {
             .expect("direct value methods should render");
 
         let point = file(&output, "Point.cs");
-        assert!(point.contains("public static Point New(double x, double y)"));
-        assert!(point.contains("public static Point Origin()"));
+        assert!(point.contains("public static global::Demo.Point New(double x, double y)"));
+        assert!(point.contains("public static global::Demo.Point Origin()"));
         assert!(point.contains("public double Distance()"));
-        assert!(point.contains("public Point Scale(double factor)"));
+        assert!(point.contains("public global::Demo.Point Scale(double factor)"));
         assert!(point.contains("out Point receiverOut"));
         assert!(point.contains("return receiverOut;"));
-        assert!(point.contains("public Point Add(Point other)"));
-        assert!(point.contains("public Point CopyFrom(Point other)"));
+        assert!(point.contains("public global::Demo.Point Add(global::Demo.Point other)"));
+        assert!(point.contains("public global::Demo.Point CopyFrom(global::Demo.Point other)"));
         assert!(point.contains("public static uint Dimensions()"));
 
         let mode = file(&output, "Mode.cs");
         assert!(mode.contains("public static class ModeMethods"));
-        assert!(mode.contains("public static Mode New(byte raw)"));
+        assert!(mode.contains("public static global::Demo.Mode New(byte raw)"));
         assert!(mode.contains("public static uint Count()"));
-        assert!(mode.contains("public static Mode Opposite(this Mode self)"));
+        assert!(mode.contains("public static global::Demo.Mode Opposite(this Mode self)"));
         assert!(mode.contains("public static bool IsFast(this Mode self)"));
 
         let module = file(&output, "Demo.cs");
@@ -1508,7 +1523,9 @@ mod tests {
             module
                 .contains("NativePointScale(Point receiver, out Point receiverOut, double factor)")
         );
-        assert!(module.contains("NativePointCopyFrom(Point receiver, in Point other)"));
+        assert!(
+            module.contains("NativePointCopyFrom(Point receiver, in global::Demo.Point other)")
+        );
         assert!(module.contains("NativeModeOpposite(Mode receiver)"));
         assert!(output.diagnostics().is_empty());
     }

--- a/boltffi_backend/src/target/csharp/render/class.rs
+++ b/boltffi_backend/src/target/csharp/render/class.rs
@@ -62,6 +62,7 @@ impl Class {
                 declaration.id(),
                 &name,
                 declaration.handle(),
+                Some(&namespace),
                 bridge,
                 context,
             ) {
@@ -89,6 +90,7 @@ impl Class {
                 declaration.id(),
                 &name,
                 declaration.handle(),
+                Some(&namespace),
                 bridge,
                 context,
             ) {

--- a/boltffi_backend/src/target/csharp/render/enumeration.rs
+++ b/boltffi_backend/src/target/csharp/render/enumeration.rs
@@ -142,6 +142,7 @@ impl Enumeration {
                     owner.clone(),
                     &name,
                     true,
+                    Some(&namespace),
                     bridge,
                     context,
                 ),
@@ -153,7 +154,15 @@ impl Enumeration {
                 &mut diagnostics,
                 "method",
                 method.name(),
-                Function::from_method(method, owner.clone(), &name, true, bridge, context),
+                Function::from_method(
+                    method,
+                    owner.clone(),
+                    &name,
+                    true,
+                    Some(&namespace),
+                    bridge,
+                    context,
+                ),
             )?;
         }
         Ok(Self {

--- a/boltffi_backend/src/target/csharp/render/mod.rs
+++ b/boltffi_backend/src/target/csharp/render/mod.rs
@@ -207,6 +207,7 @@ impl Function {
 
     pub(super) fn from_declaration(
         declaration: &FunctionDecl<Native>,
+        type_namespace: Option<&Namespace>,
         bridge: &CBridgeContract,
         context: &RenderContext<Native>,
     ) -> Result<Self> {
@@ -218,7 +219,7 @@ impl Function {
             declaration.symbol(),
             declaration.callable(),
             CallSite::Free,
-            None,
+            type_namespace,
             None,
             bridge,
             context,
@@ -231,6 +232,7 @@ impl Function {
         owner: DirectValueType,
         owner_name: &Identifier,
         extension: bool,
+        type_namespace: Option<&Namespace>,
         bridge: &CBridgeContract,
         context: &RenderContext<Native>,
     ) -> Result<Self> {
@@ -241,7 +243,7 @@ impl Function {
             owner,
             owner_name,
             extension,
-            None,
+            type_namespace,
             None,
             bridge,
             context,
@@ -254,6 +256,7 @@ impl Function {
         _owner: ClassId,
         owner_name: &Identifier,
         carrier: native::HandleCarrier,
+        type_namespace: Option<&Namespace>,
         bridge: &CBridgeContract,
         context: &RenderContext<Native>,
     ) -> Result<(Self, bool)> {
@@ -277,7 +280,7 @@ impl Function {
                 name: owner_name.clone(),
                 carrier,
             },
-            None,
+            type_namespace,
             None,
             bridge,
             context,
@@ -293,6 +296,7 @@ impl Function {
         _owner: ClassId,
         owner_name: &Identifier,
         carrier: native::HandleCarrier,
+        type_namespace: Option<&Namespace>,
         bridge: &CBridgeContract,
         context: &RenderContext<Native>,
     ) -> Result<Self> {
@@ -307,7 +311,7 @@ impl Function {
                 name: owner_name.clone(),
                 carrier,
             },
-            None,
+            type_namespace,
             None,
             bridge,
             context,
@@ -343,6 +347,7 @@ impl Function {
         owner: DirectValueType,
         owner_name: &Identifier,
         extension: bool,
+        type_namespace: Option<&Namespace>,
         bridge: &CBridgeContract,
         context: &RenderContext<Native>,
     ) -> Result<Self> {
@@ -353,7 +358,7 @@ impl Function {
             owner,
             owner_name,
             extension,
-            None,
+            type_namespace,
             None,
             bridge,
             context,

--- a/boltffi_backend/src/target/csharp/render/record.rs
+++ b/boltffi_backend/src/target/csharp/render/record.rs
@@ -130,6 +130,7 @@ impl Record {
                     owner.clone(),
                     &name,
                     false,
+                    Some(&namespace),
                     bridge,
                     context,
                 ),
@@ -141,7 +142,15 @@ impl Record {
                 &mut diagnostics,
                 "method",
                 method.name(),
-                Function::from_method(method, owner.clone(), &name, false, bridge, context),
+                Function::from_method(
+                    method,
+                    owner.clone(),
+                    &name,
+                    false,
+                    Some(&namespace),
+                    bridge,
+                    context,
+                ),
             )?;
         }
         Ok(Self {
@@ -221,6 +230,7 @@ impl Record {
                     owner.clone(),
                     &name,
                     false,
+                    Some(&namespace),
                     bridge,
                     context,
                 ),
@@ -238,7 +248,7 @@ impl Record {
                     &name,
                     declaration.read(),
                     declaration.write(),
-                    None,
+                    Some(&namespace),
                     bridge,
                     context,
                 ),

--- a/boltffi_backend/tests/csharp.rs
+++ b/boltffi_backend/tests/csharp.rs
@@ -1,0 +1,187 @@
+use std::{fs, path::Path, process::Command, time::UNIX_EPOCH};
+
+use boltffi_ast::PackageInfo;
+use boltffi_backend::{GeneratedOutput, Target, bridge::c::CBridge, target::csharp::CSharpHost};
+use boltffi_binding::{Bindings, Native, lower};
+
+fn bindings(source: &str) -> Bindings<Native> {
+    let source = boltffi_scan::scan_file(
+        syn::parse_str(source).expect("valid source"),
+        PackageInfo::new("demo", None),
+    )
+    .expect("source should scan");
+    lower::<Native>(&source).expect("source should lower")
+}
+
+fn target(host: CSharpHost) -> Target<CSharpHost, CBridge> {
+    host.into_target().expect("C# target")
+}
+
+#[test]
+fn csharp_target_qualifies_a_class_method_named_after_its_return_record() {
+    let bindings = bindings(
+        r#"
+        #[data]
+        pub struct ServerInfo {
+            pub version: String,
+        }
+
+        pub struct ParseClient {
+            id: i32,
+        }
+
+        #[export]
+        impl ParseClient {
+            pub fn new(id: i32) -> Self { Self { id } }
+
+            pub fn server_info(&self) -> Result<ServerInfo, String> {
+                Ok(ServerInfo { version: "1".to_string() })
+            }
+        }
+
+        #[export]
+        pub fn apply_server_info(
+            f: impl Fn(ServerInfo) -> ServerInfo,
+            value: ServerInfo,
+        ) -> ServerInfo {
+            f(value)
+        }
+        "#,
+    );
+    let output = target(
+        CSharpHost::new()
+            .namespace("Company.Bindings")
+            .expect("valid namespace")
+            .native_library("demo_native"),
+    )
+    .render(&bindings)
+    .expect("a class method named after its return record should still render");
+
+    assert!(
+        output.diagnostics().is_empty(),
+        "unexpected diagnostics: {:?}",
+        output.diagnostics()
+    );
+
+    let class = output
+        .files()
+        .iter()
+        .find(|file| file.path().as_path() == Path::new("ParseClient.cs"))
+        .map(|file| file.contents())
+        .expect("generated ParseClient.cs");
+
+    assert!(
+        class.contains("return global::Company.Bindings.ServerInfo.Decode(resultReader);"),
+        "expected the self-named ServerInfo() method to qualify its own Decode call:\n{class}"
+    );
+    assert!(
+        !class.contains("return ServerInfo.Decode(resultReader);"),
+        "an unqualified Decode call inside ServerInfo() would resolve to the method group, not \
+         the type (CS0119):\n{class}"
+    );
+
+    compile_csharp_with_dotnet_when_available(&output, "csharp-sibling-shadow-smoke");
+}
+
+#[test]
+fn csharp_target_qualifies_a_free_function_named_after_its_return_record() {
+    let bindings = bindings(
+        r#"
+        #[data]
+        pub struct ServerInfo {
+            pub version: String,
+        }
+
+        #[export]
+        pub fn server_info() -> Result<ServerInfo, String> {
+            Ok(ServerInfo { version: "1".to_string() })
+        }
+
+        #[export]
+        pub fn apply_server_info(
+            f: impl Fn(ServerInfo) -> ServerInfo,
+            value: ServerInfo,
+        ) -> ServerInfo {
+            f(value)
+        }
+        "#,
+    );
+    let output = target(
+        CSharpHost::new()
+            .namespace("Company.Bindings")
+            .expect("valid namespace")
+            .native_library("demo_native"),
+    )
+    .render(&bindings)
+    .expect("a free function named after its return record should still render");
+
+    assert!(
+        output.diagnostics().is_empty(),
+        "unexpected diagnostics: {:?}",
+        output.diagnostics()
+    );
+
+    let module = output
+        .files()
+        .iter()
+        .find(|file| file.path().as_path() == Path::new("Demo.cs"))
+        .map(|file| file.contents())
+        .expect("generated Demo.cs");
+
+    assert!(
+        module.contains("return global::Company.Bindings.ServerInfo.Decode(resultReader);"),
+        "expected the self-named ServerInfo() free function to qualify its own Decode call:\n{module}"
+    );
+
+    compile_csharp_with_dotnet_when_available(&output, "csharp-free-function-shadow-smoke");
+}
+
+fn compile_csharp_with_dotnet_when_available(output: &GeneratedOutput, prefix: &str) {
+    if Command::new("dotnet").arg("--version").output().is_err() {
+        return;
+    }
+
+    let directory = std::env::temp_dir().join(format!(
+        "{prefix}-{}",
+        UNIX_EPOCH.elapsed().expect("system clock").as_nanos()
+    ));
+    let src = directory.join("src");
+    fs::create_dir_all(&src).expect("create dotnet smoke src directory");
+    for file in output.files().iter().filter(|file| {
+        file.path()
+            .as_path()
+            .extension()
+            .is_some_and(|ext| ext == "cs")
+    }) {
+        let path = src.join(file.path().as_path());
+        fs::create_dir_all(path.parent().expect("generated C# parent"))
+            .expect("create generated C# parent directory");
+        fs::write(&path, file.contents()).expect("write generated C# source");
+    }
+    fs::write(
+        directory.join("Smoke.csproj"),
+        r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+</Project>
+"#,
+    )
+    .expect("write smoke csproj");
+
+    let build = Command::new("dotnet")
+        .arg("build")
+        .arg(directory.join("Smoke.csproj"))
+        .arg("--nologo")
+        .output()
+        .expect("dotnet build should execute");
+    assert!(
+        build.status.success(),
+        "generated C# failed to build:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+    fs::remove_dir_all(&directory).expect("remove dotnet smoke directory");
+}


### PR DESCRIPTION
A method named after the record it returns generates C# that doesn't compile:

```rust
#[export]
impl ParseClient {
    pub fn server_info(&self) -> Result<ServerInfo, ParseError> { ... }
}
// error CS0119: 'ParseClient.ServerInfo()' is a method, which is not valid in the given context
```

The generated body emits a bare `ServerInfo.Decode(reader)`, and C# member lookup resolves `ServerInfo` to the enclosing method group instead of the type. Free functions and record/enum methods hit the same thing.

Fix: qualify the decode call with `global::<namespace>.`. Both tests do a real `dotnet build` of the generated output (skipped when dotnet isn't installed).
