### PR TITLE
fix: actually strip debug sections when packing wasm

### DIFF
--- a/boltffi_cli/src/pack/wasm/mod.rs
+++ b/boltffi_cli/src/pack/wasm/mod.rs
@@ -1,4 +1,5 @@
 mod npm;
+mod sections;
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -21,6 +22,7 @@ use super::{print_cargo_line, resolve_build_cargo_args};
 use self::npm::{
     generate_wasm_loader_entrypoints, generate_wasm_package_json, generate_wasm_readme,
 };
+use self::sections::strip_wasm_sections;
 
 pub(crate) fn pack_wasm(
     config: &Config,
@@ -80,6 +82,15 @@ pub(crate) fn pack_wasm(
     let wasm_artifact_path = WasmArtifactPath::resolve(config, wasm_artifact_profile)?.into_path();
     if !wasm_artifact_path.exists() {
         return Err(CliError::FileNotFound(wasm_artifact_path));
+    }
+
+    let strip_debug = should_strip_debug(config, wasm_artifact_profile);
+    let step = reporter.step("Stripping WASM sections");
+    let stripped_bytes = strip_wasm_sections(&wasm_artifact_path, strip_debug)?;
+    if stripped_bytes == 0 {
+        step.finish_success();
+    } else {
+        step.finish_success_with(&format!("removed {} KiB", stripped_bytes / 1024));
     }
 
     if config.wasm_optimize_enabled(wasm_artifact_profile) {
@@ -159,6 +170,16 @@ pub(crate) fn pack_wasm(
     }
 
     Ok(())
+}
+
+/// Whether the pack should drop debug sections.
+///
+/// Debug info only goes when optimization applies — release by default — so a
+/// debug-profile pack keeps DWARF as it did before this step existed.
+/// Descriptor tables are dead weight in every profile and are handled
+/// separately by the strip itself.
+fn should_strip_debug(config: &Config, profile: WasmProfile) -> bool {
+    config.wasm_optimize_enabled(profile) && config.wasm_optimize_strip_debug()
 }
 
 fn build_wasm_target(
@@ -266,6 +287,7 @@ fn optimize_wasm_binary(config: &Config, wasm_path: &Path) -> Result<()> {
         .arg(&optimized_path);
 
     if !config.wasm_optimize_strip_debug() {
+        // Keeps the name section, and any debug sections the strip pass left.
         command.arg("-g");
     }
 
@@ -344,11 +366,78 @@ fn transpile_typescript_bundle(
 mod tests {
     use std::path::PathBuf;
 
-    use super::WasmArtifactPath;
+    use super::{WasmArtifactPath, should_strip_debug};
     use crate::config::{Config, WasmProfile};
 
     fn parse_config(input: &str) -> Config {
         toml::from_str(input).expect("toml parse failed")
+    }
+
+    const BARE_CONFIG: &str = r#"
+        [package]
+        name = "demo"
+        "#;
+
+    #[test]
+    fn release_strips_debug_by_default() {
+        assert!(should_strip_debug(
+            &parse_config(BARE_CONFIG),
+            WasmProfile::Release
+        ));
+    }
+
+    #[test]
+    fn debug_profile_keeps_debug_sections_by_default() {
+        // Optimization is release-only by default, and debug info rides with it.
+        assert!(!should_strip_debug(
+            &parse_config(BARE_CONFIG),
+            WasmProfile::Debug
+        ));
+    }
+
+    #[test]
+    fn opting_out_keeps_debug_sections_in_release() {
+        let config = parse_config(
+            r#"
+            [package]
+            name = "demo"
+
+            [targets.wasm.optimize]
+            strip_debug = false
+            "#,
+        );
+
+        assert!(!should_strip_debug(&config, WasmProfile::Release));
+    }
+
+    #[test]
+    fn enabling_optimization_strips_debug_on_a_debug_profile() {
+        let config = parse_config(
+            r#"
+            [package]
+            name = "demo"
+
+            [targets.wasm.optimize]
+            enabled = true
+            "#,
+        );
+
+        assert!(should_strip_debug(&config, WasmProfile::Debug));
+    }
+
+    #[test]
+    fn disabling_optimization_keeps_debug_sections_in_release() {
+        let config = parse_config(
+            r#"
+            [package]
+            name = "demo"
+
+            [targets.wasm.optimize]
+            enabled = false
+            "#,
+        );
+
+        assert!(!should_strip_debug(&config, WasmProfile::Release));
     }
 
     #[test]

--- a/boltffi_cli/src/pack/wasm/sections.rs
+++ b/boltffi_cli/src/pack/wasm/sections.rs
@@ -1,0 +1,219 @@
+//! Removal of custom sections from a wasm module.
+//!
+//! `wasm-opt` keeps DWARF unless it is asked to drop it, and it is an optional
+//! external tool anyway, so the packer does this itself. Only custom sections
+//! are touched: they carry no semantics, so dropping them cannot change how the
+//! module behaves.
+
+use std::path::Path;
+
+use crate::cli::{CliError, Result};
+
+/// Prefix shared by the DWARF sections a debug-carrying profile emits
+/// (`.debug_info`, `.debug_str`, ...). Matching on the prefix rather than a
+/// fixed list means a section added by a future toolchain is still dropped.
+const DEBUG_SECTION_PREFIX: &str = ".debug_";
+
+/// Descriptor table the `wasm-bindgen` proc macro leaves behind for its own
+/// CLI to consume. Nothing in the BoltFFI pipeline reads it, and the CLI never
+/// runs, so it would otherwise ship as dead weight.
+const WASM_BINDGEN_DESCRIPTORS: &str = "__wasm_bindgen_unstable";
+
+/// Strips the sections and returns how many bytes went.
+pub(crate) fn strip_wasm_sections(path: &Path, strip_debug: bool) -> Result<usize> {
+    let bytes = std::fs::read(path).map_err(|source| CliError::ReadFailed {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    let (stripped, removed) =
+        strip_bytes(&bytes, strip_debug).ok_or_else(|| CliError::CommandFailed {
+            command: format!("{} is not a valid wasm module", path.display()),
+            status: None,
+        })?;
+
+    if removed == 0 {
+        return Ok(0);
+    }
+
+    std::fs::write(path, stripped).map_err(|source| CliError::WriteFailed {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    Ok(removed)
+}
+
+/// Returns the module without the removed sections, or `None` if the input is
+/// not a wasm module the walker understands.
+fn strip_bytes(bytes: &[u8], strip_debug: bool) -> Option<(Vec<u8>, usize)> {
+    const HEADER: usize = 8;
+    if bytes.len() < HEADER || &bytes[0..4] != b"\0asm" {
+        return None;
+    }
+
+    let mut kept = Vec::with_capacity(bytes.len());
+    kept.extend_from_slice(&bytes[..HEADER]);
+    let mut removed = 0;
+    let mut offset = HEADER;
+
+    while offset < bytes.len() {
+        let start = offset;
+        let id = *bytes.get(offset)?;
+        offset += 1;
+        let (size, after_size) = read_var_u32(bytes, offset)?;
+        let body = after_size;
+        let end = body.checked_add(size as usize)?;
+        if end > bytes.len() {
+            return None;
+        }
+
+        let drop_section = (id == 0)
+            .then(|| custom_section_name(bytes, body, end))
+            .flatten()
+            .is_some_and(|name| {
+                name == WASM_BINDGEN_DESCRIPTORS
+                    || (strip_debug && name.starts_with(DEBUG_SECTION_PREFIX))
+            });
+
+        if drop_section {
+            removed += end - start;
+        } else {
+            kept.extend_from_slice(&bytes[start..end]);
+        }
+        offset = end;
+    }
+
+    Some((kept, removed))
+}
+
+fn custom_section_name(bytes: &[u8], body: usize, end: usize) -> Option<&str> {
+    let (name_len, name_start) = read_var_u32(bytes, body)?;
+    let name_end = name_start.checked_add(name_len as usize)?;
+    if name_end > end {
+        return None;
+    }
+    std::str::from_utf8(&bytes[name_start..name_end]).ok()
+}
+
+fn read_var_u32(bytes: &[u8], mut offset: usize) -> Option<(u32, usize)> {
+    let mut result: u32 = 0;
+    let mut shift = 0;
+    loop {
+        let byte = *bytes.get(offset)?;
+        offset += 1;
+        result |= u32::from(byte & 0x7f).checked_shl(shift)?;
+        if byte & 0x80 == 0 {
+            return Some((result, offset));
+        }
+        shift += 7;
+        if shift > 31 {
+            return None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a module with the given custom sections plus one non-custom
+    /// section that must survive untouched.
+    fn module(custom: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut bytes = b"\0asm\x01\x00\x00\x00".to_vec();
+        // A type section (id 1) with an empty body, standing in for real content.
+        bytes.push(1);
+        bytes.push(1);
+        bytes.push(0);
+        for (name, payload) in custom {
+            let mut body = Vec::new();
+            body.push(name.len() as u8);
+            body.extend_from_slice(name.as_bytes());
+            body.extend_from_slice(payload);
+            bytes.push(0);
+            bytes.push(body.len() as u8);
+            bytes.extend_from_slice(&body);
+        }
+        bytes
+    }
+
+    fn section_names(bytes: &[u8]) -> Vec<String> {
+        let mut names = Vec::new();
+        let mut offset = 8;
+        while offset < bytes.len() {
+            let id = bytes[offset];
+            offset += 1;
+            let (size, body) = read_var_u32(bytes, offset).expect("size");
+            let end = body + size as usize;
+            names.push(match id {
+                0 => format!("custom:{}", custom_section_name(bytes, body, end).unwrap()),
+                other => format!("id{other}"),
+            });
+            offset = end;
+        }
+        names
+    }
+
+    #[test]
+    fn drops_debug_sections_and_descriptors() {
+        let bytes = module(&[
+            (".debug_info", &[1, 2, 3]),
+            ("name", &[4, 5]),
+            (WASM_BINDGEN_DESCRIPTORS, &[6, 7, 8, 9]),
+        ]);
+        let (stripped, removed) = strip_bytes(&bytes, true).expect("valid module");
+
+        assert_eq!(section_names(&stripped), vec!["id1", "custom:name"]);
+        assert!(removed > 0);
+    }
+
+    #[test]
+    fn keeps_debug_sections_when_not_stripping() {
+        let bytes = module(&[
+            (".debug_info", &[1, 2, 3]),
+            (WASM_BINDGEN_DESCRIPTORS, &[6, 7]),
+        ]);
+        let (stripped, removed) = strip_bytes(&bytes, false).expect("valid module");
+
+        // Descriptors go regardless: the wasm-bindgen CLI never runs here.
+        assert_eq!(section_names(&stripped), vec!["id1", "custom:.debug_info"]);
+        assert!(removed > 0);
+    }
+
+    #[test]
+    fn drops_debug_sections_the_code_does_not_enumerate() {
+        let bytes = module(&[(".debug_something_new", &[1, 2, 3]), ("name", &[4])]);
+        let (stripped, removed) = strip_bytes(&bytes, true).expect("valid module");
+
+        assert_eq!(section_names(&stripped), vec!["id1", "custom:name"]);
+        assert!(removed > 0);
+    }
+
+    #[test]
+    fn keeps_the_name_section() {
+        let bytes = module(&[("name", &[1, 2, 3])]);
+        let (stripped, removed) = strip_bytes(&bytes, true).expect("valid module");
+
+        assert_eq!(section_names(&stripped), vec!["id1", "custom:name"]);
+        assert_eq!(removed, 0);
+    }
+
+    #[test]
+    fn leaves_a_module_without_matching_sections_byte_identical() {
+        let bytes = module(&[("name", &[1, 2, 3])]);
+        let (stripped, _) = strip_bytes(&bytes, true).expect("valid module");
+        assert_eq!(stripped, bytes);
+    }
+
+    #[test]
+    fn rejects_input_that_is_not_wasm() {
+        assert!(strip_bytes(b"not wasm at all", true).is_none());
+    }
+
+    #[test]
+    fn rejects_a_section_running_past_the_end() {
+        let mut bytes = b"\0asm\x01\x00\x00\x00".to_vec();
+        bytes.push(0);
+        bytes.push(64); // claims 64 bytes, none follow
+        assert!(strip_bytes(&bytes, true).is_none());
+    }
+}


### PR DESCRIPTION
`targets.wasm.optimize.strip_debug` defaults to true, but nothing ever stripped anything. Packing `examples/demo` shipped a 9.6 MiB module of which 8.4 MiB was DWARF — 89% of the artifact.

## What was wrong

The packer only decided whether to *add* `-g`:

```rust
if !config.wasm_optimize_strip_debug() {
    command.arg("-g");
}
```

Omitting `-g` is not the same as asking wasm-opt to strip. wasm-opt keeps DWARF unless told otherwise, so `strip_debug` had no effect in either state. Measured on the demo module, `wasm-opt -Os` alone removes 233 bytes of 9.6 MB; the same run with `--strip-debug` lands at 1.06 MB.

There is a second problem behind that one: the strip only ran inside `optimize_wasm_binary`, so it was reachable only when `wasm-opt` was. (Correction to an earlier revision of this description, which claimed a missing `wasm-opt` let the pack continue with a warning: `wasm_optimize_on_missing` defaults to `Error`, so a release pack fails outright. The warn/skip behaviour applies only when a project opts into it.)

## What this does

Strips the sections in the packer instead of delegating, so the result no longer depends on an optional external tool. Only custom sections are removed: they carry no semantics, so this cannot change how the module behaves.

- **Debug sections** match on the `.debug_` prefix rather than a fixed list, so a section a future toolchain adds is still dropped.
- **The wasm-bindgen descriptor table** (`__wasm_bindgen_unstable`) goes in every profile. It exists for the wasm-bindgen CLI to consume, and that CLI never runs in this pipeline, so it is dead weight wherever it appears.
- **The `name` section is kept**, so stack traces still symbolise.

Debug info is only stripped when optimization applies — release by default — so a debug-profile pack keeps DWARF exactly as before.

## Result

Packing `examples/demo` in release:

| | bytes |
| --- | ---: |
| before | 9,643,994 |
| after | 885,896 |

For reference, the wasm-bindgen build of the same crate is 1,027,907 bytes.

## Testing

- 8 unit tests on the section walker: debug sections and descriptors dropped, debug kept when `strip_debug = false`, descriptors dropped regardless, the `name` section preserved, a `.debug_` section outside any hardcoded list still dropped, byte-identical output when there is nothing to remove, and rejection of both non-wasm input and a section running past the end of the file.
- 5 tests on the strip gate, driven from parsed config: release strips by default, a debug profile does not, and each explicit opt-out in both directions. The debug-profile branch is worth pinning because the demo's config always resolves to release, so nothing exercises it end to end.
- `examples/platforms/wasm` acceptance suite passes against the stripped module.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --all`.

