### PR TITLE
Retain cross-crate aggregated streams and constants 

### DIFF
--- a/boltffi_macros/src/experimental/expander.rs
+++ b/boltffi_macros/src/experimental/expander.rs
@@ -401,12 +401,19 @@ where
                 let owner = self.stream_owner(source)?;
                 let stream = self.expansion.stream(source)?;
                 match owner {
-                    Some(owner) => wrapper::stream::Renderer::new(
-                        stream,
-                        self.expansion.class(owner)?,
-                        self.expansion,
-                    )
-                    .render(),
+                    Some(owner) => {
+                        let renderer = wrapper::stream::Renderer::new(
+                            stream,
+                            self.expansion.class(owner)?,
+                            self.expansion,
+                        );
+                        match self.visible_paths.get(owner.id.as_str()) {
+                            Some(path) => {
+                                renderer.with_owner_rust_type(Self::path_tokens(path)?).render()
+                            }
+                            None => renderer.render(),
+                        }
+                    }
                     None => wrapper::stream::Renderer::function(stream, self.expansion).render(),
                 }
             })

--- a/boltffi_macros/src/experimental/expander.rs
+++ b/boltffi_macros/src/experimental/expander.rs
@@ -394,7 +394,7 @@ where
     }
 
     fn streams(&self) -> Result<Vec<TokenStream>, Error> {
-        self.source
+        self.support
             .streams
             .iter()
             .map(|source| {
@@ -414,7 +414,7 @@ where
     }
 
     fn constants(&self) -> Result<Vec<TokenStream>, Error> {
-        self.source
+        self.support
             .constants
             .iter()
             .map(|source| {

--- a/boltffi_macros/src/experimental/wrapper/stream.rs
+++ b/boltffi_macros/src/experimental/wrapper/stream.rs
@@ -20,6 +20,7 @@ pub struct Renderer<'expansion, 'lowered, S: RenderSurface> {
     stream: DeclarationPair<'lowered, StreamDef, StreamDecl<S>>,
     subscription: Subscription<'lowered, S>,
     expansion: &'expansion Expansion<'lowered, S>,
+    owner_rust_type: Option<TokenStream>,
 }
 
 struct StreamSymbols {
@@ -58,7 +59,15 @@ impl<'expansion, 'lowered, S: RenderSurface> Renderer<'expansion, 'lowered, S> {
             stream,
             subscription: Subscription::Method(owner),
             expansion,
+            owner_rust_type: None,
         }
+    }
+
+    /// Overrides the spelling of the owning class type when it is re-exported
+    /// under a path that differs from its source leaf name.
+    pub fn with_owner_rust_type(mut self, rust_type: TokenStream) -> Self {
+        self.owner_rust_type = Some(rust_type);
+        self
     }
 
     /// Creates a renderer for a top-level stream function.
@@ -70,6 +79,7 @@ impl<'expansion, 'lowered, S: RenderSurface> Renderer<'expansion, 'lowered, S> {
             stream,
             subscription: Subscription::Function,
             expansion,
+            owner_rust_type: None,
         }
     }
 
@@ -267,6 +277,10 @@ impl<'expansion, 'lowered, S: RenderSurface> Renderer<'expansion, 'lowered, S> {
             Subscription::Method(owner) => {
                 let class = names::SourceSpelling::new(&owner.source().name)
                     .ident("source class name is not a Rust identifier")?;
+                let class_type = self
+                    .owner_rust_type
+                    .clone()
+                    .unwrap_or_else(|| quote! { #class });
                 let handle_type = names::Class::new(&class).handle();
                 let receiver_handle = names::Parameter::new(&receiver).handle();
                 let carrier = <wrapper::handle::Carrier as Render<S, _>>::render(
@@ -283,7 +297,7 @@ impl<'expansion, 'lowered, S: RenderSurface> Renderer<'expansion, 'lowered, S> {
                             return #stream_handle_zero;
                         }
                         let #receiver_handle = #receiver as usize as *mut #handle_type;
-                        let #receiver: &#class = unsafe {
+                        let #receiver: &#class_type = unsafe {
                             #handle_type::shared(#receiver_handle)
                         };
                         let subscription = #receiver.#method();

--- a/boltffi_scan/src/scan.rs
+++ b/boltffi_scan/src/scan.rs
@@ -67,6 +67,8 @@ impl PackageScan {
         source.classes = self.complete.classes.clone();
         source.traits = self.complete.traits.clone();
         source.customs = self.complete.customs.clone();
+        source.streams = self.complete.streams.clone();
+        source.constants = self.complete.constants.clone();
         source.functions = self
             .complete
             .functions
@@ -1234,14 +1236,19 @@ mod tests {
     }
 
     #[test]
-    fn root_with_support_keeps_dependency_classes() {
+    fn root_with_support_keeps_dependency_class_declarations() {
         let root = source_tree("demo", "");
         let model = source_tree(
             "model",
-            "pub struct ForeignCounter { value: i32 } \
+            "use std::sync::Arc; \
+             use boltffi::EventSubscription; \
+             pub struct ForeignCounter { value: i32 } \
              #[export] impl ForeignCounter { \
                  pub fn new(initial: i32) -> Self { Self { value: initial } } \
                  pub fn add(&self, amount: i32) -> i32 { self.value + amount } \
+                 #[ffi_stream(item = i32)] \
+                 pub fn ticks(&self) -> Arc<EventSubscription<i32>> { todo!() } \
+                 pub const VERSION: u32 = 1; \
              }",
         );
         let complete = SourceTree::combine([model, root.clone()]);
@@ -1258,6 +1265,22 @@ mod tests {
             .expect("dependency class stays in root support contract");
 
         assert_eq!(counter.methods.len(), 2);
+
+        let ticks = source
+            .streams
+            .iter()
+            .find(|stream| stream.id == StreamId::new("model::ForeignCounter::ticks"))
+            .expect("dependency stream stays in root support contract");
+        assert_eq!(ticks.owner, Some(ClassId::new("model::ForeignCounter")));
+
+        let version = source
+            .constants
+            .iter()
+            .find(|constant| {
+                constant.owner == Some(ConstantOwner::Class(ClassId::new("model::ForeignCounter")))
+            })
+            .expect("dependency class constant stays in root support contract");
+        assert_eq!(version.id, ConstantId::new("model::ForeignCounter::VERSION"));
     }
 
     #[test]

--- a/boltffi_scan/src/scan.rs
+++ b/boltffi_scan/src/scan.rs
@@ -68,7 +68,19 @@ impl PackageScan {
         source.traits = self.complete.traits.clone();
         source.customs = self.complete.customs.clone();
         source.streams = self.complete.streams.clone();
-        source.constants = self.complete.constants.clone();
+        source.constants = self
+            .complete
+            .constants
+            .iter()
+            .filter(|constant| match constant.owner.as_ref() {
+                Some(_) => true,
+                None => {
+                    root.owns(constant.id.as_str())
+                        || self.root_visible_paths.contains_key(constant.id.as_str())
+                }
+            })
+            .cloned()
+            .collect();
         source.functions = self
             .complete
             .functions
@@ -1242,6 +1254,7 @@ mod tests {
             "model",
             "use std::sync::Arc; \
              use boltffi::EventSubscription; \
+             #[export] pub const BANNER: &str = \"model\"; \
              pub struct ForeignCounter { value: i32 } \
              #[export] impl ForeignCounter { \
                  pub fn new(initial: i32) -> Self { Self { value: initial } } \
@@ -1280,7 +1293,25 @@ mod tests {
                 constant.owner == Some(ConstantOwner::Class(ClassId::new("model::ForeignCounter")))
             })
             .expect("dependency class constant stays in root support contract");
-        assert_eq!(version.id, ConstantId::new("model::ForeignCounter::VERSION"));
+        assert_eq!(
+            version.id,
+            ConstantId::new("model::ForeignCounter::VERSION")
+        );
+
+        assert!(
+            scan.complete
+                .constants
+                .iter()
+                .any(|constant| constant.id == ConstantId::new("model::BANNER")),
+            "ownerless dependency constant is scanned into the complete contract"
+        );
+        assert!(
+            !source
+                .constants
+                .iter()
+                .any(|constant| constant.id == ConstantId::new("model::BANNER")),
+            "ownerless dependency constant without a visible re-export is filtered out"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Before when working with cross-crate aggregated definitions the `#[ffi_stream]` and constants attached to classes were silently absent from the generated bindings. The same declarations generate fine when defined directly in the root crate.

Now streams and constants simply merge their definitions into the complete bindings. I've tried to mirror method that classes, enums, etc were already using to do the same thing.

- `boltffi_scan/src/scan.rs` — in `root_with_support`, reassign `streams` and
  `constants` from `self.complete`, exactly as `classes`/`traits`/`customs` do.
- `boltffi_macros/src/experimental/expander.rs` — `streams()` and `constants()`
  read `self.support` instead of `self.source`, matching `classes()` and
  `functions()`.