### PR TITLE
per-invocation source records: runtime and artifact reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ proc-macro2 = { version = "1.0", features = ["span-locations"] }
 walkdir = "2.4"
 rstest = "0.26"
 tokio = "1"
-object = "0.39"
+object = { version = "0.39", features = ["wasm"] }
 insta = "1.46"
 
 [workspace.lints.rust]

--- a/boltffi/src/lib.rs
+++ b/boltffi/src/lib.rs
@@ -35,6 +35,7 @@ pub use boltffi_core::interned_string_pool;
 
 #[doc(hidden)]
 pub mod __private {
+    pub use boltffi_core::capture;
     pub use boltffi_core::{
         ArcFromCallbackHandle, AsyncCallback, AsyncCallbackString, AsyncCallbackVoid,
         BoxFromCallbackHandle, CallbackForeignType, CallbackHandle, EventSubscription, FfiBuf,

--- a/boltffi_bindgen/src/artifact.rs
+++ b/boltffi_bindgen/src/artifact.rs
@@ -11,7 +11,8 @@ use std::path::{Path, PathBuf};
 
 use boltffi_binding::{
     BindingMetadataEnvelope, BindingMetadataError, BindingMetadataHash, BindingMetadataSection,
-    BindingMetadataSectionBytes,
+    BindingMetadataSectionBytes, RawSourceRecord, SourceRecordError, SourceRecordSectionBytes,
+    is_source_record_section,
 };
 use object::read::archive::{ArchiveFile, ArchiveMember};
 use object::read::macho::{FatArch, MachOFatFile};
@@ -38,14 +39,22 @@ impl BindingMetadataReader {
 
     /// Reads validated metadata envelopes from every artifact.
     pub fn read(&self) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
+        self.payloads::<BindingMetadataEnvelope>()
+            .map(|envelopes| DeduplicatedEnvelopes::from_envelopes(envelopes).into_vec())
+    }
+
+    /// Reads per-invocation source records from every artifact.
+    pub fn read_source_records(&self) -> Result<Vec<RawSourceRecord>, BindingMetadataReadError> {
+        self.payloads::<RawSourceRecord>()
+    }
+
+    fn payloads<P: SectionPayload>(&self) -> Result<Vec<P>, BindingMetadataReadError> {
         self.artifacts
             .iter()
             .map(|artifact| ArtifactBytes::read(artifact))
-            .map(|artifact| artifact.and_then(|artifact| artifact.envelopes()))
+            .map(|artifact| artifact.and_then(|artifact| artifact.payloads()))
             .collect::<Result<Vec<_>, _>>()
-            .map(|artifacts| {
-                DeduplicatedEnvelopes::from_envelopes(artifacts.into_iter().flatten()).into_vec()
-            })
+            .map(|artifacts| artifacts.into_iter().flatten().collect())
     }
 
     /// Reads validated metadata envelopes and rejects empty results.
@@ -88,6 +97,14 @@ pub enum BindingMetadataReadError {
         /// Metadata validation error.
         source: BindingMetadataError,
     },
+    /// A source-record section failed to decode.
+    #[error("decode source records from `{path}`: {source}")]
+    SourceRecord {
+        /// Artifact path.
+        path: PathBuf,
+        /// Source record decoding error.
+        source: SourceRecordError,
+    },
     /// No binding metadata records were found in the artifact set.
     #[error("no BoltFFI binding metadata found in compiled artifacts: {artifacts:?}")]
     NoMetadata {
@@ -114,8 +131,49 @@ impl ArtifactBytes {
             })
     }
 
-    fn envelopes(&self) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
-        ArtifactImage::new(&self.path, &self.bytes).envelopes()
+    fn payloads<P: SectionPayload>(&self) -> Result<Vec<P>, BindingMetadataReadError> {
+        ArtifactImage::new(&self.path, &self.bytes).payloads()
+    }
+}
+
+/// One decodable payload kind stored in a dedicated artifact section.
+trait SectionPayload: Sized {
+    fn matches_section(name: &str, segment: Option<&str>) -> bool;
+    fn decode_section(path: &Path, bytes: &[u8]) -> Result<Vec<Self>, BindingMetadataReadError>;
+}
+
+impl SectionPayload for BindingMetadataEnvelope {
+    fn matches_section(name: &str, segment: Option<&str>) -> bool {
+        [
+            BindingMetadataSection::MachO,
+            BindingMetadataSection::Object,
+        ]
+        .into_iter()
+        .any(|section| section.matches(name, segment))
+    }
+
+    fn decode_section(path: &Path, bytes: &[u8]) -> Result<Vec<Self>, BindingMetadataReadError> {
+        BindingMetadataSectionBytes::new(bytes)
+            .envelopes()
+            .map_err(|source| BindingMetadataReadError::Metadata {
+                path: path.to_path_buf(),
+                source,
+            })
+    }
+}
+
+impl SectionPayload for RawSourceRecord {
+    fn matches_section(name: &str, _segment: Option<&str>) -> bool {
+        is_source_record_section(name)
+    }
+
+    fn decode_section(path: &Path, bytes: &[u8]) -> Result<Vec<Self>, BindingMetadataReadError> {
+        SourceRecordSectionBytes::new(bytes)
+            .records()
+            .map_err(|source| BindingMetadataReadError::SourceRecord {
+                path: path.to_path_buf(),
+                source,
+            })
     }
 }
 
@@ -130,90 +188,75 @@ impl<'artifact> ArtifactImage<'artifact> {
         Self { path, bytes }
     }
 
-    fn envelopes(self) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
+    fn payloads<P: SectionPayload>(self) -> Result<Vec<P>, BindingMetadataReadError> {
         match FileKind::parse(self.bytes).map_err(|source| self.parse_error(source))? {
-            FileKind::Archive => self.archive_envelopes(),
-            FileKind::MachOFat32 => self.macho_fat32_envelopes(),
-            FileKind::MachOFat64 => self.macho_fat64_envelopes(),
-            _ => self.object_envelopes(self.bytes),
+            FileKind::Archive => self.archive_payloads(),
+            FileKind::MachOFat32 => self.macho_fat_payloads::<object::macho::FatArch32, P>(),
+            FileKind::MachOFat64 => self.macho_fat_payloads::<object::macho::FatArch64, P>(),
+            _ => self.object_payloads(self.bytes),
         }
     }
 
-    fn archive_envelopes(self) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
+    fn archive_payloads<P: SectionPayload>(self) -> Result<Vec<P>, BindingMetadataReadError> {
         ArchiveFile::parse(self.bytes)
             .map_err(|source| self.parse_error(source))?
             .members()
             .map(|member| {
                 member
                     .map_err(|source| self.parse_error(source))
-                    .and_then(|member| self.archive_member_envelopes(member))
+                    .and_then(|member| self.archive_member_payloads(member))
             })
             .collect::<Result<Vec<_>, _>>()
             .map(|members| members.into_iter().flatten().collect())
     }
 
-    fn archive_member_envelopes(
+    fn archive_member_payloads<P: SectionPayload>(
         self,
         member: ArchiveMember<'artifact>,
-    ) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
+    ) -> Result<Vec<P>, BindingMetadataReadError> {
         if member.is_thin() {
-            return self.thin_archive_member_envelopes(member.name());
+            return self.thin_archive_member_payloads(member.name());
         }
         let bytes = member
             .data(self.bytes)
             .map_err(|source| self.parse_error(source))?;
-        self.nested_envelopes(bytes)
+        self.nested_payloads(bytes)
     }
 
-    fn thin_archive_member_envelopes(
+    fn thin_archive_member_payloads<P: SectionPayload>(
         self,
         name: &[u8],
-    ) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
+    ) -> Result<Vec<P>, BindingMetadataReadError> {
         let path = ThinArchiveMember::new(self.path, name)?.path();
         fs::read(&path)
             .map_err(|source| BindingMetadataReadError::Read {
                 path: path.clone(),
                 source,
             })
-            .and_then(|bytes| ArtifactImage::new(&path, &bytes).envelopes())
+            .and_then(|bytes| ArtifactImage::new(&path, &bytes).payloads())
     }
 
-    fn nested_envelopes(
+    fn nested_payloads<P: SectionPayload>(
         self,
         bytes: &'artifact [u8],
-    ) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
+    ) -> Result<Vec<P>, BindingMetadataReadError> {
         match FileKind::parse(bytes) {
-            Ok(FileKind::Archive) => ArtifactImage::new(self.path, bytes).archive_envelopes(),
-            Ok(FileKind::MachOFat32) => {
-                ArtifactImage::new(self.path, bytes).macho_fat32_envelopes()
-            }
-            Ok(FileKind::MachOFat64) => {
-                ArtifactImage::new(self.path, bytes).macho_fat64_envelopes()
-            }
+            Ok(FileKind::Archive) => ArtifactImage::new(self.path, bytes).archive_payloads(),
+            Ok(FileKind::MachOFat32) => ArtifactImage::new(self.path, bytes)
+                .macho_fat_payloads::<object::macho::FatArch32, P>(),
+            Ok(FileKind::MachOFat64) => ArtifactImage::new(self.path, bytes)
+                .macho_fat_payloads::<object::macho::FatArch64, P>(),
             Ok(file_kind) if ArchiveMemberKind::from(file_kind).is_object() => {
-                self.object_envelopes(bytes)
+                self.object_payloads(bytes)
             }
             Ok(_) | Err(_) => Ok(Vec::new()),
         }
     }
 
-    fn macho_fat32_envelopes(
-        self,
-    ) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
-        self.macho_fat_envelopes::<object::macho::FatArch32>()
-    }
-
-    fn macho_fat64_envelopes(
-        self,
-    ) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
-        self.macho_fat_envelopes::<object::macho::FatArch64>()
-    }
-
-    fn macho_fat_envelopes<Fat>(
-        self,
-    ) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError>
+    fn macho_fat_payloads<Fat, P>(self) -> Result<Vec<P>, BindingMetadataReadError>
     where
         Fat: FatArch,
+        P: SectionPayload,
     {
         MachOFatFile::<Fat>::parse(self.bytes)
             .map_err(|source| self.parse_error(source))?
@@ -222,74 +265,42 @@ impl<'artifact> ArtifactImage<'artifact> {
             .map(|arch| {
                 arch.data(self.bytes)
                     .map_err(|source| self.parse_error(source))
-                    .and_then(|bytes| ArtifactImage::new(self.path, bytes).envelopes())
+                    .and_then(|bytes| ArtifactImage::new(self.path, bytes).payloads())
             })
             .collect::<Result<Vec<_>, _>>()
             .map(|arches| arches.into_iter().flatten().collect())
     }
 
-    fn object_envelopes(
+    fn object_payloads<P: SectionPayload>(
         self,
         bytes: &'artifact [u8],
-    ) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
+    ) -> Result<Vec<P>, BindingMetadataReadError> {
         let file = File::parse(bytes).map_err(|source| self.parse_error(source))?;
-        self.file_envelopes(file)
-    }
-
-    fn file_envelopes(
-        self,
-        file: File<'artifact>,
-    ) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
         file.sections()
-            .map(|section| self.section_envelopes(section))
+            .map(|section| self.section_payloads(section))
             .collect::<Result<Vec<_>, _>>()
             .map(|sections| sections.into_iter().flatten().collect())
     }
 
