### PR TITLE
fix(kotlin): suspend stream delivery instead of dropping items on a full channel

### DIFF
--- a/boltffi_backend/templates/target/kotlin/runtime/stream.kt
+++ b/boltffi_backend/templates/target/kotlin/runtime/stream.kt
@@ -8,7 +8,7 @@ internal class BoltFfiStreamContext(
     private val poll: (Long, Long) -> Unit,
     private val unsubscribe: (Long) -> Unit,
     private val free: (Long) -> Unit,
-    private val processItems: (ByteArray) -> Unit,
+    private val processItems: suspend (ByteArray) -> Unit,
     private val finish: () -> Unit
 ) {
     private val lifecycle = java.util.concurrent.atomic.AtomicInteger(0)
@@ -39,7 +39,7 @@ internal class BoltFfiStreamContext(
         }
     }
 
-    private fun handlePoll(pollResult: Byte) {
+    private suspend fun handlePoll(pollResult: Byte) {
         val closed = pollResult == BOLTFFI_STREAM_POLL_CLOSED
         if (!processing.compareAndSet(0, 1)) {
             finalizeIfIdle()
@@ -62,7 +62,7 @@ internal class BoltFfiStreamContext(
         }
     }
 
-    private fun drain() {
+    private suspend fun drain() {
         while (true) {
             val bytes = popBatch(subscription, batchSize)
                 ?: throw IllegalStateException("BoltFFI stream pop_batch returned null")

--- a/boltffi_backend/templates/target/kotlin/stream.kt
+++ b/boltffi_backend/templates/target/kotlin/stream.kt
@@ -19,7 +19,7 @@
 {%- endfor %}
             val items = {{ stream.items() }}
             items.forEach { item ->
-                trySend(item)
+                send(item)
             }
         },
         finish = { close() }

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__stream__kotlin_target_renders_stream_protocols.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__stream__kotlin_target_renders_stream_protocols.snap
@@ -160,7 +160,7 @@ fun Engine.names(): kotlinx.coroutines.flow.Flow<String> = kotlinx.coroutines.fl
             val count = reader.readU32().toInt()
             val items = List(count) { reader.readString() }
             items.forEach { item ->
-                trySend(item)
+                send(item)
             }
         },
         finish = { close() }

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__stream__kotlin_target_renders_stream_runtime.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__stream__kotlin_target_renders_stream_runtime.snap
@@ -1,0 +1,1129 @@
+---
+source: boltffi_backend/tests/kotlin/stream.rs
+expression: "rendered_fixture_with_runtime(\"stream/protocol_functions\")"
+---
+===== com/boltffi/demo/Demo.kt =====
+@file:OptIn(kotlin.ExperimentalUnsignedTypes::class)
+
+package com.boltffi.demo
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.channels.awaitClose
+
+private object Utf8Codec {
+    fun maxBytes(value: String): Int = value.length * 3
+}
+
+private val <First, Second> Pair<First, Second>.field0: First get() = first
+private val <First, Second> Pair<First, Second>.field1: Second get() = second
+private val <First, Second, Third> Triple<First, Second, Third>.field0: First get() = first
+private val <First, Second, Third> Triple<First, Second, Third>.field1: Second get() = second
+private val <First, Second, Third> Triple<First, Second, Third>.field2: Third get() = third
+
+class FfiException(message: String) : RuntimeException(message)
+
+internal class BoltFfiErrorBufferException(val bytes: ByteArray) : RuntimeException("BoltFFI call failed")
+
+private object DirectVectorCodec {
+    fun readBooleanArray(bytes: ByteArray): BooleanArray =
+        BooleanArray(bytes.size) { index -> bytes[index] != 0.toByte() }
+
+    fun readByteArray(bytes: ByteArray): ByteArray = bytes
+
+    fun writeBooleanArray(values: BooleanArray): ByteArray =
+        ByteArray(values.size) { index -> if (values[index]) 1.toByte() else 0.toByte() }
+
+    fun writeByteArray(values: ByteArray): ByteArray = values
+
+    fun <T> readRecordList(
+        bytes: ByteArray,
+        width: Int,
+        read: (java.nio.ByteBuffer, Int) -> T
+    ): List<T> {
+        val count = elementCount(bytes, width)
+        val buffer = nativeBuffer(bytes)
+        return List(count) { index -> read(buffer, index * width) }
+    }
+
+    fun <T> writeRecordList(
+        values: List<T>,
+        width: Int,
+        write: (T, java.nio.ByteBuffer, Int) -> Unit
+    ): ByteArray {
+        val bytes = ByteArray(values.size * width)
+        val buffer = nativeBuffer(bytes)
+        values.forEachIndexed { index, value -> write(value, buffer, index * width) }
+        return bytes
+    }
+
+    fun readShortArray(bytes: ByteArray): ShortArray {
+        val values = ShortArray(elementCount(bytes, 2))
+        nativeBuffer(bytes).asShortBuffer().get(values)
+        return values
+    }
+
+    fun readUShortArray(bytes: ByteArray): UShortArray =
+        readShortArray(bytes).toUShortArray()
+
+    fun writeShortArray(values: ShortArray): ByteArray {
+        val bytes = ByteArray(values.size * 2)
+        nativeBuffer(bytes).asShortBuffer().put(values)
+        return bytes
+    }
+
+    fun writeUShortArray(values: UShortArray): ByteArray =
+        writeShortArray(values.asShortArray())
+
+    fun readIntArray(bytes: ByteArray): IntArray {
+        val values = IntArray(elementCount(bytes, 4))
+        nativeBuffer(bytes).asIntBuffer().get(values)
+        return values
+    }
+
+    fun readUIntArray(bytes: ByteArray): UIntArray =
+        readIntArray(bytes).toUIntArray()
+
+    fun writeIntArray(values: IntArray): ByteArray {
+        val bytes = ByteArray(values.size * 4)
+        nativeBuffer(bytes).asIntBuffer().put(values)
+        return bytes
+    }
+
+    fun writeUIntArray(values: UIntArray): ByteArray =
+        writeIntArray(values.asIntArray())
+
+    fun readLongArray(bytes: ByteArray): LongArray {
+        val values = LongArray(elementCount(bytes, 8))
+        nativeBuffer(bytes).asLongBuffer().get(values)
+        return values
+    }
+
+    fun readULongArray(bytes: ByteArray): ULongArray =
+        readLongArray(bytes).toULongArray()
+
+    fun writeLongArray(values: LongArray): ByteArray {
+        val bytes = ByteArray(values.size * 8)
+        nativeBuffer(bytes).asLongBuffer().put(values)
+        return bytes
+    }
+
+    fun writeULongArray(values: ULongArray): ByteArray =
+        writeLongArray(values.asLongArray())
+
+    fun readFloatArray(bytes: ByteArray): FloatArray {
+        val values = FloatArray(elementCount(bytes, 4))
+        nativeBuffer(bytes).asFloatBuffer().get(values)
+        return values
+    }
+
+    fun writeFloatArray(values: FloatArray): ByteArray {
+        val bytes = ByteArray(values.size * 4)
+        nativeBuffer(bytes).asFloatBuffer().put(values)
+        return bytes
+    }
+
+    fun readDoubleArray(bytes: ByteArray): DoubleArray {
+        val values = DoubleArray(elementCount(bytes, 8))
+        nativeBuffer(bytes).asDoubleBuffer().get(values)
+        return values
+    }
+
+    fun writeDoubleArray(values: DoubleArray): ByteArray {
+        val bytes = ByteArray(values.size * 8)
+        nativeBuffer(bytes).asDoubleBuffer().put(values)
+        return bytes
+    }
+
+    private fun nativeBuffer(bytes: ByteArray): java.nio.ByteBuffer =
+        java.nio.ByteBuffer
+            .wrap(bytes)
+            .order(java.nio.ByteOrder.nativeOrder())
+
+    private fun elementCount(bytes: ByteArray, width: Int): Int {
+        require(bytes.size % width == 0)
+        return bytes.size / width
+    }
+}
+
+internal class WireReader(private val bytes: ByteArray) {
+    private var position = 0
+
+    fun readBool(): Boolean = readI8() != 0.toByte()
+
+    fun readI8(): Byte {
+        val value = bytes[position]
+        position += 1
+        return value
+    }
+
+    fun readU8(): UByte = readI8().toUByte()
+
+    fun readI16(): Short {
+        val value =
+            (bytes[position].toInt() and 0xff) or
+                ((bytes[position + 1].toInt() and 0xff) shl 8)
+        position += 2
+        return value.toShort()
+    }
+
+    fun readU16(): UShort = readI16().toUShort()
+
+    fun readI32(): Int {
+        val value =
+            (bytes[position].toInt() and 0xff) or
+                ((bytes[position + 1].toInt() and 0xff) shl 8) or
+                ((bytes[position + 2].toInt() and 0xff) shl 16) or
+                ((bytes[position + 3].toInt() and 0xff) shl 24)
+        position += 4
+        return value
+    }
+
+    fun readU32(): UInt = readI32().toUInt()
+
+    fun readI64(): Long {
+        val low = readI32().toLong() and 0xffffffffL
+        val high = readI32().toLong() and 0xffffffffL
+        return low or (high shl 32)
+    }
+
+    fun readU64(): ULong = readI64().toULong()
+
+    fun readF32(): Float = java.lang.Float.intBitsToFloat(readI32())
+
+    fun readF64(): Double = java.lang.Double.longBitsToDouble(readI64())
+
+    fun readOptionalBool(): Boolean? = readOptional { it.readBool() }
+
+    fun readOptionalI8(): Byte? = readOptional { it.readI8() }
+
+    fun readOptionalU8(): UByte? = readOptional { it.readU8() }
+
+    fun readOptionalI16(): Short? = readOptional { it.readI16() }
+
+    fun readOptionalU16(): UShort? = readOptional { it.readU16() }
+
+    fun readOptionalI32(): Int? = readOptional { it.readI32() }
+
+    fun readOptionalU32(): UInt? = readOptional { it.readU32() }
+
+    fun readOptionalI64(): Long? = readOptional { it.readI64() }
+
+    fun readOptionalU64(): ULong? = readOptional { it.readU64() }
+
+    fun readOptionalF32(): Float? = readOptional { it.readF32() }
+
+    fun readOptionalF64(): Double? = readOptional { it.readF64() }
+
+    fun readString(): String {
+        val length = readU32().toInt()
+        val value = String(bytes, position, length, Charsets.UTF_8)
+        position += length
+        return value
+    }
+
+    fun readBytes(): ByteArray {
+        val length = readU32().toInt()
+        val value = bytes.copyOfRange(position, position + length)
+        position += length
+        return value
+    }
+
+    fun readBooleanArray(): BooleanArray {
+        val length = readU32().toInt()
+        return BooleanArray(length) { readBool() }
+    }
+
+    fun readByteArray(): ByteArray = readBytes()
+
+    fun readShortArray(): ShortArray {
+        val length = readU32().toInt()
+        val byteCount = length * 2
+        val values = ShortArray(length)
+        java.nio.ByteBuffer
+            .wrap(bytes, position, byteCount)
+            .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+            .asShortBuffer()
+            .get(values)
+        position += byteCount
+        return values
+    }
+
+    fun readUShortArray(): UShortArray =
+        readShortArray().toUShortArray()
+
+    fun readIntArray(): IntArray {
+        val length = readU32().toInt()
+        val byteCount = length * 4
+        val values = IntArray(length)
+        java.nio.ByteBuffer
+            .wrap(bytes, position, byteCount)
+            .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+            .asIntBuffer()
+            .get(values)
+        position += byteCount
+        return values
+    }
+
+    fun readUIntArray(): UIntArray =
+        readIntArray().toUIntArray()
+
+    fun readLongArray(): LongArray {
+        val length = readU32().toInt()
+        val byteCount = length * 8
+        val values = LongArray(length)
+        java.nio.ByteBuffer
+            .wrap(bytes, position, byteCount)
+            .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+            .asLongBuffer()
+            .get(values)
+        position += byteCount
+        return values
+    }
+
+    fun readULongArray(): ULongArray =
+        readLongArray().toULongArray()
+
+    fun readFloatArray(): FloatArray {
+        val length = readU32().toInt()
+        val byteCount = length * 4
+        val values = FloatArray(length)
+        java.nio.ByteBuffer
+            .wrap(bytes, position, byteCount)
+            .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+            .asFloatBuffer()
+            .get(values)
+        position += byteCount
+        return values
+    }
+
+    fun readDoubleArray(): DoubleArray {
+        val length = readU32().toInt()
+        val byteCount = length * 8
+        val values = DoubleArray(length)
+        java.nio.ByteBuffer
+            .wrap(bytes, position, byteCount)
+            .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+            .asDoubleBuffer()
+            .get(values)
+        position += byteCount
+        return values
+    }
+
+    fun <T> readOptionalValue(read: (WireReader) -> T): T? = readOptional(read)
+
+    fun <T> readSequence(read: (WireReader) -> T): List<T> {
+        val length = readU32().toInt()
+        return List(length) { read(this) }
+    }
+
+    fun <K, V> readMap(readKey: (WireReader) -> K, readValue: (WireReader) -> V): Map<K, V> {
+        val length = readU32().toInt()
+        val values = LinkedHashMap<K, V>(length)
+        repeat(length) {
+            val key = readKey(this)
+            if (values.containsKey(key)) {
+                throw IllegalArgumentException("duplicate map key")
+            }
+            values[key] = readValue(this)
+        }
+        return values
+    }
+
+    private inline fun <T> readOptional(read: (WireReader) -> T): T? {
+        return when (readU8()) {
+            0.toUByte() -> null
+            1.toUByte() -> read(this)
+            else -> throw IllegalArgumentException("invalid optional wire tag")
+        }
+    }
+}
+
+internal class WireWriter(initialCapacity: Int) {
+    private var buffer = java.nio.ByteBuffer
+        .allocateDirect(initialCapacity)
+        .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+    private var position = 0
+
+    fun reset(requiredCapacity: Int) {
+        if (buffer.capacity() < requiredCapacity) {
+            buffer = java.nio.ByteBuffer
+                .allocateDirect(requiredCapacity)
+                .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        }
+        position = 0
+    }
+
+    fun toByteArray(): ByteArray {
+        val bytes = ByteArray(position)
+        val view = buffer.duplicate()
+        view.position(0)
+        view.get(bytes, 0, position)
+        return bytes
+    }
+
+    fun directBuffer(): java.nio.ByteBuffer = buffer
+
+    fun size(): Int = position
+
+    fun writeBool(value: Boolean) {
+        ensureCapacity(1)
+        buffer.put(position, if (value) 1.toByte() else 0.toByte())
+        position += 1
+    }
+
+    fun writeI8(value: Byte) {
+        ensureCapacity(1)
+        buffer.put(position, value)
+        position += 1
+    }
+
+    fun writeU8(value: UByte) {
+        writeI8(value.toByte())
+    }
+
+    fun writeI16(value: Short) {
+        ensureCapacity(2)
+        buffer.putShort(position, value)
+        position += 2
+    }
+
+    fun writeU16(value: UShort) {
+        writeI16(value.toShort())
+    }
+
+    fun writeI32(value: Int) {
+        ensureCapacity(4)
+        buffer.putInt(position, value)
+        position += 4
+    }
+
+    fun writeU32(value: UInt) {
+        writeI32(value.toInt())
+    }
+
+    fun writeI64(value: Long) {
+        ensureCapacity(8)
+        buffer.putLong(position, value)
+        position += 8
+    }
+
+    fun writeU64(value: ULong) {
+        writeI64(value.toLong())
+    }
+
+    fun writeF32(value: Float) {
+        writeI32(java.lang.Float.floatToRawIntBits(value))
+    }
+
+    fun writeF64(value: Double) {
+        writeI64(java.lang.Double.doubleToRawLongBits(value))
+    }
+
+    fun writeOptionalBool(value: Boolean?) = writeOptional(value) { writer, present ->
+        writer.writeBool(present)
+    }
+
+    fun writeOptionalI8(value: Byte?) = writeOptional(value) { writer, present ->
+        writer.writeI8(present)
+    }
+
+    fun writeOptionalU8(value: UByte?) = writeOptional(value) { writer, present ->
+        writer.writeU8(present)
+    }
+
+    fun writeOptionalI16(value: Short?) = writeOptional(value) { writer, present ->
+        writer.writeI16(present)
+    }
+
+    fun writeOptionalU16(value: UShort?) = writeOptional(value) { writer, present ->
+        writer.writeU16(present)
+    }
+
+    fun writeOptionalI32(value: Int?) = writeOptional(value) { writer, present ->
+        writer.writeI32(present)
+    }
+
+    fun writeOptionalU32(value: UInt?) = writeOptional(value) { writer, present ->
+        writer.writeU32(present)
+    }
+
+    fun writeOptionalI64(value: Long?) = writeOptional(value) { writer, present ->
+        writer.writeI64(present)
+    }
+
+    fun writeOptionalU64(value: ULong?) = writeOptional(value) { writer, present ->
+        writer.writeU64(present)
+    }
+
+    fun writeOptionalF32(value: Float?) = writeOptional(value) { writer, present ->
+        writer.writeF32(present)
+    }
+
+    fun writeOptionalF64(value: Double?) = writeOptional(value) { writer, present ->
+        writer.writeF64(present)
+    }
+
+    fun writeString(value: String) {
+        val bytes = value.toByteArray(Charsets.UTF_8)
+        writeU32(bytes.size.toUInt())
+        writeBytesRaw(bytes)
+    }
+
+    fun writeBytes(value: ByteArray) {
+        writeU32(value.size.toUInt())
+        writeBytesRaw(value)
+    }
+
+    fun writeBooleanArray(values: BooleanArray) {
+        writeU32(values.size.toUInt())
+        values.forEach { writeBool(it) }
+    }
+
+    fun writeByteArray(values: ByteArray) = writeBytes(values)
+
+    fun writeShortArray(values: ShortArray) {
+        writeU32(values.size.toUInt())
+        val byteCount = values.size * 2
+        ensureCapacity(byteCount)
+        val view = buffer.duplicate().order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        view.position(position)
+        view.asShortBuffer().put(values)
+        position += byteCount
+    }
+
+    fun writeUShortArray(values: UShortArray) =
+        writeShortArray(values.asShortArray())
+
+    fun writeIntArray(values: IntArray) {
+        writeU32(values.size.toUInt())
+        val byteCount = values.size * 4
+        ensureCapacity(byteCount)
+        val view = buffer.duplicate().order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        view.position(position)
+        view.asIntBuffer().put(values)
+        position += byteCount
+    }
+
+    fun writeUIntArray(values: UIntArray) =
+        writeIntArray(values.asIntArray())
+
+    fun writeLongArray(values: LongArray) {
+        writeU32(values.size.toUInt())
+        val byteCount = values.size * 8
+        ensureCapacity(byteCount)
+        val view = buffer.duplicate().order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        view.position(position)
+        view.asLongBuffer().put(values)
+        position += byteCount
+    }
+
+    fun writeULongArray(values: ULongArray) =
+        writeLongArray(values.asLongArray())
+
+    fun writeFloatArray(values: FloatArray) {
+        writeU32(values.size.toUInt())
+        val byteCount = values.size * 4
+        ensureCapacity(byteCount)
+        val view = buffer.duplicate().order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        view.position(position)
+        view.asFloatBuffer().put(values)
+        position += byteCount
+    }
+
+    fun writeDoubleArray(values: DoubleArray) {
+        writeU32(values.size.toUInt())
+        val byteCount = values.size * 8
+        ensureCapacity(byteCount)
+        val view = buffer.duplicate().order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        view.position(position)
+        view.asDoubleBuffer().put(values)
+        position += byteCount
+    }
+
+    fun <T> writeOptionalValue(value: T?, write: (WireWriter, T) -> Unit) {
+        writeOptional(value, write)
+    }
+
+    fun <T> writeSequence(value: Iterable<T>, count: Int, write: (WireWriter, T) -> Unit) {
+        writeU32(count.toUInt())
+        value.forEach { item -> write(this, item) }
+    }
+
+    fun <K, V> writeMap(
+        value: Map<K, V>,
+        writeKey: (WireWriter, K) -> Unit,
+        writeValue: (WireWriter, V) -> Unit,
+    ) {
+        writeU32(value.size.toUInt())
+        value.entries.forEach { entry ->
+            writeKey(this, entry.key)
+            writeValue(this, entry.value)
+        }
+    }
+
+    private fun writeBytesRaw(bytes: ByteArray) {
+        ensureCapacity(bytes.size)
+        val view = buffer.duplicate().order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        view.position(position)
+        view.put(bytes)
+        position += bytes.size
+    }
+
+    private fun ensureCapacity(needed: Int) {
+        val required = position + needed
+        if (required <= buffer.capacity()) {
+            return
+        }
+        val nextCapacity = maxOf(buffer.capacity() * 2, required)
+        val next = java.nio.ByteBuffer
+            .allocateDirect(nextCapacity)
+            .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        val source = buffer.duplicate().order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        source.limit(position)
+        source.position(0)
+        next.put(source)
+        buffer = next
+    }
+
+    private inline fun <T> writeOptional(value: T?, write: (WireWriter, T) -> Unit) {
+        if (value == null) {
+            writeU8(0.toUByte())
+            return
+        }
+        writeU8(1.toUByte())
+        write(this, value)
+    }
+}
+
+private const val MAX_CACHED_WIRE_WRITER_BYTES: Int = 1024 * 1024
+
+private class WireWriterPoolState(private val cacheSize: Int = 4) {
+    private val cachedWriters: Array<WireWriter?> = arrayOfNulls(cacheSize)
+    private var depth = 0
+
+    fun acquire(requiredCapacity: Int): BorrowedWireWriter {
+        val slot = depth
+        depth = slot + 1
+        val shouldCache = requiredCapacity <= MAX_CACHED_WIRE_WRITER_BYTES && slot < cacheSize
+        val writer = if (shouldCache) {
+            cachedWriters[slot] ?: WireWriter(requiredCapacity).also { cachedWriters[slot] = it }
+        } else {
+            WireWriter(requiredCapacity)
+        }
+
+        writer.reset(requiredCapacity)
+        return BorrowedWireWriter(this, writer)
+    }
+
+    fun release() {
+        depth -= 1
+    }
+}
+
+private class BorrowedWireWriter(
+    private val state: WireWriterPoolState,
+    val writer: WireWriter,
+) : AutoCloseable {
+    fun bytes(): ByteArray = writer.toByteArray()
+
+    fun directBuffer(): java.nio.ByteBuffer = writer.directBuffer()
+
+    fun size(): Int = writer.size()
+
+    override fun close() {
+        state.release()
+    }
+}
+
+private object WireWriterPool {
+    private val state: ThreadLocal<WireWriterPoolState> =
+        ThreadLocal.withInitial { WireWriterPoolState() }
+
+    fun acquire(requiredCapacity: Int): BorrowedWireWriter {
+        val poolState = state.get() ?: WireWriterPoolState().also { state.set(it) }
+        return poolState.acquire(requiredCapacity)
+    }
+}
+
+private inline fun <K, V> Map<K, V>.wireSize(
+    keySize: (K) -> Int,
+    valueSize: (V) -> Int,
+): Int = 4 + entries.sumOf { entry -> keySize(entry.key) + valueSize(entry.value) }
+
+private const val BOLTFFI_FUTURE_POLL_READY: Byte = 0
+
+private class BoltFfiHandleMap<T> {
+    private val next = java.util.concurrent.atomic.AtomicLong(1)
+    private val values = java.util.concurrent.ConcurrentHashMap<Long, T>()
+
+    fun insert(value: T): Long {
+        val handle = next.getAndIncrement()
+        values[handle] = value
+        return handle
+    }
+
+    fun remove(handle: Long): T? = values.remove(handle)
+}
+
+private val boltffiContinuationMap =
+    BoltFfiHandleMap<kotlinx.coroutines.CancellableContinuation<Byte>>()
+
+private val boltffiCallbackScope =
+    kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Default + kotlinx.coroutines.SupervisorJob())
+
+private object BoltFfiAsync {
+    fun resume(handle: Long, pollResult: Byte) {
+        val continuation = boltffiContinuationMap.remove(handle) ?: return
+        continuation.resumeWith(Result.success(pollResult))
+    }
+}
+
+internal fun boltffiLaunchCallback(block: suspend () -> Unit) {
+    boltffiCallbackScope.launch {
+        block()
+    }
+}
+
+internal suspend fun <T> boltffiCallAsync(
+    createFuture: () -> Long,
+    poll: (Long, Long) -> Unit,
+    complete: (Long) -> T,
+    free: (Long) -> Unit,
+    cancel: (Long) -> Unit,
+): T {
+    val rustFuture = createFuture()
+    try {
+        var pollResult: Byte
+        do {
+            pollResult = kotlinx.coroutines.suspendCancellableCoroutine { continuation ->
+                val continuationHandle = boltffiContinuationMap.insert(continuation)
+                continuation.invokeOnCancellation {
+                    if (boltffiContinuationMap.remove(continuationHandle) != null) {
+                        cancel(rustFuture)
+                    }
+                }
+                poll(rustFuture, continuationHandle)
+            }
+        } while (pollResult != BOLTFFI_FUTURE_POLL_READY)
+        return complete(rustFuture)
+    } finally {
+        free(rustFuture)
+    }
+}
+
+private const val BOLTFFI_STREAM_POLL_CLOSED: Byte = 1
+
+internal class BoltFfiStreamContext(
+    private val scope: kotlinx.coroutines.CoroutineScope,
+    private val subscription: Long,
+    private val batchSize: Long,
+    private val popBatch: (Long, Long) -> ByteArray?,
+    private val poll: (Long, Long) -> Unit,
+    private val unsubscribe: (Long) -> Unit,
+    private val free: (Long) -> Unit,
+    private val processItems: suspend (ByteArray) -> Unit,
+    private val finish: () -> Unit
+) {
+    private val lifecycle = java.util.concurrent.atomic.AtomicInteger(0)
+    private val processing = java.util.concurrent.atomic.AtomicInteger(0)
+
+    fun start() {
+        registerPoll()
+    }
+
+    fun requestTermination() {
+        if (lifecycle.compareAndSet(0, 1)) {
+            unsubscribe(subscription)
+            lifecycle.compareAndSet(1, 2)
+        }
+        finalizeIfIdle()
+    }
+
+    private fun registerPoll() {
+        if (!lifecycle.compareAndSet(0, 0)) {
+            finalizeIfIdle()
+            return
+        }
+        scope.launch {
+            val pollResult = kotlinx.coroutines.suspendCancellableCoroutine { continuation ->
+                poll(subscription, boltffiContinuationMap.insert(continuation))
+            }
+            handlePoll(pollResult)
+        }
+    }
+
+    private suspend fun handlePoll(pollResult: Byte) {
+        val closed = pollResult == BOLTFFI_STREAM_POLL_CLOSED
+        if (!processing.compareAndSet(0, 1)) {
+            finalizeIfIdle()
+            return
+        }
+        try {
+            if (lifecycle.compareAndSet(0, 0)) {
+                drain()
+            }
+        } finally {
+            processing.compareAndSet(1, 0)
+            finalizeIfIdle()
+        }
+        if (closed) {
+            requestTermination()
+            return
+        }
+        if (lifecycle.compareAndSet(0, 0)) {
+            registerPoll()
+        }
+    }
+
+    private suspend fun drain() {
+        while (true) {
+            val bytes = popBatch(subscription, batchSize)
+                ?: throw IllegalStateException("BoltFFI stream pop_batch returned null")
+            if (bytes.isEmpty()) return
+            processItems(bytes)
+        }
+    }
+
+    private fun finalizeIfIdle() {
+        if (!processing.compareAndSet(0, 0)) return
+        if (!lifecycle.compareAndSet(2, 3)) return
+        free(subscription)
+        finish()
+    }
+}
+
+@Suppress("FunctionName")
+private object Native {
+    init {
+        val androidLibrary = "boltffi"
+        val desktopPreferredLibrary = "boltffi_jni"
+        val desktopFallbackLibrary = "boltffi"
+        val vmName = System.getProperty("java.vm.name").orEmpty()
+        val isAndroidRuntime =
+            vmName.contains("dalvik", ignoreCase = true) ||
+            vmName.contains("art", ignoreCase = true)
+        if (isAndroidRuntime) {
+            System.loadLibrary(androidLibrary)
+        } else {
+            loadDesktopLibraries(desktopPreferredLibrary, desktopFallbackLibrary)
+        }
+    }
+
+    @Volatile
+    private var bundledLibraryDirectory: java.io.File? = null
+
+    private fun loadDesktopLibraries(preferredLibrary: String, fallbackLibrary: String) {
+        var preferredFailure = tryLoadDesktopLibrary(preferredLibrary)
+        if (preferredFailure == null) {
+            return
+        }
+
+        if (tryLoadOptionalDesktopLibrary(fallbackLibrary)) {
+            preferredFailure = tryLoadDesktopLibrary(preferredLibrary)
+            if (preferredFailure == null) {
+                return
+            }
+        }
+
+        throw preferredFailure
+    }
+
+    private fun tryLoadDesktopLibrary(libraryName: String): UnsatisfiedLinkError? {
+        try {
+            if (loadBundledLibraryIfPresent(libraryName) || loadExternalLibraryIfPresent(libraryName)) {
+                return null
+            }
+            return UnsatisfiedLinkError("Could not load native library '$libraryName'")
+        } catch (error: UnsatisfiedLinkError) {
+            return error
+        }
+    }
+
+    private fun tryLoadOptionalDesktopLibrary(libraryName: String): Boolean {
+        return try {
+            loadBundledLibraryIfPresent(libraryName) || loadExternalLibraryIfPresent(libraryName)
+        } catch (_: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    private fun loadExternalLibraryIfPresent(libraryName: String): Boolean {
+        return try {
+            System.loadLibrary(libraryName)
+            true
+        } catch (_: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    private fun loadBundledLibraryIfPresent(libraryName: String): Boolean {
+        val mappedName = System.mapLibraryName(libraryName)
+        for (resourcePath in bundledLibraryResourceCandidates(mappedName)) {
+            Native::class.java.getResourceAsStream(resourcePath)?.use { input ->
+                val extracted = extractBundledLibrary(resourcePath, input)
+                System.load(extracted.absolutePath)
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun extractBundledLibrary(
+        resourcePath: String,
+        input: java.io.InputStream,
+    ): java.io.File {
+        val fileName = resourcePath.substringAfterLast('/')
+        val extracted = java.io.File(bundledLibraryDirectory(), fileName)
+        if (!extracted.isFile) {
+            java.io.FileOutputStream(extracted).use { output ->
+                input.copyTo(output)
+            }
+            extracted.deleteOnExit()
+        }
+        return extracted
+    }
+
+    private fun bundledLibraryDirectory(): java.io.File {
+        bundledLibraryDirectory?.let { return it }
+        synchronized(this) {
+            bundledLibraryDirectory?.let { return it }
+            val created = java.io.File.createTempFile("boltffi-native-", "")
+            if (!created.delete() || !created.mkdir()) {
+                throw java.io.IOException("failed to create temp directory for bundled native extraction")
+            }
+            created.deleteOnExit()
+            bundledLibraryDirectory = created
+            return created
+        }
+    }
+
+    private fun bundledLibraryResourceCandidates(mappedName: String): List<String> {
+        val candidates = mutableListOf<String>()
+        for (directory in desktopNativeDirectories()) {
+            candidates += "/$directory/$mappedName"
+            candidates += "/native/$directory/$mappedName"
+        }
+        candidates += "/$mappedName"
+        return candidates
+    }
+
+    private fun desktopNativeDirectories(): List<String> {
+        val osName = System.getProperty("os.name").orEmpty().lowercase()
+        val osArch = System.getProperty("os.arch").orEmpty().lowercase()
+        return when {
+            (osName.contains("mac") || osName.contains("darwin")) &&
+                (osArch == "aarch64" || osArch == "arm64") ->
+                listOf("darwin-arm64", "darwin-aarch64")
+            (osName.contains("mac") || osName.contains("darwin")) &&
+                (osArch == "x86_64" || osArch == "amd64") ->
+                listOf("darwin-x86_64", "darwin-x86-64")
+            (osName.contains("linux")) &&
+                (osArch == "x86_64" || osArch == "amd64") ->
+                listOf("linux-x86_64", "linux-x86-64")
+            (osName.contains("linux")) &&
+                (osArch == "aarch64" || osArch == "arm64") ->
+                listOf("linux-aarch64", "linux-arm64")
+            (osName.contains("windows")) &&
+                (osArch == "x86_64" || osArch == "amd64") ->
+                listOf("windows-x86_64", "windows-x86-64", "win32-x86_64")
+            (osName.contains("windows")) &&
+                (osArch == "aarch64" || osArch == "arm64") ->
+                listOf("windows-aarch64", "windows-arm64", "win32-arm64")
+            else -> emptyList()
+        }
+    }
+    @JvmStatic external fun boltffi_release_class_demo_engine(handle: Long): Unit
+    @JvmStatic external fun boltffi_stream_demo_engine_points_subscribe(`receiver`: Long): Long
+    @JvmStatic external fun boltffi_stream_demo_engine_points_pop_batch(subscription: Long, maxCount: Long): ByteArray?
+    @JvmStatic external fun boltffi_stream_demo_engine_points_wait(subscription: Long, timeout_milliseconds: Int): Int
+    @JvmStatic external fun boltffi_stream_demo_engine_points_poll(subscription: Long, callback_data: Long): Unit
+    @JvmStatic external fun boltffi_stream_demo_engine_points_unsubscribe(subscription: Long): Unit
+    @JvmStatic external fun boltffi_stream_demo_engine_points_free(subscription: Long): Unit
+    @JvmStatic external fun boltffi_stream_demo_engine_names_subscribe(`receiver`: Long): Long
+    @JvmStatic external fun boltffi_stream_demo_engine_names_pop_batch(subscription: Long, max_count: Long): ByteArray?
+    @JvmStatic external fun boltffi_stream_demo_engine_names_wait(subscription: Long, timeout_milliseconds: Int): Int
+    @JvmStatic external fun boltffi_stream_demo_engine_names_poll(subscription: Long, callback_data: Long): Unit
+    @JvmStatic external fun boltffi_stream_demo_engine_names_unsubscribe(subscription: Long): Unit
+    @JvmStatic external fun boltffi_stream_demo_engine_names_free(subscription: Long): Unit
+    @JvmStatic external fun boltffi_stream_demo_engine_ticks_subscribe(`receiver`: Long): Long
+    @JvmStatic external fun boltffi_stream_demo_engine_ticks_pop_batch(subscription: Long, maxCount: Long): ByteArray?
+    @JvmStatic external fun boltffi_stream_demo_engine_ticks_wait(subscription: Long, timeout_milliseconds: Int): Int
+    @JvmStatic external fun boltffi_stream_demo_engine_ticks_poll(subscription: Long, callback_data: Long): Unit
+    @JvmStatic external fun boltffi_stream_demo_engine_ticks_unsubscribe(subscription: Long): Unit
+    @JvmStatic external fun boltffi_stream_demo_engine_ticks_free(subscription: Long): Unit
+
+    @JvmStatic fun boltffiFutureContinuationCallback(handle: Long, pollResult: Byte) {
+        BoltFfiAsync.resume(handle, pollResult)
+    }
+}
+
+
+data class Point(
+    val x: Double,
+    val y: Double
+) {
+    internal fun toByteArray(): ByteArray {
+        val buffer = java.nio.ByteBuffer
+            .allocate(STRUCT_SIZE)
+            .order(java.nio.ByteOrder.nativeOrder())
+        writeTo(buffer, 0)
+        return buffer.array()
+    }
+
+    internal fun toDirectBuffer(): java.nio.ByteBuffer {
+        val buffer = java.nio.ByteBuffer
+            .allocateDirect(STRUCT_SIZE)
+            .order(java.nio.ByteOrder.nativeOrder())
+        writeTo(buffer, 0)
+        return buffer
+    }
+
+    internal fun writeTo(buffer: java.nio.ByteBuffer, offset: Int) {
+        buffer.putDouble(offset, x)
+        buffer.putDouble(offset + 8, y)
+    }
+
+    companion object {
+        internal const val STRUCT_SIZE: Int = 16
+
+        internal fun fromByteArray(bytes: ByteArray): Point {
+            require(bytes.size == STRUCT_SIZE)
+            val buffer = java.nio.ByteBuffer
+                .wrap(bytes)
+                .order(java.nio.ByteOrder.nativeOrder())
+            return fromBuffer(buffer, 0)
+        }
+
+        internal fun fromBuffer(buffer: java.nio.ByteBuffer, offset: Int): Point {
+            return Point(
+                buffer.getDouble(offset),
+                buffer.getDouble(offset + 8)
+            )
+        }
+    }
+}
+
+class Engine internal constructor(internal val handle: Long) : AutoCloseable {
+    private val __boltffi_closed = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    override fun close() {
+        if (__boltffi_closed.compareAndSet(false, true)) {
+            Native.boltffi_release_class_demo_engine(handle)
+        }
+    }
+
+    internal fun boltffiHandle(): Long {
+        check(!__boltffi_closed.get()) { "Engine is closed" }
+        return handle
+    }
+}
+
+fun Engine.points(): PointsSubscription =
+    PointsSubscription(
+        handle = Native.boltffi_stream_demo_engine_points_subscribe(boltffiHandle()),
+        popBatch = Native::boltffi_stream_demo_engine_points_pop_batch,
+        wait = Native::boltffi_stream_demo_engine_points_wait,
+        unsubscribe = Native::boltffi_stream_demo_engine_points_unsubscribe,
+        free = Native::boltffi_stream_demo_engine_points_free
+    )
+
+class PointsSubscription(
+    private val handle: Long,
+    private val popBatch: (Long, Long) -> ByteArray?,
+    private val wait: (Long, Int) -> Int,
+    private val unsubscribe: (Long) -> Unit,
+    private val free: (Long) -> Unit
+) : AutoCloseable {
+    private val closed = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        if (handle == 0L) return
+        free(handle)
+    }
+
+    fun popBatch(maxCount: Long = 16L): List<Point> {
+        if (handle == 0L) return emptyList()
+        val bytes = popBatch(handle, maxCount)
+            ?: throw IllegalStateException("BoltFFI stream pop_batch returned null")
+        if (bytes.isEmpty()) return emptyList()
+        val items = DirectVectorCodec.readRecordList(bytes, 16, { buffer, offset -> Point.fromBuffer(buffer, offset) })
+        return items
+    }
+
+    fun wait(timeout: Int): Int {
+        if (handle == 0L) return -1
+        return wait(handle, timeout)
+    }
+
+    fun unsubscribe() {
+        if (handle == 0L) return
+        unsubscribe(handle)
+    }
+}
+
+fun Engine.names(): kotlinx.coroutines.flow.Flow<String> = kotlinx.coroutines.flow.callbackFlow {
+    val subscription = Native.boltffi_stream_demo_engine_names_subscribe(boltffiHandle())
+    if (subscription == 0L) {
+        close()
+        return@callbackFlow
+    }
+    val context = BoltFfiStreamContext(
+        scope = this,
+        subscription = subscription,
+        batchSize = 16L,
+        popBatch = Native::boltffi_stream_demo_engine_names_pop_batch,
+        poll = Native::boltffi_stream_demo_engine_names_poll,
+        unsubscribe = Native::boltffi_stream_demo_engine_names_unsubscribe,
+        free = Native::boltffi_stream_demo_engine_names_free,
+        processItems = { bytes ->
+            val reader = WireReader(bytes)
+            val count = reader.readU32().toInt()
+            val items = List(count) { reader.readString() }
+            items.forEach { item ->
+                send(item)
+            }
+        },
+        finish = { close() }
+    )
+    context.start()
+    awaitClose { context.requestTermination() }
+}
+
+fun Engine.ticks(callback: (Int) -> Unit): TicksCancellable {
+    val subscription = Native.boltffi_stream_demo_engine_ticks_subscribe(boltffiHandle())
+    if (subscription == 0L) return TicksCancellable {}
+    val context = BoltFfiStreamContext(
+        scope = boltffiCallbackScope,
+        subscription = subscription,
+        batchSize = 16L,
+        popBatch = Native::boltffi_stream_demo_engine_ticks_pop_batch,
+        poll = Native::boltffi_stream_demo_engine_ticks_poll,
+        unsubscribe = Native::boltffi_stream_demo_engine_ticks_unsubscribe,
+        free = Native::boltffi_stream_demo_engine_ticks_free,
+        processItems = { bytes ->
+            val items = DirectVectorCodec.readIntArray(bytes).toList()
+            items.forEach { item ->
+                callback(item)
+            }
+        },
+        finish = {}
+    )
+    context.start()
+    return TicksCancellable { context.requestTermination() }
+}
+
+class TicksCancellable(
+    private val onCancel: () -> Unit = {}
+) : AutoCloseable {
+    private val cancelled = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    fun cancel() {
+        if (!cancelled.compareAndSet(false, true)) return
+        onCancel()
+    }
+
+    override fun close() {
+        cancel()
+    }
+}

--- a/boltffi_backend/tests/kotlin/stream.rs
+++ b/boltffi_backend/tests/kotlin/stream.rs
@@ -1,6 +1,11 @@
-use super::rendered_fixture;
+use super::{rendered_fixture, rendered_fixture_with_runtime};
 
 #[test]
 fn kotlin_target_renders_stream_protocols() {
     insta::assert_snapshot!(rendered_fixture("stream/protocol_functions"));
+}
+
+#[test]
+fn kotlin_target_renders_stream_runtime() {
+    insta::assert_snapshot!(rendered_fixture_with_runtime("stream/protocol_functions"));
 }

--- a/boltffi_bindgen/src/render/kotlin/templates/render_kotlin/class.txt
+++ b/boltffi_bindgen/src/render/kotlin/templates/render_kotlin/class.txt
@@ -115,7 +115,7 @@
             freeFn = Native::{{ stream.free }},
             processItems = { bytes ->
                 for (item in {{ stream.pop_batch_items_expr }}) {
-                    trySend(item)
+                    send(item)
                 }
             },
             finish = { close() }

--- a/boltffi_bindgen/src/render/kotlin/templates/render_kotlin/preamble.txt
+++ b/boltffi_bindgen/src/render/kotlin/templates/render_kotlin/preamble.txt
@@ -164,7 +164,7 @@ internal class BoltFFIStreamContext(
     private val poll: (SubscriptionHandle, Long) -> Unit,
     private val unsubscribe: (SubscriptionHandle) -> Unit,
     private val freeFn: (SubscriptionHandle) -> Unit,
-    private val processItems: (ByteArray) -> Unit,
+    private val processItems: suspend (ByteArray) -> Unit,
     private val finish: () -> Unit
 ) {
     // 0 = running, 1 = unsubscribe called, 2 = unsubscribed, 3 = freed
@@ -209,7 +209,7 @@ internal class BoltFFIStreamContext(
         }
     }
 
-    private fun handlePoll(pollResult: Byte) {
+    private suspend fun handlePoll(pollResult: Byte) {
         val isClosed = pollResult == BOLTFFI_STREAM_POLL_CLOSED
         if (!callbackTag.compareAndSet(0, 1)) {
             attemptFinalize()

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoStreamBackpressureTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoStreamBackpressureTest.kt
@@ -1,0 +1,52 @@
+package com.boltffi.demo
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DemoStreamBackpressureTest {
+    private fun burstThrough(bus: EventBus, perItemDelayMs: Long): List<Int> = runBlocking {
+        val ready = CompletableDeferred<Unit>()
+        val items = async(Dispatchers.Default) {
+            withTimeout(15_000) {
+                bus.subscribeValues()
+                    .onEach { value ->
+                        if (value == -1) ready.complete(Unit)
+                        if (perItemDelayMs > 0) delay(perItemDelayMs)
+                    }
+                    .filter { it > 0 }
+                    .take(200)
+                    .toList()
+            }
+        }
+        while (!ready.isCompleted) {
+            bus.emitValue(-1)
+            delay(20)
+        }
+        assertEquals(200u, bus.emitBatch(IntArray(200) { it + 1 }))
+        items.await()
+    }
+
+    @Test
+    fun burstDeliversEveryItemToFastCollector() {
+        EventBus().use { bus ->
+            assertEquals((1..200).toList(), burstThrough(bus, perItemDelayMs = 0))
+        }
+    }
+
+    @Test
+    fun burstSuspendsInsteadOfDroppingForSlowCollector() {
+        EventBus().use { bus ->
+            assertEquals((1..200).toList(), burstThrough(bus, perItemDelayMs = 1))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The Kotlin async stream mode delivers drained items into the `callbackFlow` channel with `trySend` and discards the result. `callbackFlow` uses a `Channel.BUFFERED` channel (capacity 64), so whenever the drain loop outruns the collector by more than 64 items, `trySend` fails without suspending and the item is silently gone — no exception, no closed flow, no signal anywhere. The collector receives a stream with holes.

Measured on the demo `EventBus` (JVM, macOS): a 200-item burst against a collector doing 1 ms of work per item delivered **65/200**, with a contiguous gap starting exactly at item 66 (marker + 64 = the channel capacity); even a no-delay collector delivered 117/200 under burst. The native ring ingested 200/200 in every run — the loss is entirely inside the generated binding, after the items crossed the FFI boundary. It also silently overrides the stream author's capacity choice: the documented remedy ("increase the capacity") cannot help while an undocumented 64-slot buffer sits in front of the ring.

Both Kotlin generators carry the same shape (`boltffi_backend/templates/target/kotlin/stream.kt`, `boltffi_bindgen/.../render_kotlin/class.txt`). Swift is unbounded, Java delivers synchronously, C# pulls, Kotlin batch mode pulls — Kotlin async was the only mode that could lose items in-binding.

## Fix

Deliver with `send` and make the delivery path suspending. The drain already runs inside a coroutine (`scope.launch { … handlePoll(pollResult) }`), so `processItems` becomes a `suspend` lambda and `handlePoll`/`drain` become `suspend` functions — no structural change:

```kotlin
processItems = { bytes ->
    val items = DirectVectorCodec.readIntArray(bytes).toList()
    items.forEach { item ->
        send(item)          // was: trySend(item) with the result discarded
    }
},
```

When the channel fills, the drain loop now suspends instead of dropping; back-pressure propagates to the subscription's ring buffer, i.e. overflow degrades to the documented, author-tunable native capacity policy instead of an invisible 64-item cliff. With the fix, both burst scenarios above deliver 200/200 in order (new `DemoStreamBackpressureTest`). Callback and batch modes are unchanged.

This fixes the silent-loss defect from the ffi_stream delivery-semantics report; the delivery-policy design (per-stream buffering/overflow declaration honored by every backend) is deliberately left to the follow-up RFC.
