### PR TITLE
C#: route enum variant-alias constants through the companion class

### DIFF
--- a/boltffi_backend/src/target/csharp/mod.rs
+++ b/boltffi_backend/src/target/csharp/mod.rs
@@ -1064,8 +1064,9 @@ mod tests {
 
         assert!(source.contains("public static Color Black"));
         assert!(source.contains("public const byte ChannelCount = 4;"));
-        assert!(mode.contains("Default = Fast"));
+        assert!(!mode.contains("Default = Fast"));
         assert!(mode.contains("public static class ModeConstants"));
+        assert!(mode.contains("public const global::Demo.Mode Default = global::Demo.Mode.Fast;"));
         assert!(mode.contains("public static Mode Fallback"));
         assert!(mode.contains("public const byte VariantCount = 2;"));
         assert!(palette.contains("public const byte MaxColors = 16;"));
@@ -1074,7 +1075,7 @@ mod tests {
     }
 
     #[test]
-    fn csharp_target_omits_redundant_enum_aliases_after_name_normalization() {
+    fn csharp_target_routes_variant_alias_constants_through_companion_class() {
         let bindings = bindings(
             r#"
             #[repr(u8)]
@@ -1097,7 +1098,10 @@ mod tests {
 
         assert!(mode.contains("Default = 1"));
         assert!(!mode.contains("Default = Default"));
-        assert!(!mode.contains("ModeConstants"));
+        assert!(mode.contains("public static class ModeConstants"));
+        assert!(
+            mode.contains("public const global::Demo.Mode Default = global::Demo.Mode.Default;")
+        );
     }
 
     #[test]

--- a/boltffi_backend/src/target/csharp/render/constant.rs
+++ b/boltffi_backend/src/target/csharp/render/constant.rs
@@ -1,6 +1,6 @@
 use boltffi_binding::{
-    CStyleEnumDecl, ConstantDecl, ConstantOwner, ConstantValueDecl, DefaultValue, EnumDecl,
-    FloatValue, Native, Primitive, TypeRef,
+    ConstantDecl, ConstantOwner, ConstantValueDecl, DefaultValue, EnumDecl, FloatValue, Native,
+    Primitive, TypeRef,
 };
 
 use crate::{
@@ -87,55 +87,6 @@ impl AssociatedConstants {
             .map(|constant| Constant::from_declaration(constant, namespace, bridge, context))
             .collect::<Result<Vec<_>>>()
             .map(Self)
-    }
-
-    pub fn from_c_style_enum(
-        enumeration: &CStyleEnumDecl<Native>,
-        namespace: &Namespace,
-        bridge: &CBridgeContract,
-        context: &RenderContext<Native>,
-    ) -> Result<(Vec<String>, Self)> {
-        context
-            .associated_constants(ConstantOwner::Enum(enumeration.id()))
-            .try_fold(
-                (Vec::new(), Vec::new()),
-                |(mut aliases, mut constants), declaration| {
-                    let constant_name = Name::new(declaration.name()).pascal()?;
-                    let colliding_variant = enumeration.variants().iter().try_fold(
-                        None,
-                        |colliding_variant, variant| -> Result<_> {
-                            match colliding_variant {
-                                Some(_) => Ok(colliding_variant),
-                                None => {
-                                    let variant_name = Name::new(variant.name()).pascal()?;
-                                    Ok((variant_name == constant_name).then_some(variant))
-                                }
-                            }
-                        },
-                    )?;
-                    match (declaration.owned_enum_variant_alias(), colliding_variant) {
-                        (Some((owner, aliased_variant)), Some(colliding_variant))
-                            if owner == enumeration.id()
-                                && aliased_variant == colliding_variant.name() => {}
-                        (Some((owner, aliased_variant)), None) if owner == enumeration.id() => {
-                            let documentation =
-                                Documentation::summary(declaration.meta().doc(), "        ");
-                            let aliased_variant = Name::new(aliased_variant).pascal()?;
-                            aliases.push(format!(
-                                "{documentation}        {constant_name} = {aliased_variant}"
-                            ));
-                        }
-                        _ => constants.push(Constant::from_declaration(
-                            declaration,
-                            namespace,
-                            bridge,
-                            context,
-                        )?),
-                    }
-                    Ok((aliases, constants))
-                },
-            )
-            .map(|(aliases, constants)| (aliases, Self(constants)))
     }
 
     pub fn members(&self) -> Result<Vec<String>> {

--- a/boltffi_backend/src/target/csharp/render/enumeration.rs
+++ b/boltffi_backend/src/target/csharp/render/enumeration.rs
@@ -34,7 +34,6 @@ pub(in crate::target::csharp) struct Enumeration {
     underlying_type: TypeFragment,
     variants: Vec<Variant>,
     data_variants: Vec<DataVariant>,
-    constant_aliases: Vec<String>,
     constants: AssociatedConstants,
     methods: Vec<Function>,
     diagnostics: Vec<Diagnostic>,
@@ -168,8 +167,12 @@ impl Enumeration {
                 ),
             )?;
         }
-        let (constant_aliases, constants) =
-            AssociatedConstants::from_c_style_enum(declaration, &namespace, bridge, context)?;
+        let constants = AssociatedConstants::from_owner(
+            ConstantOwner::Enum(declaration.id()),
+            &namespace,
+            bridge,
+            context,
+        )?;
         Ok(Self {
             documentation: Documentation::summary(declaration.meta().doc(), "    "),
             namespace,
@@ -179,7 +182,6 @@ impl Enumeration {
             underlying_type: primitive_type(primitive),
             variants,
             data_variants: Vec::new(),
-            constant_aliases,
             constants,
             methods,
             diagnostics,
@@ -319,7 +321,6 @@ impl Enumeration {
             underlying_type: TypeFragment::void(),
             variants: Vec::new(),
             data_variants,
-            constant_aliases: Vec::new(),
             constants,
             methods,
             diagnostics,

--- a/boltffi_backend/templates/target/csharp/enumeration.cs
+++ b/boltffi_backend/templates/target/csharp/enumeration.cs
@@ -7,8 +7,7 @@ namespace {{ enumeration.namespace }}
 {
 {{ enumeration.documentation }}{% if enumeration.c_style %}    public enum {{ enumeration.name }} : {{ enumeration.underlying_type }}
     {
-{% for variant in enumeration.variants %}{{ variant.documentation }}        {{ variant.name }} = {{ variant.discriminant }}{% if !loop.last || !enumeration.constant_aliases.is_empty() %},{% endif %}
-{% endfor %}{% for alias in enumeration.constant_aliases %}{{ alias }}{% if !loop.last %},{% endif %}
+{% for variant in enumeration.variants %}{{ variant.documentation }}        {{ variant.name }} = {{ variant.discriminant }}{% if !loop.last %},{% endif %}
 {% endfor %}    }
 {%- if !constants.is_empty() %}
 

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -3371,8 +3371,8 @@ public static class DemoTest
     {
         DemoCase("case:constants.associated.should_expose_values_on_exported_types");
         Require(
-            global::Demo.DemoMode.Preferred == global::Demo.DemoMode.Safe,
-            "DemoMode.Preferred"
+            global::Demo.DemoModeConstants.Preferred == global::Demo.DemoMode.Safe,
+            "DemoModeConstants.Preferred"
         );
         Require(
             global::Demo.DemoModeConstants.Fallback == global::Demo.DemoMode.Safe,


### PR DESCRIPTION
#718 emits a Rust variant-alias constant as an extra C# enum member:

```csharp
public enum Mode : byte
{
    Fast = 1,
    Slow = 2,
    Default = Fast
}
```

A duplicate-valued member leaks into every reflective view of the enum, and .NET documents name resolution for duplicated values as unspecified, so serialized names can change across runtimes:

```csharp
Enum.GetNames(typeof(Mode))   // Fast, Default, Slow
Enum.GetValues(typeof(Mode))  // Fast, Fast, Slow
Mode.Default.ToString()       // "Fast" or "Default" — unspecified
```

Aliases now render into the `{Enum}Constants` companion class that already carries the enum's other associated constants, keeping the enum's member set identical to its Rust variant set:

```csharp
public enum Mode : byte
{
    Fast = 1,
    Slow = 2
}

public static class ModeConstants
{
    public const global::Demo.Mode Default = global::Demo.Mode.Fast;
}
```

`const` keeps the alias usable anywhere the member was (switch arms, attributes, default parameter values). Since #718 is unreleased, no shipped generated API changes shape.