-    fn section_envelopes(
+    fn section_payloads<P: SectionPayload>(
         self,
         section: impl ObjectSection<'artifact>,
-    ) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
+    ) -> Result<Vec<P>, BindingMetadataReadError> {
         let name = section.name().map_err(|source| self.parse_error(source))?;
         let segment = section
             .segment_name()
             .map_err(|source| self.parse_error(source))?;
-        if !self.is_metadata_section(name, segment) {
+        if !P::matches_section(name, segment) {
             return Ok(Vec::new());
         }
         section
             .uncompressed_data()
             .map_err(|source| self.parse_error(source))
-            .and_then(|bytes| self.decode_section(bytes))
-    }
-
-    fn is_metadata_section(self, name: &str, segment: Option<&str>) -> bool {
-        [
-            BindingMetadataSection::MachO,
-            BindingMetadataSection::Object,
-        ]
-        .into_iter()
-        .any(|section| section.matches(name, segment))
-    }
-
-    fn decode_section(
-        self,
-        bytes: Cow<'artifact, [u8]>,
-    ) -> Result<Vec<BindingMetadataEnvelope>, BindingMetadataReadError> {
-        BindingMetadataSectionBytes::new(bytes.as_ref())
-            .envelopes()
-            .map_err(|source| self.metadata_error(source))
+            .and_then(|bytes: Cow<'artifact, [u8]>| P::decode_section(self.path, bytes.as_ref()))
     }
 
     fn parse_error(self, source: object::Error) -> BindingMetadataReadError {
         BindingMetadataReadError::Parse {
-            path: self.path.to_path_buf(),
-            source,
-        }
-    }
-
-    fn metadata_error(self, source: BindingMetadataError) -> BindingMetadataReadError {
-        BindingMetadataReadError::Metadata {
             path: self.path.to_path_buf(),
             source,
         }

--- a/boltffi_bindgen/src/artifact.rs
+++ b/boltffi_bindgen/src/artifact.rs
@@ -424,6 +424,21 @@ mod tests {
     }
 
     #[test]
+    fn reads_source_records_from_compiled_static_library() {
+        let artifact = MetadataArtifact::compile_with_source_records();
+
+        let records = BindingMetadataReader::new([artifact.path()])
+            .read_source_records()
+            .expect("artifact source records read");
+
+        assert_eq!(records.len(), 2, "each invocation's record survives");
+        assert_eq!(records[0].package.name, "demo");
+        assert_eq!(records[0].module, "demo::geometry");
+        assert_eq!(records[0].slots, vec![r#"{"prim":"f64"}"#.to_owned()]);
+        assert_eq!(records[1].module, "demo");
+    }
+
+    #[test]
     fn required_read_rejects_artifact_without_metadata() {
         let artifact = MetadataArtifact::compile_without_metadata();
 
@@ -506,16 +521,43 @@ mod tests {
             Self::compile_with_records_and_kind(1, ArtifactKind::Object)
         }
 
+        fn compile_with_source_records() -> Self {
+            let statics = [
+                source_record_bytes("demo", "1.0.0", "demo::geometry", &[r#"{"prim":"f64"}"#], b"{}"),
+                source_record_bytes("demo", "1.0.0", "demo", &[], b"{}"),
+            ]
+            .iter()
+            .enumerate()
+            .map(|(index, record)| {
+                let length = record.len();
+                let bytes = record
+                    .iter()
+                    .map(u8::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "#[cfg_attr(target_vendor = \"apple\", unsafe(link_section = \"__DATA,__boltffisrc\"))]\n#[cfg_attr(not(target_vendor = \"apple\"), unsafe(link_section = \".boltffisrc\"))]\n#[used]\nstatic BOLTFFI_SOURCE_{index}: [u8; {length}] = [{bytes}];"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+            Self::compile_source(&statics, ArtifactKind::StaticLibrary)
+        }
+
         fn compile_with_records(records: usize) -> Self {
             Self::compile_with_records_and_kind(records, ArtifactKind::StaticLibrary)
         }
 
         fn compile_with_records_and_kind(records: usize, kind: ArtifactKind) -> Self {
+            Self::compile_source(&Self::source(records), kind)
+        }
+
+        fn compile_source(source_text: &str, kind: ArtifactKind) -> Self {
             let root = temp_root("boltffi-bindgen-metadata");
             fs::create_dir_all(&root).expect("create metadata fixture root");
             let source = root.join("lib.rs");
             let artifact = root.join(kind.file_name());
-            fs::write(&source, Self::source(records)).expect("write metadata fixture source");
+            fs::write(&source, source_text).expect("write metadata fixture source");
 
             let output = Command::new(rustc())
                 .arg("--crate-name")
@@ -653,6 +695,32 @@ mod tests {
             .expect("metadata envelope")
             .to_section_bytes()
             .expect("metadata section bytes")
+    }
+
+    fn source_record_bytes(
+        package: &str,
+        version: &str,
+        module: &str,
+        slots: &[&str],
+        json: &[u8],
+    ) -> Vec<u8> {
+        let mut payload = Vec::new();
+        for field in [package, version, module] {
+            payload.extend_from_slice(&(field.len() as u16).to_le_bytes());
+            payload.extend_from_slice(field.as_bytes());
+        }
+        payload.extend_from_slice(&(slots.len() as u16).to_le_bytes());
+        for slot in slots {
+            payload.extend_from_slice(&(slot.len() as u16).to_le_bytes());
+            payload.extend_from_slice(slot.as_bytes());
+        }
+        payload.extend_from_slice(&(json.len() as u32).to_le_bytes());
+        payload.extend_from_slice(json);
+
+        let mut bytes = b"BFFISRC1".to_vec();
+        bytes.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&payload);
+        bytes
     }
 
     fn malformed_archive_member() -> Vec<u8> {

--- a/boltffi_binding/src/ir/mod.rs
+++ b/boltffi_binding/src/ir/mod.rs
@@ -89,6 +89,7 @@ mod name;
 mod op;
 mod primitive;
 mod reference;
+mod source_fragment;
 mod source_record;
 mod surface;
 mod symbol;
@@ -145,6 +146,9 @@ pub use op::{
 };
 pub use primitive::{IntegerRepr, Primitive};
 pub use reference::DeclarationShape;
+pub use source_fragment::{
+    SELF_ID, SLOT_ID_PREFIX, SourceFragment, SourceFragmentError, TypeNode, aggregate_records,
+};
 pub use source_record::{
     RawSourceRecord, SOURCE_RECORD_MAGIC, SOURCE_SECTION_MACH_O_NAME, SOURCE_SECTION_OBJECT_NAME,
     SourceRecordError, SourceRecordSectionBytes, is_source_record_section,

--- a/boltffi_binding/src/ir/mod.rs
+++ b/boltffi_binding/src/ir/mod.rs
@@ -89,6 +89,7 @@ mod name;
 mod op;
 mod primitive;
 mod reference;
+mod source_record;
 mod surface;
 mod symbol;
 mod types;
@@ -144,6 +145,10 @@ pub use op::{
 };
 pub use primitive::{IntegerRepr, Primitive};
 pub use reference::DeclarationShape;
+pub use source_record::{
+    RawSourceRecord, SOURCE_RECORD_MAGIC, SOURCE_SECTION_MACH_O_NAME, SOURCE_SECTION_OBJECT_NAME,
+    SourceRecordError, SourceRecordSectionBytes, is_source_record_section,
+};
 pub use surface::{
     AsyncProtocolIntrospect, BufferShapeRules, CallbackProtocolIntrospect,
     ClosureRegistrationIntrospect, Native, Surface, Wasm32, native, wasm32,

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -102,14 +102,14 @@ pub fn aggregate_records(
     }
 
     let mut kinds = HashMap::new();
-    let mut unique = HashMap::new();
-    for (fragment, _) in &fragments {
+    let mut unique: HashMap<String, (&SourceFragment, &[TypeNode])> = HashMap::new();
+    for (fragment, slots) in &fragments {
         let id = fragment_id(fragment).to_owned();
         match unique.entry(id.clone()) {
             Entry::Vacant(entry) => {
-                entry.insert(fragment.clone());
+                entry.insert((fragment, slots));
             }
-            Entry::Occupied(entry) if entry.get() == fragment => {}
+            Entry::Occupied(entry) if *entry.get() == (fragment, slots.as_slice()) => {}
             Entry::Occupied(_) => {
                 return Err(SourceFragmentError::DuplicateDeclaration { id });
             }
@@ -763,6 +763,19 @@ mod tests {
             .expect_err("conflicting duplicates fail");
         assert!(
             matches!(error, SourceFragmentError::DuplicateDeclaration { id } if id == "demo::geometry::Point")
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_declarations_whose_slots_differ() {
+        let json = record_fragment(vec![FieldDef::new(name("start"), slot_leaf(0, "Alias"))]);
+        let first = raw("demo", &[r#"{"prim":"f32"}"#], json.clone());
+        let second = raw("demo", &[r#"{"prim":"f64"}"#], json);
+
+        let error = aggregate_records(&[first, second], PackageInfo::new("demo", None))
+            .expect_err("identical fragments with differing slots fail");
+        assert!(
+            matches!(error, SourceFragmentError::DuplicateDeclaration { id } if id == "demo::Route")
         );
     }
 

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -1,0 +1,778 @@
+//! Interpreting per-invocation source records into one aggregated [`SourceContract`].
+//!
+//! A record's JSON payload is one [`SourceFragment`]: the `boltffi_ast` declaration the
+//! macro invocation saw, with two kinds of placeholder the macro cannot fill in itself.
+//! Ids are written `$self::Name` and minted here against the record's `module_path!()`. Named type references are provisional [`TypeExpr::Record`] leaves
+//! whose id is `$slot:N`, replaced here by the type node the referenced type's own
+//! definition site resolved through rustc.
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+
+use boltffi_ast::{
+    ClassDef, ClassId, ConstantDef, ConstantId, CustomTypeDef, EnumDef, EnumId, FieldDef,
+    FunctionDef, FunctionId, MethodDef, NamePart, PackageInfo, Path, PathSegment, Primitive,
+    RecordDef, RecordId, ReturnDef, SourceContract, StreamDef, StreamId, TraitDef, TraitId,
+    TypeExpr, VariantPayload,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::ir::source_record::RawSourceRecord;
+
+/// Id prefix marking a declaration's own identity, minted from the record's module path.
+pub const SELF_ID: &str = "$self";
+
+/// Id prefix marking a slot-deferred type reference inside a fragment.
+pub const SLOT_ID_PREFIX: &str = "$slot:";
+
+/// One declaration captured by one macro invocation.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SourceFragment {
+    /// A `#[data]` struct.
+    Record(RecordDef),
+    /// A `#[data]` enum.
+    Enum(EnumDef),
+    /// An `#[export]` free function.
+    Function(FunctionDef),
+    /// An `#[export]`ed class-style object.
+    Class(ClassDef),
+    /// An `#[export]`ed callback trait.
+    Trait(TraitDef),
+    /// A stream export.
+    Stream(StreamDef),
+    /// An `#[export]`ed constant.
+    Constant(ConstantDef),
+    /// A `custom_type!` registration.
+    Custom(CustomTypeDef),
+}
+
+/// One resolved type node from a slot descriptor.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TypeNode {
+    /// A named declaration, by canonical id.
+    Id {
+        /// Canonical id of the referenced declaration.
+        id: String,
+    },
+    /// A primitive or builtin leaf.
+    Prim {
+        /// Rust spelling of the leaf type.
+        prim: String,
+    },
+    /// A container shape with type arguments.
+    Shape {
+        /// Shape name, such as `Vec` or `HashMap`.
+        shape: String,
+        /// Type arguments in declaration order.
+        args: Vec<TypeNode>,
+    },
+}
+
+/// Aggregates decoded source records into one source contract.
+///
+/// The contract's declarations are sorted by id within each family, so the result does
+/// not depend on link order.
+pub fn aggregate_records(
+    records: &[RawSourceRecord],
+    package: PackageInfo,
+) -> Result<SourceContract, SourceFragmentError> {
+    let mut fragments = Vec::new();
+    for record in records {
+        let mut fragment: SourceFragment =
+            serde_json::from_slice(&record.json).map_err(|error| SourceFragmentError::Decode {
+                module: record.module.clone(),
+                message: error.to_string(),
+            })?;
+        let slots = record
+            .slots
+            .iter()
+            .map(|slot| {
+                serde_json::from_str::<TypeNode>(slot).map_err(|error| {
+                    SourceFragmentError::SlotDescriptor {
+                        module: record.module.clone(),
+                        message: error.to_string(),
+                    }
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        mint_self_ids(&mut fragment, &record.module);
+        fragments.push((fragment, slots));
+    }
+
+    let mut kinds = HashMap::new();
+    let mut unique = HashMap::new();
+    for (fragment, _) in &fragments {
+        let id = fragment_id(fragment).to_owned();
+        match unique.entry(id.clone()) {
+            Entry::Vacant(entry) => {
+                entry.insert(fragment.clone());
+            }
+            Entry::Occupied(entry) if entry.get() == fragment => {}
+            Entry::Occupied(_) => {
+                return Err(SourceFragmentError::DuplicateDeclaration { id });
+            }
+        }
+        if let Some(kind) = declared_kind(fragment) {
+            kinds.insert(id, kind);
+        }
+    }
+
+    let mut contract = SourceContract::new(package);
+    let mut seen = HashMap::new();
+    for (mut fragment, slots) in fragments {
+        let id = fragment_id(&fragment).to_owned();
+        if seen.insert(id, ()).is_some() {
+            continue;
+        }
+        resolve_fragment(&mut fragment, &slots, &kinds)?;
+        match fragment {
+            SourceFragment::Record(def) => contract.records.push(def),
+            SourceFragment::Enum(def) => contract.enums.push(def),
+            SourceFragment::Function(def) => contract.functions.push(def),
+            SourceFragment::Class(def) => contract.classes.push(def),
+            SourceFragment::Trait(def) => contract.traits.push(def),
+            SourceFragment::Stream(def) => contract.streams.push(def),
+            SourceFragment::Constant(def) => contract.constants.push(def),
+            SourceFragment::Custom(def) => contract.customs.push(def),
+        }
+    }
+
+    contract.records.sort_by(|a, b| a.id.cmp(&b.id));
+    contract.enums.sort_by(|a, b| a.id.cmp(&b.id));
+    contract.functions.sort_by(|a, b| a.id.cmp(&b.id));
+    contract.classes.sort_by(|a, b| a.id.cmp(&b.id));
+    contract.traits.sort_by(|a, b| a.id.cmp(&b.id));
+    contract.streams.sort_by(|a, b| a.id.cmp(&b.id));
+    contract.constants.sort_by(|a, b| a.id.cmp(&b.id));
+    contract.customs.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(contract)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DeclaredKind {
+    Record,
+    Enum,
+    Class,
+    Custom,
+}
+
+fn declared_kind(fragment: &SourceFragment) -> Option<DeclaredKind> {
+    match fragment {
+        SourceFragment::Record(_) => Some(DeclaredKind::Record),
+        SourceFragment::Enum(_) => Some(DeclaredKind::Enum),
+        SourceFragment::Class(_) => Some(DeclaredKind::Class),
+        SourceFragment::Custom(_) => Some(DeclaredKind::Custom),
+        SourceFragment::Function(_)
+        | SourceFragment::Trait(_)
+        | SourceFragment::Stream(_)
+        | SourceFragment::Constant(_) => None,
+    }
+}
+
+fn fragment_id(fragment: &SourceFragment) -> &str {
+    match fragment {
+        SourceFragment::Record(def) => def.id.as_str(),
+        SourceFragment::Enum(def) => def.id.as_str(),
+        SourceFragment::Function(def) => def.id.as_str(),
+        SourceFragment::Class(def) => def.id.as_str(),
+        SourceFragment::Trait(def) => def.id.as_str(),
+        SourceFragment::Stream(def) => def.id.as_str(),
+        SourceFragment::Constant(def) => def.id.as_str(),
+        SourceFragment::Custom(def) => def.id.as_str(),
+    }
+}
+
+fn minted(id: &str, module: &str) -> Option<String> {
+    id.strip_prefix(SELF_ID)
+        .filter(|rest| rest.is_empty() || rest.starts_with("::"))
+        .map(|rest| format!("{module}{rest}"))
+}
+
+fn mint_self_ids(fragment: &mut SourceFragment, module: &str) {
+    match fragment {
+        SourceFragment::Record(def) => {
+            if let Some(value) = minted(def.id.as_str(), module) {
+                def.id = RecordId::new(value);
+            }
+            mint_methods(&mut def.methods, module);
+        }
+        SourceFragment::Enum(def) => {
+            if let Some(value) = minted(def.id.as_str(), module) {
+                def.id = EnumId::new(value);
+            }
+            mint_methods(&mut def.methods, module);
+        }
+        SourceFragment::Function(def) => {
+            if let Some(value) = minted(def.id.as_str(), module) {
+                def.id = FunctionId::new(value);
+            }
+        }
+        SourceFragment::Class(def) => {
+            if let Some(value) = minted(def.id.as_str(), module) {
+                def.id = ClassId::new(value);
+            }
+            mint_methods(&mut def.methods, module);
+        }
+        SourceFragment::Trait(def) => {
+            if let Some(value) = minted(def.id.as_str(), module) {
+                def.id = TraitId::new(value);
+            }
+            mint_methods(&mut def.methods, module);
+        }
+        SourceFragment::Stream(def) => {
+            if let Some(value) = minted(def.id.as_str(), module) {
+                def.id = StreamId::new(value);
+            }
+            if let Some(owner) = &mut def.owner
+                && let Some(value) = minted(owner.as_str(), module)
+            {
+                *owner = ClassId::new(value);
+            }
+        }
+        SourceFragment::Constant(def) => {
+            if let Some(value) = minted(def.id.as_str(), module) {
+                def.id = ConstantId::new(value);
+            }
+        }
+        SourceFragment::Custom(_) => {}
+    }
+}
+
+fn mint_methods(methods: &mut [MethodDef], prefix: &str) {
+    for method in methods {
+        if let Some(value) = minted(method.id.as_str(), prefix) {
+            method.id = boltffi_ast::MethodId::new(value);
+        }
+    }
+}
+
+fn resolve_fragment(
+    fragment: &mut SourceFragment,
+    slots: &[TypeNode],
+    kinds: &HashMap<String, DeclaredKind>,
+) -> Result<(), SourceFragmentError> {
+    let mut resolve = |expr: &mut TypeExpr| resolve_expr(expr, slots, kinds);
+    match fragment {
+        SourceFragment::Record(def) => {
+            resolve_fields(&mut def.fields, &mut resolve)?;
+            resolve_methods(&mut def.methods, &mut resolve)
+        }
+        SourceFragment::Enum(def) => {
+            for variant in &mut def.variants {
+                match &mut variant.payload {
+                    VariantPayload::Unit => {}
+                    VariantPayload::Tuple(types) => {
+                        for expr in types {
+                            resolve(expr)?;
+                        }
+                    }
+                    VariantPayload::Struct(fields) => resolve_fields(fields, &mut resolve)?,
+                }
+            }
+            resolve_methods(&mut def.methods, &mut resolve)
+        }
+        SourceFragment::Function(def) => {
+            resolve_callable(&mut def.parameters, &mut def.returns, &mut resolve)
+        }
+        SourceFragment::Class(def) => resolve_methods(&mut def.methods, &mut resolve),
+        SourceFragment::Trait(def) => resolve_methods(&mut def.methods, &mut resolve),
+        SourceFragment::Stream(def) => resolve(&mut def.item_type),
+        SourceFragment::Constant(def) => resolve(&mut def.type_expr),
+        SourceFragment::Custom(def) => resolve(&mut def.repr),
+    }
+}
+
+fn resolve_fields(
+    fields: &mut [FieldDef],
+    resolve: &mut impl FnMut(&mut TypeExpr) -> Result<(), SourceFragmentError>,
+) -> Result<(), SourceFragmentError> {
+    for field in fields {
+        resolve(&mut field.type_expr)?;
+    }
+    Ok(())
+}
+
+fn resolve_methods(
+    methods: &mut [MethodDef],
+    resolve: &mut impl FnMut(&mut TypeExpr) -> Result<(), SourceFragmentError>,
+) -> Result<(), SourceFragmentError> {
+    for method in methods {
+        resolve_callable(&mut method.parameters, &mut method.returns, resolve)?;
+    }
+    Ok(())
+}
+
+fn resolve_callable(
+    parameters: &mut [boltffi_ast::ParameterDef],
+    returns: &mut ReturnDef,
+    resolve: &mut impl FnMut(&mut TypeExpr) -> Result<(), SourceFragmentError>,
+) -> Result<(), SourceFragmentError> {
+    for parameter in parameters {
+        resolve(&mut parameter.type_expr)?;
+    }
+    if let ReturnDef::Value(expr) = returns {
+        resolve(expr)?;
+    }
+    Ok(())
+}
+
+fn resolve_expr(
+    expr: &mut TypeExpr,
+    slots: &[TypeNode],
+    kinds: &HashMap<String, DeclaredKind>,
+) -> Result<(), SourceFragmentError> {
+    if let TypeExpr::Record { id, path } = expr
+        && let Some(index) = id.as_str().strip_prefix(SLOT_ID_PREFIX)
+    {
+        let index: usize = index
+            .parse()
+            .map_err(|_| SourceFragmentError::UnknownSlot {
+                slot: index.to_owned(),
+            })?;
+        let node = slots.get(index).ok_or(SourceFragmentError::MissingSlot {
+            index,
+            available: slots.len(),
+        })?;
+        *expr = node_expr(node, Some(path.clone()), kinds)?;
+        return Ok(());
+    }
+
+    match expr {
+        TypeExpr::Boxed(inner)
+        | TypeExpr::Arc(inner)
+        | TypeExpr::Vec(inner)
+        | TypeExpr::Slice(inner)
+        | TypeExpr::Option(inner) => resolve_expr(inner, slots, kinds),
+        TypeExpr::Result { ok, err } => {
+            resolve_expr(ok, slots, kinds)?;
+            resolve_expr(err, slots, kinds)
+        }
+        TypeExpr::Map { key, value, .. } => {
+            resolve_expr(key, slots, kinds)?;
+            resolve_expr(value, slots, kinds)
+        }
+        TypeExpr::Tuple(elements) => {
+            for element in elements {
+                resolve_expr(element, slots, kinds)?;
+            }
+            Ok(())
+        }
+        TypeExpr::FnPtr(signature) => resolve_fn_sig(signature, slots, kinds),
+        TypeExpr::Dyn(bounds) | TypeExpr::ImplTrait(bounds) => {
+            if let boltffi_ast::BaseTrait::Function(function_trait) = &mut bounds.base {
+                resolve_fn_sig(&mut function_trait.signature, slots, kinds)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn resolve_fn_sig(
+    signature: &mut boltffi_ast::FnSig,
+    slots: &[TypeNode],
+    kinds: &HashMap<String, DeclaredKind>,
+) -> Result<(), SourceFragmentError> {
+    for parameter in &mut signature.parameters {
+        resolve_expr(parameter, slots, kinds)?;
+    }
+    if let ReturnDef::Value(expr) = &mut signature.returns {
+        resolve_expr(expr, slots, kinds)?;
+    }
+    Ok(())
+}
+
+fn node_expr(
+    node: &TypeNode,
+    path: Option<Path>,
+    kinds: &HashMap<String, DeclaredKind>,
+) -> Result<TypeExpr, SourceFragmentError> {
+    match node {
+        TypeNode::Id { id } => {
+            let kind = kinds
+                .get(id)
+                .ok_or_else(|| SourceFragmentError::UnresolvedReference { id: id.clone() })?;
+            let path = path.unwrap_or_else(|| synthesized_path(id));
+            Ok(match kind {
+                DeclaredKind::Record => TypeExpr::record(RecordId::new(id.clone()), path),
+                DeclaredKind::Enum => TypeExpr::enumeration(EnumId::new(id.clone()), path),
+                DeclaredKind::Class => TypeExpr::class(ClassId::new(id.clone()), path),
+                DeclaredKind::Custom => {
+                    TypeExpr::custom(boltffi_ast::CustomTypeId::new(id.clone()), path)
+                }
+            })
+        }
+        TypeNode::Prim { prim } => leaf_expr(prim),
+        TypeNode::Shape { shape, args } => {
+            let mut resolved = args
+                .iter()
+                .map(|arg| node_expr(arg, None, kinds))
+                .collect::<Result<Vec<_>, _>>()?;
+            shape_expr(shape, &mut resolved)
+        }
+    }
+}
+
+fn synthesized_path(id: &str) -> Path {
+    let name = id.rsplit("::").next().unwrap_or(id);
+    Path::new(
+        boltffi_ast::PathRoot::Relative,
+        vec![PathSegment::new(NamePart::new(name))],
+    )
+}
+
+fn leaf_expr(name: &str) -> Result<TypeExpr, SourceFragmentError> {
+    let primitive = match name {
+        "bool" => Some(Primitive::Bool),
+        "i8" => Some(Primitive::I8),
+        "u8" => Some(Primitive::U8),
+        "i16" => Some(Primitive::I16),
+        "u16" => Some(Primitive::U16),
+        "i32" => Some(Primitive::I32),
+        "u32" => Some(Primitive::U32),
+        "i64" => Some(Primitive::I64),
+        "u64" => Some(Primitive::U64),
+        "isize" => Some(Primitive::ISize),
+        "usize" => Some(Primitive::USize),
+        "f32" => Some(Primitive::F32),
+        "f64" => Some(Primitive::F64),
+        _ => None,
+    };
+    if let Some(primitive) = primitive {
+        return Ok(TypeExpr::Primitive(primitive));
+    }
+    match name {
+        "String" => Ok(TypeExpr::String),
+        "Duration" => Ok(TypeExpr::builtin(boltffi_ast::BuiltinType::Duration)),
+        "SystemTime" => Ok(TypeExpr::builtin(boltffi_ast::BuiltinType::SystemTime)),
+        "Uuid" => Ok(TypeExpr::builtin(boltffi_ast::BuiltinType::Uuid)),
+        "Url" => Ok(TypeExpr::builtin(boltffi_ast::BuiltinType::Url)),
+        _ => Err(SourceFragmentError::UnknownLeaf {
+            name: name.to_owned(),
+        }),
+    }
+}
+
+fn shape_expr(shape: &str, args: &mut Vec<TypeExpr>) -> Result<TypeExpr, SourceFragmentError> {
+    let arity_error = |expected: usize, args: &Vec<TypeExpr>| SourceFragmentError::ShapeArity {
+        shape: shape.to_owned(),
+        expected,
+        actual: args.len(),
+    };
+    match shape {
+        "Vec" | "Option" | "Box" | "Arc" => {
+            if args.len() != 1 {
+                return Err(arity_error(1, args));
+            }
+            let inner = args.remove(0);
+            Ok(match shape {
+                "Vec" => TypeExpr::vec(inner),
+                "Option" => TypeExpr::option(inner),
+                "Box" => TypeExpr::boxed(inner),
+                _ => TypeExpr::arc(inner),
+            })
+        }
+        "HashMap" | "BTreeMap" | "Result" => {
+            if args.len() != 2 {
+                return Err(arity_error(2, args));
+            }
+            let second = args.remove(1);
+            let first = args.remove(0);
+            Ok(match shape {
+                "HashMap" => TypeExpr::hash_map(first, second),
+                "BTreeMap" => TypeExpr::btree_map(first, second),
+                _ => TypeExpr::result(first, second),
+            })
+        }
+        _ => Err(SourceFragmentError::UnknownShape {
+            shape: shape.to_owned(),
+        }),
+    }
+}
+
+/// Failure while interpreting source records into a contract.
+#[derive(Debug)]
+pub enum SourceFragmentError {
+    /// A record payload did not deserialize as a fragment.
+    Decode {
+        /// Module path of the emitting invocation.
+        module: String,
+        /// Deserialization error text.
+        message: String,
+    },
+    /// A slot descriptor did not parse as a type node.
+    SlotDescriptor {
+        /// Module path of the emitting invocation.
+        module: String,
+        /// Parse error text.
+        message: String,
+    },
+    /// A slot placeholder index is not a number.
+    UnknownSlot {
+        /// The malformed index text.
+        slot: String,
+    },
+    /// A slot placeholder points past the record's slot table.
+    MissingSlot {
+        /// Placeholder index.
+        index: usize,
+        /// Number of slots the record carries.
+        available: usize,
+    },
+    /// A referenced declaration is missing from the aggregated records.
+    UnresolvedReference {
+        /// Canonical id of the missing declaration.
+        id: String,
+    },
+    /// A slot leaf names an unknown primitive or builtin.
+    UnknownLeaf {
+        /// The unknown leaf name.
+        name: String,
+    },
+    /// A slot shape is not a known container.
+    UnknownShape {
+        /// The unknown shape name.
+        shape: String,
+    },
+    /// A slot shape carries the wrong number of arguments.
+    ShapeArity {
+        /// Shape name.
+        shape: String,
+        /// Expected argument count.
+        expected: usize,
+        /// Actual argument count.
+        actual: usize,
+    },
+    /// Two records declare the same id with different content.
+    DuplicateDeclaration {
+        /// The conflicting canonical id.
+        id: String,
+    },
+}
+
+impl std::fmt::Display for SourceFragmentError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Decode { module, message } => {
+                write!(
+                    formatter,
+                    "source record in `{module}` failed to decode: {message}"
+                )
+            }
+            Self::SlotDescriptor { module, message } => write!(
+                formatter,
+                "source record in `{module}` has an unreadable slot descriptor: {message}"
+            ),
+            Self::UnknownSlot { slot } => {
+                write!(formatter, "slot placeholder `{slot}` is not an index")
+            }
+            Self::MissingSlot { index, available } => write!(
+                formatter,
+                "slot {index} is out of range for a record with {available} slots"
+            ),
+            Self::UnresolvedReference { id } => write!(
+                formatter,
+                "`{id}` is referenced but no aggregated record declares it"
+            ),
+            Self::UnknownLeaf { name } => {
+                write!(formatter, "slot leaf `{name}` is not a known FFI type")
+            }
+            Self::UnknownShape { shape } => {
+                write!(formatter, "slot shape `{shape}` is not a known container")
+            }
+            Self::ShapeArity {
+                shape,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "slot shape `{shape}` expects {expected} arguments, found {actual}"
+            ),
+            Self::DuplicateDeclaration { id } => write!(
+                formatter,
+                "two records declare `{id}` with different content"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SourceFragmentError {}
+
+#[cfg(test)]
+mod tests {
+    use boltffi_ast::CanonicalName;
+
+    use super::*;
+
+    fn name(spelling: &str) -> boltffi_ast::SourceName {
+        boltffi_ast::SourceName::new(spelling, CanonicalName::single(spelling.to_lowercase()))
+    }
+
+    fn slot_leaf(index: usize, written: &str) -> TypeExpr {
+        TypeExpr::record(
+            RecordId::new(format!("{SLOT_ID_PREFIX}{index}")),
+            Path::single(written),
+        )
+    }
+
+    fn record_fragment(fields: Vec<FieldDef>) -> Vec<u8> {
+        let mut def = RecordDef::new(RecordId::new(format!("{SELF_ID}::Route")), name("Route"));
+        def.fields = fields;
+        serde_json::to_vec(&SourceFragment::Record(def)).expect("fragment serializes")
+    }
+
+    fn raw(module: &str, slots: &[&str], json: Vec<u8>) -> RawSourceRecord {
+        RawSourceRecord {
+            package: PackageInfo::new("demo", None),
+            module: module.to_owned(),
+            slots: slots.iter().map(|slot| (*slot).to_owned()).collect(),
+            json,
+        }
+    }
+
+    fn point_record() -> RawSourceRecord {
+        let mut def = RecordDef::new(RecordId::new(format!("{SELF_ID}::Point")), name("Point"));
+        def.fields = vec![FieldDef::new(
+            name("x"),
+            TypeExpr::Primitive(Primitive::F64),
+        )];
+        raw(
+            "demo::geometry",
+            &[],
+            serde_json::to_vec(&SourceFragment::Record(def)).expect("fragment serializes"),
+        )
+    }
+
+    #[test]
+    fn mints_self_ids_and_resolves_slot_references() {
+        let route = raw(
+            "demo",
+            &[r#"{"id":"demo::geometry::Point"}"#],
+            record_fragment(vec![FieldDef::new(name("start"), slot_leaf(0, "Point"))]),
+        );
+
+        let contract = aggregate_records(&[route, point_record()], PackageInfo::new("demo", None))
+            .expect("records aggregate");
+
+        assert_eq!(
+            contract.records.len(),
+            2,
+            "both records land in the contract"
+        );
+        assert_eq!(
+            contract.records[0].id,
+            RecordId::new("demo::Route"),
+            "self id is minted from the record's module path"
+        );
+        let field = &contract.records[0].fields[0];
+        match &field.type_expr {
+            TypeExpr::Record { id, path } => {
+                assert_eq!(id, &RecordId::new("demo::geometry::Point"));
+                assert_eq!(
+                    path.last().expect("written path kept").name.as_str(),
+                    "Point",
+                    "the spelling at the use site survives resolution"
+                );
+            }
+            other => panic!("slot leaf did not resolve to a record: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolves_a_container_alias_slot_to_its_structure() {
+        let route = raw(
+            "demo",
+            &[r#"{"shape":"Vec","args":[{"id":"demo::geometry::Point"}]}"#],
+            record_fragment(vec![FieldDef::new(name("points"), slot_leaf(0, "Points"))]),
+        );
+
+        let contract = aggregate_records(&[route, point_record()], PackageInfo::new("demo", None))
+            .expect("records aggregate");
+
+        match &contract.records[0].fields[0].type_expr {
+            TypeExpr::Vec(inner) => match inner.as_ref() {
+                TypeExpr::Record { id, .. } => {
+                    assert_eq!(id, &RecordId::new("demo::geometry::Point"));
+                }
+                other => panic!("vec element did not resolve: {other:?}"),
+            },
+            other => panic!("alias slot did not resolve to a container: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classifies_references_by_the_defining_fragment() {
+        let mut status = EnumDef::new(EnumId::new(format!("{SELF_ID}::Status")), name("Status"));
+        status.variants = vec![];
+        let status = raw(
+            "demo",
+            &[],
+            serde_json::to_vec(&SourceFragment::Enum(status)).expect("fragment serializes"),
+        );
+        let holder = raw(
+            "demo",
+            &[r#"{"id":"demo::Status"}"#],
+            record_fragment(vec![FieldDef::new(name("status"), slot_leaf(0, "Status"))]),
+        );
+
+        let contract = aggregate_records(&[holder, status], PackageInfo::new("demo", None))
+            .expect("records aggregate");
+
+        assert!(
+            matches!(
+                &contract.records[0].fields[0].type_expr,
+                TypeExpr::Enum { id, .. } if id == &EnumId::new("demo::Status")
+            ),
+            "the reference takes the kind of its defining fragment"
+        );
+    }
+
+    #[test]
+    fn rejects_a_reference_no_record_declares() {
+        let route = raw(
+            "demo",
+            &[r#"{"id":"demo::Missing"}"#],
+            record_fragment(vec![FieldDef::new(name("gone"), slot_leaf(0, "Missing"))]),
+        );
+
+        let error = aggregate_records(&[route], PackageInfo::new("demo", None))
+            .expect_err("missing declaration fails");
+        assert!(
+            matches!(error, SourceFragmentError::UnresolvedReference { id } if id == "demo::Missing"),
+            "the missing id is named"
+        );
+    }
+
+    #[test]
+    fn rejects_conflicting_duplicate_declarations() {
+        let first = point_record();
+        let mut def = RecordDef::new(RecordId::new(format!("{SELF_ID}::Point")), name("Point"));
+        def.fields = vec![FieldDef::new(
+            name("x"),
+            TypeExpr::Primitive(Primitive::F32),
+        )];
+        let second = raw(
+            "demo::geometry",
+            &[],
+            serde_json::to_vec(&SourceFragment::Record(def)).expect("fragment serializes"),
+        );
+
+        let error = aggregate_records(&[first, second], PackageInfo::new("demo", None))
+            .expect_err("conflicting duplicates fail");
+        assert!(
+            matches!(error, SourceFragmentError::DuplicateDeclaration { id } if id == "demo::geometry::Point")
+        );
+    }
+
+    #[test]
+    fn collapses_identical_duplicate_declarations() {
+        let contract = aggregate_records(
+            &[point_record(), point_record()],
+            PackageInfo::new("demo", None),
+        )
+        .expect("identical duplicates collapse");
+        assert_eq!(contract.records.len(), 1, "one declaration survives");
+    }
+}

--- a/boltffi_binding/src/ir/source_record.rs
+++ b/boltffi_binding/src/ir/source_record.rs
@@ -1,0 +1,328 @@
+//! Per-invocation source records read back from a compiled artifact.
+//!
+//! Each `#[data]`/`#[export]` invocation emits one framed record into a dedicated link
+//! section. The frame constants here mirror `boltffi_core::capture` byte for byte; the
+//! two crates cannot share them without a dependency cycle, so `boltffi_tests` pins the
+//! round-trip between the const writer and this reader.
+
+use boltffi_ast::PackageInfo;
+
+/// Frame marker for one per-invocation source record.
+pub const SOURCE_RECORD_MAGIC: &[u8; 8] = b"BFFISRC1";
+
+/// Mach-O section name carrying source records, without the segment.
+pub const SOURCE_SECTION_MACH_O_NAME: &str = "__boltffisrc";
+
+/// ELF/COFF/wasm section name carrying source records.
+pub const SOURCE_SECTION_OBJECT_NAME: &str = ".boltffisrc";
+
+/// Returns whether a section name carries per-invocation source records.
+pub fn is_source_record_section(name: &str) -> bool {
+    name == SOURCE_SECTION_MACH_O_NAME || name == SOURCE_SECTION_OBJECT_NAME
+}
+
+/// One per-invocation source record, frame-decoded but not yet interpreted.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct RawSourceRecord {
+    /// Cargo package that compiled the emitting invocation.
+    pub package: PackageInfo,
+    /// `module_path!()` at the emitting invocation.
+    pub module: String,
+    /// Slot descriptors, resolved by rustc at each referenced type's definition site.
+    pub slots: Vec<String>,
+    /// JSON payload describing the invocation's declaration.
+    pub json: Vec<u8>,
+}
+
+/// Bytes read from a compiled artifact's source-record section.
+///
+/// A section holds one record per macro invocation; records are length-prefixed so
+/// concatenated statics remain parseable after the linker merges them.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct SourceRecordSectionBytes<'bytes> {
+    bytes: &'bytes [u8],
+}
+
+impl<'bytes> SourceRecordSectionBytes<'bytes> {
+    /// Stores the raw section bytes.
+    pub const fn new(bytes: &'bytes [u8]) -> Self {
+        Self { bytes }
+    }
+
+    /// Decodes every source record in section order.
+    pub fn records(self) -> Result<Vec<RawSourceRecord>, SourceRecordError> {
+        let mut offset = 0;
+        std::iter::from_fn(|| {
+            (offset < self.bytes.len()).then(|| {
+                let record = self.record_at(offset);
+                offset = record.as_ref().map_or(self.bytes.len(), |(_, next)| *next);
+                record.map(|(record, _)| record)
+            })
+        })
+        .collect()
+    }
+
+    fn record_at(self, offset: usize) -> Result<(RawSourceRecord, usize), SourceRecordError> {
+        let mut cursor = Cursor {
+            bytes: self.bytes,
+            at: offset,
+            record: offset,
+        };
+        let magic = cursor.take(SOURCE_RECORD_MAGIC.len())?;
+        if magic != SOURCE_RECORD_MAGIC {
+            return Err(SourceRecordError::InvalidMagic { offset });
+        }
+        let payload_length = cursor.length_u64()?;
+        let payload_end = cursor
+            .at
+            .checked_add(payload_length)
+            .filter(|end| *end <= self.bytes.len())
+            .ok_or(SourceRecordError::Truncated { offset })?;
+
+        let name = cursor.string_u16()?;
+        let version = cursor.string_u16()?;
+        let module = cursor.string_u16()?;
+        let slot_count = cursor.value_u16()?;
+        let slots = (0..slot_count)
+            .map(|_| cursor.string_u16())
+            .collect::<Result<Vec<_>, _>>()?;
+        let json_length = cursor.value_u32()?;
+        let json = cursor.take(json_length)?.to_vec();
+
+        if cursor.at != payload_end {
+            return Err(SourceRecordError::PayloadLengthMismatch { offset });
+        }
+
+        let record = RawSourceRecord {
+            package: PackageInfo::new(name, Some(version).filter(|value| !value.is_empty())),
+            module,
+            slots,
+            json,
+        };
+        Ok((record, payload_end))
+    }
+}
+
+struct Cursor<'bytes> {
+    bytes: &'bytes [u8],
+    at: usize,
+    record: usize,
+}
+
+impl<'bytes> Cursor<'bytes> {
+    fn take(&mut self, length: usize) -> Result<&'bytes [u8], SourceRecordError> {
+        let end = self
+            .at
+            .checked_add(length)
+            .ok_or(SourceRecordError::Truncated {
+                offset: self.record,
+            })?;
+        let bytes = self
+            .bytes
+            .get(self.at..end)
+            .ok_or(SourceRecordError::Truncated {
+                offset: self.record,
+            })?;
+        self.at = end;
+        Ok(bytes)
+    }
+
+    fn value_u16(&mut self) -> Result<usize, SourceRecordError> {
+        let bytes = self.take(size_of::<u16>())?;
+        Ok(u16::from_le_bytes(bytes.try_into().expect("u16 width")) as usize)
+    }
+
+    fn value_u32(&mut self) -> Result<usize, SourceRecordError> {
+        let bytes = self.take(size_of::<u32>())?;
+        let value = u32::from_le_bytes(bytes.try_into().expect("u32 width"));
+        usize::try_from(value).map_err(|_| SourceRecordError::Truncated {
+            offset: self.record,
+        })
+    }
+
+    fn length_u64(&mut self) -> Result<usize, SourceRecordError> {
+        let bytes = self.take(size_of::<u64>())?;
+        let value = u64::from_le_bytes(bytes.try_into().expect("u64 width"));
+        usize::try_from(value).map_err(|_| SourceRecordError::TooLarge {
+            offset: self.record,
+            length: value,
+        })
+    }
+
+    fn string_u16(&mut self) -> Result<String, SourceRecordError> {
+        let length = self.value_u16()?;
+        let bytes = self.take(length)?;
+        String::from_utf8(bytes.to_vec()).map_err(|_| SourceRecordError::InvalidUtf8 {
+            offset: self.record,
+        })
+    }
+}
+
+/// Source-record frame decoding failure.
+#[derive(Debug)]
+pub enum SourceRecordError {
+    /// A record does not start with the source-record marker.
+    InvalidMagic {
+        /// Byte offset of the invalid record.
+        offset: usize,
+    },
+    /// A record ended before its header or payload was complete.
+    Truncated {
+        /// Byte offset of the truncated record.
+        offset: usize,
+    },
+    /// A record length cannot be represented on this platform.
+    TooLarge {
+        /// Byte offset of the record.
+        offset: usize,
+        /// Payload length written in the record header.
+        length: u64,
+    },
+    /// The declared payload length disagrees with the decoded fields.
+    PayloadLengthMismatch {
+        /// Byte offset of the record.
+        offset: usize,
+    },
+    /// A record string field is not UTF-8.
+    InvalidUtf8 {
+        /// Byte offset of the record.
+        offset: usize,
+    },
+}
+
+impl std::fmt::Display for SourceRecordError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidMagic { offset } => {
+                write!(formatter, "source record at {offset} has an invalid marker")
+            }
+            Self::Truncated { offset } => {
+                write!(formatter, "source record at {offset} is truncated")
+            }
+            Self::TooLarge { offset, length } => write!(
+                formatter,
+                "source record at {offset} declares an unrepresentable length {length}"
+            ),
+            Self::PayloadLengthMismatch { offset } => write!(
+                formatter,
+                "source record at {offset} declares a payload length its fields disagree with"
+            ),
+            Self::InvalidUtf8 { offset } => write!(
+                formatter,
+                "source record at {offset} holds a non-UTF-8 string field"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SourceRecordError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame(package: &str, version: &str, module: &str, slots: &[&str], json: &[u8]) -> Vec<u8> {
+        let mut payload = Vec::new();
+        for field in [package, version, module] {
+            payload.extend_from_slice(&(field.len() as u16).to_le_bytes());
+            payload.extend_from_slice(field.as_bytes());
+        }
+        payload.extend_from_slice(&(slots.len() as u16).to_le_bytes());
+        for slot in slots {
+            payload.extend_from_slice(&(slot.len() as u16).to_le_bytes());
+            payload.extend_from_slice(slot.as_bytes());
+        }
+        payload.extend_from_slice(&(json.len() as u32).to_le_bytes());
+        payload.extend_from_slice(json);
+
+        let mut bytes = SOURCE_RECORD_MAGIC.to_vec();
+        bytes.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&payload);
+        bytes
+    }
+
+    #[test]
+    fn decodes_concatenated_records_in_section_order() {
+        let mut bytes = frame(
+            "demo",
+            "1.0.0",
+            "demo::geometry",
+            &[r#"{"id":"demo::Point"}"#],
+            br#"{"kind":"record"}"#,
+        );
+        bytes.extend_from_slice(&frame("demo", "", "demo", &[], br#"{"kind":"function"}"#));
+
+        let records = SourceRecordSectionBytes::new(&bytes)
+            .records()
+            .expect("both records decode");
+        assert_eq!(records.len(), 2, "section holds one record per invocation");
+        assert_eq!(
+            records[0].package,
+            PackageInfo::new("demo", Some("1.0.0".into()))
+        );
+        assert_eq!(records[0].module, "demo::geometry");
+        assert_eq!(records[0].slots, vec![r#"{"id":"demo::Point"}"#.to_owned()]);
+        assert_eq!(records[0].json, br#"{"kind":"record"}"#);
+        assert_eq!(
+            records[1].package,
+            PackageInfo::new("demo", None),
+            "an empty version decodes as no version"
+        );
+        assert!(records[1].slots.is_empty(), "records may carry no slots");
+    }
+
+    #[test]
+    fn rejects_a_wrong_marker() {
+        let mut bytes = frame("demo", "", "demo", &[], b"{}");
+        bytes[0] = b'X';
+        let error = SourceRecordSectionBytes::new(&bytes)
+            .records()
+            .expect_err("marker mismatch fails");
+        assert!(
+            matches!(error, SourceRecordError::InvalidMagic { offset: 0 }),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_truncated_record() {
+        let bytes = frame("demo", "", "demo", &[], b"{}");
+        let error = SourceRecordSectionBytes::new(&bytes[..bytes.len() - 1])
+            .records()
+            .expect_err("short section fails");
+        assert!(
+            matches!(
+                error,
+                SourceRecordError::Truncated { offset: 0 }
+                    | SourceRecordError::PayloadLengthMismatch { offset: 0 }
+            ),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_payload_length_that_disagrees_with_fields() {
+        let mut bytes = frame("demo", "", "demo", &[], b"{}");
+        let length = u64::from_le_bytes(bytes[8..16].try_into().expect("u64 width"));
+        bytes[8..16].copy_from_slice(&(length + 4).to_le_bytes());
+        bytes.extend_from_slice(&[0, 0, 0, 0]);
+        let error = SourceRecordSectionBytes::new(&bytes)
+            .records()
+            .expect_err("padding after fields fails");
+        assert!(
+            matches!(
+                error,
+                SourceRecordError::PayloadLengthMismatch { offset: 0 }
+            ),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn matches_only_the_source_sections() {
+        assert!(is_source_record_section("__boltffisrc"));
+        assert!(is_source_record_section(".boltffisrc"));
+        assert!(!is_source_record_section("__boltffi"));
+        assert!(!is_source_record_section(".boltffi"));
+    }
+}

--- a/boltffi_core/src/capture/mod.rs
+++ b/boltffi_core/src/capture/mod.rs
@@ -2,8 +2,10 @@
 //! link-section record, built in const context so type references resolve through rustc.
 
 mod record;
+mod type_info;
 
 pub use record::{
     SOURCE_RECORD_MAGIC, SOURCE_SECTION_MACH_O, SOURCE_SECTION_MACH_O_NAME, SOURCE_SECTION_OBJECT,
     record, record_len,
 };
+pub use type_info::{DESC_CAPACITY, DescBuf, TypeDesc, TypeInfo};

--- a/boltffi_core/src/capture/mod.rs
+++ b/boltffi_core/src/capture/mod.rs
@@ -1,0 +1,9 @@
+//! Per-invocation metadata capture: each `#[data]`/`#[export]` expansion emits its own
+//! link-section record, built in const context so type references resolve through rustc.
+
+mod record;
+
+pub use record::{
+    SOURCE_RECORD_MAGIC, SOURCE_SECTION_MACH_O, SOURCE_SECTION_MACH_O_NAME, SOURCE_SECTION_OBJECT,
+    record, record_len,
+};

--- a/boltffi_core/src/capture/record.rs
+++ b/boltffi_core/src/capture/record.rs
@@ -1,0 +1,177 @@
+/// Frame marker for one per-invocation source record.
+pub const SOURCE_RECORD_MAGIC: [u8; 8] = *b"BFFISRC1";
+
+/// Mach-O `link_section` value for per-invocation source records.
+pub const SOURCE_SECTION_MACH_O: &str = "__DATA,__boltffisrc";
+
+/// Mach-O section name without the segment, as the reader sees it.
+pub const SOURCE_SECTION_MACH_O_NAME: &str = "__boltffisrc";
+
+/// ELF/COFF/wasm `link_section` value for per-invocation source records.
+pub const SOURCE_SECTION_OBJECT: &str = ".boltffisrc";
+
+/// Byte length of the record produced by [`record`] for the same inputs.
+pub const fn record_len(
+    package: &str,
+    version: &str,
+    module: &str,
+    slots: &[&str],
+    json: &[u8],
+) -> usize {
+    let mut length = SOURCE_RECORD_MAGIC.len() + size_of::<u64>();
+    length += size_of::<u16>() + package.len();
+    length += size_of::<u16>() + version.len();
+    length += size_of::<u16>() + module.len();
+    length += size_of::<u16>();
+
+    let mut index = 0;
+    while index < slots.len() {
+        length += size_of::<u16>() + slots[index].len();
+        index += 1;
+    }
+
+    length + size_of::<u32>() + json.len()
+}
+
+/// Builds one framed source record in const context.
+///
+/// `N` must equal [`record_len`] for the same inputs; the build fails otherwise.
+pub const fn record<const N: usize>(
+    package: &str,
+    version: &str,
+    module: &str,
+    slots: &[&str],
+    json: &[u8],
+) -> [u8; N] {
+    let mut bytes = [0u8; N];
+    let mut at = write(&mut bytes, 0, &SOURCE_RECORD_MAGIC);
+
+    let payload = (N - SOURCE_RECORD_MAGIC.len() - size_of::<u64>()) as u64;
+    at = write(&mut bytes, at, &payload.to_le_bytes());
+    at = write_str(&mut bytes, at, package);
+    at = write_str(&mut bytes, at, version);
+    at = write_str(&mut bytes, at, module);
+
+    assert!(
+        slots.len() <= u16::MAX as usize,
+        "record has too many slots"
+    );
+    at = write(&mut bytes, at, &(slots.len() as u16).to_le_bytes());
+
+    let mut index = 0;
+    while index < slots.len() {
+        at = write_str(&mut bytes, at, slots[index]);
+        index += 1;
+    }
+
+    assert!(
+        json.len() <= u32::MAX as usize,
+        "record payload is too large"
+    );
+    at = write(&mut bytes, at, &(json.len() as u32).to_le_bytes());
+    at = write(&mut bytes, at, json);
+
+    assert!(at == N, "record length disagrees with record_len");
+    bytes
+}
+
+const fn write(bytes: &mut [u8], at: usize, source: &[u8]) -> usize {
+    let mut index = 0;
+    while index < source.len() {
+        bytes[at + index] = source[index];
+        index += 1;
+    }
+    at + source.len()
+}
+
+const fn write_str(bytes: &mut [u8], at: usize, value: &str) -> usize {
+    assert!(
+        value.len() <= u16::MAX as usize,
+        "record string is too long"
+    );
+    let at = write(bytes, at, &(value.len() as u16).to_le_bytes());
+    write(bytes, at, value.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PACKAGE: &str = "demo-pkg";
+    const VERSION: &str = "1.2.3";
+    const MODULE: &str = "demo_pkg::geometry";
+    const SLOTS: &[&str] = &["{\"id\":\"demo_pkg::Point\"}"];
+    const JSON: &[u8] = br#"{"kind":"record"}"#;
+    const LEN: usize = record_len(PACKAGE, VERSION, MODULE, SLOTS, JSON);
+    static RECORD: [u8; LEN] = record(PACKAGE, VERSION, MODULE, SLOTS, JSON);
+
+    fn read_u16(bytes: &[u8], at: usize) -> (usize, usize) {
+        let value = u16::from_le_bytes(bytes[at..at + 2].try_into().expect("u16 width"));
+        (value as usize, at + 2)
+    }
+
+    #[test]
+    fn frames_a_record_built_in_const_context() {
+        assert_eq!(&RECORD[..8], b"BFFISRC1", "record starts with the magic");
+        let length = u64::from_le_bytes(RECORD[8..16].try_into().expect("u64 width"));
+        assert_eq!(
+            length as usize,
+            LEN - 16,
+            "payload length covers everything after the header"
+        );
+
+        let (package_len, at) = read_u16(&RECORD, 16);
+        assert_eq!(
+            &RECORD[at..at + package_len],
+            PACKAGE.as_bytes(),
+            "package name follows the header"
+        );
+
+        let (version_len, at) = read_u16(&RECORD, at + package_len);
+        assert_eq!(
+            &RECORD[at..at + version_len],
+            VERSION.as_bytes(),
+            "package version follows the name"
+        );
+
+        let (module_len, at) = read_u16(&RECORD, at + version_len);
+        assert_eq!(
+            &RECORD[at..at + module_len],
+            MODULE.as_bytes(),
+            "module path follows the version"
+        );
+
+        let (slot_count, mut at) = read_u16(&RECORD, at + module_len);
+        assert_eq!(slot_count, SLOTS.len(), "slot count matches");
+        for slot in SLOTS {
+            let (slot_len, start) = read_u16(&RECORD, at);
+            assert_eq!(
+                &RECORD[start..start + slot_len],
+                slot.as_bytes(),
+                "slot descriptor round-trips"
+            );
+            at = start + slot_len;
+        }
+
+        let json_len = u32::from_le_bytes(RECORD[at..at + 4].try_into().expect("u32 width"));
+        let at = at + 4;
+        assert_eq!(
+            &RECORD[at..at + json_len as usize],
+            JSON,
+            "json payload closes the record"
+        );
+        assert_eq!(at + json_len as usize, LEN, "nothing trails the payload");
+    }
+
+    #[test]
+    fn frames_an_empty_version_and_no_slots() {
+        const LEN: usize = record_len("p", "", "p", &[], b"{}");
+        static RECORD: [u8; LEN] = record("p", "", "p", &[], b"{}");
+        let (version_len, _) = (
+            u16::from_le_bytes(RECORD[19..21].try_into().expect("u16 width")),
+            0,
+        );
+        assert_eq!(version_len, 0, "missing version is an empty string");
+        assert_eq!(RECORD[LEN - 2..], *b"{}", "payload still lands at the end");
+    }
+}

--- a/boltffi_core/src/capture/type_info.rs
+++ b/boltffi_core/src/capture/type_info.rs
@@ -1,0 +1,244 @@
+/// Canonical identity of a named FFI type, implemented at its `#[data]`/`custom_type!` site.
+///
+/// `Tag` is the referencing crate's anchor type, which is what keeps remote registrations
+/// inside the orphan rule.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` has no canonical id, so it cannot cross the FFI boundary",
+    label = "no canonical id",
+    note = "annotate `{Self}` with `#[data]`, or declare it with `custom_type!` if it is foreign"
+)]
+pub trait TypeInfo<Tag> {
+    /// The defining module path, as `module_path!()` sees it at the definition site.
+    const MODULE: &'static str;
+    /// The type name at the definition site.
+    const NAME: &'static str;
+}
+
+/// Structural descriptor of a type at an FFI use site, composable in const context so
+/// aliases to containers resolve through the compiler.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` has no canonical id, so it cannot cross the FFI boundary",
+    label = "no canonical id",
+    note = "annotate `{Self}` with `#[data]`, or declare it with `custom_type!` if it is foreign"
+)]
+pub trait TypeDesc<Tag> {
+    /// One JSON type node: `{"id":..}`, `{"prim":..}`, or `{"shape":..,"args":[..]}`.
+    const DESC: DescBuf;
+}
+
+/// Capacity of a [`DescBuf`]; deep nesting past this is a compile error.
+pub const DESC_CAPACITY: usize = 1024;
+
+/// A fixed-capacity const string buffer holding one composed type descriptor.
+#[derive(Clone, Copy)]
+pub struct DescBuf {
+    bytes: [u8; DESC_CAPACITY],
+    len: usize,
+}
+
+impl DescBuf {
+    /// Creates an empty buffer.
+    pub const fn new() -> Self {
+        Self {
+            bytes: [0; DESC_CAPACITY],
+            len: 0,
+        }
+    }
+
+    /// Builds the node for a named type from its [`TypeInfo`] constants.
+    pub const fn named(module: &str, name: &str) -> Self {
+        Self::new()
+            .push(b"{\"id\":\"")
+            .push_str(module)
+            .push(b"::")
+            .push_str(name)
+            .push(b"\"}")
+    }
+
+    /// Builds the node for a primitive or builtin leaf type.
+    pub const fn primitive(name: &str) -> Self {
+        Self::new()
+            .push(b"{\"prim\":\"")
+            .push_str(name)
+            .push(b"\"}")
+    }
+
+    /// Builds the node for a one-argument container shape.
+    pub const fn shape1(name: &str, arg: Self) -> Self {
+        Self::shape_open(name).concat(arg).push(b"]}")
+    }
+
+    /// Builds the node for a two-argument container shape.
+    pub const fn shape2(name: &str, first: Self, second: Self) -> Self {
+        Self::shape_open(name)
+            .concat(first)
+            .push(b",")
+            .concat(second)
+            .push(b"]}")
+    }
+
+    const fn shape_open(name: &str) -> Self {
+        Self::new()
+            .push(b"{\"shape\":\"")
+            .push_str(name)
+            .push(b"\",\"args\":[")
+    }
+
+    const fn push(mut self, source: &[u8]) -> Self {
+        assert!(
+            self.len + source.len() <= DESC_CAPACITY,
+            "type descriptor exceeds the capture buffer"
+        );
+
+        let mut index = 0;
+        while index < source.len() {
+            self.bytes[self.len + index] = source[index];
+            index += 1;
+        }
+        self.len += source.len();
+        self
+    }
+
+    const fn push_str(self, value: &str) -> Self {
+        self.push(value.as_bytes())
+    }
+
+    const fn concat(self, other: Self) -> Self {
+        self.push(other.as_bytes())
+    }
+
+    /// Returns the composed descriptor bytes.
+    pub const fn as_bytes(&self) -> &[u8] {
+        self.bytes.split_at(self.len).0
+    }
+
+    /// Returns the composed descriptor as a string.
+    pub const fn as_str(&self) -> &str {
+        match str::from_utf8(self.as_bytes()) {
+            Ok(value) => value,
+            Err(_) => panic!("type descriptor is not utf-8"),
+        }
+    }
+}
+
+impl Default for DescBuf {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+macro_rules! primitive_desc {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl<Tag> TypeDesc<Tag> for $ty {
+                const DESC: DescBuf = DescBuf::primitive(stringify!($ty));
+            }
+        )*
+    };
+}
+
+primitive_desc!(
+    bool, u8, u16, u32, u64, i8, i16, i32, i64, usize, isize, f32, f64
+);
+
+impl<Tag> TypeDesc<Tag> for String {
+    const DESC: DescBuf = DescBuf::primitive("String");
+}
+
+impl<Tag, T: TypeDesc<Tag>> TypeDesc<Tag> for Vec<T> {
+    const DESC: DescBuf = DescBuf::shape1("Vec", T::DESC);
+}
+
+impl<Tag, T: TypeDesc<Tag>> TypeDesc<Tag> for Option<T> {
+    const DESC: DescBuf = DescBuf::shape1("Option", T::DESC);
+}
+
+impl<Tag, T: TypeDesc<Tag>> TypeDesc<Tag> for Box<T> {
+    const DESC: DescBuf = DescBuf::shape1("Box", T::DESC);
+}
+
+impl<Tag, T: TypeDesc<Tag>> TypeDesc<Tag> for std::sync::Arc<T> {
+    const DESC: DescBuf = DescBuf::shape1("Arc", T::DESC);
+}
+
+impl<Tag, K: TypeDesc<Tag>, V: TypeDesc<Tag>> TypeDesc<Tag> for std::collections::HashMap<K, V> {
+    const DESC: DescBuf = DescBuf::shape2("HashMap", K::DESC, V::DESC);
+}
+
+impl<Tag, K: TypeDesc<Tag>, V: TypeDesc<Tag>> TypeDesc<Tag> for std::collections::BTreeMap<K, V> {
+    const DESC: DescBuf = DescBuf::shape2("BTreeMap", K::DESC, V::DESC);
+}
+
+impl<Tag, T: TypeDesc<Tag>, E: TypeDesc<Tag>> TypeDesc<Tag> for Result<T, E> {
+    const DESC: DescBuf = DescBuf::shape2("Result", T::DESC, E::DESC);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct ProbeTag;
+
+    struct Point;
+
+    impl<Tag> TypeInfo<Tag> for Point {
+        const MODULE: &'static str = "demo::geometry";
+        const NAME: &'static str = "Point";
+    }
+
+    impl<Tag> TypeDesc<Tag> for Point {
+        const DESC: DescBuf = DescBuf::named(
+            <Point as TypeInfo<Tag>>::MODULE,
+            <Point as TypeInfo<Tag>>::NAME,
+        );
+    }
+
+    type Points = Vec<Point>;
+
+    #[test]
+    fn composes_a_named_leaf() {
+        const DESC: &DescBuf = &<Point as TypeDesc<ProbeTag>>::DESC;
+        assert_eq!(
+            DESC.as_str(),
+            r#"{"id":"demo::geometry::Point"}"#,
+            "named types carry their canonical id"
+        );
+    }
+
+    #[test]
+    fn composes_through_container_aliases() {
+        const DESC: &DescBuf = &<Points as TypeDesc<ProbeTag>>::DESC;
+        assert_eq!(
+            DESC.as_str(),
+            r#"{"shape":"Vec","args":[{"id":"demo::geometry::Point"}]}"#,
+            "an alias to a container resolves to the container's structure"
+        );
+    }
+
+    #[test]
+    fn composes_nested_two_argument_shapes() {
+        const DESC: &DescBuf = &<HashMapAlias as TypeDesc<ProbeTag>>::DESC;
+        type HashMapAlias = std::collections::HashMap<String, Option<Point>>;
+        assert_eq!(
+            DESC.as_str(),
+            concat!(
+                r#"{"shape":"HashMap","args":[{"prim":"String"},"#,
+                r#"{"shape":"Option","args":[{"id":"demo::geometry::Point"}]}]}"#
+            ),
+            "two-argument shapes separate their arguments"
+        );
+    }
+
+    #[test]
+    fn descriptor_strings_promote_to_static_slots() {
+        const DESC: &DescBuf = &<Points as TypeDesc<ProbeTag>>::DESC;
+        const SLOT: &str = DESC.as_str();
+        const SLOTS: &[&str] = &[SLOT];
+        const LEN: usize = crate::capture::record_len("p", "", "m", SLOTS, b"{}");
+        static RECORD: [u8; LEN] = crate::capture::record("p", "", "m", SLOTS, b"{}");
+        assert!(
+            RECORD.len() > SLOT.len(),
+            "a record embeds the promoted descriptor"
+        );
+    }
+}

--- a/boltffi_core/src/capture/type_info.rs
+++ b/boltffi_core/src/capture/type_info.rs
@@ -64,12 +64,12 @@ impl DescBuf {
     }
 
     /// Builds the node for a one-argument container shape.
-    pub const fn shape1(name: &str, arg: Self) -> Self {
+    pub const fn shape_with_one_arg(name: &str, arg: Self) -> Self {
         Self::shape_open(name).concat(arg).push(b"]}")
     }
 
     /// Builds the node for a two-argument container shape.
-    pub const fn shape2(name: &str, first: Self, second: Self) -> Self {
+    pub const fn shape_with_two_args(name: &str, first: Self, second: Self) -> Self {
         Self::shape_open(name)
             .concat(first)
             .push(b",")
@@ -146,36 +146,37 @@ impl<Tag> TypeDesc<Tag> for String {
 }
 
 impl<Tag, T: TypeDesc<Tag>> TypeDesc<Tag> for Vec<T> {
-    const DESC: DescBuf = DescBuf::shape1("Vec", T::DESC);
+    const DESC: DescBuf = DescBuf::shape_with_one_arg("Vec", T::DESC);
 }
 
 impl<Tag, T: TypeDesc<Tag>> TypeDesc<Tag> for Option<T> {
-    const DESC: DescBuf = DescBuf::shape1("Option", T::DESC);
+    const DESC: DescBuf = DescBuf::shape_with_one_arg("Option", T::DESC);
 }
 
 impl<Tag, T: TypeDesc<Tag>> TypeDesc<Tag> for Box<T> {
-    const DESC: DescBuf = DescBuf::shape1("Box", T::DESC);
+    const DESC: DescBuf = DescBuf::shape_with_one_arg("Box", T::DESC);
 }
 
 impl<Tag, T: TypeDesc<Tag>> TypeDesc<Tag> for std::sync::Arc<T> {
-    const DESC: DescBuf = DescBuf::shape1("Arc", T::DESC);
+    const DESC: DescBuf = DescBuf::shape_with_one_arg("Arc", T::DESC);
 }
 
 impl<Tag, K: TypeDesc<Tag>, V: TypeDesc<Tag>> TypeDesc<Tag> for std::collections::HashMap<K, V> {
-    const DESC: DescBuf = DescBuf::shape2("HashMap", K::DESC, V::DESC);
+    const DESC: DescBuf = DescBuf::shape_with_two_args("HashMap", K::DESC, V::DESC);
 }
 
 impl<Tag, K: TypeDesc<Tag>, V: TypeDesc<Tag>> TypeDesc<Tag> for std::collections::BTreeMap<K, V> {
-    const DESC: DescBuf = DescBuf::shape2("BTreeMap", K::DESC, V::DESC);
+    const DESC: DescBuf = DescBuf::shape_with_two_args("BTreeMap", K::DESC, V::DESC);
 }
 
 impl<Tag, T: TypeDesc<Tag>, E: TypeDesc<Tag>> TypeDesc<Tag> for Result<T, E> {
-    const DESC: DescBuf = DescBuf::shape2("Result", T::DESC, E::DESC);
+    const DESC: DescBuf = DescBuf::shape_with_two_args("Result", T::DESC, E::DESC);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::capture::{record, record_len};
 
     struct ProbeTag;
 
@@ -234,8 +235,8 @@ mod tests {
         const DESC: &DescBuf = &<Points as TypeDesc<ProbeTag>>::DESC;
         const SLOT: &str = DESC.as_str();
         const SLOTS: &[&str] = &[SLOT];
-        const LEN: usize = crate::capture::record_len("p", "", "m", SLOTS, b"{}");
-        static RECORD: [u8; LEN] = crate::capture::record("p", "", "m", SLOTS, b"{}");
+        const LEN: usize = record_len("p", "", "m", SLOTS, b"{}");
+        static RECORD: [u8; LEN] = record("p", "", "m", SLOTS, b"{}");
         assert!(
             RECORD.len() > SLOT.len(),
             "a record embeds the promoted descriptor"

--- a/boltffi_core/src/lib.rs
+++ b/boltffi_core/src/lib.rs
@@ -5,6 +5,7 @@ extern crate self as boltffi_core;
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 pub mod callback;
+pub mod capture;
 pub mod custom_ffi;
 pub mod handle;
 pub mod interned_string;

--- a/boltffi_tests/tests/source_records.rs
+++ b/boltffi_tests/tests/source_records.rs
@@ -1,0 +1,74 @@
+//! Pins the per-invocation record contract between the const writer in `boltffi_core`
+//! and the reader in `boltffi_binding`, which mirror each other's framing by hand.
+
+use boltffi_binding::SourceRecordSectionBytes;
+use boltffi_core::capture::{self, DescBuf, TypeDesc, TypeInfo};
+
+struct ProbeTag;
+
+struct Point;
+
+impl<Tag> TypeInfo<Tag> for Point {
+    const MODULE: &'static str = "demo::geometry";
+    const NAME: &'static str = "Point";
+}
+
+impl<Tag> TypeDesc<Tag> for Point {
+    const DESC: DescBuf = DescBuf::named(
+        <Point as TypeInfo<Tag>>::MODULE,
+        <Point as TypeInfo<Tag>>::NAME,
+    );
+}
+
+type Points = Vec<Point>;
+
+const PACKAGE: &str = "demo";
+const VERSION: &str = "1.2.3";
+const MODULE: &str = "demo::geometry";
+const POINTS_DESC: &DescBuf = &<Points as TypeDesc<ProbeTag>>::DESC;
+const SLOTS: &[&str] = &[POINTS_DESC.as_str()];
+const JSON: &[u8] = br#"{"kind":"record","id":"$self::Route","name":{"spelling":"Route","canonical":{"parts":["route"]}}}"#;
+
+const RECORD_LEN: usize = capture::record_len(PACKAGE, VERSION, MODULE, SLOTS, JSON);
+static RECORD: [u8; RECORD_LEN] = capture::record(PACKAGE, VERSION, MODULE, SLOTS, JSON);
+
+#[test]
+fn const_written_records_decode_through_the_binding_reader() {
+    let mut section = RECORD.to_vec();
+    section.extend_from_slice(&RECORD);
+
+    let records = SourceRecordSectionBytes::new(&section)
+        .records()
+        .expect("const-written records decode");
+
+    assert_eq!(records.len(), 2, "concatenated statics stay parseable");
+    assert_eq!(records[0].package.name, PACKAGE);
+    assert_eq!(records[0].package.version.as_deref(), Some(VERSION));
+    assert_eq!(records[0].module, MODULE);
+    assert_eq!(
+        records[0].slots,
+        vec![r#"{"shape":"Vec","args":[{"id":"demo::geometry::Point"}]}"#.to_owned()],
+        "the descriptor composed in const context matches the reader's grammar"
+    );
+    assert_eq!(records[0].json, JSON);
+}
+
+#[test]
+fn section_names_agree_between_writer_and_reader() {
+    assert!(boltffi_binding::is_source_record_section(
+        capture::SOURCE_SECTION_MACH_O_NAME
+    ));
+    assert!(boltffi_binding::is_source_record_section(
+        capture::SOURCE_SECTION_OBJECT
+    ));
+    assert_eq!(
+        capture::SOURCE_RECORD_MAGIC.as_slice(),
+        boltffi_binding::SOURCE_RECORD_MAGIC.as_slice(),
+        "the frame marker is byte-identical on both sides"
+    );
+    assert_eq!(
+        capture::SOURCE_SECTION_MACH_O,
+        format!("__DATA,{}", boltffi_binding::SOURCE_SECTION_MACH_O_NAME),
+        "the Mach-O link_section value carries the reader's section name"
+    );
+}


### PR DESCRIPTION
First slice of #665. Inert plumbing only: nothing emits records yet, generated bindings are byte-identical.

- `boltffi_core`: const-buildable framing for per-invocation source records — one `BFFISRC1` frame per macro invocation in `__DATA,__boltffisrc` / `.boltffisrc`:

  ```
  magic | u64 LE length | package | version | module_path
        | u16 slot count | slot descriptors | u32-len JSON fragment
  ```

  plus the `TypeInfo`/`TypeDesc` identity traits capture slots project through (`<Point as TypeDesc<Tag>>::DESC` resolves a written reference at the referenced type's own definition site).
- `boltffi_binding`: the mirror frame reader and `aggregate_records`, which mints `$self::Name` ids from each record's `module_path!()`, resolves `$slot:N` leaves against the defining fragments, collapses identical duplicates (multi-artifact reads stay safe), and refuses incomplete sets so consumers fall back to the legacy path.
- `boltffi_bindgen`: `read_source` — reads records from every artifact of a plain cargo build, dependency rlibs and wasm32 objects included (`object` gains its `wasm` read feature; without it wasm members in rlibs were silently skipped).

Part of #665. Next: emission on every macro entry point, then the discovery flip.
