### PR TITLE
stop inlining the error path into every generated wasm shim

### DIFF
--- a/boltffi/src/lib.rs
+++ b/boltffi/src/lib.rs
@@ -41,7 +41,8 @@ pub mod __private {
         FfiSpan, FfiStatus, InternedString, InternedStringPool, InternedStringRepr,
         NativeCallbackOwner, Passable, RustFutureContinuationCallback, RustFutureHandle,
         StreamContinuationCallback, StreamPollResult, SubscriptionHandle, VecTransport, WaitResult,
-        WirePassable, rustfuture, set_last_error, take_last_error, wire,
+        WirePassable, rustfuture, set_last_error, set_last_error_debug, set_last_error_display,
+        set_last_error_len, take_last_error, wire,
     };
     #[cfg(target_arch = "wasm32")]
     pub use boltffi_core::{

--- a/boltffi_core/src/lib.rs
+++ b/boltffi_core/src/lib.rs
@@ -66,7 +66,10 @@ pub use runtime::subscription::{
     SubscriptionHandle, WaitResult,
 };
 pub use safety::catch_ffi_panic;
-pub use status::{FfiStatus, clear_last_error, set_last_error, take_last_error};
+pub use status::{
+    FfiStatus, clear_last_error, set_last_error, set_last_error_debug, set_last_error_display,
+    set_last_error_len, take_last_error,
+};
 
 pub use types::{FfiBuf, FfiError, FfiOption, FfiSlice, FfiSpan, FfiString};
 pub use wasm::WASM_ABI_VERSION;

--- a/boltffi_core/src/status.rs
+++ b/boltffi_core/src/status.rs
@@ -49,10 +49,58 @@ thread_local! {
     static LAST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
+/// Records the message the next `boltffi_last_error` call will return.
+///
+/// Cold and never inlined on purpose. Without that, LLVM pulls the whole body
+/// (thread-local access, the `RefCell` borrow guard, and a `String`
+/// allocation) into every generated export shim, which on the demo crate cost
+/// ~71 KiB of wasm across ~300 shims.
+#[cold]
+#[inline(never)]
 pub fn set_last_error(message: impl Into<String>) {
     LAST_ERROR.with(|cell| {
         *cell.borrow_mut() = Some(message.into());
     });
+}
+
+/// Records a parameter-decoding failure that carries no error value.
+///
+/// These helpers exist so the generated shims call one outlined function
+/// instead of inlining a `format!` per failure site. Keeping them `#[cold]`
+/// and taking `&dyn` receivers also collapses what used to be one
+/// monomorphisation per error type down to a single instantiation.
+#[cold]
+#[inline(never)]
+pub fn set_last_error_len(parameter: &str, problem: &str, buf_len: usize) {
+    set_last_error(format!("{parameter}: {problem} (buf_len={buf_len})"));
+}
+
+/// Records a parameter-decoding failure whose cause implements [`Display`].
+#[cold]
+#[inline(never)]
+pub fn set_last_error_display(
+    parameter: &str,
+    problem: &str,
+    error: &dyn core::fmt::Display,
+    buf_len: usize,
+) {
+    set_last_error(format!(
+        "{parameter}: {problem}: {error} (buf_len={buf_len})"
+    ));
+}
+
+/// Records a parameter-decoding failure whose cause only implements [`Debug`].
+#[cold]
+#[inline(never)]
+pub fn set_last_error_debug(
+    parameter: &str,
+    problem: &str,
+    error: &dyn core::fmt::Debug,
+    buf_len: usize,
+) {
+    set_last_error(format!(
+        "{parameter}: {problem}: {error:?} (buf_len={buf_len})"
+    ));
 }
 
 pub fn take_last_error() -> Option<String> {

--- a/boltffi_macros/src/experimental/expansion/mod.rs
+++ b/boltffi_macros/src/experimental/expansion/mod.rs
@@ -2539,11 +2539,7 @@ mod tests {
                 ) -> u32 {
                     let when = {
                         if __boltffi_when_ptr.is_null() && __boltffi_when_len > 0 {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: null pointer with non-zero length (buf_len={})",
-                                stringify!(when),
-                                __boltffi_when_len
-                            ));
+                            ::boltffi::__private::set_last_error_len(stringify!(when), "null pointer with non-zero length", __boltffi_when_len as usize);
                             return <u32 as ::core::default::Default>::default();
                         }
                         let __boltffi_bytes: &[u8] = if __boltffi_when_len == 0 {
@@ -2559,12 +2555,7 @@ mod tests {
                         let __boltffi_decoded = match ::boltffi::__private::wire::decode::<i64>(__boltffi_bytes) {
                             Ok(value) => value,
                             Err(error) => {
-                                ::boltffi::__private::set_last_error(format!(
-                                    "{}: wire decode failed: {} (buf_len={})",
-                                    stringify!(when),
-                                    error,
-                                    __boltffi_when_len
-                                ));
+                                ::boltffi::__private::set_last_error_display(stringify!(when), "wire decode failed", &error, __boltffi_when_len as usize);
                                 return <u32 as ::core::default::Default>::default();
                             }
                         };
@@ -2573,12 +2564,7 @@ mod tests {
                         ) {
                             Ok(value) => value,
                             Err(error) => {
-                                ::boltffi::__private::set_last_error(format!(
-                                    "{}: custom conversion failed: {:?} (buf_len={})",
-                                    stringify!(when),
-                                    error,
-                                    __boltffi_when_len
-                                ));
+                                ::boltffi::__private::set_last_error_debug(stringify!(when), "custom conversion failed", &error, __boltffi_when_len as usize);
                                 return <u32 as ::core::default::Default>::default();
                             }
                         }
@@ -4665,11 +4651,7 @@ mod tests {
                 ) -> ::boltffi::__private::RustFutureHandle {
                     let name: String = {
                         if __boltffi_name_ptr.is_null() && __boltffi_name_len > 0 {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: null pointer with non-zero length (buf_len={})",
-                                stringify!(name),
-                                __boltffi_name_len
-                            ));
+                            ::boltffi::__private::set_last_error_len(stringify!(name), "null pointer with non-zero length", __boltffi_name_len as usize);
                             return ::boltffi::__private::rustfuture::rust_future_invalid_arg::<u32>();
                         }
                         let __boltffi_bytes: &[u8] = if __boltffi_name_len == 0 {
@@ -4685,12 +4667,7 @@ mod tests {
                         match ::boltffi::__private::wire::decode::<String>(__boltffi_bytes) {
                             Ok(value) => value,
                             Err(error) => {
-                                ::boltffi::__private::set_last_error(format!(
-                                    "{}: wire decode failed: {} (buf_len={})",
-                                    stringify!(name),
-                                    error,
-                                    __boltffi_name_len
-                                ));
+                                ::boltffi::__private::set_last_error_display(stringify!(name), "wire decode failed", &error, __boltffi_name_len as usize);
                                 return ::boltffi::__private::rustfuture::rust_future_invalid_arg::<u32>();
                             }
                         }
@@ -4879,10 +4856,7 @@ mod tests {
                     point: *const u8
                 ) -> f64 {
                     if point.is_null() {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: null direct record pointer",
-                            stringify!(point)
-                        ));
+                        ::boltffi::__private::set_last_error(concat!(stringify!(point), ": null direct record pointer"));
                         return <f64 as ::core::default::Default>::default();
                     }
                     let point: Point = unsafe {
@@ -4927,10 +4901,7 @@ mod tests {
                     point: *mut <Point as ::boltffi::__private::Passable>::In
                 ) -> f64 {
                     if point.is_null() {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: null direct record pointer",
-                            stringify!(point)
-                        ));
+                        ::boltffi::__private::set_last_error(concat!(stringify!(point), ": null direct record pointer"));
                         return <f64 as ::core::default::Default>::default();
                     }
                     let point: &mut Point = unsafe { &mut *(point as *mut Point) };
@@ -4970,10 +4941,7 @@ mod tests {
                 ) -> f64 {
                     let __boltffi_point_out = point;
                     if __boltffi_point_out.is_null() {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: null direct record pointer",
-                            stringify!(point)
-                        ));
+                        ::boltffi::__private::set_last_error(concat!(stringify!(point), ": null direct record pointer"));
                         return <f64 as ::core::default::Default>::default();
                     }
                     let mut point: Point = unsafe {
@@ -5059,11 +5027,7 @@ mod tests {
                 ) -> u32 {
                     let name: String = {
                         if __boltffi_name_ptr.is_null() && __boltffi_name_len > 0 {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: null pointer with non-zero length (buf_len={})",
-                                stringify!(name),
-                                __boltffi_name_len
-                            ));
+                            ::boltffi::__private::set_last_error_len(stringify!(name), "null pointer with non-zero length", __boltffi_name_len as usize);
                             return <u32 as ::core::default::Default>::default();
                         }
                         let __boltffi_bytes: &[u8] = if __boltffi_name_len == 0 {
@@ -5079,12 +5043,7 @@ mod tests {
                         match ::boltffi::__private::wire::decode::<String>(__boltffi_bytes) {
                             Ok(value) => value,
                             Err(error) => {
-                                ::boltffi::__private::set_last_error(format!(
-                                    "{}: wire decode failed: {} (buf_len={})",
-                                    stringify!(name),
-                                    error,
-                                    __boltffi_name_len
-                                ));
+                                ::boltffi::__private::set_last_error_display(stringify!(name), "wire decode failed", &error, __boltffi_name_len as usize);
                                 return <u32 as ::core::default::Default>::default();
                             }
                         }
@@ -5124,11 +5083,7 @@ mod tests {
                 ) -> u32 {
                     let __boltffi_name_storage: String = {
                         if __boltffi_name_ptr.is_null() && __boltffi_name_len > 0 {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: null pointer with non-zero length (buf_len={})",
-                                stringify!(__boltffi_name_storage),
-                                __boltffi_name_len
-                            ));
+                            ::boltffi::__private::set_last_error_len(stringify!(__boltffi_name_storage), "null pointer with non-zero length", __boltffi_name_len as usize);
                             return <u32 as ::core::default::Default>::default();
                         }
                         let __boltffi_bytes: &[u8] = if __boltffi_name_len == 0 {
@@ -5144,12 +5099,7 @@ mod tests {
                         match ::boltffi::__private::wire::decode::<String>(__boltffi_bytes) {
                             Ok(value) => value,
                             Err(error) => {
-                                ::boltffi::__private::set_last_error(format!(
-                                    "{}: wire decode failed: {} (buf_len={})",
-                                    stringify!(__boltffi_name_storage),
-                                    error,
-                                    __boltffi_name_len
-                                ));
+                                ::boltffi::__private::set_last_error_display(stringify!(__boltffi_name_storage), "wire decode failed", &error, __boltffi_name_len as usize);
                                 return <u32 as ::core::default::Default>::default();
                             }
                         }
@@ -5191,11 +5141,7 @@ mod tests {
                 ) -> u32 {
                     let mut __boltffi_name_storage: String = {
                         if __boltffi_name_ptr.is_null() && __boltffi_name_len > 0 {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: null pointer with non-zero length (buf_len={})",
-                                stringify!(__boltffi_name_storage),
-                                __boltffi_name_len
-                            ));
+                            ::boltffi::__private::set_last_error_len(stringify!(__boltffi_name_storage), "null pointer with non-zero length", __boltffi_name_len as usize);
                             return <u32 as ::core::default::Default>::default();
                         }
                         let __boltffi_bytes: &[u8] = if __boltffi_name_len == 0 {
@@ -5211,22 +5157,14 @@ mod tests {
                         match ::boltffi::__private::wire::decode::<String>(__boltffi_bytes) {
                             Ok(value) => value,
                             Err(error) => {
-                                ::boltffi::__private::set_last_error(format!(
-                                    "{}: wire decode failed: {} (buf_len={})",
-                                    stringify!(__boltffi_name_storage),
-                                    error,
-                                    __boltffi_name_len
-                                ));
+                                ::boltffi::__private::set_last_error_display(stringify!(__boltffi_name_storage), "wire decode failed", &error, __boltffi_name_len as usize);
                                 return <u32 as ::core::default::Default>::default();
                             }
                         }
                     };
                     let name = __boltffi_name_storage.as_mut_str();
                     if __boltffi_name_out.is_null() {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: writeback pointer is null",
-                            stringify!(__boltffi_name_out)
-                        ));
+                        ::boltffi::__private::set_last_error(concat!(stringify!(__boltffi_name_out), ": writeback pointer is null"));
                         return <u32 as ::core::default::Default>::default();
                     }
                     let __boltffi_result = rewrite(name);
@@ -5273,11 +5211,7 @@ mod tests {
                 ) -> u32 {
                     let bytes: Vec<u8> = {
                         if __boltffi_bytes_ptr.is_null() && __boltffi_bytes_len > 0 {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: null pointer with non-zero length (buf_len={})",
-                                stringify!(bytes),
-                                __boltffi_bytes_len
-                            ));
+                            ::boltffi::__private::set_last_error_len(stringify!(bytes), "null pointer with non-zero length", __boltffi_bytes_len as usize);
                             return <u32 as ::core::default::Default>::default();
                         }
                         let __boltffi_bytes: &[u8] = if __boltffi_bytes_len == 0 {
@@ -5293,12 +5227,7 @@ mod tests {
                         match ::boltffi::__private::wire::decode::<Vec<u8> >(__boltffi_bytes) {
                             Ok(value) => value,
                             Err(error) => {
-                                ::boltffi::__private::set_last_error(format!(
-                                    "{}: wire decode failed: {} (buf_len={})",
-                                    stringify!(bytes),
-                                    error,
-                                    __boltffi_bytes_len
-                                ));
+                                ::boltffi::__private::set_last_error_display(stringify!(bytes), "wire decode failed", &error, __boltffi_bytes_len as usize);
                                 return <u32 as ::core::default::Default>::default();
                             }
                         }
@@ -5338,11 +5267,7 @@ mod tests {
                 ) -> u32 {
                     let mut __boltffi_bytes_storage: Vec<u8> = {
                         if __boltffi_bytes_ptr.is_null() && __boltffi_bytes_len > 0 {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: null pointer with non-zero length (buf_len={})",
-                                stringify!(__boltffi_bytes_storage),
-                                __boltffi_bytes_len
-                            ));
+                            ::boltffi::__private::set_last_error_len(stringify!(__boltffi_bytes_storage), "null pointer with non-zero length", __boltffi_bytes_len as usize);
                             return <u32 as ::core::default::Default>::default();
                         }
                         let __boltffi_bytes: &[u8] = if __boltffi_bytes_len == 0 {
@@ -5358,12 +5283,7 @@ mod tests {
                         match ::boltffi::__private::wire::decode::<Vec<u8> >(__boltffi_bytes) {
                             Ok(value) => value,
                             Err(error) => {
-                                ::boltffi::__private::set_last_error(format!(
-                                    "{}: wire decode failed: {} (buf_len={})",
-                                    stringify!(__boltffi_bytes_storage),
-                                    error,
-                                    __boltffi_bytes_len
-                                ));
+                                ::boltffi::__private::set_last_error_display(stringify!(__boltffi_bytes_storage), "wire decode failed", &error, __boltffi_bytes_len as usize);
                                 return <u32 as ::core::default::Default>::default();
                             }
                         }
@@ -5409,12 +5329,7 @@ mod tests {
                         }) {
                             Ok(value) => value,
                             Err(error) => {
-                                ::boltffi::__private::set_last_error(format!(
-                                    "{}: invalid optional scalar payload: {} (buf_len={})",
-                                    stringify!(count),
-                                    error,
-                                    __boltffi_count_len
-                                ));
+                                ::boltffi::__private::set_last_error_display(stringify!(count), "invalid optional scalar payload", &error, __boltffi_count_len as usize);
                                 return ::boltffi::__private::FfiStatus::INVALID_ARG;
                             }
                         }
@@ -5455,11 +5370,7 @@ mod tests {
                 ) -> u32 {
                     let profile: Profile = {
                         if __boltffi_profile_ptr.is_null() && __boltffi_profile_len > 0 {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: null pointer with non-zero length (buf_len={})",
-                                stringify!(profile),
-                                __boltffi_profile_len
-                            ));
+                            ::boltffi::__private::set_last_error_len(stringify!(profile), "null pointer with non-zero length", __boltffi_profile_len as usize);
                             return <u32 as ::core::default::Default>::default();
                         }
                         let __boltffi_bytes: &[u8] = if __boltffi_profile_len == 0 {
@@ -5475,12 +5386,7 @@ mod tests {
                         match ::boltffi::__private::wire::decode::<Profile>(__boltffi_bytes) {
                             Ok(value) => value,
                             Err(error) => {
-                                ::boltffi::__private::set_last_error(format!(
-                                    "{}: wire decode failed: {} (buf_len={})",
-                                    stringify!(profile),
-                                    error,
-                                    __boltffi_profile_len
-                                ));
+                                ::boltffi::__private::set_last_error_display(stringify!(profile), "wire decode failed", &error, __boltffi_profile_len as usize);
                                 return <u32 as ::core::default::Default>::default();
                             }
                         }
@@ -5521,11 +5427,7 @@ mod tests {
                 ) -> u32 {
                     let mut __boltffi_profile_storage: Profile = {
                         if __boltffi_profile_ptr.is_null() && __boltffi_profile_len > 0 {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: null pointer with non-zero length (buf_len={})",
-                                stringify!(__boltffi_profile_storage),
-                                __boltffi_profile_len
-                            ));
+                            ::boltffi::__private::set_last_error_len(stringify!(__boltffi_profile_storage), "null pointer with non-zero length", __boltffi_profile_len as usize);
                             return <u32 as ::core::default::Default>::default();
                         }
                         let __boltffi_bytes: &[u8] = if __boltffi_profile_len == 0 {
@@ -5541,22 +5443,14 @@ mod tests {
                         match ::boltffi::__private::wire::decode::<Profile>(__boltffi_bytes) {
                             Ok(value) => value,
                             Err(error) => {
-                                ::boltffi::__private::set_last_error(format!(
-                                    "{}: wire decode failed: {} (buf_len={})",
-                                    stringify!(__boltffi_profile_storage),
-                                    error,
-                                    __boltffi_profile_len
-                                ));
+                                ::boltffi::__private::set_last_error_display(stringify!(__boltffi_profile_storage), "wire decode failed", &error, __boltffi_profile_len as usize);
                                 return <u32 as ::core::default::Default>::default();
                             }
                         }
                     };
                     let profile = &mut __boltffi_profile_storage;
                     if __boltffi_profile_out.is_null() {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: writeback pointer is null",
-                            stringify!(__boltffi_profile_out)
-                        ));
+                        ::boltffi::__private::set_last_error(concat!(stringify!(__boltffi_profile_out), ": writeback pointer is null"));
                         return <u32 as ::core::default::Default>::default();
                     }
                     let __boltffi_result = rename(profile);
@@ -5601,10 +5495,7 @@ mod tests {
                     engine: u64
                 ) -> u64 {
                     if engine == 0 {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: null class handle",
-                            stringify!(engine)
-                        ));
+                        ::boltffi::__private::set_last_error(concat!(stringify!(engine), ": null class handle"));
                         return 0;
                     }
                     let engine: Engine = match unsafe {
@@ -5612,10 +5503,7 @@ mod tests {
                     } {
                         Some(value) => value,
                         None => {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: released class handle",
-                                stringify!(engine)
-                            ));
+                            ::boltffi::__private::set_last_error(concat!(stringify!(engine), ": released class handle"));
                             return 0;
                         }
                     };
@@ -6770,10 +6658,7 @@ mod tests {
                 ) -> ::boltffi::__private::FfiStatus {
                     let __boltffi_listener_handle = listener;
                     if __boltffi_listener_handle.is_null() {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: null callback handle",
-                            stringify!(listener)
-                        ));
+                        ::boltffi::__private::set_last_error(concat!(stringify!(listener), ": null callback handle"));
                         return ::boltffi::__private::FfiStatus::INVALID_ARG;
                     }
                     let listener: Box<dyn Listener> = unsafe {
@@ -7819,10 +7704,7 @@ mod tests {
                         fn __boltffi_callback_closure____closure__u32_to_u32_free(handle: u32);
                     }
                     if callback == 0 {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: null closure handle",
-                            stringify!(callback)
-                        ));
+                        ::boltffi::__private::set_last_error(concat!(stringify!(callback), ": null closure handle"));
                         return <u32 as ::core::default::Default>::default();
                     }
                     let __boltffi_callback_owner =
@@ -8670,10 +8552,7 @@ mod tests {
                     engine: u32
                 ) -> u32 {
                     if engine == 0 {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: null class handle",
-                            stringify!(engine)
-                        ));
+                        ::boltffi::__private::set_last_error(concat!(stringify!(engine), ": null class handle"));
                         return <u32 as ::core::default::Default>::default();
                     }
                     let engine: &Engine = unsafe {

--- a/boltffi_macros/src/experimental/wrapper/class.rs
+++ b/boltffi_macros/src/experimental/wrapper/class.rs
@@ -562,10 +562,7 @@ impl<'lowered, C: Copy> ClassOwner<'lowered, C> {
                 let #receiver_handle = match unsafe { #handle_type::retain(#receiver_handle) } {
                     Some(handle) => handle,
                     None => {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: released class handle",
-                            stringify!(#receiver)
-                        ));
+                        ::boltffi::__private::set_last_error(concat!(stringify!(#receiver), ": released class handle"));
                         #failure
                     }
                 };
@@ -577,10 +574,7 @@ impl<'lowered, C: Copy> ClassOwner<'lowered, C> {
 
         quote! {
             if #receiver == #zero {
-                ::boltffi::__private::set_last_error(format!(
-                    "{}: null class handle",
-                    stringify!(#receiver)
-                ));
+                ::boltffi::__private::set_last_error(concat!(stringify!(#receiver), ": null class handle"));
                 #failure
             }
             let #receiver_handle = #receiver as usize as *mut #handle_type;

--- a/boltffi_macros/src/experimental/wrapper/encoded/incoming.rs
+++ b/boltffi_macros/src/experimental/wrapper/encoded/incoming.rs
@@ -184,11 +184,7 @@ impl Input {
         Ok(quote! {
             let #mutability #binding: #rust_type = {
                 if #pointer.is_null() && #length > 0 {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: null pointer with non-zero length (buf_len={})",
-                        stringify!(#binding),
-                        #length
-                    ));
+                    ::boltffi::__private::set_last_error_len(stringify!(#binding), "null pointer with non-zero length", #length as usize);
                     #failure
                 }
                 let __boltffi_packed =
@@ -238,11 +234,7 @@ impl Input {
             return Ok(quote! {
                 let #mutability #binding: #rust_type = {
                     if #pointer.is_null() && #length > 0 {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: null pointer with non-zero length (buf_len={})",
-                            stringify!(#binding),
-                            #length
-                        ));
+                        ::boltffi::__private::set_last_error_len(stringify!(#binding), "null pointer with non-zero length", #length as usize);
                         #failure
                     }
                     let __boltffi_bytes: &[u8] = if #length == 0 {
@@ -253,12 +245,7 @@ impl Input {
                     match ::boltffi::__private::wire::decode::<#rust_type>(__boltffi_bytes) {
                         Ok(value) => value,
                         Err(error) => {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: wire decode failed: {} (buf_len={})",
-                                stringify!(#binding),
-                                error,
-                                #length
-                            ));
+                            ::boltffi::__private::set_last_error_display(stringify!(#binding), "wire decode failed", &error, #length as usize);
                             #failure
                         }
                     }
@@ -271,12 +258,7 @@ impl Input {
                 match #converted_value {
                     Ok(value) => value,
                     Err(error) => {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: custom conversion failed: {:?} (buf_len={})",
-                            stringify!(#binding),
-                            error,
-                            #length
-                        ));
+                        ::boltffi::__private::set_last_error_debug(stringify!(#binding), "custom conversion failed", &error, #length as usize);
                         #failure
                     }
                 }
@@ -292,11 +274,7 @@ impl Input {
         Ok(quote! {
             let #mutability #binding #type_annotation = {
                 if #pointer.is_null() && #length > 0 {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: null pointer with non-zero length (buf_len={})",
-                        stringify!(#binding),
-                        #length
-                    ));
+                    ::boltffi::__private::set_last_error_len(stringify!(#binding), "null pointer with non-zero length", #length as usize);
                     #failure
                 }
                 let __boltffi_bytes: &[u8] = if #length == 0 {
@@ -307,12 +285,7 @@ impl Input {
                 let __boltffi_decoded = match ::boltffi::__private::wire::decode::<#decode_type>(__boltffi_bytes) {
                     Ok(value) => value,
                     Err(error) => {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: wire decode failed: {} (buf_len={})",
-                            stringify!(#binding),
-                            error,
-                            #length
-                        ));
+                        ::boltffi::__private::set_last_error_display(stringify!(#binding), "wire decode failed", &error, #length as usize);
                         #failure
                     }
                 };

--- a/boltffi_macros/src/experimental/wrapper/param/closure.rs
+++ b/boltffi_macros/src/experimental/wrapper/param/closure.rs
@@ -1406,10 +1406,7 @@ impl ClosureBinding {
                     }
                     (None, None) => None,
                     _ => {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: invalid nullable closure registration",
-                            stringify!(#ident)
-                        ));
+                        ::boltffi::__private::set_last_error(concat!(stringify!(#ident), ": invalid nullable closure registration"));
                         #failure
                     }
                 };
@@ -1429,10 +1426,7 @@ impl ClosureBinding {
         match self {
             Self::ImplTrait(_) => Ok(quote! {
                 if #ident == 0 {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: null closure handle",
-                        stringify!(#ident)
-                    ));
+                    ::boltffi::__private::set_last_error(concat!(stringify!(#ident), ": null closure handle"));
                     #failure
                 }
                 let #owner = ::boltffi::__private::WasmCallbackOwner::new(#ident, #free);
@@ -1442,10 +1436,7 @@ impl ClosureBinding {
             }),
             Self::Boxed(_, ty) => Ok(quote! {
                 if #ident == 0 {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: null closure handle",
-                        stringify!(#ident)
-                    ));
+                    ::boltffi::__private::set_last_error(concat!(stringify!(#ident), ": null closure handle"));
                     #failure
                 }
                 let #owner = ::boltffi::__private::WasmCallbackOwner::new(#ident, #free);

--- a/boltffi_macros/src/experimental/wrapper/param/direct.rs
+++ b/boltffi_macros/src/experimental/wrapper/param/direct.rs
@@ -267,20 +267,14 @@ impl NativeRecordParam {
         match self.receive {
             Receive::ByRef => Ok(quote! {
                 if #ident.is_null() {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: null direct record pointer",
-                        stringify!(#ident)
-                    ));
+                    ::boltffi::__private::set_last_error(concat!(stringify!(#ident), ": null direct record pointer"));
                     #failure
                 }
                 let #ident: &#rust_type = unsafe { &*(#ident as *const #rust_type) };
             }),
             Receive::ByMutRef => Ok(quote! {
                 if #ident.is_null() {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: null direct record pointer",
-                        stringify!(#ident)
-                    ));
+                    ::boltffi::__private::set_last_error(concat!(stringify!(#ident), ": null direct record pointer"));
                     #failure
                 }
                 let #ident: &mut #rust_type = unsafe { &mut *(#ident as *mut #rust_type) };
@@ -341,10 +335,7 @@ impl WasmRecordParam {
             Receive::ByMutRef => Ok(quote! {
                 let #out = #ident;
                 if #out.is_null() {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: null direct record pointer",
-                        stringify!(#ident)
-                    ));
+                    ::boltffi::__private::set_last_error(concat!(stringify!(#ident), ": null direct record pointer"));
                     #failure
                 }
                 let mut #ident: #rust_type = unsafe {
@@ -355,10 +346,7 @@ impl WasmRecordParam {
             }),
             Receive::ByValue | Receive::ByRef => Ok(quote! {
                 if #ident.is_null() {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: null direct record pointer",
-                        stringify!(#ident)
-                    ));
+                    ::boltffi::__private::set_last_error(concat!(stringify!(#ident), ": null direct record pointer"));
                     #failure
                 }
                 let #ident: #rust_type = unsafe {

--- a/boltffi_macros/src/experimental/wrapper/param/encoded.rs
+++ b/boltffi_macros/src/experimental/wrapper/param/encoded.rs
@@ -187,11 +187,7 @@ impl<'expansion, 'lowered, S: RenderSurface> Slice<'expansion, 'lowered, S> {
         let failure = &self.failure;
         let conversion = quote! {
             let #ident: &mut [u8] = if #pointer.is_null() && #length > 0 {
-                ::boltffi::__private::set_last_error(format!(
-                    "{}: null pointer with non-zero length (buf_len={})",
-                    stringify!(#ident),
-                    #length
-                ));
+                ::boltffi::__private::set_last_error_len(stringify!(#ident), "null pointer with non-zero length", #length as usize);
                 #failure
             } else if #length == 0 {
                 &mut []
@@ -237,10 +233,7 @@ impl<'expansion, 'lowered, S: RenderSurface> Slice<'expansion, 'lowered, S> {
             ffi_parameter_types: vec![quote! { *mut ::boltffi::__private::FfiBuf }],
             conversions: vec![quote! {
                 if #out.is_null() {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: writeback pointer is null",
-                        stringify!(#out)
-                    ));
+                    ::boltffi::__private::set_last_error(concat!(stringify!(#out), ": writeback pointer is null"));
                     #failure
                 }
             }],

--- a/boltffi_macros/src/experimental/wrapper/param/handle.rs
+++ b/boltffi_macros/src/experimental/wrapper/param/handle.rs
@@ -194,10 +194,7 @@ impl<'lowered, C> Input<'lowered, C> {
         let null_check = matches!(self.plan.presence, HandlePresence::Required).then(|| {
             quote! {
                 if #ident == #zero {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: null class handle",
-                        stringify!(#ident)
-                    ));
+                    ::boltffi::__private::set_last_error(concat!(stringify!(#ident), ": null class handle"));
                     #failure
                 }
             }
@@ -209,10 +206,7 @@ impl<'lowered, C> Input<'lowered, C> {
                 let #ident: #ty = match unsafe { #handle_type::take(#handle_pointer) } {
                     Some(value) => value,
                     None => {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: released class handle",
-                            stringify!(#ident)
-                        ));
+                        ::boltffi::__private::set_last_error(concat!(stringify!(#ident), ": released class handle"));
                         #failure
                     }
                 };
@@ -224,10 +218,7 @@ impl<'lowered, C> Input<'lowered, C> {
                     Some(match unsafe { #handle_type::take(#handle_pointer) } {
                         Some(value) => value,
                         None => {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: released class handle",
-                                stringify!(#ident)
-                            ));
+                            ::boltffi::__private::set_last_error(concat!(stringify!(#ident), ": released class handle"));
                             #failure
                         }
                     })
@@ -276,10 +267,7 @@ impl rust_api::CallbackObject {
             HandlePresence::Required => Ok(quote! {
                 let #handle = #handle_binding;
                 if #handle.is_null() {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: null callback handle",
-                        stringify!(#ident)
-                    ));
+                    ::boltffi::__private::set_last_error(concat!(stringify!(#ident), ": null callback handle"));
                     #failure
                 }
                 let #ident: #ty = unsafe {

--- a/boltffi_macros/src/experimental/wrapper/param/scalar_option.rs
+++ b/boltffi_macros/src/experimental/wrapper/param/scalar_option.rs
@@ -57,12 +57,7 @@ impl Render<Native, Input> for Renderer {
                     }) {
                         Ok(value) => value,
                         Err(error) => {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: invalid optional scalar payload: {} (buf_len={})",
-                                stringify!(#ident),
-                                error,
-                                #length
-                            ));
+                            ::boltffi::__private::set_last_error_display(stringify!(#ident), "invalid optional scalar payload", &error, #length as usize);
                             #failure
                         }
                     }

--- a/boltffi_macros/src/lowering/params/value.rs
+++ b/boltffi_macros/src/lowering/params/value.rs
@@ -49,12 +49,7 @@ impl<'a> ValueParamDecoder<'a> {
             match ::core::str::from_utf8(#bytes_expr) {
                 Ok(value) => value,
                 Err(error) => {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: invalid UTF-8: {} (buf_len={})",
-                        stringify!(#name),
-                        error,
-                        #len_name
-                    ));
+                    ::boltffi::__private::set_last_error_display(stringify!(#name), "invalid UTF-8", &error, #len_name as usize);
                     ""
                 }
             }
@@ -73,12 +68,7 @@ impl<'a> ValueParamDecoder<'a> {
             match ::core::str::from_utf8(#bytes_expr) {
                 Ok(value) => value.to_string(),
                 Err(error) => {
-                    ::boltffi::__private::set_last_error(format!(
-                        "{}: invalid UTF-8: {} (buf_len={})",
-                        stringify!(#name),
-                        error,
-                        #len_name
-                    ));
+                    ::boltffi::__private::set_last_error_display(stringify!(#name), "invalid UTF-8", &error, #len_name as usize);
                     String::new()
                 }
             }
@@ -114,11 +104,7 @@ impl<'a> ValueParamDecoder<'a> {
                 return quote! {
                     let #name: #rust_type = {
                         if #ptr_name.is_null() && #len_name > 0 {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: null pointer with non-zero length (buf_len={})",
-                                stringify!(#name),
-                                #len_name
-                            ));
+                            ::boltffi::__private::set_last_error_len(stringify!(#name), "null pointer with non-zero length", #len_name as usize);
                             #on_wire_record_error
                         }
                         let __bytes: &[u8] = if #len_name == 0 {
@@ -129,12 +115,7 @@ impl<'a> ValueParamDecoder<'a> {
                         let #wire_value_ident: #wire_type = match ::boltffi::__private::wire::decode(__bytes) {
                             Ok(value) => value,
                             Err(error) => {
-                                ::boltffi::__private::set_last_error(format!(
-                                    "{}: wire decode failed: {} (buf_len={})",
-                                    stringify!(#name),
-                                    error,
-                                    #len_name
-                                ));
+                                ::boltffi::__private::set_last_error_display(stringify!(#name), "wire decode failed", &error, #len_name as usize);
                                 #on_wire_record_error
                             }
                         };
@@ -152,12 +133,7 @@ impl<'a> ValueParamDecoder<'a> {
                     match ::boltffi::__private::wire::decode::<#wire_type>(__bytes) {
                         Ok(#wire_value_ident) => { #from_wire },
                         Err(error) => {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: wire decode failed: {} (buf_len={})",
-                                stringify!(#name),
-                                error,
-                                #len_name
-                            ));
+                            ::boltffi::__private::set_last_error_display(stringify!(#name), "wire decode failed", &error, #len_name as usize);
                             #empty_value
                         }
                     }
@@ -169,11 +145,7 @@ impl<'a> ValueParamDecoder<'a> {
             return quote! {
                 let #name: #rust_type = {
                     if #ptr_name.is_null() && #len_name > 0 {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: null pointer with non-zero length (buf_len={})",
-                            stringify!(#name),
-                            #len_name
-                        ));
+                        ::boltffi::__private::set_last_error_len(stringify!(#name), "null pointer with non-zero length", #len_name as usize);
                         #on_wire_record_error
                     }
                     let __bytes: &[u8] = if #len_name == 0 {
@@ -184,12 +156,7 @@ impl<'a> ValueParamDecoder<'a> {
                     match ::boltffi::__private::wire::decode(__bytes) {
                         Ok(value) => value,
                         Err(error) => {
-                            ::boltffi::__private::set_last_error(format!(
-                                "{}: wire decode failed: {} (buf_len={})",
-                                stringify!(#name),
-                                error,
-                                #len_name
-                            ));
+                            ::boltffi::__private::set_last_error_display(stringify!(#name), "wire decode failed", &error, #len_name as usize);
                             #on_wire_record_error
                         }
                     }
@@ -206,12 +173,7 @@ impl<'a> ValueParamDecoder<'a> {
                 match ::boltffi::__private::wire::decode::<#rust_type>(__bytes) {
                     Ok(value) => value,
                     Err(error) => {
-                        ::boltffi::__private::set_last_error(format!(
-                            "{}: wire decode failed: {} (buf_len={})",
-                            stringify!(#name),
-                            error,
-                            #len_name
-                        ));
+                        ::boltffi::__private::set_last_error_display(stringify!(#name), "wire decode failed", &error, #len_name as usize);
                         #empty_value
                     }
                 }
@@ -895,10 +857,7 @@ fn class_handle_binding(
     match (class_param.kind, class_param.nullable) {
         (ClassHandleParamKind::SharedRef, false) => quote! {
             let #name: &#rust_type = if #name.is_null() {
-                ::boltffi::__private::set_last_error(format!(
-                    "{}: null class handle",
-                    stringify!(#name)
-                ));
+                ::boltffi::__private::set_last_error(concat!(stringify!(#name), ": null class handle"));
                 #on_null
             } else {
                 unsafe { #name.as_ref().expect("checked non-null class handle") }
@@ -906,10 +865,7 @@ fn class_handle_binding(
         },
         (ClassHandleParamKind::MutableRef, false) => quote! {
             let #name: &mut #rust_type = if #name.is_null() {
-                ::boltffi::__private::set_last_error(format!(
-                    "{}: null class handle",
-                    stringify!(#name)
-                ));
+                ::boltffi::__private::set_last_error(concat!(stringify!(#name), ": null class handle"));
                 #on_null
             } else {
                 unsafe { #name.as_mut().expect("checked non-null class handle") }


### PR DESCRIPTION
The generated export shims each carry their own inlined copy of the error path. Removing that takes the demo's wasm from 885,896 to 788,479 bytes (-11.0%), with no API or behaviour change.

## What was happening

`set_last_error` (`boltffi_core/src/status.rs`) is a small non-`#[cold]` generic, so LLVM inlines the whole body — thread-local access, the `RefCell` borrow-flag check, a `String` allocation, and the unwind-free panic trailer — into every function that can fail. On `examples/demo` that is ~300 exported shims.

Counting call targets across the shims in the baseline module:

| inlined callee | shims carrying a copy |
| --- | ---: |
| `core::cell::panic_already_borrowed` | 308 |
| `__rust_dealloc` | 350 |
| `__rust_no_alloc_shim_is_unstable_v2` | 332 |
| `alloc::raw_vec::handle_error` | 309 |
| `__rust_alloc` | 239 |
| `alloc::fmt::format_inner` | 188 |

Generated shims account for 267 KiB of the 536 KiB code section, averaging 463 bytes each — most of which is failure handling that never runs.

## Three changes

Each measured on `pack wasm --release` of `examples/demo`:

**1. `set_last_error` is `#[cold] #[inline(never)]`.** 885,896 → 814,448 bytes. `panic_already_borrowed` callers drop from 308 to 15. Error paths are cold by definition, and the happy path benefits from the lower register pressure.

**2. `concat!` where the message is a compile-time constant.** 26 sites whose only interpolation was `stringify!(#ident)` now reference a `&'static str` instead of building a `String`. → 810,435 bytes.

**3. Outline the failures that carry a runtime value.** Three `#[cold]` helpers — `set_last_error_len`, `set_last_error_display`, `set_last_error_debug` — replace 36 inlined `format!` sites. Taking `&dyn Display` / `&dyn Debug` also collapses what was one monomorphisation per error type into a single instantiation. → 788,479 bytes.

| | bytes |
| --- | ---: |
| before | 885,896 |
| after | **788,479** |

## Messages are unchanged

What changes is how many copies ship, not what they say. Counted in the wasm data section, before → after:

| message | before | after |
| --- | ---: | ---: |
| `wire decode failed` | 77 | 1 |
| `null pointer with non-zero length` | 86 | 1 |
| `custom conversion failed` | 6 | 1 |
| `" (buf_len="` | 174 | 6 |

Two message families (`invalid UTF-8`, `invalid optional scalar payload`) appear zero times both before and after — the demo does not reach those paths, so nothing was lost there either.

## Testing

- `cargo test --workspace` — 46 groups, no failures. The token-stream expectations in `boltffi_macros` were updated to match the new expansion; they assert on the same messages.
- `examples/platforms/wasm` acceptance suite passes.
- `cargo clippy --workspace --all-targets` clean, `cargo fmt --all` applied.

## Not included

Shortening the exported symbol names would recover up to another 54 KiB, but the name section is stripped from release artifacts, so export names are the only human-readable symbols left in a shipped `.wasm`. Making them opaque would darken browser stack frames and post-hoc inspection of production artifacts, so it is left out.

Two smaller things found while measuring, worth their own issues rather than bundling here: ~94 async-completion shims carry an identical `assert_failed::<bool,bool>` trailer (~2.4 KiB total), and the build embeds absolute paths from the machine that produced it (`/home/<user>/.cargo/registry/...`, ~2.6 KiB) — more a privacy matter than a size one.
