### PR TITLE
share the class handle lifecycle instead of emitting it per class

### DIFF
--- a/boltffi_backend/src/target/typescript/render/function.rs
+++ b/boltffi_backend/src/target/typescript/render/function.rs
@@ -15,8 +15,7 @@ use super::super::{
     primitive::Scalar,
     render::{Type, direct_vector::DirectVector, scalar_option::ScalarOption},
     syntax::{
-        ArgumentList, Expression, Identifier, MemberName, MethodDeclaration, Statement,
-        StringLiteral, TypeName,
+        ArgumentList, Expression, Identifier, MemberName, MethodDeclaration, Statement, TypeName,
     },
 };
 use super::closure::ClosureAdapter;
@@ -604,18 +603,17 @@ impl CallReceiver {
         })
     }
 
-    fn class(class: &TypeName) -> Self {
-        let disposed = Expression::property(Expression::this(), Identifier::known("_disposed"));
-        let message = format!("{class} has been disposed");
-        let error = Expression::construct(
-            "Error",
-            [Expression::string(StringLiteral::new(&message))]
-                .into_iter()
-                .collect::<ArgumentList>(),
+    fn class(_class: &TypeName) -> Self {
+        // Calls the inherited guard rather than inlining the check and its
+        // message into every method body.
+        let assert = Expression::call(
+            Expression::this(),
+            Identifier::known("_assertNotDisposed"),
+            ArgumentList::default(),
         );
         Self {
             parameter: None,
-            setup: vec![Statement::throw_when(disposed, error)],
+            setup: vec![Statement::expression(assert)],
             arguments: vec![Expression::property(
                 Expression::this(),
                 Identifier::known("_handle"),

--- a/boltffi_backend/templates/target/typescript/browser.ts
+++ b/boltffi_backend/templates/target/typescript/browser.ts
@@ -1,4 +1,4 @@
-import { BoltFFIModule, CallbackRegistry, StreamCancellable, StreamSession, WASM_ABI_VERSION, instantiateBoltFFI, matchWireResult, utf8ByteCount, wireArraySize, wireMapSize, wireOptionalSize, wireResultSize, wireStringSize } from {{ runtime_package }};
+import { BoltFFIHandle, BoltFFIModule, CallbackRegistry, StreamCancellable, StreamSession, WASM_ABI_VERSION, instantiateBoltFFI, matchWireResult, utf8ByteCount, wireArraySize, wireMapSize, wireOptionalSize, wireResultSize, wireStringSize } from {{ runtime_package }};
 import type { BoltFFIExports, Duration, WireCodec, WireResult } from {{ runtime_package }};
 
 let _module: BoltFFIModule;

--- a/boltffi_backend/templates/target/typescript/class.ts
+++ b/boltffi_backend/templates/target/typescript/class.ts
@@ -5,13 +5,20 @@ const {{ finalizer }}: FinalizationRegistry<number> | null =
         (_exports.{{ release }} as Function)(handle);
       });
 
-export class {{ name }} {
-  private _handle: number;
-  private _disposed = false;
+export class {{ name }} extends BoltFFIHandle {
+  protected static override _typeName = "{{ name }}";
 
   private constructor(handle: number) {
-    this._handle = handle;
+    super(handle);
     {{ finalizer }}?.register(this, handle, this);
+  }
+
+  protected override _release(handle: number): void {
+    (_exports.{{ release }} as Function)(handle);
+  }
+
+  protected override _unregister(): void {
+    {{ finalizer }}?.unregister(this);
   }
 
   static _fromHandle(handle: number): {{ name }} {
@@ -19,31 +26,6 @@ export class {{ name }} {
       throw new Error("{{ name }} received a null handle");
     }
     return new {{ name }}(handle);
-  }
-
-  static _toHandle(value: {{ name }} | null): number {
-    return value === null ? 0 : value._borrowHandle();
-  }
-
-  dispose(): void {
-    if (this._disposed) {
-      return;
-    }
-    this._disposed = true;
-    {{ finalizer }}?.unregister(this);
-    (_exports.{{ release }} as Function)(this._handle);
-    this._handle = 0;
-  }
-
-  private _borrowHandle(): number {
-    this._assertNotDisposed();
-    return this._handle;
-  }
-
-  private _assertNotDisposed(): void {
-    if (this._disposed) {
-      throw new Error("{{ name }} has been disposed");
-    }
   }
 {% for constant in constants.members %}
   {{ constant }}

--- a/boltffi_backend/templates/target/typescript/node.ts
+++ b/boltffi_backend/templates/target/typescript/node.ts
@@ -1,4 +1,4 @@
-import { BoltFFIModule, CallbackRegistry, StreamCancellable, StreamSession, WASM_ABI_VERSION, instantiateBoltFFISync, matchWireResult, utf8ByteCount, wireArraySize, wireMapSize, wireOptionalSize, wireResultSize, wireStringSize } from {{ runtime_package }};
+import { BoltFFIHandle, BoltFFIModule, CallbackRegistry, StreamCancellable, StreamSession, WASM_ABI_VERSION, instantiateBoltFFISync, matchWireResult, utf8ByteCount, wireArraySize, wireMapSize, wireOptionalSize, wireResultSize, wireStringSize } from {{ runtime_package }};
 import type { BoltFFIExports, Duration, WireCodec, WireResult } from {{ runtime_package }};
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";

--- a/examples/platforms/wasm/tests/contract.test.mjs
+++ b/examples/platforms/wasm/tests/contract.test.mjs
@@ -200,7 +200,7 @@ function parseGeneratedSurface(source) {
   );
 
   const classes = Object.fromEntries(
-    [...source.matchAll(/^export declare class (\w+) \{([\s\S]*?)^\}/gm)].map((match) => [
+    [...source.matchAll(/^export declare class (\w+)(?: extends \w+)? \{([\s\S]*?)^\}/gm)].map((match) => [
       match[1],
       new Set(
         [...match[2].matchAll(/^\s+(?:static\s+)?(\w+)\(/gm)]

--- a/runtime/typescript/src/handle.ts
+++ b/runtime/typescript/src/handle.ts
@@ -1,0 +1,58 @@
+/**
+ * Base class for generated class bindings.
+ *
+ * Every generated class needs the same handle lifecycle: hold a wasm handle,
+ * borrow it for a call, refuse to be used after disposal, and release exactly
+ * once. Emitting that per class costs roughly 300 bytes of identical glue each
+ * time, so it lives here instead. Generated classes supply only what differs:
+ * their name, their finalizer, and how to release the handle.
+ */
+export abstract class BoltFFIHandle {
+  /** Zero once disposed. */
+  protected _handle: number;
+  protected _disposed = false;
+
+  protected constructor(handle: number) {
+    this._handle = handle;
+  }
+
+  /** Type name used in error messages. Generated classes override it. */
+  protected static _typeName = "BoltFFIHandle";
+
+  /** Releases the wasm-side handle. Generated classes override it. */
+  protected _release(_handle: number): void {}
+
+  /** Unregisters from the finalizer, if the runtime has one. */
+  protected _unregister(): void {}
+
+  dispose(): void {
+    if (this._disposed) {
+      return;
+    }
+    this._disposed = true;
+    this._unregister();
+    this._release(this._handle);
+    this._handle = 0;
+  }
+
+  /**
+   * Handle to pass across the boundary, refusing a disposed instance so a
+   * use-after-free surfaces as an error rather than a wasm trap.
+   */
+  protected _borrowHandle(): number {
+    this._assertNotDisposed();
+    return this._handle;
+  }
+
+  protected _assertNotDisposed(): void {
+    if (this._disposed) {
+      const name = (this.constructor as typeof BoltFFIHandle)._typeName;
+      throw new Error(`${name} has been disposed`);
+    }
+  }
+
+  /** Null maps to the zero handle, matching the wasm-side convention. */
+  static _toHandle(value: BoltFFIHandle | null): number {
+    return value === null ? 0 : value._borrowHandle();
+  }
+}

--- a/runtime/typescript/src/index.ts
+++ b/runtime/typescript/src/index.ts
@@ -12,6 +12,7 @@ export {
   wireStringSize,
 } from "./wire.js";
 export type { Duration, WireOk, WireErr, WireResult, WasmWireWriterAllocator, WireCodec } from "./wire.js";
+export { BoltFFIHandle } from "./handle.js";
 export { CallbackRegistry } from "./callback.js";
 export { StreamCancellable, StreamPollManager, StreamPollResult, StreamSession } from "./stream.js";
 export type { StreamBatch, StreamLifecycle, StreamPoll } from "./stream.js";


### PR DESCRIPTION
Every generated class emits its own copy of the same handle lifecycle. Sharing it takes the demo's TypeScript glue from 400,486 to 388,700 bytes (-2.9%), with no change to the public API.

## The duplication

A generated class declares `_toHandle`, `_borrowHandle`, `_assertNotDisposed`, `dispose`, and the disposed-flag bookkeeping. Those bodies are identical across classes — only the class name, the finalizer, and the release symbol differ. With 18 classes in the demo, that is the same ~300 bytes of glue 18 times over.

This moves the lifecycle into a `BoltFFIHandle` base class in the runtime, and generates `extends`. A class now emits only what actually differs:

```ts
export class ForeignCounter extends BoltFFIHandle {
  protected static override _typeName = "ForeignCounter";

  private constructor(handle: number) {
    super(handle);
    _ForeignCounterFinalizer?.register(this, handle, this);
  }

  protected override _release(handle: number): void { ... }
  protected override _unregister(): void { ... }

  static _fromHandle(handle: number): ForeignCounter { ... }
  // methods follow
}
```

The public surface is unchanged: the inherited members are the same ones each class used to declare.

## Second pattern

Method bodies inlined the disposal guard together with its full message:

```ts
if (this._disposed)
    throw new Error("ForeignCounter has been disposed");
```

85 occurrences across the demo, 7,002 bytes. They call the inherited `_assertNotDisposed()` now, which throws the same message.

| | before | after |
| --- | ---: | ---: |
| glue | 400,486 B | **388,700 B** |
| bytes per exported function | 929 | 902 |

## Testing

- `examples/platforms/wasm` acceptance suite passes, including the disposal tests.
- Runtime suite (37 tests) and `cargo test --workspace` (46 groups) pass.
- `cargo clippy --workspace --all-targets` clean, `cargo fmt --all` applied.

One test needed updating: `tests/contract.test.mjs` matched `^export declare class (\w+) \{`, which no longer holds once a class extends a base, so the regex now accepts the clause. Every member it checked before is still checked — without the fix it reported all class members as missing, which is how the change was caught.

## Considered and dropped

Eta-reducing the generated lambdas — `(reader) => XCodec.decode(reader)` into `XCodec.decode` — looked free, since the codecs do not use `this`. It is not: `_exports` is defined at byte 388,262 while the first codec sits at byte 38,539, and 3 codecs reference each other forward. The lambda defers resolution until call time; a direct reference would be evaluated at definition and hit the temporal dead zone. Worth ~0.3% and not worth the fragility.
