### PR TITLE
fix workspace crate publishing

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,69 @@
+name: Publish crates
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+    secrets:
+      CARGO_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.28.0 or 0.28.0-beta.1)'
+        required: true
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish v${{ inputs.version }} to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: v${{ inputs.version }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Publish workspace crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          package_selection=()
+          while IFS= read -r crate; do
+            if cargo info --registry crates-io "$crate@$VERSION" >/dev/null 2>&1; then
+              echo "$crate $VERSION is already published; skipping"
+            else
+              package_selection+=(--package "$crate")
+            fi
+          done < <(
+            cargo metadata --no-deps --format-version 1 |
+              jq -r '
+                .workspace_members[] as $member
+                | .packages[]
+                | select(.id == $member and .publish != [])
+                | .name
+              '
+          )
+
+          if ((${#package_selection[@]} == 0)); then
+            echo "Every workspace crate is already published at $VERSION"
+            exit 0
+          fi
+
+          cargo publish "${package_selection[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,69 +184,10 @@ jobs:
     name: Publish to crates.io
     needs: [release, build-release]
     if: ${{ !inputs.skip_publish }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: v${{ needs.release.outputs.version }}
-
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          # caching handled by Swatinem/rust-cache below
-          cache: false
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Publish crates
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
-          VERSION: ${{ needs.release.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          crate_is_published() {
-            cargo info --registry crates-io "$1@$VERSION" >/dev/null 2>&1
-          }
-
-          wait_for_crate() {
-            local crate="$1"
-
-            for attempt in $(seq 1 20); do
-              if crate_is_published "$crate"; then
-                echo "$crate $VERSION is visible on crates.io"
-                return 0
-              fi
-
-              echo "Waiting for $crate $VERSION to become visible on crates.io ($attempt/20)"
-              sleep 15
-            done
-
-            echo "$crate $VERSION did not become visible on crates.io" >&2
-            return 1
-          }
-
-          publish_crate() {
-            local crate="$1"
-
-            if crate_is_published "$crate"; then
-              echo "$crate $VERSION is already published; skipping"
-              return 0
-            fi
-
-            cargo publish -p "$crate"
-            wait_for_crate "$crate"
-          }
-
-          publish_crate boltffi_ast
-          publish_crate boltffi_binding
-          publish_crate boltffi_scan
-          publish_crate boltffi_ffi_rules
-          publish_crate boltffi_backend
-          publish_crate boltffi_bindgen
-          publish_crate boltffi_macros
-          publish_crate boltffi_verify
-          publish_crate boltffi_core
-          publish_crate boltffi
-          publish_crate boltffi_cli
+    uses: ./.github/workflows/publish-crates.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit
 
   publish-npm:
     name: Publish to npm


### PR DESCRIPTION
The crates.io release job maintained a handwritten package order that drifted from the workspace dependency graph. The v0.28.0 release published boltffi_ast and then failed because boltffi_binding was attempted before boltffi_scan.

This change moves crates.io publication into a reusable recovery workflow. It discovers publishable workspace members from cargo metadata, skips versions already visible on crates.io, and passes every missing package to one cargo publish invocation so Cargo owns dependency ordering. The same workflow can resume partially completed releases without recreating tags or GitHub releases.

Validated with actionlint and a complete dry-run publication of all ten missing v0.28.0 crates.