### PR TITLE
Add lock free async callback polling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         with:
           components: miri
       - run: cargo +nightly miri setup
-      - run: cargo +nightly miri test -p boltffi -p boltffi_tests
+      - run: cargo +nightly miri test -p boltffi -p boltffi_core -p boltffi_tests
 
   android-packaging:
     name: Android Packaging (${{ matrix.os }})

--- a/boltffi/src/lib.rs
+++ b/boltffi/src/lib.rs
@@ -38,7 +38,7 @@ pub mod __private {
     pub use boltffi_core::{
         ArcFromCallbackHandle, AsyncCallback, AsyncCallbackString, AsyncCallbackVoid,
         BoxFromCallbackHandle, CallbackForeignType, CallbackHandle, EventSubscription, FfiBuf,
-        FfiSpan, FfiStatus, InternedString, InternedStringPool, InternedStringRepr,
+        FfiSpan, FfiStatus, ForeignCall, InternedString, InternedStringPool, InternedStringRepr,
         NativeCallbackOwner, Passable, RustFutureContinuationCallback, RustFutureHandle,
         StreamContinuationCallback, StreamPollResult, SubscriptionHandle, VecTransport, WaitResult,
         WirePassable, rustfuture, set_last_error, take_last_error, wire,
@@ -47,8 +47,8 @@ pub mod __private {
     pub use boltffi_core::{
         AsyncCallbackCompletion, AsyncCallbackCompletionCode, AsyncCallbackCompletionResult,
         AsyncCallbackRegistry, AsyncCallbackRequestGuard, AsyncCallbackRequestId,
-        WasmCallbackOutBuf, WasmCallbackOwner, rust_future_panic_message, rust_future_poll_sync,
-        take_packed_bytes, take_packed_utf8_string, take_return_slot_vec,
+        AsyncCallbackWait, WasmCallbackOutBuf, WasmCallbackOwner, rust_future_panic_message,
+        rust_future_poll_sync, take_packed_bytes, take_packed_utf8_string, take_return_slot_vec,
         write_option_f64_presence, write_return_slot,
     };
 }

--- a/boltffi_core/src/lib.rs
+++ b/boltffi_core/src/lib.rs
@@ -46,11 +46,12 @@ pub use handle::HandleBox;
 pub use interned_string::{InternedString, InternedStringPool, InternedStringRepr};
 pub use passable::{Passable, VecTransport, WirePassable};
 pub use ringbuffer::SpscRingBuffer;
+pub use runtime::ForeignCall;
 pub use runtime::async_callback;
 pub use runtime::async_callback::{
     AsyncCallback, AsyncCallbackCompletion, AsyncCallbackCompletionCode,
     AsyncCallbackCompletionResult, AsyncCallbackRegistry, AsyncCallbackRequestGuard,
-    AsyncCallbackRequestId, AsyncCallbackString, AsyncCallbackVoid,
+    AsyncCallbackRequestId, AsyncCallbackString, AsyncCallbackVoid, AsyncCallbackWait,
 };
 pub use runtime::future as rustfuture;
 pub use runtime::future::{

--- a/boltffi_core/src/runtime/async_callback.rs
+++ b/boltffi_core/src/runtime/async_callback.rs
@@ -1,6 +1,8 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::task::Waker;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
 
 /// Callback ABI for async completions that carry a result payload.
 ///
@@ -219,6 +221,13 @@ impl AsyncCallbackRegistry {
         self.with_state(|registry_state| registry_state.cancel(request_id))
     }
 
+    pub fn wait(&self, request_id: AsyncCallbackRequestId) -> AsyncCallbackWait {
+        AsyncCallbackWait {
+            request_id,
+            guard: Some(AsyncCallbackRequestGuard::new(request_id)),
+        }
+    }
+
     #[cfg(target_arch = "wasm32")]
     pub unsafe fn complete_from_ffi(
         &self,
@@ -269,5 +278,107 @@ impl AsyncCallbackRequestGuard {
 impl Drop for AsyncCallbackRequestGuard {
     fn drop(&mut self) {
         AsyncCallbackRegistry::current().remove(self.request_id);
+    }
+}
+
+pub struct AsyncCallbackWait {
+    request_id: AsyncCallbackRequestId,
+    guard: Option<AsyncCallbackRequestGuard>,
+}
+
+impl Future for AsyncCallbackWait {
+    type Output = AsyncCallbackCompletion;
+
+    fn poll(self: Pin<&mut Self>, task: &mut Context<'_>) -> Poll<Self::Output> {
+        let wait = self.get_mut();
+        let registry = AsyncCallbackRegistry::current();
+        registry.set_waker(wait.request_id, task.waker().clone());
+        match registry.take_completion(wait.request_id) {
+            Some(completion) => {
+                drop(wait.guard.take());
+                Poll::Ready(completion)
+            }
+            None => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context, Poll, Wake, Waker};
+
+    use super::{
+        AsyncCallbackCompletionCode, AsyncCallbackCompletionResult, AsyncCallbackRegistry,
+    };
+
+    struct WakeCounter(AtomicUsize);
+
+    impl Wake for WakeCounter {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn wait_resolves_completed_request() {
+        let registry = AsyncCallbackRegistry::current();
+        let request = registry.allocate();
+        let mut wait = registry.wait(request);
+        let waker = Waker::noop();
+        let mut task = Context::from_waker(waker);
+
+        assert!(Pin::new(&mut wait).poll(&mut task).is_pending());
+        assert_eq!(
+            registry.complete(
+                request,
+                AsyncCallbackCompletionCode::Completed,
+                vec![1, 2, 3],
+            ),
+            AsyncCallbackCompletionResult::Accepted
+        );
+
+        let Poll::Ready(completion) = Pin::new(&mut wait).poll(&mut task) else {
+            panic!("completed request is ready")
+        };
+        assert_eq!(completion.code, AsyncCallbackCompletionCode::Completed);
+        assert_eq!(completion.data, [1, 2, 3]);
+    }
+
+    #[test]
+    fn completion_wakes_waiter() {
+        let registry = AsyncCallbackRegistry::current();
+        let request = registry.allocate();
+        let mut wait = registry.wait(request);
+        let wake_counter = Arc::new(WakeCounter(AtomicUsize::new(0)));
+        let waker = Waker::from(Arc::clone(&wake_counter));
+        let mut task = Context::from_waker(&waker);
+
+        assert!(Pin::new(&mut wait).poll(&mut task).is_pending());
+        assert_eq!(
+            registry.complete(request, AsyncCallbackCompletionCode::Completed, Vec::new()),
+            AsyncCallbackCompletionResult::Accepted
+        );
+        assert_eq!(wake_counter.0.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn dropping_wait_removes_request() {
+        let registry = AsyncCallbackRegistry::current();
+        let request = registry.allocate();
+        let wait = registry.wait(request);
+
+        drop(wait);
+
+        assert_eq!(
+            registry.complete(request, AsyncCallbackCompletionCode::Completed, Vec::new()),
+            AsyncCallbackCompletionResult::UnknownOrAlreadyCompleted
+        );
     }
 }

--- a/boltffi_core/src/runtime/async_callback.rs
+++ b/boltffi_core/src/runtime/async_callback.rs
@@ -251,7 +251,7 @@ impl AsyncCallbackRegistry {
         };
 
         if data_ptr != 0 && data_cap > 0 {
-            crate::wasm::boltffi_wasm_free_impl(data_ptr as usize, data_cap as usize);
+            crate::wasm::boltffi_wasm_free_impl(data_ptr as *mut u8, data_cap as usize);
         }
 
         self.complete(request_id, completion_code, data) as i32

--- a/boltffi_core/src/runtime/foreign_call.rs
+++ b/boltffi_core/src/runtime/foreign_call.rs
@@ -1,0 +1,396 @@
+use std::cell::UnsafeCell;
+use std::ffi::c_void;
+use std::future::Future;
+use std::mem::MaybeUninit;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::task::{Context, Poll, Waker};
+
+use crate::{AsyncCallback, AsyncCallbackVoid, FfiStatus};
+
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CompletionState {
+    Pending = 0,
+    Ready = 1,
+    Taken = 2,
+}
+
+impl CompletionState {
+    const fn as_repr(self) -> u8 {
+        self as u8
+    }
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum WakerState {
+    Waiting = 0,
+    Registering = 1,
+    Waking = 2,
+    RegisteringWaking = 3,
+}
+
+impl WakerState {
+    const fn as_repr(self) -> u8 {
+        self as u8
+    }
+}
+
+struct Completion<Payload> {
+    status: FfiStatus,
+    payload: Payload,
+}
+
+struct CallState<Payload> {
+    completion_state: AtomicU8,
+    completion: UnsafeCell<MaybeUninit<Completion<Payload>>>,
+    waker_state: AtomicU8,
+    waker: UnsafeCell<Option<Waker>>,
+}
+
+unsafe impl<Payload: Send> Send for CallState<Payload> {}
+unsafe impl<Payload: Send> Sync for CallState<Payload> {}
+
+impl<Payload> CallState<Payload> {
+    fn new() -> Self {
+        Self {
+            completion_state: AtomicU8::new(CompletionState::Pending.as_repr()),
+            completion: UnsafeCell::new(MaybeUninit::uninit()),
+            waker_state: AtomicU8::new(WakerState::Waiting.as_repr()),
+            waker: UnsafeCell::new(None),
+        }
+    }
+
+    fn complete(&self, completion: Completion<Payload>) {
+        unsafe {
+            (*self.completion.get()).write(completion);
+        }
+        self.completion_state
+            .store(CompletionState::Ready.as_repr(), Ordering::Release);
+        self.wake();
+    }
+
+    fn poll(&self, task: &mut Context<'_>) -> Poll<(FfiStatus, Payload)> {
+        loop {
+            match self.completion_state.load(Ordering::Acquire) {
+                state if state == CompletionState::Ready.as_repr() => {
+                    if self
+                        .completion_state
+                        .compare_exchange(
+                            CompletionState::Ready.as_repr(),
+                            CompletionState::Taken.as_repr(),
+                            Ordering::AcqRel,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        let completion = unsafe { (*self.completion.get()).assume_init_read() };
+                        return Poll::Ready((completion.status, completion.payload));
+                    }
+                }
+                state if state == CompletionState::Taken.as_repr() => {
+                    panic!("foreign call polled after completion")
+                }
+                _ => {
+                    self.register(task.waker());
+                    if self.completion_state.load(Ordering::Acquire)
+                        == CompletionState::Pending.as_repr()
+                    {
+                        return Poll::Pending;
+                    }
+                }
+            }
+        }
+    }
+
+    fn register(&self, waker: &Waker) {
+        match self.waker_state.compare_exchange(
+            WakerState::Waiting.as_repr(),
+            WakerState::Registering.as_repr(),
+            Ordering::Acquire,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => {
+                unsafe {
+                    let slot = &mut *self.waker.get();
+                    if !slot
+                        .as_ref()
+                        .is_some_and(|registered| registered.will_wake(waker))
+                    {
+                        *slot = Some(waker.clone());
+                    }
+                }
+
+                if self
+                    .waker_state
+                    .compare_exchange(
+                        WakerState::Registering.as_repr(),
+                        WakerState::Waiting.as_repr(),
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    )
+                    .is_err()
+                {
+                    let registered = unsafe { (&mut *self.waker.get()).take() };
+                    self.waker_state
+                        .store(WakerState::Waiting.as_repr(), Ordering::Release);
+                    registered.into_iter().for_each(Waker::wake);
+                }
+            }
+            Err(state) if state == WakerState::Waking.as_repr() => waker.wake_by_ref(),
+            Err(_) => {}
+        }
+    }
+
+    fn wake(&self) {
+        match self
+            .waker_state
+            .fetch_or(WakerState::Waking.as_repr(), Ordering::AcqRel)
+        {
+            state if state == WakerState::Waiting.as_repr() => {
+                let registered = unsafe { (&mut *self.waker.get()).take() };
+                self.waker_state
+                    .store(WakerState::Waiting.as_repr(), Ordering::Release);
+                registered.into_iter().for_each(Waker::wake);
+            }
+            state
+                if state == WakerState::Registering.as_repr()
+                    || state == WakerState::Waking.as_repr()
+                    || state == WakerState::RegisteringWaking.as_repr() => {}
+            _ => unreachable!("foreign call waker state is invalid"),
+        }
+    }
+}
+
+impl<Payload> Drop for CallState<Payload> {
+    fn drop(&mut self) {
+        if self.completion_state.load(Ordering::Acquire) == CompletionState::Ready.as_repr() {
+            unsafe {
+                self.completion.get_mut().assume_init_drop();
+            }
+        }
+    }
+}
+
+pub struct ForeignCall<Payload> {
+    state: Arc<CallState<Payload>>,
+}
+
+impl<Payload: Send + 'static> ForeignCall<Payload> {
+    pub unsafe fn start(
+        begin: impl FnOnce(AsyncCallback<Payload>, *mut c_void),
+    ) -> ForeignCall<Payload> {
+        let state = Arc::new(CallState::new());
+        let completion_data = Arc::into_raw(Arc::clone(&state)) as *mut c_void;
+        begin(Self::complete, completion_data);
+        Self { state }
+    }
+
+    extern "C" fn complete(completion_data: *mut c_void, status: FfiStatus, payload: Payload) {
+        let state = unsafe { Arc::from_raw(completion_data.cast::<CallState<Payload>>()) };
+        state.complete(Completion { status, payload });
+    }
+}
+
+impl ForeignCall<()> {
+    pub unsafe fn start_void(
+        begin: impl FnOnce(AsyncCallbackVoid, *mut c_void),
+    ) -> ForeignCall<()> {
+        let state = Arc::new(CallState::new());
+        let completion_data = Arc::into_raw(Arc::clone(&state)) as *mut c_void;
+        begin(Self::complete_void, completion_data);
+        Self { state }
+    }
+
+    extern "C" fn complete_void(completion_data: *mut c_void, status: FfiStatus) {
+        let state = unsafe { Arc::from_raw(completion_data.cast::<CallState<()>>()) };
+        state.complete(Completion {
+            status,
+            payload: (),
+        });
+    }
+}
+
+impl<Payload: Send> Future for ForeignCall<Payload> {
+    type Output = (FfiStatus, Payload);
+
+    fn poll(self: Pin<&mut Self>, task: &mut Context<'_>) -> Poll<Self::Output> {
+        self.state.poll(task)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::mpsc;
+    use std::task::{Context, Poll, Wake, Waker};
+    use std::thread;
+
+    use super::ForeignCall;
+    use crate::{AsyncCallback, FfiBuf, FfiStatus};
+
+    struct WakeCounter(AtomicUsize);
+
+    impl Wake for WakeCounter {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[repr(C)]
+    struct DropProbe {
+        count: Arc<AtomicUsize>,
+    }
+
+    impl Drop for DropProbe {
+        fn drop(&mut self) {
+            self.count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn poll<Payload: Send>(
+        call: &mut ForeignCall<Payload>,
+        waker: &Waker,
+    ) -> Poll<(FfiStatus, Payload)> {
+        let mut task = Context::from_waker(waker);
+        Pin::new(call).poll(&mut task)
+    }
+
+    #[test]
+    fn resolves_synchronous_completion() {
+        let mut call = unsafe {
+            ForeignCall::start(|complete, completion_data| {
+                complete(completion_data, FfiStatus::OK, 17_u32);
+            })
+        };
+        let waker = Waker::noop();
+
+        assert_eq!(poll(&mut call, waker), Poll::Ready((FfiStatus::OK, 17)));
+    }
+
+    #[test]
+    fn wakes_after_cross_thread_completion() {
+        let (sender, receiver) = mpsc::channel();
+        let mut call = unsafe {
+            ForeignCall::start(|complete, completion_data| {
+                sender
+                    .send((complete, completion_data as usize))
+                    .expect("completion registration sends");
+            })
+        };
+        let wake_counter = Arc::new(WakeCounter(AtomicUsize::new(0)));
+        let waker = Waker::from(Arc::clone(&wake_counter));
+
+        assert_eq!(poll(&mut call, &waker), Poll::Pending);
+
+        let (complete, completion_data) =
+            receiver.recv().expect("completion registration receives");
+        thread::spawn(move || {
+            complete(completion_data as *mut _, FfiStatus::INTERNAL_ERROR, 29_u32);
+        })
+        .join()
+        .expect("completion thread joins");
+
+        assert_eq!(wake_counter.0.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            poll(&mut call, &waker),
+            Poll::Ready((FfiStatus::INTERNAL_ERROR, 29))
+        );
+    }
+
+    #[test]
+    fn owns_buffer_without_copying() {
+        let bytes = vec![1_u8, 2, 3, 4];
+        let pointer = bytes.as_ptr();
+        let buffer = FfiBuf::from_vec(bytes);
+        let mut call = unsafe {
+            ForeignCall::start(|complete, completion_data| {
+                complete(completion_data, FfiStatus::OK, buffer);
+            })
+        };
+        let waker = Waker::noop();
+        let Poll::Ready((status, buffer)) = poll(&mut call, waker) else {
+            panic!("synchronous completion is ready")
+        };
+
+        assert_eq!(status, FfiStatus::OK);
+        assert_eq!(buffer.as_ptr(), pointer);
+        assert_eq!(unsafe { buffer.as_byte_slice() }, &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn drops_late_payload_after_future_drop() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let (sender, receiver) = mpsc::channel();
+        let call = unsafe {
+            ForeignCall::start(|complete: AsyncCallback<DropProbe>, completion_data| {
+                sender
+                    .send((complete, completion_data as usize))
+                    .expect("completion registration sends");
+            })
+        };
+        drop(call);
+
+        let (complete, completion_data) =
+            receiver.recv().expect("completion registration receives");
+        complete(
+            completion_data as *mut _,
+            FfiStatus::OK,
+            DropProbe {
+                count: Arc::clone(&count),
+            },
+        );
+
+        assert_eq!(count.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn drops_ready_payload_when_future_is_not_polled() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let call = unsafe {
+            ForeignCall::start(|complete, completion_data| {
+                complete(
+                    completion_data,
+                    FfiStatus::OK,
+                    DropProbe {
+                        count: Arc::clone(&count),
+                    },
+                );
+            })
+        };
+
+        drop(call);
+
+        assert_eq!(count.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn resolves_void_completion() {
+        let mut call = unsafe {
+            ForeignCall::start_void(|complete, completion_data| {
+                complete(completion_data, FfiStatus::CANCELLED);
+            })
+        };
+        let waker = Waker::noop();
+
+        assert_eq!(
+            poll(&mut call, waker),
+            Poll::Ready((FfiStatus::CANCELLED, ()))
+        );
+    }
+
+    #[test]
+    fn foreign_call_with_owned_buffer_is_send() {
+        fn assert_send<SendValue: Send>() {}
+
+        assert_send::<ForeignCall<FfiBuf>>();
+    }
+}

--- a/boltffi_core/src/runtime/foreign_call.rs
+++ b/boltffi_core/src/runtime/foreign_call.rs
@@ -223,6 +223,7 @@ impl<Payload: Send> Future for ForeignCall<Payload> {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::c_void;
     use std::pin::Pin;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -232,6 +233,21 @@ mod tests {
 
     use super::ForeignCall;
     use crate::{AsyncCallback, FfiBuf, FfiStatus};
+
+    #[repr(transparent)]
+    struct CompletionData(*mut c_void);
+
+    impl CompletionData {
+        fn from_ffi(pointer: *mut c_void) -> Self {
+            Self(pointer)
+        }
+
+        fn into_ffi(self) -> *mut c_void {
+            self.0
+        }
+    }
+
+    unsafe impl Send for CompletionData {}
 
     struct WakeCounter(AtomicUsize);
 
@@ -282,7 +298,7 @@ mod tests {
         let mut call = unsafe {
             ForeignCall::start(|complete, completion_data| {
                 sender
-                    .send((complete, completion_data as usize))
+                    .send((complete, CompletionData::from_ffi(completion_data)))
                     .expect("completion registration sends");
             })
         };
@@ -294,7 +310,11 @@ mod tests {
         let (complete, completion_data) =
             receiver.recv().expect("completion registration receives");
         thread::spawn(move || {
-            complete(completion_data as *mut _, FfiStatus::INTERNAL_ERROR, 29_u32);
+            complete(
+                completion_data.into_ffi(),
+                FfiStatus::INTERNAL_ERROR,
+                29_u32,
+            );
         })
         .join()
         .expect("completion thread joins");
@@ -333,7 +353,7 @@ mod tests {
         let call = unsafe {
             ForeignCall::start(|complete: AsyncCallback<DropProbe>, completion_data| {
                 sender
-                    .send((complete, completion_data as usize))
+                    .send((complete, CompletionData::from_ffi(completion_data)))
                     .expect("completion registration sends");
             })
         };
@@ -342,7 +362,7 @@ mod tests {
         let (complete, completion_data) =
             receiver.recv().expect("completion registration receives");
         complete(
-            completion_data as *mut _,
+            completion_data.into_ffi(),
             FfiStatus::OK,
             DropProbe {
                 count: Arc::clone(&count),

--- a/boltffi_core/src/runtime/mod.rs
+++ b/boltffi_core/src/runtime/mod.rs
@@ -1,5 +1,8 @@
 pub mod async_callback;
 mod continuation;
+mod foreign_call;
 pub mod future;
 pub mod pending;
 pub mod subscription;
+
+pub use foreign_call::ForeignCall;

--- a/boltffi_core/src/types/buf.rs
+++ b/boltffi_core/src/types/buf.rs
@@ -9,6 +9,8 @@ pub struct FfiBuf {
     align: usize,
 }
 
+unsafe impl Send for FfiBuf {}
+
 impl FfiBuf {
     pub const fn empty() -> Self {
         Self {
@@ -19,7 +21,7 @@ impl FfiBuf {
         }
     }
 
-    pub fn from_vec<T>(vec: Vec<T>) -> Self {
+    pub fn from_vec<T: Send + 'static>(vec: Vec<T>) -> Self {
         let mut vec = ManuallyDrop::new(vec);
         let len = vec.len() * mem::size_of::<T>();
         let cap = vec.capacity() * mem::size_of::<T>();

--- a/boltffi_core/src/wasm.rs
+++ b/boltffi_core/src/wasm.rs
@@ -4,6 +4,8 @@ pub const WASM_ABI_VERSION: u32 = 2;
 use std::alloc::{Layout, alloc, dealloc};
 #[cfg(target_arch = "wasm32")]
 use std::mem;
+#[cfg(any(test, target_arch = "wasm32"))]
+use std::ptr;
 
 #[cfg(target_arch = "wasm32")]
 #[repr(C)]
@@ -36,33 +38,28 @@ impl WasmCallbackOutBuf {
 impl Drop for WasmCallbackOutBuf {
     fn drop(&mut self) {
         if self.ptr != 0 && self.cap > 0 {
-            boltffi_wasm_free_impl(self.ptr as usize, self.cap as usize);
+            boltffi_wasm_free_impl(self.ptr as *mut u8, self.cap as usize);
         }
     }
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
-fn boltffi_wasm_alloc_impl(size: usize) -> usize {
+fn boltffi_wasm_alloc_impl(size: usize) -> *mut u8 {
     if size == 0 {
-        return 0;
+        return ptr::null_mut();
     }
 
     let layout = match Layout::from_size_align(size, 8) {
         Ok(layout) => layout,
-        Err(_) => return 0,
+        Err(_) => return ptr::null_mut(),
     };
 
-    let pointer = unsafe { alloc(layout) };
-    if pointer.is_null() {
-        0
-    } else {
-        pointer as usize
-    }
+    unsafe { alloc(layout) }
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
-pub(crate) fn boltffi_wasm_free_impl(ptr: usize, size: usize) {
-    if ptr == 0 || size == 0 {
+pub(crate) fn boltffi_wasm_free_impl(pointer: *mut u8, size: usize) {
+    if pointer.is_null() || size == 0 {
         return;
     }
 
@@ -71,68 +68,58 @@ pub(crate) fn boltffi_wasm_free_impl(ptr: usize, size: usize) {
         Err(_) => return,
     };
 
-    unsafe { dealloc(ptr as *mut u8, layout) };
+    unsafe { dealloc(pointer, layout) };
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
-pub(crate) fn boltffi_wasm_free_buf_impl(ptr: usize, size: usize, align: usize) {
-    if ptr == 0 || size == 0 || align == 0 {
+pub(crate) fn boltffi_wasm_free_buf_impl(pointer: *mut u8, size: usize, align: usize) {
+    if pointer.is_null() || size == 0 || align == 0 {
         return;
     }
     let layout = match Layout::from_size_align(size, align) {
         Ok(layout) => layout,
         Err(_) => return,
     };
-    unsafe { dealloc(ptr as *mut u8, layout) };
+    unsafe { dealloc(pointer, layout) };
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
-pub(crate) unsafe fn boltffi_wasm_free_string_return_impl(ptr: usize, len: usize) {
-    if ptr == 0 || len == 0 {
+pub(crate) unsafe fn boltffi_wasm_free_string_return_impl(pointer: *mut u8, len: usize) {
+    if pointer.is_null() || len == 0 {
         return;
     }
-    unsafe { drop(Vec::from_raw_parts(ptr as *mut u8, len, len)) };
+    unsafe { drop(Vec::from_raw_parts(pointer, len, len)) };
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
-fn boltffi_wasm_alloc_owned_bytes_impl(len: usize) -> usize {
+fn boltffi_wasm_alloc_owned_bytes_impl(len: usize) -> *mut u8 {
     if len == 0 {
-        return 0;
+        return ptr::null_mut();
     }
     let layout = match Layout::array::<u8>(len) {
         Ok(layout) => layout,
-        Err(_) => return 0,
+        Err(_) => return ptr::null_mut(),
     };
-    let pointer = unsafe { alloc(layout) };
-    if pointer.is_null() {
-        0
-    } else {
-        pointer as usize
-    }
+    unsafe { alloc(layout) }
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
-fn boltffi_wasm_realloc_impl(ptr: usize, old_size: usize, new_size: usize) -> usize {
+fn boltffi_wasm_realloc_impl(pointer: *mut u8, old_size: usize, new_size: usize) -> *mut u8 {
     if new_size == 0 {
-        boltffi_wasm_free_impl(ptr, old_size);
-        return 0;
+        boltffi_wasm_free_impl(pointer, old_size);
+        return ptr::null_mut();
     }
 
-    if ptr == 0 {
+    if pointer.is_null() {
         return boltffi_wasm_alloc_impl(new_size);
     }
 
     let old_layout = match Layout::from_size_align(old_size, 8) {
         Ok(layout) => layout,
-        Err(_) => return 0,
+        Err(_) => return ptr::null_mut(),
     };
 
-    let new_pointer = unsafe { std::alloc::realloc(ptr as *mut u8, old_layout, new_size) };
-    if new_pointer.is_null() {
-        0
-    } else {
-        new_pointer as usize
-    }
+    unsafe { std::alloc::realloc(pointer, old_layout, new_size) }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -219,17 +206,18 @@ mod exports {
 
     #[unsafe(no_mangle)]
     pub extern "C" fn boltffi_wasm_free(ptr: u32, size: u32) {
-        super::boltffi_wasm_free_impl(ptr as usize, size as usize);
+        super::boltffi_wasm_free_impl(ptr as *mut u8, size as usize);
     }
 
     #[unsafe(no_mangle)]
     pub extern "C" fn boltffi_wasm_realloc(ptr: u32, old_size: u32, new_size: u32) -> u32 {
-        super::boltffi_wasm_realloc_impl(ptr as usize, old_size as usize, new_size as usize) as u32
+        super::boltffi_wasm_realloc_impl(ptr as *mut u8, old_size as usize, new_size as usize)
+            as u32
     }
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn boltffi_wasm_free_string_return(ptr: u32, len: u32) {
-        unsafe { super::boltffi_wasm_free_string_return_impl(ptr as usize, len as usize) };
+        unsafe { super::boltffi_wasm_free_string_return_impl(ptr as *mut u8, len as usize) };
     }
 
     #[unsafe(no_mangle)]
@@ -239,12 +227,14 @@ mod exports {
 
     #[unsafe(no_mangle)]
     pub extern "C" fn boltffi_wasm_free_buf(ptr: u32, size: u32, align: u32) {
-        super::boltffi_wasm_free_buf_impl(ptr as usize, size as usize, align as usize);
+        super::boltffi_wasm_free_buf_impl(ptr as *mut u8, size as usize, align as usize);
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::ptr::{self, NonNull};
+
     use super::{
         WASM_ABI_VERSION, boltffi_wasm_alloc_impl, boltffi_wasm_alloc_owned_bytes_impl,
         boltffi_wasm_free_buf_impl, boltffi_wasm_free_impl, boltffi_wasm_free_string_return_impl,
@@ -258,20 +248,20 @@ mod tests {
 
     #[test]
     fn alloc_zero_returns_zero_pointer() {
-        assert_eq!(boltffi_wasm_alloc_impl(0), 0);
+        assert!(boltffi_wasm_alloc_impl(0).is_null());
     }
 
     #[test]
     fn alloc_non_zero_returns_pointer_and_free_accepts_it() {
         let pointer = boltffi_wasm_alloc_impl(16);
-        assert_ne!(pointer, 0);
+        assert!(!pointer.is_null());
         boltffi_wasm_free_impl(pointer, 16);
     }
 
     #[test]
     fn realloc_from_null_matches_alloc_behavior() {
-        let pointer = boltffi_wasm_realloc_impl(0, 0, 24);
-        assert_ne!(pointer, 0);
+        let pointer = boltffi_wasm_realloc_impl(ptr::null_mut(), 0, 24);
+        assert!(!pointer.is_null());
         boltffi_wasm_free_impl(pointer, 24);
     }
 
@@ -280,22 +270,20 @@ mod tests {
         let old_size = 32usize;
         let new_size = 96usize;
         let old_pointer = boltffi_wasm_alloc_impl(old_size);
-        assert_ne!(old_pointer, 0);
+        assert!(!old_pointer.is_null());
 
         let expected_prefix = (0..old_size)
             .map(|index| ((index * 7 + 3) % 256) as u8)
             .collect::<Vec<_>>();
 
         unsafe {
-            std::slice::from_raw_parts_mut(old_pointer as *mut u8, old_size)
-                .copy_from_slice(&expected_prefix);
+            std::slice::from_raw_parts_mut(old_pointer, old_size).copy_from_slice(&expected_prefix);
         }
 
         let new_pointer = boltffi_wasm_realloc_impl(old_pointer, old_size, new_size);
-        assert_ne!(new_pointer, 0);
+        assert!(!new_pointer.is_null());
 
-        let actual_prefix =
-            unsafe { std::slice::from_raw_parts(new_pointer as *const u8, old_size) }.to_vec();
+        let actual_prefix = unsafe { std::slice::from_raw_parts(new_pointer, old_size) }.to_vec();
         assert_eq!(actual_prefix, expected_prefix);
 
         boltffi_wasm_free_impl(new_pointer, new_size);
@@ -304,41 +292,40 @@ mod tests {
     #[test]
     fn realloc_to_zero_returns_null_pointer() {
         let pointer = boltffi_wasm_alloc_impl(64);
-        assert_ne!(pointer, 0);
+        assert!(!pointer.is_null());
 
         let reallocated = boltffi_wasm_realloc_impl(pointer, 64, 0);
-        assert_eq!(reallocated, 0);
+        assert!(reallocated.is_null());
     }
 
     #[test]
     fn free_ignores_zero_inputs() {
-        boltffi_wasm_free_impl(0, 32);
-        boltffi_wasm_free_impl(1024, 0);
+        boltffi_wasm_free_impl(ptr::null_mut(), 32);
+        boltffi_wasm_free_impl(NonNull::dangling().as_ptr(), 0);
     }
 
     #[test]
     fn free_buf_releases_with_explicit_alignment() {
         let pointer = boltffi_wasm_alloc_impl(64);
-        assert_ne!(pointer, 0);
+        assert!(!pointer.is_null());
         boltffi_wasm_free_buf_impl(pointer, 64, 8);
     }
 
     #[test]
     fn free_string_return_releases_owned_buffer() {
         let text = "boltffi";
-        let mut boxed = text.as_bytes().to_vec().into_boxed_slice();
-        let ptr = boxed.as_mut_ptr() as usize;
-        let len = boxed.len();
-        std::mem::forget(boxed);
-        unsafe { boltffi_wasm_free_string_return_impl(ptr, len) };
+        let bytes = text.as_bytes().to_vec().into_boxed_slice();
+        let len = bytes.len();
+        let pointer = Box::into_raw(bytes).cast::<u8>();
+        unsafe { boltffi_wasm_free_string_return_impl(pointer, len) };
     }
 
     #[test]
     fn owned_byte_allocation_matches_string_return_release() {
         let len = 16;
         let pointer = boltffi_wasm_alloc_owned_bytes_impl(len);
-        assert_ne!(pointer, 0);
-        unsafe { core::ptr::write_bytes(pointer as *mut u8, 0, len) };
+        assert!(!pointer.is_null());
+        unsafe { core::ptr::write_bytes(pointer, 0, len) };
         unsafe { boltffi_wasm_free_string_return_impl(pointer, len) };
     }
 }

--- a/boltffi_macros/src/experimental/expansion/mod.rs
+++ b/boltffi_macros/src/experimental/expansion/mod.rs
@@ -7309,7 +7309,8 @@ mod tests {
         assert!(
             rendered.contains("async fn try_numbers (& self) -> Result < Vec < u8 > , String >")
         );
-        assert!(rendered.contains("if state . status . is_err ()"));
+        assert!(rendered.contains("ForeignCall :: < :: boltffi :: __private :: FfiBuf > :: start"));
+        assert!(rendered.contains("if __boltffi_status . is_err ()"));
         assert!(rendered.contains(":: boltffi :: __private :: wire :: decode :: < u32 >"));
         assert!(rendered.contains(":: boltffi :: __private :: wire :: decode :: < Vec < u8 > >"));
         assert!(rendered.contains(":: boltffi :: __private :: wire :: decode :: < String >"));

--- a/boltffi_macros/src/experimental/wrapper/callback.rs
+++ b/boltffi_macros/src/experimental/wrapper/callback.rs
@@ -2213,7 +2213,7 @@ where
             InfallibleMethodReturn::Encoded { codec, .. } => {
                 let value = self.native_async_encoded_value(
                     codec.root(),
-                    quote! { __boltffi_result.as_slice() },
+                    quote! { unsafe { __boltffi_result.as_byte_slice() } },
                 )?;
                 Ok(self.native_async_bytes_body(call, value))
             }
@@ -2269,9 +2269,7 @@ where
                     wrapper::returns::scalar_option::IncomingInput::new(
                         primitive,
                         rust_type,
-                        quote! {
-                            ::boltffi::__private::FfiBuf::from_vec(__boltffi_result)
-                        },
+                        quote! { __boltffi_result },
                     ),
                 )?;
                 Ok(self.native_async_bytes_body(call, value))
@@ -2282,9 +2280,7 @@ where
                     wrapper::returns::direct_vec::Incoming,
                     wrapper::returns::direct_vec::IncomingInput::new(
                         element,
-                        quote! {
-                            ::boltffi::__private::FfiBuf::from_vec(__boltffi_result)
-                        },
+                        quote! { __boltffi_result },
                     ),
                 )?;
                 Ok(self.native_async_bytes_body(call, value))
@@ -2551,10 +2547,12 @@ where
     ) -> Result<TokenStream, Error> {
         S::callback_encoded_error(error_shape)?;
         let success = self.async_fallible_success_value(quote! {
-            __boltffi_result.as_slice()
+            unsafe { __boltffi_result.as_byte_slice() }
         })?;
-        let error =
-            self.async_fallible_error_value(error_codec, quote! { __boltffi_result.as_slice() })?;
+        let error = self.async_fallible_error_value(
+            error_codec,
+            quote! { unsafe { __boltffi_result.as_byte_slice() } },
+        )?;
         Ok(self.native_async_bytes_result_body(call, success, error))
     }
 
@@ -2576,72 +2574,23 @@ where
 
     fn native_async_void_body(&self, call: TokenStream) -> TokenStream {
         quote! {
-            use std::sync::{Arc, Mutex};
-            use std::task::Waker;
-
-            struct __BoltffiAsyncState {
-                completed: bool,
-                status: ::boltffi::__private::FfiStatus,
-                waker: Option<Waker>,
-            }
-
-            struct __BoltffiAsyncContext {
-                state: Mutex<__BoltffiAsyncState>,
-            }
-
-            extern "C" fn __boltffi_completion(
-                completion_data: *mut ::core::ffi::c_void,
-                status: ::boltffi::__private::FfiStatus,
-            ) {
-                let context =
-                    unsafe { Arc::from_raw(completion_data as *const __BoltffiAsyncContext) };
-                let waker = context
-                    .state
-                    .lock()
-                    .ok()
-                    .and_then(|mut state| {
-                        state.completed = true;
-                        state.status = status;
-                        state.waker.take()
-                    });
-                if let Some(waker) = waker {
-                    waker.wake();
+            let (__boltffi_status, ()) =
+                unsafe {
+                    ::boltffi::__private::ForeignCall::start_void(
+                        |__boltffi_completion, __boltffi_completion_data| unsafe {
+                            #call;
+                        },
+                    )
                 }
+                .await;
+            if __boltffi_status.is_err() {
+                eprintln!(
+                    "boltffi: an infallible async callback completed with a failure \
+                     status; the trait method has no Result to report it through, so \
+                     this is a host language binding bug, not a normal error -- \
+                     continuing as if it completed successfully"
+                );
             }
-
-            let __boltffi_context = Arc::new(__BoltffiAsyncContext {
-                state: Mutex::new(__BoltffiAsyncState {
-                    completed: false,
-                    status: ::boltffi::__private::FfiStatus::OK,
-                    waker: None,
-                }),
-            });
-            let __boltffi_completion_data =
-                Arc::into_raw(Arc::clone(&__boltffi_context)) as *mut ::core::ffi::c_void;
-            unsafe {
-                #call;
-            }
-
-            std::future::poll_fn(move |task| {
-                let mut state = __boltffi_context
-                    .state
-                    .lock()
-                    .expect("async callback mutex poisoned");
-                if state.completed {
-                    if state.status.is_err() {
-                        eprintln!(
-                            "boltffi: an infallible async callback completed with a failure \
-                             status; the trait method has no Result to report it through, so \
-                             this is a host language binding bug, not a normal error -- \
-                             continuing as if it completed successfully"
-                        );
-                    }
-                    std::task::Poll::Ready(())
-                } else {
-                    state.waker = Some(task.waker().clone());
-                    std::task::Poll::Pending
-                }
-            }).await
         }
     }
 
@@ -2673,215 +2622,42 @@ where
         on_failure: TokenStream,
     ) -> TokenStream {
         quote! {
-            use std::sync::{Arc, Mutex};
-            use std::task::Waker;
-
-            struct __BoltffiAsyncState {
-                result: Option<#result_type>,
-                status: ::boltffi::__private::FfiStatus,
-                waker: Option<Waker>,
-            }
-
-            struct __BoltffiAsyncContext {
-                state: Mutex<__BoltffiAsyncState>,
-            }
-
-            extern "C" fn __boltffi_completion(
-                completion_data: *mut ::core::ffi::c_void,
-                status: ::boltffi::__private::FfiStatus,
-                result: #result_type,
-            ) {
-                let context =
-                    unsafe { Arc::from_raw(completion_data as *const __BoltffiAsyncContext) };
-                let waker = context
-                    .state
-                    .lock()
-                    .ok()
-                    .and_then(|mut state| {
-                        state.result = Some(result);
-                        state.status = status;
-                        state.waker.take()
-                    });
-                if let Some(waker) = waker {
-                    waker.wake();
+            let (__boltffi_status, __boltffi_result) =
+                unsafe {
+                    ::boltffi::__private::ForeignCall::<#result_type>::start(
+                        |__boltffi_completion, __boltffi_completion_data| unsafe {
+                            #call;
+                        },
+                    )
                 }
+                .await;
+            if __boltffi_status.is_err() {
+                #on_failure
             }
-
-            let __boltffi_context = Arc::new(__BoltffiAsyncContext {
-                state: Mutex::new(__BoltffiAsyncState {
-                    result: None,
-                    status: ::boltffi::__private::FfiStatus::OK,
-                    waker: None,
-                }),
-            });
-            let __boltffi_completion_data =
-                Arc::into_raw(Arc::clone(&__boltffi_context)) as *mut ::core::ffi::c_void;
-            unsafe {
-                #call;
-            }
-
-            std::future::poll_fn(move |task| {
-                let mut state = __boltffi_context
-                    .state
-                    .lock()
-                    .expect("async callback mutex poisoned");
-                if let Some(__boltffi_result) = state.result.take() {
-                    if state.status.is_err() {
-                        #on_failure
-                    }
-                    std::task::Poll::Ready(#value)
-                } else {
-                    state.waker = Some(task.waker().clone());
-                    std::task::Poll::Pending
-                }
-            }).await
+            #value
         }
     }
 
     fn native_async_bytes_body(&self, call: TokenStream, value: TokenStream) -> TokenStream {
         quote! {
-            use std::sync::{Arc, Mutex};
-            use std::task::Waker;
-
-            struct __BoltffiAsyncState {
-                result: Option<Vec<u8>>,
-                status: ::boltffi::__private::FfiStatus,
-                waker: Option<Waker>,
-            }
-
-            struct __BoltffiAsyncContext {
-                state: Mutex<__BoltffiAsyncState>,
-            }
-
-            extern "C" fn __boltffi_completion(
-                completion_data: *mut ::core::ffi::c_void,
-                status: ::boltffi::__private::FfiStatus,
-                result: ::boltffi::__private::FfiBuf,
-            ) {
-                let context =
-                    unsafe { Arc::from_raw(completion_data as *const __BoltffiAsyncContext) };
-                let bytes = unsafe { result.as_byte_slice() }.to_vec();
-                let waker = context
-                    .state
-                    .lock()
-                    .ok()
-                    .and_then(|mut state| {
-                        state.result = Some(bytes);
-                        state.status = status;
-                        state.waker.take()
-                    });
-                if let Some(waker) = waker {
-                    waker.wake();
+            let (__boltffi_status, __boltffi_result) =
+                unsafe {
+                    ::boltffi::__private::ForeignCall::<::boltffi::__private::FfiBuf>::start(
+                        |__boltffi_completion, __boltffi_completion_data| unsafe {
+                            #call;
+                        },
+                    )
                 }
+                .await;
+            if __boltffi_status.is_err() {
+                panic!(
+                    "boltffi: an infallible async callback completed with a failure \
+                     status; the trait method has no Result to report it through and \
+                     its payload requires wire-decoding, which has no defined shape on \
+                     failure -- this is a host language binding bug, not a normal error"
+                );
             }
-
-            let __boltffi_context = Arc::new(__BoltffiAsyncContext {
-                state: Mutex::new(__BoltffiAsyncState {
-                    result: None,
-                    status: ::boltffi::__private::FfiStatus::OK,
-                    waker: None,
-                }),
-            });
-            let __boltffi_completion_data =
-                Arc::into_raw(Arc::clone(&__boltffi_context)) as *mut ::core::ffi::c_void;
-            unsafe {
-                #call;
-            }
-
-            std::future::poll_fn(move |task| {
-                let mut state = __boltffi_context
-                    .state
-                    .lock()
-                    .expect("async callback mutex poisoned");
-                if let Some(__boltffi_result) = state.result.take() {
-                    if state.status.is_err() {
-                        panic!(
-                            "boltffi: an infallible async callback completed with a failure \
-                             status; the trait method has no Result to report it through and \
-                             its payload requires wire-decoding, which has no defined shape on \
-                             failure -- this is a host language binding bug, not a normal error"
-                        );
-                    }
-                    std::task::Poll::Ready(#value)
-                } else {
-                    state.waker = Some(task.waker().clone());
-                    std::task::Poll::Pending
-                }
-            }).await
-        }
-    }
-
-    fn native_async_result_body(
-        &self,
-        call: TokenStream,
-        success: TokenStream,
-        error: TokenStream,
-    ) -> TokenStream {
-        quote! {
-            use std::sync::{Arc, Mutex};
-            use std::task::Waker;
-
-            struct __BoltffiAsyncState {
-                result: Option<::boltffi::__private::FfiBuf>,
-                status: ::boltffi::__private::FfiStatus,
-                waker: Option<Waker>,
-            }
-
-            struct __BoltffiAsyncContext {
-                state: Mutex<__BoltffiAsyncState>,
-            }
-
-            extern "C" fn __boltffi_completion(
-                completion_data: *mut ::core::ffi::c_void,
-                status: ::boltffi::__private::FfiStatus,
-                result: ::boltffi::__private::FfiBuf,
-            ) {
-                let context =
-                    unsafe { Arc::from_raw(completion_data as *const __BoltffiAsyncContext) };
-                let waker = context
-                    .state
-                    .lock()
-                    .ok()
-                    .and_then(|mut state| {
-                        state.result = Some(result);
-                        state.status = status;
-                        state.waker.take()
-                    });
-                if let Some(waker) = waker {
-                    waker.wake();
-                }
-            }
-
-            let __boltffi_context = Arc::new(__BoltffiAsyncContext {
-                state: Mutex::new(__BoltffiAsyncState {
-                    result: None,
-                    status: ::boltffi::__private::FfiStatus::OK,
-                    waker: None,
-                }),
-            });
-            let __boltffi_completion_data =
-                Arc::into_raw(Arc::clone(&__boltffi_context)) as *mut ::core::ffi::c_void;
-            unsafe {
-                #call;
-            }
-
-            std::future::poll_fn(move |task| {
-                let mut state = __boltffi_context
-                    .state
-                    .lock()
-                    .expect("async callback mutex poisoned");
-                if let Some(__boltffi_result) = state.result.take() {
-                    let __boltffi_return = if state.status.is_err() {
-                        Err(#error)
-                    } else {
-                        Ok(#success)
-                    };
-                    std::task::Poll::Ready(__boltffi_return)
-                } else {
-                    state.waker = Some(task.waker().clone());
-                    std::task::Poll::Pending
-                }
-            }).await
+            #value
         }
     }
 
@@ -2892,71 +2668,20 @@ where
         error: TokenStream,
     ) -> TokenStream {
         quote! {
-            use std::sync::{Arc, Mutex};
-            use std::task::Waker;
-
-            struct __BoltffiAsyncState {
-                result: Option<Vec<u8>>,
-                status: ::boltffi::__private::FfiStatus,
-                waker: Option<Waker>,
-            }
-
-            struct __BoltffiAsyncContext {
-                state: Mutex<__BoltffiAsyncState>,
-            }
-
-            extern "C" fn __boltffi_completion(
-                completion_data: *mut ::core::ffi::c_void,
-                status: ::boltffi::__private::FfiStatus,
-                result: ::boltffi::__private::FfiBuf,
-            ) {
-                let context =
-                    unsafe { Arc::from_raw(completion_data as *const __BoltffiAsyncContext) };
-                let bytes = unsafe { result.as_byte_slice() }.to_vec();
-                let waker = context
-                    .state
-                    .lock()
-                    .ok()
-                    .and_then(|mut state| {
-                        state.result = Some(bytes);
-                        state.status = status;
-                        state.waker.take()
-                    });
-                if let Some(waker) = waker {
-                    waker.wake();
+            let (__boltffi_status, __boltffi_result) =
+                unsafe {
+                    ::boltffi::__private::ForeignCall::<::boltffi::__private::FfiBuf>::start(
+                        |__boltffi_completion, __boltffi_completion_data| unsafe {
+                            #call;
+                        },
+                    )
                 }
+                .await;
+            if __boltffi_status.is_err() {
+                Err(#error)
+            } else {
+                Ok(#success)
             }
-
-            let __boltffi_context = Arc::new(__BoltffiAsyncContext {
-                state: Mutex::new(__BoltffiAsyncState {
-                    result: None,
-                    status: ::boltffi::__private::FfiStatus::OK,
-                    waker: None,
-                }),
-            });
-            let __boltffi_completion_data =
-                Arc::into_raw(Arc::clone(&__boltffi_context)) as *mut ::core::ffi::c_void;
-            unsafe {
-                #call;
-            }
-
-            std::future::poll_fn(move |task| {
-                let mut state = __boltffi_context
-                    .state
-                    .lock()
-                    .expect("async callback mutex poisoned");
-                if let Some(__boltffi_result) = state.result.take() {
-                    let __boltffi_return = if state.status.is_err() {
-                        Err(#error)
-                    } else {
-                        Ok(#success)
-                    };
-                    std::task::Poll::Ready(__boltffi_return)
-                } else {
-                    state.waker = Some(task.waker().clone());
-                    std::task::Poll::Pending
-                }
-            }).await
         }
     }
 
@@ -2964,30 +2689,19 @@ where
         quote! {
             let __boltffi_registry = ::boltffi::__private::AsyncCallbackRegistry::current();
             let __boltffi_request = __boltffi_registry.allocate();
-            let mut __boltffi_guard = Some(
-                ::boltffi::__private::AsyncCallbackRequestGuard::new(__boltffi_request)
-            );
+            let __boltffi_wait = __boltffi_registry.wait(__boltffi_request);
             unsafe {
                 #call;
             }
-            std::future::poll_fn(move |task| {
-                __boltffi_registry.set_waker(__boltffi_request, task.waker().clone());
-                match __boltffi_registry.take_completion(__boltffi_request) {
-                    Some(__boltffi_completion) => {
-                        if !__boltffi_completion.code.is_success() {
-                            eprintln!(
-                                "boltffi: an infallible async callback completed with a failure \
-                                 status; the trait method has no Result to report it through, \
-                                 so this is a host language binding bug, not a normal error -- \
-                                 continuing as if it completed successfully"
-                            );
-                        }
-                        drop(__boltffi_guard.take());
-                        std::task::Poll::Ready(())
-                    }
-                    None => std::task::Poll::Pending,
-                }
-            }).await
+            let __boltffi_completion = __boltffi_wait.await;
+            if !__boltffi_completion.code.is_success() {
+                eprintln!(
+                    "boltffi: an infallible async callback completed with a failure \
+                     status; the trait method has no Result to report it through, \
+                     so this is a host language binding bug, not a normal error -- \
+                     continuing as if it completed successfully"
+                );
+            }
         }
     }
 
@@ -3000,27 +2714,16 @@ where
         quote! {
             let __boltffi_registry = ::boltffi::__private::AsyncCallbackRegistry::current();
             let __boltffi_request = __boltffi_registry.allocate();
-            let mut __boltffi_guard = Some(
-                ::boltffi::__private::AsyncCallbackRequestGuard::new(__boltffi_request)
-            );
+            let __boltffi_wait = __boltffi_registry.wait(__boltffi_request);
             unsafe {
                 #call;
             }
-            std::future::poll_fn(move |task| {
-                __boltffi_registry.set_waker(__boltffi_request, task.waker().clone());
-                match __boltffi_registry.take_completion(__boltffi_request) {
-                    Some(__boltffi_completion) => {
-                        let __boltffi_return = if __boltffi_completion.code.is_success() {
-                            Ok(#success)
-                        } else {
-                            Err(#error)
-                        };
-                        drop(__boltffi_guard.take());
-                        std::task::Poll::Ready(__boltffi_return)
-                    }
-                    None => std::task::Poll::Pending,
-                }
-            }).await
+            let __boltffi_completion = __boltffi_wait.await;
+            if __boltffi_completion.code.is_success() {
+                Ok(#success)
+            } else {
+                Err(#error)
+            }
         }
     }
 
@@ -3028,31 +2731,21 @@ where
         quote! {
             let __boltffi_registry = ::boltffi::__private::AsyncCallbackRegistry::current();
             let __boltffi_request = __boltffi_registry.allocate();
-            let mut __boltffi_guard = Some(
-                ::boltffi::__private::AsyncCallbackRequestGuard::new(__boltffi_request)
-            );
+            let __boltffi_wait = __boltffi_registry.wait(__boltffi_request);
             unsafe {
                 #call;
             }
-            std::future::poll_fn(move |task| {
-                __boltffi_registry.set_waker(__boltffi_request, task.waker().clone());
-                match __boltffi_registry.take_completion(__boltffi_request) {
-                    Some(__boltffi_completion) => {
-                        if !__boltffi_completion.code.is_success() {
-                            panic!(
-                                "boltffi: an infallible async callback completed with a failure \
-                                 status; the trait method has no Result to report it through \
-                                 and its payload requires wire-decoding, which has no defined \
-                                 shape on failure -- this is a host language binding bug, not a \
-                                 normal error"
-                            );
-                        }
-                        drop(__boltffi_guard.take());
-                        std::task::Poll::Ready(#value)
-                    }
-                    None => std::task::Poll::Pending,
-                }
-            }).await
+            let __boltffi_completion = __boltffi_wait.await;
+            if !__boltffi_completion.code.is_success() {
+                panic!(
+                    "boltffi: an infallible async callback completed with a failure \
+                     status; the trait method has no Result to report it through \
+                     and its payload requires wire-decoding, which has no defined \
+                     shape on failure -- this is a host language binding bug, not a \
+                     normal error"
+                );
+            }
+            #value
         }
     }
 


### PR DESCRIPTION
This changes async callback trait methods implemented by foreign code and called from Rust. It does not change exported Rust async functions.

 For a callback such as:

 ```rust
   #[async_trait::async_trait]
   pub trait DataSource {
       async fn load(&self, key: String) -> Result<Vec<u8>, String>;
   }
```

The value directions are:

 1. Rust calls the foreign implementation and sends parameters OutOfRust.
 2. The foreign implementation completes asynchronously.
 3. The completion payload or error returns IntoRust.
 4. The waiting Rust future resumes.

#### Native callbacks

 Native callbacks invoke the foreign implementation through its registered vtable. Previously, every generated async callback method emitted its own Arc<Mutex<...>>, completion function, waker storage, and poll_fn loop. Encoded payloads were also copied  from `FfiBuf `into a `Vec<u8>` before the future could consume them.

The generated path now uses ForeignCall:

``` rust
   let (status, result) = unsafe {
       ForeignCall::<FfiBuf>::start(|completion, completion_data| unsafe {
           ((*self.vtable).load)(
               self.handle,
               key_ptr,
               key_len,
               completion,
               completion_data,
           );
       })
   }
   .await;

   if status.is_err() {
       Err(decode_error(result))
   } else {
       Ok(decode_value(result))
   }
```

ForeignCall owns the completion payload, coordinates the callback and waiting task without a mutex, and safely handles synchronous, cross-thread, and late completion.

#### Wasm callbacks

Wasm callbacks invoke the host implementation through an imported function. Completion arrives later through the exported request-completion function. The generated path now creates an AsyncCallbackWait before making the import call:

``` rust
   let registry = AsyncCallbackRegistry::current();
   let request = registry.allocate();
   let wait = registry.wait(request);

   unsafe {
       imported_load(self.handle, request.as_u32(), key_ptr, key_len);
   }

   let completion = wait.await;

   if completion.code.is_success() {
       Ok(decode_value(&completion.data))
   } else {
       Err(decode_error(&completion.data))
   }
```

Dropping AsyncCallbackWait removes the pending request, so cancellation remains tied to the future’s lifetime.