### PR TITLE
Java: deliver accessor constants lazily through a holder class

### DIFF
--- a/boltffi_backend/src/target/java/render/constant.rs
+++ b/boltffi_backend/src/target/java/render/constant.rs
@@ -32,7 +32,7 @@ pub struct Constant {
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum Body {
     Inline(Expression),
-    Accessor(Box<Call>),
+    Accessor { holder: Identifier, call: Box<Call> },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -80,6 +80,10 @@ impl Constant {
                     format!("__boltffiReadConstant{}", declaration.id().raw()),
                     version,
                 )?;
+                let holder = Identifier::parse_for(
+                    format!("__BoltffiConstantHolder{}", declaration.id().raw()),
+                    version,
+                )?;
                 let accessor = Call::from_constant_accessor(
                     helper,
                     symbol,
@@ -96,7 +100,10 @@ impl Constant {
                 Ok(Self {
                     name,
                     ty,
-                    body: Body::Accessor(Box::new(accessor)),
+                    body: Body::Accessor {
+                        holder,
+                        call: Box::new(accessor),
+                    },
                     doc,
                 })
             }
@@ -154,7 +161,7 @@ impl Constant {
     }
 
     pub fn extend(&self, emitted: Emitted) -> Result<Emitted> {
-        let Body::Accessor(call) = &self.body else {
+        let Body::Accessor { call, .. } = &self.body else {
             return Ok(emitted);
         };
         let emitted = call
@@ -186,14 +193,21 @@ impl Constant {
     pub fn value(&self) -> Option<&Expression> {
         match &self.body {
             Body::Inline(value) => Some(value),
-            Body::Accessor(_) => None,
+            Body::Accessor { .. } => None,
         }
     }
 
     pub fn accessor(&self) -> Option<&Call> {
         match &self.body {
             Body::Inline(_) => None,
-            Body::Accessor(call) => Some(call),
+            Body::Accessor { call, .. } => Some(call),
+        }
+    }
+
+    pub fn holder(&self) -> Option<&Identifier> {
+        match &self.body {
+            Body::Inline(_) => None,
+            Body::Accessor { holder, .. } => Some(holder),
         }
     }
 

--- a/boltffi_backend/src/target/java/render/constant.rs
+++ b/boltffi_backend/src/target/java/render/constant.rs
@@ -32,7 +32,7 @@ pub struct Constant {
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum Body {
     Inline(Expression),
-    Accessor { holder: Identifier, call: Box<Call> },
+    Accessor(Box<Call>),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -80,10 +80,6 @@ impl Constant {
                     format!("__boltffiReadConstant{}", declaration.id().raw()),
                     version,
                 )?;
-                let holder = Identifier::parse_for(
-                    format!("__BoltffiConstantHolder{}", declaration.id().raw()),
-                    version,
-                )?;
                 let accessor = Call::from_constant_accessor(
                     helper,
                     symbol,
@@ -100,10 +96,7 @@ impl Constant {
                 Ok(Self {
                     name,
                     ty,
-                    body: Body::Accessor {
-                        holder,
-                        call: Box::new(accessor),
-                    },
+                    body: Body::Accessor(Box::new(accessor)),
                     doc,
                 })
             }
@@ -161,7 +154,7 @@ impl Constant {
     }
 
     pub fn extend(&self, emitted: Emitted) -> Result<Emitted> {
-        let Body::Accessor { call, .. } = &self.body else {
+        let Body::Accessor(call) = &self.body else {
             return Ok(emitted);
         };
         let emitted = call
@@ -200,14 +193,7 @@ impl Constant {
     pub fn accessor(&self) -> Option<&Call> {
         match &self.body {
             Body::Inline(_) => None,
-            Body::Accessor { call, .. } => Some(call),
-        }
-    }
-
-    pub fn holder(&self) -> Option<&Identifier> {
-        match &self.body {
-            Body::Inline(_) => None,
-            Body::Accessor { holder, .. } => Some(holder),
+            Body::Accessor(call) => Some(call),
         }
     }
 

--- a/boltffi_backend/templates/target/java/constant.java
+++ b/boltffi_backend/templates/target/java/constant.java
@@ -1,14 +1,10 @@
 {% if let Some(doc) = constant.doc() %}{{ doc }}
 {% endif %}{% if let Some(value) = constant.value() %}    public static final {{ constant.ty() }} {{ constant.name() }} = {{ value }};
-{% endif %}{% if let Some(accessor) = constant.accessor() %}{% if let Some(holder) = constant.holder() %}    public static {{ constant.ty() }} {{ constant.name() }}() {
-        return {{ holder }}.VALUE;
-    }
-
-    private static final class {{ holder }} {
-        static final {{ constant.ty() }} VALUE = {{ accessor.name() }}();
+{% endif %}{% if let Some(accessor) = constant.accessor() %}    public static {{ constant.ty() }} {{ constant.name() }}() {
+        return {{ accessor.name() }}();
     }
 
     private static {{ accessor.returns() }} {{ accessor.name() }}() {
 {% for statement in accessor.body() %}        {{ statement }}
 {% endfor %}    }
-{% endif %}{% endif %}
+{% endif %}

--- a/boltffi_backend/templates/target/java/constant.java
+++ b/boltffi_backend/templates/target/java/constant.java
@@ -1,7 +1,14 @@
 {% if let Some(doc) = constant.doc() %}{{ doc }}
-{% endif %}    public static final {{ constant.ty() }} {{ constant.name() }} = {% if let Some(value) = constant.value() %}{{ value }}{% else if let Some(accessor) = constant.accessor() %}{{ accessor.name() }}(){% endif %};
-{% if let Some(accessor) = constant.accessor() %}
+{% endif %}{% if let Some(value) = constant.value() %}    public static final {{ constant.ty() }} {{ constant.name() }} = {{ value }};
+{% endif %}{% if let Some(accessor) = constant.accessor() %}{% if let Some(holder) = constant.holder() %}    public static {{ constant.ty() }} {{ constant.name() }}() {
+        return {{ holder }}.VALUE;
+    }
+
+    private static final class {{ holder }} {
+        static final {{ constant.ty() }} VALUE = {{ accessor.name() }}();
+    }
+
     private static {{ accessor.returns() }} {{ accessor.name() }}() {
 {% for statement in accessor.body() %}        {{ statement }}
 {% endfor %}    }
-{% endif %}
+{% endif %}{% endif %}

--- a/boltffi_backend/tests/fixtures/source/constant/data_enum_accessor.rs
+++ b/boltffi_backend/tests/fixtures/source/constant/data_enum_accessor.rs
@@ -1,0 +1,10 @@
+#[data]
+pub enum State {
+    Idle,
+    Busy { jobs: u32 },
+}
+
+#[data(impl)]
+impl State {
+    pub const INITIAL_BUSY: Self = State::Busy { jobs: 0 };
+}

--- a/boltffi_backend/tests/java.rs
+++ b/boltffi_backend/tests/java.rs
@@ -1373,11 +1373,12 @@ fn java_target_renders_associated_constants_on_the_owner() {
     let state = java_source(&output, "com.boltffi.demo", "State");
     let palette = java_source(&output, "com.boltffi.demo", "Palette");
 
-    assert!(color.contains("public static final Color BLACK = __boltffiReadConstant"));
+    assert!(color.contains("public static Color BLACK() {"));
+    assert!(color.contains("private static final class __BoltffiConstantHolder"));
     assert!(color.contains("public static final byte CHANNEL_COUNT = (byte) (4);"));
     assert!(color.contains("private static Color __boltffiReadConstant"));
     assert!(mode.contains("public static final Mode DEFAULT = Mode.FAST;"));
-    assert!(mode.contains("public static final Mode FALLBACK = __boltffiReadConstant"));
+    assert!(mode.contains("public static Mode FALLBACK() {"));
     assert!(mode.contains("public static final byte VARIANT_COUNT = (byte) (2);"));
     assert!(state.contains("public static final State INITIAL = new State.Idle();"));
     assert!(palette.contains("public static final byte MAX_COLORS = (byte) (16);"));
@@ -1404,7 +1405,8 @@ fn java_target_renders_top_level_constants_in_the_module() {
     assert!(module.contains("public static final double HALF = 0.5;"));
     assert!(module.contains("public static final String GREETING = \"hello\";"));
     assert!(module.contains("public static final Mode DEFAULT_MODE = Mode.FAST;"));
-    assert!(module.contains("public static final byte[] MAGIC = __boltffiReadConstant"));
+    assert!(module.contains("public static byte[] MAGIC() {"));
+    assert!(module.contains("private static final class __BoltffiConstantHolder"));
 }
 
 #[test]

--- a/boltffi_backend/tests/java.rs
+++ b/boltffi_backend/tests/java.rs
@@ -100,6 +100,8 @@ const TOP_LEVEL_CONSTANTS: &str =
     include_str!("fixtures/source/constant/literals_and_accessors.rs");
 
 const DATA_ENUM_CONSTANT: &str = include_str!("fixtures/source/constant/data_enum.rs");
+const DATA_ENUM_ACCESSOR_CONSTANT: &str =
+    include_str!("fixtures/source/constant/data_enum_accessor.rs");
 
 const ENCODED_RECORD: &str = r#"
     #[data]
@@ -1374,7 +1376,7 @@ fn java_target_renders_associated_constants_on_the_owner() {
     let palette = java_source(&output, "com.boltffi.demo", "Palette");
 
     assert!(color.contains("public static Color BLACK() {"));
-    assert!(color.contains("private static final class __BoltffiConstantHolder"));
+    assert!(color.contains("return __boltffiReadConstant"));
     assert!(color.contains("public static final byte CHANNEL_COUNT = (byte) (4);"));
     assert!(color.contains("private static Color __boltffiReadConstant"));
     assert!(mode.contains("public static final Mode DEFAULT = Mode.FAST;"));
@@ -1406,7 +1408,7 @@ fn java_target_renders_top_level_constants_in_the_module() {
     assert!(module.contains("public static final String GREETING = \"hello\";"));
     assert!(module.contains("public static final Mode DEFAULT_MODE = Mode.FAST;"));
     assert!(module.contains("public static byte[] MAGIC() {"));
-    assert!(module.contains("private static final class __BoltffiConstantHolder"));
+    assert!(module.contains("return __boltffiReadConstant"));
 }
 
 #[test]
@@ -1415,6 +1417,23 @@ fn java_target_renders_data_enum_constants_for_the_selected_enum_form() {
     let module = java_source(&output, "com.boltffi.demo", "Demo");
 
     assert!(module.contains("public static final State IDLE = State.Idle.INSTANCE;"));
+}
+
+#[test]
+fn java_target_renders_accessor_constants_inside_sealed_interfaces() {
+    let output = render_with_host(
+        DATA_ENUM_ACCESSOR_CONSTANT,
+        CoverageMode::Complete,
+        JavaHost::for_version("com.boltffi.demo", "Demo", JavaVersion::JAVA_17)
+            .expect("Java 17 host")
+            .desktop_loader(JavaDesktopLoader::None),
+    );
+    let state = java_source(&output, "com.boltffi.demo", "State");
+
+    assert!(state.contains("public sealed interface State"));
+    assert!(state.contains("public static State INITIAL_BUSY() {"));
+    assert!(state.contains("private static State __boltffiReadConstant"));
+    assert!(!state.contains("class __BoltffiConstantHolder"));
 }
 
 #[test]
@@ -2666,6 +2685,21 @@ fn generated_top_level_constants_compile_for_java_eight_when_available() {
                 &format!("boltffi-java-top-level-constants-{index}"),
             );
         });
+}
+
+#[test]
+fn generated_sealed_interface_accessor_constants_compile_for_java_seventeen_when_available() {
+    let Some(compiler) = JavaCompiler::discover() else {
+        return;
+    };
+
+    let output = render_with_host(
+        DATA_ENUM_ACCESSOR_CONSTANT,
+        CoverageMode::Complete,
+        JavaHost::for_version("com.boltffi.demo", "Demo", JavaVersion::JAVA_17)
+            .expect("Java 17 host"),
+    );
+    compile_generated_java_for_release(&compiler, &output, "boltffi-java-sealed-constants", 17);
 }
 
 #[test]

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -78,10 +78,10 @@ public final class DemoTest {
     private static void testAssociatedConstants() {
         demoCase("case:constants.associated.should_expose_values_on_exported_types");
         assert DemoMode.PREFERRED == DemoMode.SAFE;
-        assert DemoMode.FALLBACK == DemoMode.SAFE;
+        assert DemoMode.FALLBACK() == DemoMode.SAFE;
         assert DemoMode.VARIANT_COUNT == 2;
         assert DemoState.INITIAL instanceof DemoState.Idle;
-        assert Point.ZERO.equals(new Point(0.0, 0.0));
+        assert Point.ZERO().equals(new Point(0.0, 0.0));
         assert MathUtils.DEFAULT_PRECISION == 2;
     }
 


### PR DESCRIPTION
#718 initializes accessor-delivered constants eagerly in the owner's `<clinit>`:

```java
public static final Color BLACK = __boltffiReadConstant0();
```

That makes the native library a prerequisite for *touching the class at all*. With the library missing or not yet loadable, even `new Color(...)` — a pure data class — throws `UnsatisfiedLinkError` during class init, and the JVM then poisons `Color` permanently: every later use throws `NoClassDefFoundError`.

Accessor constants are now a method that reads the value per access:

```java
public static Color BLACK() {
    return __boltffiReadConstant0();
}
```

Verified on a JVM with no native library present: constructing `Color` and reading inline constants now work; only calling `Color.BLACK()` itself fails, and the failure poisons nothing — `Color` stays usable, and the call succeeds once the library is loadable.

Per-access matters beyond laziness: data enums render as `sealed interface` on Java 17+, where a private holder class would be illegal (interface member types are implicitly public), and a cached `byte[]` constant would be one shared mutable array across all callers. A plain method avoids both, and matches the Kotlin/Swift/C# backends, which already compute accessor constants per access.

This changes the generated API for accessor constants from a field to a method (`Color.BLACK` → `Color.BLACK()`). Inline constants (`CHANNEL_COUNT`, enum-variant aliases) stay `public static final` fields — they never needed the library. Since #718 is unreleased, no shipped generated API changes shape.
