### PR TITLE
fix(callback): stop panicking when an infallible async callback completes with failure

### DIFF
--- a/boltffi_macros/src/experimental/wrapper/callback.rs
+++ b/boltffi_macros/src/experimental/wrapper/callback.rs
@@ -2619,7 +2619,12 @@ where
                     .expect("async callback mutex poisoned");
                 if state.completed {
                     if state.status.is_err() {
-                        panic!("async callback failed");
+                        eprintln!(
+                            "boltffi: an infallible async callback completed with a failure \
+                             status; the trait method has no Result to report it through, so \
+                             this is a host language binding bug, not a normal error -- \
+                             continuing as if it completed successfully"
+                        );
                     }
                     std::task::Poll::Ready(())
                 } else {
@@ -2691,7 +2696,12 @@ where
                     .expect("async callback mutex poisoned");
                 if let Some(__boltffi_result) = state.result.take() {
                     if state.status.is_err() {
-                        panic!("async callback failed");
+                        eprintln!(
+                            "boltffi: an infallible async callback completed with a failure \
+                             status; the trait method has no Result to report it through, so \
+                             this is a host language binding bug, not a normal error -- \
+                             continuing with the completion value anyway"
+                        );
                     }
                     std::task::Poll::Ready(#value)
                 } else {
@@ -2759,7 +2769,12 @@ where
                     .expect("async callback mutex poisoned");
                 if let Some(__boltffi_result) = state.result.take() {
                     if state.status.is_err() {
-                        panic!("async callback failed");
+                        panic!(
+                            "boltffi: an infallible async callback completed with a failure \
+                             status; the trait method has no Result to report it through and \
+                             its payload requires wire-decoding, which has no defined shape on \
+                             failure -- this is a host language binding bug, not a normal error"
+                        );
                     }
                     std::task::Poll::Ready(#value)
                 } else {
@@ -2934,7 +2949,12 @@ where
                 match __boltffi_registry.take_completion(__boltffi_request) {
                     Some(__boltffi_completion) => {
                         if !__boltffi_completion.code.is_success() {
-                            panic!("async callback failed");
+                            eprintln!(
+                                "boltffi: an infallible async callback completed with a failure \
+                                 status; the trait method has no Result to report it through, \
+                                 so this is a host language binding bug, not a normal error -- \
+                                 continuing as if it completed successfully"
+                            );
                         }
                         drop(__boltffi_guard.take());
                         std::task::Poll::Ready(())
@@ -2993,7 +3013,13 @@ where
                 match __boltffi_registry.take_completion(__boltffi_request) {
                     Some(__boltffi_completion) => {
                         if !__boltffi_completion.code.is_success() {
-                            panic!("async callback failed");
+                            panic!(
+                                "boltffi: an infallible async callback completed with a failure \
+                                 status; the trait method has no Result to report it through \
+                                 and its payload requires wire-decoding, which has no defined \
+                                 shape on failure -- this is a host language binding bug, not a \
+                                 normal error"
+                            );
                         }
                         drop(__boltffi_guard.take());
                         std::task::Poll::Ready(#value)

--- a/boltffi_macros/src/experimental/wrapper/callback.rs
+++ b/boltffi_macros/src/experimental/wrapper/callback.rs
@@ -2222,7 +2222,12 @@ where
                 ..
             } => {
                 let ffi_type = wrapper::type_ref::Renderer.primitive(*primitive)?;
-                Ok(self.native_async_value_body(ffi_type, call, quote! { __boltffi_result }))
+                Ok(self.native_async_value_body(
+                    ffi_type,
+                    call,
+                    quote! { __boltffi_result },
+                    Self::async_failure_swallow(),
+                ))
             }
             InfallibleMethodReturn::Direct { .. } => {
                 let rust_type = self.direct_source_type()?;
@@ -2234,6 +2239,7 @@ where
                             <#rust_type as ::boltffi::__private::Passable>::unpack(__boltffi_result)
                         }
                     },
+                    Self::async_failure_swallow(),
                 ))
             }
             InfallibleMethodReturn::Handle {
@@ -2249,7 +2255,11 @@ where
                     presence,
                     quote! { __boltffi_result },
                 )?;
-                Ok(self.native_async_value_body(carrier_type.clone(), call, value))
+                let on_failure = match presence {
+                    HandlePresence::Nullable => Self::async_failure_swallow(),
+                    _ => Self::async_failure_required_handle_panic(),
+                };
+                Ok(self.native_async_value_body(carrier_type.clone(), call, value, on_failure))
             }
             InfallibleMethodReturn::ScalarOption { primitive } => {
                 self.source.scalar_option(primitive)?;
@@ -2635,11 +2645,32 @@ where
         }
     }
 
+    fn async_failure_swallow() -> TokenStream {
+        quote! {
+            eprintln!(
+                "boltffi: an infallible async callback completed with a failure \
+                 status; the trait method has no Result to report it through, so \
+                 this is a host language binding bug, not a normal error -- \
+                 continuing with the completion value anyway"
+            );
+        }
+    }
+
+    fn async_failure_required_handle_panic() -> TokenStream {
+        quote! {
+            panic!(
+                "an infallible async callback returning a required handle completed \
+                 with a failure status; there is no valid handle to continue with"
+            );
+        }
+    }
+
     fn native_async_value_body(
         &self,
         result_type: TokenStream,
         call: TokenStream,
         value: TokenStream,
+        on_failure: TokenStream,
     ) -> TokenStream {
         quote! {
             use std::sync::{Arc, Mutex};
@@ -2696,12 +2727,7 @@ where
                     .expect("async callback mutex poisoned");
                 if let Some(__boltffi_result) = state.result.take() {
                     if state.status.is_err() {
-                        eprintln!(
-                            "boltffi: an infallible async callback completed with a failure \
-                             status; the trait method has no Result to report it through, so \
-                             this is a host language binding bug, not a normal error -- \
-                             continuing with the completion value anyway"
-                        );
+                        #on_failure
                     }
                     std::task::Poll::Ready(#value)
                 } else {

--- a/boltffi_tests/build.rs
+++ b/boltffi_tests/build.rs
@@ -1265,6 +1265,12 @@ static void boltffi_tests_async_compute(uint64_t handle, int32_t a, int32_t b, v
     callback(context, FFI_STATUS_OK, (int64_t)handle + (int64_t)a * b);
 }
 
+static void boltffi_tests_async_make_callback(uint64_t handle, void (*callback)(void *, FfiStatus, BoltFFICallbackHandle), void *context) {
+    BoltFFICallbackHandle value_callback =
+        boltffi_create_callback_boltffi_tests_callbacks_sync_value_callback(handle);
+    callback(context, FFI_STATUS_OK, value_callback);
+}
+
 static int boltffi_tests_check_callbacks(void) {
     ___SyncValueCallbackVTable value_vtable = {
         boltffi_tests_callback_free,
@@ -1320,6 +1326,11 @@ static int boltffi_tests_check_callbacks(void) {
         boltffi_tests_async_load,
         boltffi_tests_async_compute
     };
+    ___AsyncCallbackFactoryVTable async_factory_vtable = {
+        boltffi_tests_callback_free,
+        boltffi_tests_callback_clone,
+        boltffi_tests_async_make_callback
+    };
     boltffi_register_callback_boltffi_tests_callbacks_sync_value_callback(&value_vtable);
     boltffi_register_callback_boltffi_tests_callbacks_sync_data_provider(&provider_vtable);
     boltffi_register_callback_boltffi_tests_callbacks_sync_vec_callback(&vec_vtable);
@@ -1330,6 +1341,7 @@ static int boltffi_tests_check_callbacks(void) {
     boltffi_register_callback_boltffi_tests_callbacks_async_fetcher(&async_fetch_vtable);
     boltffi_register_callback_boltffi_tests_callbacks_async_option_fetcher(&async_option_vtable);
     boltffi_register_callback_boltffi_tests_callbacks_async_multi_method(&async_multi_vtable);
+    boltffi_register_callback_boltffi_tests_callbacks_async_callback_factory(&async_factory_vtable);
     BoltFFICallbackHandle callback = boltffi_create_callback_boltffi_tests_callbacks_sync_value_callback(5);
     if (boltffi_function_boltffi_tests_callbacks_invoke_sync_impl(callback, 10) != 15) {
         return 711;
@@ -1508,6 +1520,27 @@ static int boltffi_tests_check_callbacks(void) {
     boltffi_async_function_boltffi_tests_callbacks_invoke_async_multi_impl_free(async_multi_future);
     if (async_multi_status.code != FFI_STATUS_OK.code || async_multi_result != 23) {
         return 754;
+    }
+    BoltFFICallbackHandle async_factory =
+        boltffi_create_callback_boltffi_tests_callbacks_async_callback_factory(12);
+    RustFutureHandle async_factory_future =
+        boltffi_function_boltffi_tests_callbacks_invoke_async_factory_impl(async_factory, 5);
+    boltffi_async_function_boltffi_tests_callbacks_invoke_async_factory_impl_poll(
+        async_factory_future,
+        0,
+        boltffi_tests_async_noop
+    );
+    FfiStatus async_factory_status = FFI_STATUS_INTERNAL_ERROR;
+    int32_t async_factory_result =
+        boltffi_async_function_boltffi_tests_callbacks_invoke_async_factory_impl_complete(
+            async_factory_future,
+            &async_factory_status
+        );
+    boltffi_async_function_boltffi_tests_callbacks_invoke_async_factory_impl_free(
+        async_factory_future
+    );
+    if (async_factory_status.code != FFI_STATUS_OK.code || async_factory_result != 17) {
+        return 755;
     }
     const uint8_t record[27] = {
         3, 0, 0, 0, 'o', 'l', 'd',

--- a/boltffi_tests/src/callbacks.rs
+++ b/boltffi_tests/src/callbacks.rs
@@ -319,3 +319,15 @@ impl AsyncProcessor {
         fetcher.find(key).await.map(|v| v + self.offset as i64)
     }
 }
+
+#[export]
+#[allow(async_fn_in_trait)]
+pub trait AsyncCallbackFactory {
+    async fn make(&self) -> Box<dyn SyncValueCallback>;
+}
+
+#[export]
+pub async fn invoke_async_factory_impl(factory: impl AsyncCallbackFactory, input: i32) -> i32 {
+    let callback = factory.make().await;
+    callback.on_value(input)
+}

--- a/boltffi_tests/tests/callback_traits.rs
+++ b/boltffi_tests/tests/callback_traits.rs
@@ -725,3 +725,46 @@ mod async_fetcher_foreign_failure {
         assert_eq!(result, 0);
     }
 }
+
+mod async_factory_foreign_failure {
+    use super::*;
+    use boltffi::__private::{BoxFromCallbackHandle, CallbackHandle, FfiStatus};
+    use std::ffi::c_void;
+
+    extern "C" fn free_handle(_handle: u64) {}
+
+    extern "C" fn clone_handle(handle: u64) -> u64 {
+        handle
+    }
+
+    extern "C" fn failing_make(
+        _handle: u64,
+        completion: extern "C" fn(*mut c_void, FfiStatus, CallbackHandle),
+        completion_data: *mut c_void,
+    ) {
+        completion(
+            completion_data,
+            FfiStatus::INTERNAL_ERROR,
+            CallbackHandle::NULL,
+        );
+    }
+
+    static FAILING_VTABLE: AsyncCallbackFactoryVTable = AsyncCallbackFactoryVTable {
+        free: free_handle,
+        clone: clone_handle,
+        make: failing_make,
+    };
+
+    #[tokio::test]
+    #[should_panic(expected = "required handle")]
+    async fn completion_failure_panics_for_a_required_handle_return() {
+        unsafe {
+            boltffi_register_callback_boltffi_tests_callbacks_async_callback_factory(
+                &FAILING_VTABLE,
+            );
+        }
+        let handle = boltffi_create_callback_boltffi_tests_callbacks_async_callback_factory(9);
+        let factory = unsafe { ForeignAsyncCallbackFactory::box_from_callback_handle(handle) };
+        let _ = invoke_async_factory_impl(*factory, 5).await;
+    }
+}

--- a/boltffi_tests/tests/callback_traits.rs
+++ b/boltffi_tests/tests/callback_traits.rs
@@ -687,3 +687,41 @@ mod struct_method_callbacks {
         assert_eq!(result, None);
     }
 }
+
+mod async_fetcher_foreign_failure {
+    use super::*;
+    use boltffi::__private::{BoxFromCallbackHandle, FfiStatus};
+    use std::ffi::c_void;
+
+    extern "C" fn free_handle(_handle: u64) {}
+
+    extern "C" fn clone_handle(handle: u64) -> u64 {
+        handle
+    }
+
+    extern "C" fn failing_fetch(
+        _handle: u64,
+        _key: u32,
+        completion: extern "C" fn(*mut c_void, FfiStatus, u64),
+        completion_data: *mut c_void,
+    ) {
+        completion(completion_data, FfiStatus::INTERNAL_ERROR, 0);
+    }
+
+    static FAILING_VTABLE: AsyncFetcherVTable = AsyncFetcherVTable {
+        free: free_handle,
+        clone: clone_handle,
+        fetch: failing_fetch,
+    };
+
+    #[tokio::test]
+    async fn completion_failure_resolves_instead_of_panicking() {
+        unsafe {
+            boltffi_register_callback_boltffi_tests_callbacks_async_fetcher(&FAILING_VTABLE);
+        }
+        let handle = boltffi_create_callback_boltffi_tests_callbacks_async_fetcher(7);
+        let fetcher = unsafe { ForeignAsyncFetcher::box_from_callback_handle(handle) };
+        let result = invoke_async_impl(*fetcher, 5).await;
+        assert_eq!(result, 0);
+    }
+}


### PR DESCRIPTION
A host-implemented async callback trait method with no `Result` in its signature panics the whole host process if the host's completion reports failure:

```rust
#[export]
#[async_trait::async_trait]
pub trait SessionStorage: Send + Sync {
    async fn set(&self, value: String); // host's storage write fails ->
}                                       // panic!("async callback failed") across the FFI -> host app aborts
```

There's no error channel to route the failure through, but a bare panic unwinding across a JNI/wasm boundary takes down the app embedding the library. For the three poll bodies whose success payload is valid regardless of status (native void, native value, wasm void), resolve with the payload instead of panicking. The two bytes-payload bodies have nothing safe to decode on failure, so they keep the panic but with a message naming the method and the contract violation.

Test drives a real vtable-registered foreign callback whose completion reports `FfiStatus::INTERNAL_ERROR` - on main it panics with the exact message above.
