### PR TITLE
Per-invocation capture on every macro entry point

### DIFF
--- a/boltffi/src/lib.rs
+++ b/boltffi/src/lib.rs
@@ -5,7 +5,7 @@ pub use boltffi_core::{
     CustomFfiConvertible, CustomTypeConversionError, Data, EventSubscription, FfiType,
     InternedString, InternedStringPool, InternedStringRepr, StreamProducer,
     UnexpectedFfiCallbackError, custom_ffi, custom_type, data, default, error, export, ffi_stream,
-    name, skip,
+    name, scaffolding, skip,
 };
 
 /// Defines a static interned-string pool.

--- a/boltffi/tests/facade_smoke.rs
+++ b/boltffi/tests/facade_smoke.rs
@@ -1,5 +1,7 @@
 use boltffi::*;
 
+scaffolding!();
+
 #[data]
 #[derive(Clone, Copy)]
 struct Point {

--- a/boltffi_bindgen/Cargo.toml
+++ b/boltffi_bindgen/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["ffi", "codegen", "swift", "kotlin", "typescript"]
 categories = ["development-tools::ffi", "development-tools::build-utils"]
 
 [dependencies]
+boltffi_ast.workspace = true
 boltffi_binding.workspace = true
 boltffi_backend.workspace = true
 boltffi_ffi_rules = { workspace = true, features = ["serde"] }
@@ -26,7 +27,6 @@ indexmap = "2.7"
 object.workspace = true
 
 [dev-dependencies]
-boltffi_ast.workspace = true
 insta.workspace = true
 rstest.workspace = true
 

--- a/boltffi_bindgen/Cargo.toml
+++ b/boltffi_bindgen/Cargo.toml
@@ -27,6 +27,7 @@ indexmap = "2.7"
 object.workspace = true
 
 [dev-dependencies]
+boltffi_scan.workspace = true
 insta.workspace = true
 rstest.workspace = true
 

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1145,6 +1145,15 @@ mod tests {
             "class method references resolve through the compiler"
         );
         assert_eq!(contract.constants.len(), 1, "the constant is captured");
+        assert_eq!(
+            contract.records[0].methods.len(),
+            1,
+            "the data(impl) block merges into its record"
+        );
+        assert_eq!(
+            contract.records[0].methods[0].id.as_str(),
+            "metadata_fixture::domain::Point::doubled"
+        );
         let boltffi_ast::ReturnDef::Value(returned) = &contract.functions[0].returns else {
             panic!("origin returns a value");
         };
@@ -1495,6 +1504,13 @@ pub mod domain {
     #[derive(Clone, Copy)]
     pub struct Point {
         pub x: f64,
+    }
+
+    #[boltffi::data(impl)]
+    impl Point {
+        pub fn doubled(&self) -> Point {
+            Point { x: self.x * 2.0 }
+        }
     }
 }
 

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1149,9 +1149,18 @@ mod tests {
                 .iter()
                 .any(|function| function.id.as_str() == "metadata_fixture::api::origin")
         );
-        assert_eq!(contract.enums.len(), 1, "the error enum is captured");
+        assert_eq!(
+            contract.enums.len(),
+            2,
+            "the error and data enums are captured"
+        );
+        let shift_error = contract
+            .enums
+            .iter()
+            .find(|declared| declared.id.as_str() == "metadata_fixture::api::ShiftError")
+            .expect("the error enum is captured");
         assert!(
-            contract.enums[0].user_attrs.iter().any(|attr| {
+            shift_error.user_attrs.iter().any(|attr| {
                 attr.path
                     .last()
                     .is_some_and(|segment| segment.name.as_str() == "error")
@@ -1209,7 +1218,32 @@ mod tests {
             ),
             "the stream item resolves cross-module through the compiler"
         );
-        assert_eq!(contract.constants.len(), 1, "the constant is captured");
+        assert_eq!(
+            contract.constants.len(),
+            5,
+            "the free constant and the associated constants are captured"
+        );
+        let origin_const = contract
+            .constants
+            .iter()
+            .find(|constant| constant.id.as_str() == "metadata_fixture::domain::Point::ORIGIN")
+            .expect("the record's associated constant is captured");
+        assert!(
+            matches!(
+                &origin_const.owner,
+                Some(boltffi_ast::ConstantOwner::Record(id))
+                    if id.as_str() == "metadata_fixture::domain::Point"
+            ),
+            "the associated constant's owner resolves through the target"
+        );
+        assert!(
+            contract
+                .constants
+                .iter()
+                .any(|constant| constant.id.as_str()
+                    == "metadata_fixture::api::Session::MAX_SHIFT"),
+            "the class's associated constant is captured"
+        );
         assert_eq!(
             contract.customs.len(),
             3,
@@ -1747,9 +1781,27 @@ pub mod domain {
 
     #[boltffi::data(impl)]
     impl Point {
+        pub const ORIGIN: Point = Point { x: 0.0 };
+        pub const UNIT: Self = Point { x: 1.0 };
+        const PRIVATE: f64 = 0.5;
+        #[boltffi::skip]
+        pub const HIDDEN: f64 = 0.25;
+
         pub fn doubled(&self) -> Point {
             Point { x: self.x * 2.0 }
         }
+    }
+
+    #[data]
+    #[derive(Clone, Copy)]
+    pub enum Mode {
+        Fast,
+        Slow,
+    }
+
+    #[boltffi::data(impl)]
+    impl Mode {
+        pub const DEFAULT: Self = Mode::Fast;
     }
 }
 
@@ -1888,6 +1940,8 @@ pub mod api {
 
     #[export(single_threaded)]
     impl Session {
+        pub const MAX_SHIFT: f64 = 9.0;
+
         pub fn new() -> Self {
             Self { origin: Point { x: 0.0 } }
         }

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1125,7 +1125,7 @@ mod tests {
             "metadata_fixture::domain::Point",
             "the record's identity comes from its defining module"
         );
-        assert_eq!(contract.functions.len(), 4);
+        assert_eq!(contract.functions.len(), 5);
         let browser_fn = contract
             .functions
             .iter()
@@ -1210,10 +1210,32 @@ mod tests {
             "the stream item resolves cross-module through the compiler"
         );
         assert_eq!(contract.constants.len(), 1, "the constant is captured");
-        assert_eq!(contract.customs.len(), 1, "the custom type is captured");
-        assert_eq!(
-            contract.customs[0].id.as_str(),
-            "metadata_fixture::clock::Stamp"
+        assert_eq!(contract.customs.len(), 2, "both custom types are captured");
+        assert!(
+            contract
+                .customs
+                .iter()
+                .any(|custom| custom.id.as_str() == "metadata_fixture::clock::Stamp")
+        );
+        assert!(
+            contract
+                .customs
+                .iter()
+                .any(|custom| custom.id.as_str() == "metadata_fixture::clock::Label"),
+            "the custom_ffi impl is captured"
+        );
+        let label_fn = contract
+            .functions
+            .iter()
+            .find(|function| function.id.as_str() == "metadata_fixture::api::label_text")
+            .expect("the custom_ffi-typed function is captured");
+        assert!(
+            matches!(
+                &label_fn.parameters[0].type_expr,
+                boltffi_ast::TypeExpr::Custom { id, .. }
+                    if id.as_str() == "metadata_fixture::clock::Label"
+            ),
+            "the custom_ffi reference classifies through its defining fragment"
         );
         let stamp_fn = contract
             .functions
@@ -1262,8 +1284,8 @@ mod tests {
                 .iter()
                 .filter(|decl| matches!(decl, Decl::Record(_) | Decl::Function(_)))
                 .count(),
-            5,
-            "the point record and all four functions lower"
+            6,
+            "the point record and all five functions lower"
         );
     }
 
@@ -1339,7 +1361,7 @@ mod tests {
             boltffi_binding::aggregate_records(&source.source_records, source.package.clone())
                 .expect("wasm32-built records aggregate");
         assert_eq!(contract.records.len(), 1);
-        assert_eq!(contract.functions.len(), 4);
+        assert_eq!(contract.functions.len(), 5);
         assert_eq!(contract.classes.len(), 1);
         assert_eq!(contract.streams.len(), 1);
 
@@ -1351,8 +1373,8 @@ mod tests {
                 .iter()
                 .filter(|decl| matches!(decl, Decl::Record(_) | Decl::Function(_)))
                 .count(),
-            5,
-            "the point record and all four functions lower from the wasm32 artifacts"
+            6,
+            "the point record and all five functions lower from the wasm32 artifacts"
         );
     }
 
@@ -1390,7 +1412,7 @@ mod tests {
                 .iter()
                 .filter(|decl| matches!(decl, Decl::Function(_)))
                 .count(),
-            4
+            5
         );
     }
 
@@ -1693,7 +1715,7 @@ pub mod domain {
 }
 
 pub mod clock {
-    use boltffi::custom_type;
+    use boltffi::{CustomFfiConvertible, custom_ffi, custom_type};
 
     pub struct Stamp(pub i64);
 
@@ -1704,6 +1726,22 @@ pub mod clock {
         into_ffi = |stamp: &Stamp| stamp.0,
         try_from_ffi = |value: i64| Ok::<_, boltffi::CustomTypeConversionError>(Stamp(value)),
     );
+
+    pub struct Label(pub String);
+
+    #[custom_ffi]
+    impl CustomFfiConvertible for Label {
+        type FfiRepr = String;
+        type Error = String;
+
+        fn into_ffi(&self) -> String {
+            self.0.clone()
+        }
+
+        fn try_from_ffi(repr: String) -> Result<Self, String> {
+            Ok(Label(repr))
+        }
+    }
 }
 
 pub mod pools {
@@ -1720,13 +1758,18 @@ pub mod api {
 
     use boltffi::{EventSubscription, InternedString, export, ffi_stream};
 
-    use crate::clock::Stamp;
+    use crate::clock::{Label, Stamp};
     use crate::domain::Point;
     use crate::pools::Browser;
 
     #[export]
     pub fn origin() -> Point {
         Point { x: 0.0 }
+    }
+
+    #[export]
+    pub fn label_text(label: Label) -> String {
+        label.0
     }
 
     #[export]

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1268,6 +1268,47 @@ mod tests {
     }
 
     #[test]
+    fn cargo_build_source_records_lower_equivalently_to_the_legacy_scan() {
+        if cfg!(miri) {
+            return;
+        }
+
+        let fixture = FixtureCrate::with_boltffi_macros();
+
+        let source = BindingMetadataBuild::new(fixture.manifest())
+            .read_source()
+            .expect("cargo source metadata read");
+        let contract =
+            boltffi_binding::aggregate_records(&source.source_records, source.package.clone())
+                .expect("records aggregate");
+        let actual =
+            boltffi_binding::lower::<Native>(&contract).expect("aggregated contract lowers");
+
+        let lib_rs = fixture
+            .manifest()
+            .parent()
+            .expect("fixture manifest has a directory")
+            .join("src/lib.rs");
+        let mut scanned = boltffi_scan::scan_source(&lib_rs, source.package.clone())
+            .expect("legacy scan reads the fixture source");
+        scanned.records.sort_by(|a, b| a.id.cmp(&b.id));
+        scanned.enums.sort_by(|a, b| a.id.cmp(&b.id));
+        scanned.functions.sort_by(|a, b| a.id.cmp(&b.id));
+        scanned.classes.sort_by(|a, b| a.id.cmp(&b.id));
+        scanned.traits.sort_by(|a, b| a.id.cmp(&b.id));
+        scanned.streams.sort_by(|a, b| a.id.cmp(&b.id));
+        scanned.constants.sort_by(|a, b| a.id.cmp(&b.id));
+        scanned.customs.sort_by(|a, b| a.id.cmp(&b.id));
+        let expected = boltffi_binding::lower::<Native>(&scanned).expect("scanned contract lowers");
+
+        assert_eq!(
+            actual.decls(),
+            expected.decls(),
+            "records-fed lowering matches the legacy scanner's declarations"
+        );
+    }
+
+    #[test]
     fn cargo_build_reads_macro_emitted_metadata_without_expanding_wrappers() {
         if cfg!(miri) {
             return;

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1125,12 +1125,38 @@ mod tests {
             "metadata_fixture::domain::Point",
             "the record's identity comes from its defining module"
         );
-        assert_eq!(contract.functions.len(), 2);
+        assert_eq!(contract.functions.len(), 3);
         assert!(
             contract
                 .functions
                 .iter()
                 .any(|function| function.id.as_str() == "metadata_fixture::api::origin")
+        );
+        assert_eq!(contract.enums.len(), 1, "the error enum is captured");
+        assert!(
+            contract.enums[0].user_attrs.iter().any(|attr| {
+                attr.path
+                    .last()
+                    .is_some_and(|segment| segment.name.as_str() == "error")
+            }),
+            "the error marker rides the captured enum"
+        );
+        let shift_fn = contract
+            .functions
+            .iter()
+            .find(|function| function.id.as_str() == "metadata_fixture::api::checked_shift")
+            .expect("the fallible function is captured");
+        assert!(
+            matches!(
+                &shift_fn.returns,
+                boltffi_ast::ReturnDef::Value(boltffi_ast::TypeExpr::Result { err, .. })
+                    if matches!(
+                        err.as_ref(),
+                        boltffi_ast::TypeExpr::Enum { id, .. }
+                            if id.as_str() == "metadata_fixture::api::ShiftError"
+                    )
+            ),
+            "the error reference classifies as an enum through its defining fragment"
         );
         assert_eq!(contract.classes.len(), 1, "the class impl is captured");
         assert_eq!(
@@ -1194,7 +1220,12 @@ mod tests {
             contract.records[0].methods[0].id.as_str(),
             "metadata_fixture::domain::Point::doubled"
         );
-        let boltffi_ast::ReturnDef::Value(returned) = &contract.functions[0].returns else {
+        let origin_fn = contract
+            .functions
+            .iter()
+            .find(|function| function.id.as_str() == "metadata_fixture::api::origin")
+            .expect("origin is captured");
+        let boltffi_ast::ReturnDef::Value(returned) = &origin_fn.returns else {
             panic!("origin returns a value");
         };
         assert!(
@@ -1214,8 +1245,8 @@ mod tests {
                 .iter()
                 .filter(|decl| matches!(decl, Decl::Record(_) | Decl::Function(_)))
                 .count(),
-            3,
-            "the point record and both functions lower"
+            4,
+            "the point record and all three functions lower"
         );
     }
 
@@ -1253,7 +1284,7 @@ mod tests {
                 .iter()
                 .filter(|decl| matches!(decl, Decl::Function(_)))
                 .count(),
-            2
+            3
         );
     }
 
@@ -1588,6 +1619,29 @@ pub mod api {
     #[export]
     pub fn stamp_value(stamp: Stamp) -> i64 {
         stamp.0
+    }
+
+    #[boltffi::error]
+    #[derive(Clone, Debug)]
+    pub enum ShiftError {
+        OutOfRange,
+    }
+
+    impl std::fmt::Display for ShiftError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "out of range")
+        }
+    }
+
+    impl std::error::Error for ShiftError {}
+
+    #[export]
+    pub fn checked_shift(point: Point, by: f64) -> Result<Point, ShiftError> {
+        if by.is_finite() {
+            Ok(Point { x: point.x + by })
+        } else {
+            Err(ShiftError::OutOfRange)
+        }
     }
 
     pub struct Session {

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1233,7 +1233,7 @@ mod tests {
                 .iter()
                 .filter(|decl| matches!(decl, Decl::Function(_)))
                 .count(),
-            1
+            2
         );
     }
 

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1122,7 +1122,7 @@ mod tests {
             .expect("write metadata fixture manifest");
             fs::write(
                 source_dir.join("lib.rs"),
-                "#[cfg(feature = \"native-ffi\")]\npub mod ffi;\n",
+                "boltffi::scaffolding!();\n\n#[cfg(feature = \"native-ffi\")]\npub mod ffi;\n",
             )
             .expect("write metadata fixture lib");
             fs::write(
@@ -1239,6 +1239,8 @@ pub fn view() -> CoreFfi {
         fn with_boltffi_macros() -> Self {
             Self {
                 code: r#"
+boltffi::scaffolding!();
+
 pub mod domain {
     use boltffi::data;
 

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1130,6 +1130,21 @@ mod tests {
             contract.functions[0].id.as_str(),
             "metadata_fixture::api::origin"
         );
+        assert_eq!(contract.classes.len(), 1, "the class impl is captured");
+        assert_eq!(
+            contract.classes[0].id.as_str(),
+            "metadata_fixture::api::Session"
+        );
+        assert_eq!(contract.classes[0].methods.len(), 2);
+        assert!(
+            matches!(
+                &contract.classes[0].methods[1].returns,
+                boltffi_ast::ReturnDef::Value(boltffi_ast::TypeExpr::Record { id, .. })
+                    if id.as_str() == "metadata_fixture::domain::Point"
+            ),
+            "class method references resolve through the compiler"
+        );
+        assert_eq!(contract.constants.len(), 1, "the constant is captured");
         let boltffi_ast::ReturnDef::Value(returned) = &contract.functions[0].returns else {
             panic!("origin returns a value");
         };
@@ -1491,6 +1506,24 @@ pub mod api {
     #[export]
     pub fn origin() -> Point {
         Point { x: 0.0 }
+    }
+
+    #[export]
+    pub const LIMIT: u32 = 8;
+
+    pub struct Session {
+        origin: Point,
+    }
+
+    #[export]
+    impl Session {
+        pub fn new() -> Self {
+            Self { origin: Point { x: 0.0 } }
+        }
+
+        pub fn shift(&self, by: f64) -> Point {
+            Point { x: self.origin.x + by }
+        }
     }
 }
 "#

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1125,7 +1125,7 @@ mod tests {
             "metadata_fixture::domain::Point",
             "the record's identity comes from its defining module"
         );
-        assert_eq!(contract.functions.len(), 5);
+        assert_eq!(contract.functions.len(), 8);
         let browser_fn = contract
             .functions
             .iter()
@@ -1210,7 +1210,11 @@ mod tests {
             "the stream item resolves cross-module through the compiler"
         );
         assert_eq!(contract.constants.len(), 1, "the constant is captured");
-        assert_eq!(contract.customs.len(), 2, "both custom types are captured");
+        assert_eq!(
+            contract.customs.len(),
+            3,
+            "all three custom types are captured"
+        );
         assert!(
             contract
                 .customs
@@ -1236,6 +1240,41 @@ mod tests {
                     if id.as_str() == "metadata_fixture::clock::Label"
             ),
             "the custom_ffi reference classifies through its defining fragment"
+        );
+        assert_eq!(contract.traits.len(), 1, "the callback trait is captured");
+        assert_eq!(
+            contract.traits[0].id.as_str(),
+            "metadata_fixture::api::Doubler"
+        );
+        let doubler_fn = contract
+            .functions
+            .iter()
+            .find(|function| function.id.as_str() == "metadata_fixture::api::apply_doubler")
+            .expect("the impl-Trait function is captured");
+        assert!(
+            matches!(
+                &doubler_fn.parameters[0].type_expr,
+                boltffi_ast::TypeExpr::ImplTrait(bounds)
+                    if matches!(
+                        &bounds.base,
+                        boltffi_ast::BaseTrait::Named { id, .. }
+                            if id.as_str() == "metadata_fixture::api::Doubler"
+                    )
+            ),
+            "the impl-Trait callback resolves through the trait's dyn identity"
+        );
+        let span_fn = contract
+            .functions
+            .iter()
+            .find(|function| function.id.as_str() == "metadata_fixture::clock::range_width")
+            .expect("the generic-remote function is captured");
+        assert!(
+            matches!(
+                &span_fn.parameters[0].type_expr,
+                boltffi_ast::TypeExpr::Custom { id, .. }
+                    if id.as_str() == "metadata_fixture::clock::ByteSpan"
+            ),
+            "the generic remote classifies through its custom_type! fragment"
         );
         let stamp_fn = contract
             .functions
@@ -1284,8 +1323,8 @@ mod tests {
                 .iter()
                 .filter(|decl| matches!(decl, Decl::Record(_) | Decl::Function(_)))
                 .count(),
-            6,
-            "the point record and all five functions lower"
+            9,
+            "the point record and all eight functions lower"
         );
     }
 
@@ -1361,7 +1400,7 @@ mod tests {
             boltffi_binding::aggregate_records(&source.source_records, source.package.clone())
                 .expect("wasm32-built records aggregate");
         assert_eq!(contract.records.len(), 1);
-        assert_eq!(contract.functions.len(), 5);
+        assert_eq!(contract.functions.len(), 8);
         assert_eq!(contract.classes.len(), 1);
         assert_eq!(contract.streams.len(), 1);
 
@@ -1373,8 +1412,8 @@ mod tests {
                 .iter()
                 .filter(|decl| matches!(decl, Decl::Record(_) | Decl::Function(_)))
                 .count(),
-            6,
-            "the point record and all five functions lower from the wasm32 artifacts"
+            9,
+            "the point record and all eight functions lower from the wasm32 artifacts"
         );
     }
 
@@ -1412,7 +1451,7 @@ mod tests {
                 .iter()
                 .filter(|decl| matches!(decl, Decl::Function(_)))
                 .count(),
-            5
+            8
         );
     }
 
@@ -1715,9 +1754,26 @@ pub mod domain {
 }
 
 pub mod clock {
+    use std::ops::Range;
+
     use boltffi::{CustomFfiConvertible, custom_ffi, custom_type};
 
     pub struct Stamp(pub i64);
+
+    custom_type!(
+        ByteSpan,
+        remote = Range<u32>,
+        repr = u64,
+        into_ffi = |span: &Range<u32>| (u64::from(span.start) << 32) | u64::from(span.end),
+        try_from_ffi = |bits: u64| {
+            Ok::<_, boltffi::CustomTypeConversionError>((bits >> 32) as u32..bits as u32)
+        },
+    );
+
+    #[boltffi::export]
+    pub fn range_width(span: Range<u32>) -> u32 {
+        span.end - span.start
+    }
 
     custom_type!(
         Stamp,
@@ -1770,6 +1826,21 @@ pub mod api {
     #[export]
     pub fn label_text(label: Label) -> String {
         label.0
+    }
+
+    #[export]
+    pub trait Doubler {
+        fn double(&self, value: i32) -> i32;
+    }
+
+    #[export]
+    pub fn apply_doubler(doubler: impl Doubler, value: i32) -> i32 {
+        doubler.double(value)
+    }
+
+    #[export]
+    pub fn apply_boxed_doubler(doubler: Box<dyn Doubler>, value: i32) -> i32 {
+        doubler.double(value)
     }
 
     #[export]

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1125,10 +1125,12 @@ mod tests {
             "metadata_fixture::domain::Point",
             "the record's identity comes from its defining module"
         );
-        assert_eq!(contract.functions.len(), 1);
-        assert_eq!(
-            contract.functions[0].id.as_str(),
-            "metadata_fixture::api::origin"
+        assert_eq!(contract.functions.len(), 2);
+        assert!(
+            contract
+                .functions
+                .iter()
+                .any(|function| function.id.as_str() == "metadata_fixture::api::origin")
         );
         assert_eq!(contract.classes.len(), 1, "the class impl is captured");
         assert_eq!(
@@ -1145,6 +1147,24 @@ mod tests {
             "class method references resolve through the compiler"
         );
         assert_eq!(contract.constants.len(), 1, "the constant is captured");
+        assert_eq!(contract.customs.len(), 1, "the custom type is captured");
+        assert_eq!(
+            contract.customs[0].id.as_str(),
+            "metadata_fixture::clock::Stamp"
+        );
+        let stamp_fn = contract
+            .functions
+            .iter()
+            .find(|function| function.id.as_str() == "metadata_fixture::api::stamp_value")
+            .expect("the custom-typed function is captured");
+        assert!(
+            matches!(
+                &stamp_fn.parameters[0].type_expr,
+                boltffi_ast::TypeExpr::Custom { id, .. }
+                    if id.as_str() == "metadata_fixture::clock::Stamp"
+            ),
+            "the custom reference classifies through its defining fragment"
+        );
         assert_eq!(
             contract.records[0].methods.len(),
             1,
@@ -1174,7 +1194,8 @@ mod tests {
                 .iter()
                 .filter(|decl| matches!(decl, Decl::Record(_) | Decl::Function(_)))
                 .count(),
-            2
+            3,
+            "the point record and both functions lower"
         );
     }
 
@@ -1514,9 +1535,24 @@ pub mod domain {
     }
 }
 
+pub mod clock {
+    use boltffi::custom_type;
+
+    pub struct Stamp(pub i64);
+
+    custom_type!(
+        Stamp,
+        remote = Stamp,
+        repr = i64,
+        into_ffi = |stamp: &Stamp| stamp.0,
+        try_from_ffi = |value: i64| Ok::<_, boltffi::CustomTypeConversionError>(Stamp(value)),
+    );
+}
+
 pub mod api {
     use boltffi::export;
 
+    use crate::clock::Stamp;
     use crate::domain::Point;
 
     #[export]
@@ -1526,6 +1562,11 @@ pub mod api {
 
     #[export]
     pub const LIMIT: u32 = 8;
+
+    #[export]
+    pub fn stamp_value(stamp: Stamp) -> i64 {
+        stamp.0
+    }
 
     pub struct Session {
         origin: Point,

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -7,9 +7,10 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 
 use boltffi_binding::{
-    BINDING_METADATA_BUILD_ENV, BINDING_METADATA_FEATURES_ENV, BINDING_METADATA_ROOT_ENV,
-    BINDING_METADATA_SOURCE_ENV, BINDING_METADATA_SURFACE_ENV, BindingMetadataEnvelope,
-    BindingMetadataSurface,
+    BINDING_EXPANSION_BUILD_ENV, BINDING_EXPANSION_ROOT_ENV, BINDING_EXPANSION_SOURCE_ENV,
+    BINDING_EXPANSION_SURFACE_ENV, BINDING_METADATA_BUILD_ENV, BINDING_METADATA_FEATURES_ENV,
+    BINDING_METADATA_ROOT_ENV, BINDING_METADATA_SOURCE_ENV, BINDING_METADATA_SURFACE_ENV,
+    BindingMetadataEnvelope, BindingMetadataSurface, RawSourceRecord,
 };
 use serde::Deserialize;
 use thiserror::Error;
@@ -111,6 +112,48 @@ impl BindingMetadataBuild {
             .read_required()
             .map_err(BindingMetadataBuildError::Metadata)
     }
+
+    /// Runs a plain Cargo build (no metadata env gates) and reads per-invocation source
+    /// records from every reported artifact, dependency crates included.
+    pub fn read_source(&self) -> Result<SourceMetadata, BindingMetadataBuildError> {
+        let cargo_args = self
+            .cargo_args
+            .as_ref()
+            .map_err(|source| BindingMetadataBuildError::CargoArguments(source.clone()))?;
+        let manifest = CargoManifest::new(&self.manifest_path)?;
+        let metadata = CargoMetadata::load(
+            &manifest,
+            self.toolchain_selector.as_deref(),
+            &self.cargo_environment,
+        )?;
+        let source_root = SourceRoot::resolve(&metadata, &manifest)?;
+        let features = metadata.active_features(&manifest, cargo_args)?;
+        let output =
+            CargoBuild::new(self, &manifest, &source_root, cargo_args, features).plain_output()?;
+        let package = metadata.package_info(&manifest)?;
+
+        let artifacts = output.all_artifacts(&manifest)?.into_paths();
+        let source_records = BindingMetadataReader::new(artifacts.clone())
+            .read_source_records()
+            .map_err(BindingMetadataBuildError::Metadata)?;
+
+        Ok(SourceMetadata {
+            source_records,
+            package,
+            artifacts,
+        })
+    }
+}
+
+/// Per-invocation source records read from one plain Cargo build.
+#[derive(Debug)]
+pub struct SourceMetadata {
+    /// Source records from every artifact, dependencies included.
+    pub source_records: Vec<RawSourceRecord>,
+    /// Root package identity from `cargo metadata`.
+    pub package: boltffi_ast::PackageInfo,
+    /// Compiled artifact paths the records were read from.
+    pub artifacts: Vec<PathBuf>,
 }
 
 /// Failure while building a crate for embedded binding metadata.
@@ -309,10 +352,28 @@ impl CargoMetadata {
         self.package(manifest)
             .map(|package| MetadataFeatures::resolve(package.features(), args))
     }
+
+    fn package_info(
+        &self,
+        manifest: &CargoManifest,
+    ) -> Result<boltffi_ast::PackageInfo, BindingMetadataBuildError> {
+        self.package(manifest).map(|package| {
+            boltffi_ast::PackageInfo::new(
+                package.name.clone(),
+                package
+                    .version
+                    .clone()
+                    .filter(|version| !version.is_empty()),
+            )
+        })
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
 struct MetadataPackage {
+    name: String,
+    #[serde(default)]
+    version: Option<String>,
     manifest_path: PathBuf,
     targets: Vec<MetadataTarget>,
     #[serde(default)]
@@ -386,11 +447,32 @@ impl<'build> CargoBuild<'build> {
             .and_then(CargoOutput::from_output)
     }
 
-    fn command(self) -> Command {
-        let surface = self.build.surface.unwrap_or_else(|| {
-            BindingMetadataSurface::from_target_triple(self.build.target.as_deref())
-        });
+    fn plain_output(self) -> Result<CargoOutput, BindingMetadataBuildError> {
+        self.plain_command()
+            .output()
+            .map_err(|source| BindingMetadataBuildError::CargoSpawn { source })
+            .and_then(CargoOutput::from_output)
+    }
+
+    fn plain_command(self) -> Command {
+        self.base_command()
+    }
+
+    fn base_command(&self) -> Command {
         let mut command = Command::new(CargoProgram::from_env().into_os_string());
+        for ambient_gate in [
+            BINDING_METADATA_BUILD_ENV,
+            BINDING_METADATA_SOURCE_ENV,
+            BINDING_METADATA_SURFACE_ENV,
+            BINDING_METADATA_FEATURES_ENV,
+            BINDING_METADATA_ROOT_ENV,
+            BINDING_EXPANSION_BUILD_ENV,
+            BINDING_EXPANSION_SOURCE_ENV,
+            BINDING_EXPANSION_SURFACE_ENV,
+            BINDING_EXPANSION_ROOT_ENV,
+        ] {
+            command.env_remove(ambient_gate);
+        }
         command.envs(
             self.build
                 .cargo_environment
@@ -410,6 +492,14 @@ impl<'build> CargoBuild<'build> {
             command.arg("--target").arg(target);
         }
         command.args(self.cargo_args.iter());
+        command
+    }
+
+    fn command(self) -> Command {
+        let surface = self.build.surface.unwrap_or_else(|| {
+            BindingMetadataSurface::from_target_triple(self.build.target.as_deref())
+        });
+        let mut command = self.base_command();
         command.env(BINDING_METADATA_BUILD_ENV, "1");
         command.env(BINDING_METADATA_SOURCE_ENV, self.source_root.path());
         command.env(BINDING_METADATA_SURFACE_ENV, surface.as_str());
@@ -643,17 +733,35 @@ impl CargoOutput {
         manifest: &CargoManifest,
     ) -> Result<MetadataArtifacts, BindingMetadataBuildError> {
         let artifacts = self
-            .stdout
-            .lines()
-            .filter(|line| !line.trim().is_empty())
-            .map(CargoMessage::parse)
-            .collect::<Result<Vec<_>, _>>()?
+            .messages()?
             .into_iter()
             .flat_map(|message| message.filenames(manifest))
             .filter_map(MetadataArtifact::from_cargo_filename)
             .collect::<Vec<_>>();
 
         MetadataArtifacts::new(manifest.path(), artifacts)
+    }
+
+    fn all_artifacts(
+        &self,
+        manifest: &CargoManifest,
+    ) -> Result<MetadataArtifacts, BindingMetadataBuildError> {
+        let artifacts = self
+            .messages()?
+            .into_iter()
+            .flat_map(CargoMessage::into_filenames)
+            .filter_map(MetadataArtifact::from_cargo_filename)
+            .collect::<Vec<_>>();
+
+        MetadataArtifacts::new(manifest.path(), artifacts)
+    }
+
+    fn messages(&self) -> Result<Vec<CargoMessage>, BindingMetadataBuildError> {
+        self.stdout
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(CargoMessage::parse)
+            .collect()
     }
 }
 
@@ -736,6 +844,13 @@ impl CargoMessage {
             } if manifest.matches(&manifest_path) => filenames,
             Self::Other => Vec::new(),
             Self::CompilerArtifact { .. } => Vec::new(),
+        }
+    }
+
+    fn into_filenames(self) -> Vec<PathBuf> {
+        match self {
+            Self::CompilerArtifact { filenames, .. } => filenames,
+            Self::Other => Vec::new(),
         }
     }
 }
@@ -926,6 +1041,117 @@ mod tests {
             .expect("cargo metadata build reads");
 
         assert_eq!(envelopes, vec![expected]);
+    }
+
+    #[test]
+    fn cargo_build_combines_source_records_across_dependency_artifacts() {
+        if cfg!(miri) {
+            return;
+        }
+
+        let fixture = FixtureCrate::with_source_record_dependency();
+
+        let source = BindingMetadataBuild::new(fixture.manifest())
+            .read_source()
+            .expect("cargo source metadata read");
+
+        assert_eq!(
+            source.source_records.len(),
+            2,
+            "root and dependency records both surface"
+        );
+        assert_eq!(
+            source.package,
+            PackageInfo::new("metadata_fixture", Some("0.0.0".to_owned()))
+        );
+
+        let contract =
+            boltffi_binding::aggregate_records(&source.source_records, source.package.clone())
+                .expect("source records aggregate");
+        assert_eq!(
+            contract.records.len(),
+            1,
+            "dependency record joins the contract"
+        );
+        assert_eq!(
+            contract.records[0].id.as_str(),
+            "metadata_dependency::Point",
+            "dependency identity comes from its own module path"
+        );
+        assert_eq!(
+            contract.functions.len(),
+            1,
+            "root function joins the contract"
+        );
+
+        let bindings =
+            boltffi_binding::lower::<Native>(&contract).expect("aggregated contract lowers");
+        assert_eq!(
+            bindings
+                .decls()
+                .iter()
+                .filter(|decl| matches!(decl, Decl::Record(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            bindings
+                .decls()
+                .iter()
+                .filter(|decl| matches!(decl, Decl::Function(_)))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn cargo_build_aggregates_macro_emitted_source_records() {
+        if cfg!(miri) {
+            return;
+        }
+
+        let fixture = FixtureCrate::with_boltffi_macros();
+
+        let source = BindingMetadataBuild::new(fixture.manifest())
+            .read_source()
+            .expect("cargo source metadata read");
+
+        let contract =
+            boltffi_binding::aggregate_records(&source.source_records, source.package.clone())
+                .expect("macro-emitted records aggregate");
+        assert_eq!(contract.records.len(), 1);
+        assert_eq!(
+            contract.records[0].id.as_str(),
+            "metadata_fixture::domain::Point",
+            "the record's identity comes from its defining module"
+        );
+        assert_eq!(contract.functions.len(), 1);
+        assert_eq!(
+            contract.functions[0].id.as_str(),
+            "metadata_fixture::api::origin"
+        );
+        let boltffi_ast::ReturnDef::Value(returned) = &contract.functions[0].returns else {
+            panic!("origin returns a value");
+        };
+        assert!(
+            matches!(
+                returned,
+                boltffi_ast::TypeExpr::Record { id, .. }
+                    if id.as_str() == "metadata_fixture::domain::Point"
+            ),
+            "the cross-module reference resolves through the compiler: {returned:?}"
+        );
+
+        let bindings =
+            boltffi_binding::lower::<Native>(&contract).expect("aggregated contract lowers");
+        assert_eq!(
+            bindings
+                .decls()
+                .iter()
+                .filter(|decl| matches!(decl, Decl::Record(_) | Decl::Function(_)))
+                .count(),
+            2
+        );
     }
 
     #[test]
@@ -1159,6 +1385,10 @@ pub fn view() -> CoreFfi {
             Self::write(Source::without_metadata(), Dependency::None)
         }
 
+        fn with_source_record_dependency() -> Self {
+            Self::write(Source::with_root_source_record(), Dependency::SourceRecord)
+        }
+
         fn write(source: Source, dependency: Dependency<'_>) -> Self {
             let root = temp_root("boltffi-bindgen-cargo-metadata");
             let source_dir = root.join("src");
@@ -1186,6 +1416,7 @@ pub fn view() -> CoreFfi {
     enum Dependency<'envelope> {
         Boltffi,
         Metadata(&'envelope BindingMetadataEnvelope),
+        SourceRecord,
         None,
     }
 
@@ -1196,7 +1427,7 @@ pub fn view() -> CoreFfi {
                     "\n[dependencies]\nboltffi = {{ path = \"{}\" }}\n",
                     workspace_crate("boltffi").display()
                 ),
-                Self::Metadata(_) => {
+                Self::Metadata(_) | Self::SourceRecord => {
                     "\n[dependencies]\nmetadata_dependency = { path = \"metadata_dependency\" }\n"
                         .to_owned()
                 }
@@ -1208,22 +1439,23 @@ pub fn view() -> CoreFfi {
         }
 
         fn write(self, root: &Path) {
-            if let Self::Metadata(envelope) = self {
-                let package = root.join("metadata_dependency");
-                let source = package.join("src");
-                fs::create_dir_all(&source).expect("create metadata dependency source dir");
-                fs::write(
-                    package.join("Cargo.toml"),
-                    "[package]\nname = \"metadata_dependency\"\nversion = \"0.0.0\"\nedition = \"2024\"\n\n[lib]\npath = \"src/lib.rs\"\n",
-                )
-                .expect("write metadata dependency manifest");
-                fs::write(
-                    source.join("lib.rs"),
+            let body = match self {
+                Self::Metadata(envelope) => {
                     Source::with_metadata_and_body(envelope, "pub fn value() -> u32 { 7 }\n")
-                        .into_string(),
-                )
-                .expect("write metadata dependency lib");
-            }
+                        .into_string()
+                }
+                Self::SourceRecord => Source::with_dependency_source_record().into_string(),
+                Self::Boltffi | Self::None => return,
+            };
+            let package = root.join("metadata_dependency");
+            let source = package.join("src");
+            fs::create_dir_all(&source).expect("create metadata dependency source dir");
+            fs::write(
+                package.join("Cargo.toml"),
+                "[package]\nname = \"metadata_dependency\"\nversion = \"0.0.0\"\nedition = \"2024\"\n\n[lib]\npath = \"src/lib.rs\"\n",
+            )
+            .expect("write metadata dependency manifest");
+            fs::write(source.join("lib.rs"), body).expect("write metadata dependency lib");
         }
     }
 
@@ -1245,6 +1477,7 @@ pub mod domain {
     use boltffi::data;
 
     #[data]
+    #[derive(Clone, Copy)]
     pub struct Point {
         pub x: f64,
     }
@@ -1295,9 +1528,100 @@ pub mod api {
             }
         }
 
+        fn with_root_source_record() -> Self {
+            let mut function = boltffi_ast::FunctionDef::new(
+                boltffi_ast::FunctionId::new("$self::origin"),
+                source_name("origin"),
+            );
+            function.returns = boltffi_ast::ReturnDef::value(boltffi_ast::TypeExpr::record(
+                boltffi_ast::RecordId::new("$slot:0"),
+                boltffi_ast::Path::single("Point"),
+            ));
+            let json = serde_json::to_vec(&boltffi_binding::SourceFragment::Function(function))
+                .expect("function fragment serializes");
+            Self::with_source_record_static(
+                "metadata_fixture",
+                &[r#"{"id":"metadata_dependency::Point"}"#],
+                &json,
+                "pub fn exported() -> u32 { metadata_dependency::value() }\n",
+            )
+        }
+
+        fn with_dependency_source_record() -> Self {
+            let mut record = boltffi_ast::RecordDef::new(
+                boltffi_ast::RecordId::new("$self::Point"),
+                source_name("Point"),
+            );
+            record.fields = vec![boltffi_ast::FieldDef::new(
+                source_name("x"),
+                boltffi_ast::TypeExpr::Primitive(boltffi_ast::Primitive::F64),
+            )];
+            let json = serde_json::to_vec(&boltffi_binding::SourceFragment::Record(record))
+                .expect("record fragment serializes");
+            Self::with_source_record_static(
+                "metadata_dependency",
+                &[],
+                &json,
+                "pub fn value() -> u32 { 7 }\n",
+            )
+        }
+
+        fn with_source_record_static(
+            module: &str,
+            slots: &[&str],
+            json: &[u8],
+            body: &str,
+        ) -> Self {
+            let record_bytes = source_record_bytes(module, "0.0.0", module, slots, json);
+            let length = record_bytes.len();
+            let bytes = record_bytes
+                .iter()
+                .map(u8::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            Self {
+                code: format!(
+                    "#[cfg_attr(target_vendor = \"apple\", unsafe(link_section = \"__DATA,__boltffisrc\"))]\n#[cfg_attr(not(target_vendor = \"apple\"), unsafe(link_section = \".boltffisrc\"))]\n#[used]\nstatic BOLTFFI_SOURCE: [u8; {length}] = [{bytes}];\n{body}"
+                ),
+            }
+        }
+
         fn into_string(self) -> String {
             self.code
         }
+    }
+
+    fn source_name(spelling: &str) -> boltffi_ast::SourceName {
+        boltffi_ast::SourceName::new(
+            spelling,
+            boltffi_ast::CanonicalName::single(spelling.to_lowercase()),
+        )
+    }
+
+    fn source_record_bytes(
+        package: &str,
+        version: &str,
+        module: &str,
+        slots: &[&str],
+        json: &[u8],
+    ) -> Vec<u8> {
+        let mut payload = Vec::new();
+        for field in [package, version, module] {
+            payload.extend_from_slice(&(field.len() as u16).to_le_bytes());
+            payload.extend_from_slice(field.as_bytes());
+        }
+        payload.extend_from_slice(&(slots.len() as u16).to_le_bytes());
+        for slot in slots {
+            payload.extend_from_slice(&(slot.len() as u16).to_le_bytes());
+            payload.extend_from_slice(slot.as_bytes());
+        }
+        payload.extend_from_slice(&(json.len() as u32).to_le_bytes());
+        payload.extend_from_slice(json);
+
+        let mut bytes = b"BFFISRC1".to_vec();
+        bytes.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&payload);
+        bytes
     }
 
     fn metadata_envelope(package: &str) -> BindingMetadataEnvelope {

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1125,7 +1125,24 @@ mod tests {
             "metadata_fixture::domain::Point",
             "the record's identity comes from its defining module"
         );
-        assert_eq!(contract.functions.len(), 3);
+        assert_eq!(contract.functions.len(), 4);
+        let browser_fn = contract
+            .functions
+            .iter()
+            .find(|function| function.id.as_str() == "metadata_fixture::api::browser_len")
+            .expect("the interned-string function is captured");
+        assert!(
+            matches!(
+                &browser_fn.parameters[0].type_expr,
+                boltffi_ast::TypeExpr::InternedString {
+                    pool_id,
+                    static_values,
+                    ..
+                } if pool_id == "metadata_fixture::pools::Browser"
+                    && static_values == &["Chrome".to_owned(), "Firefox".to_owned()]
+            ),
+            "the pool's values inline at the use site through its fragment"
+        );
         assert!(
             contract
                 .functions
@@ -1245,8 +1262,8 @@ mod tests {
                 .iter()
                 .filter(|decl| matches!(decl, Decl::Record(_) | Decl::Function(_)))
                 .count(),
-            4,
-            "the point record and all three functions lower"
+            5,
+            "the point record and all four functions lower"
         );
     }
 
@@ -1284,7 +1301,7 @@ mod tests {
                 .iter()
                 .filter(|decl| matches!(decl, Decl::Function(_)))
                 .count(),
-            3
+            4
         );
     }
 
@@ -1600,13 +1617,23 @@ pub mod clock {
     );
 }
 
+pub mod pools {
+    boltffi::interned_string_pool! {
+        pub Browser {
+            CHROME = "Chrome",
+            FIREFOX = "Firefox",
+        }
+    }
+}
+
 pub mod api {
     use std::sync::Arc;
 
-    use boltffi::{EventSubscription, export, ffi_stream};
+    use boltffi::{EventSubscription, InternedString, export, ffi_stream};
 
     use crate::clock::Stamp;
     use crate::domain::Point;
+    use crate::pools::Browser;
 
     #[export]
     pub fn origin() -> Point {
@@ -1619,6 +1646,14 @@ pub mod api {
     #[export]
     pub fn stamp_value(stamp: Stamp) -> i64 {
         stamp.0
+    }
+
+    #[export]
+    pub fn browser_len(name: InternedString<Browser>) -> u32 {
+        match name.repr() {
+            boltffi::InternedStringRepr::Interned(id) => *id,
+            boltffi::InternedStringRepr::Dynamic(value) => value.len() as u32,
+        }
     }
 
     #[boltffi::error]

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -867,7 +867,7 @@ mod tests {
     use boltffi_ast::{PackageInfo, SourceContract};
     use boltffi_binding::{
         BINDING_METADATA_SURFACE_ENV, BindingMetadataEnvelope, BindingMetadataSection,
-        BindingMetadataSurface, Decl, Native, SerializedBindings, lower_with_declarations,
+        BindingMetadataSurface, Decl, Native, SerializedBindings, Wasm32, lower_with_declarations,
     };
 
     use super::{
@@ -1305,6 +1305,54 @@ mod tests {
             actual.decls(),
             expected.decls(),
             "records-fed lowering matches the legacy scanner's declarations"
+        );
+
+        let actual_wasm = boltffi_binding::lower::<Wasm32>(&contract)
+            .expect("aggregated contract lowers to wasm32");
+        let expected_wasm =
+            boltffi_binding::lower::<Wasm32>(&scanned).expect("scanned contract lowers to wasm32");
+        assert_eq!(
+            actual_wasm.decls(),
+            expected_wasm.decls(),
+            "the same host-built records serve the wasm32 surface without cross-compiling"
+        );
+    }
+
+    #[test]
+    fn cargo_build_reads_source_records_from_a_wasm32_target_build() {
+        if cfg!(miri) {
+            return;
+        }
+        if !wasm32_target_installed() {
+            eprintln!("skipping: the wasm32-unknown-unknown target is not installed");
+            return;
+        }
+
+        let fixture = FixtureCrate::with_boltffi_macros();
+
+        let source = BindingMetadataBuild::new(fixture.manifest())
+            .target("wasm32-unknown-unknown")
+            .read_source()
+            .expect("wasm32 source metadata read");
+
+        let contract =
+            boltffi_binding::aggregate_records(&source.source_records, source.package.clone())
+                .expect("wasm32-built records aggregate");
+        assert_eq!(contract.records.len(), 1);
+        assert_eq!(contract.functions.len(), 4);
+        assert_eq!(contract.classes.len(), 1);
+        assert_eq!(contract.streams.len(), 1);
+
+        let bindings =
+            boltffi_binding::lower::<Wasm32>(&contract).expect("wasm32-built contract lowers");
+        assert_eq!(
+            bindings
+                .decls()
+                .iter()
+                .filter(|decl| matches!(decl, Decl::Record(_) | Decl::Function(_)))
+                .count(),
+            5,
+            "the point record and all four functions lower from the wasm32 artifacts"
         );
     }
 
@@ -1876,6 +1924,23 @@ pub mod api {
         let lowered = lower_with_declarations::<Native>(&source).expect("empty source lowers");
         BindingMetadataEnvelope::new(SerializedBindings::native(lowered.into_bindings()))
             .expect("metadata envelope")
+    }
+
+    fn wasm32_target_installed() -> bool {
+        std::process::Command::new("rustc")
+            .args([
+                "--print",
+                "target-libdir",
+                "--target",
+                "wasm32-unknown-unknown",
+            ])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .map(|output| PathBuf::from(String::from_utf8_lossy(&output.stdout).trim()))
+            .is_some_and(|libdir| {
+                fs::read_dir(libdir).is_ok_and(|mut entries| entries.next().is_some())
+            })
     }
 
     fn workspace_crate(name: &str) -> PathBuf {

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1146,6 +1146,26 @@ mod tests {
             ),
             "class method references resolve through the compiler"
         );
+        assert_eq!(contract.streams.len(), 1, "the stream method is captured");
+        assert_eq!(
+            contract.streams[0].id.as_str(),
+            "metadata_fixture::api::Session::moves"
+        );
+        assert_eq!(
+            contract.streams[0]
+                .owner
+                .as_ref()
+                .map(|owner| owner.as_str()),
+            Some("metadata_fixture::api::Session")
+        );
+        assert!(
+            matches!(
+                &contract.streams[0].item_type,
+                boltffi_ast::TypeExpr::Record { id, .. }
+                    if id.as_str() == "metadata_fixture::domain::Point"
+            ),
+            "the stream item resolves cross-module through the compiler"
+        );
         assert_eq!(contract.constants.len(), 1, "the constant is captured");
         assert_eq!(contract.customs.len(), 1, "the custom type is captured");
         assert_eq!(
@@ -1550,7 +1570,9 @@ pub mod clock {
 }
 
 pub mod api {
-    use boltffi::export;
+    use std::sync::Arc;
+
+    use boltffi::{EventSubscription, export, ffi_stream};
 
     use crate::clock::Stamp;
     use crate::domain::Point;
@@ -1580,6 +1602,11 @@ pub mod api {
 
         pub fn shift(&self, by: f64) -> Point {
             Point { x: self.origin.x + by }
+        }
+
+        #[ffi_stream(item = Point)]
+        pub fn moves(&self) -> Arc<EventSubscription<Point>> {
+            todo!()
         }
     }
 }

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -1724,7 +1724,7 @@ pub mod api {
         origin: Point,
     }
 
-    #[export]
+    #[export(single_threaded)]
     impl Session {
         pub fn new() -> Self {
             Self { origin: Point { x: 0.0 } }

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -10,10 +10,10 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
 use boltffi_ast::{
-    ClassDef, ClassId, ConstantDef, ConstantId, CustomTypeConverter, CustomTypeDef, CustomTypeId,
-    EnumDef, EnumId, FieldDef, FunctionDef, FunctionId, MethodDef, NamePart, PackageInfo, Path,
-    PathSegment, Primitive, RecordDef, RecordId, ReturnDef, SourceContract, StreamDef, StreamId,
-    TraitDef, TraitId, TypeExpr, VariantPayload,
+    ClassDef, ClassId, ConstantDef, ConstantId, ConstantOwner, CustomTypeConverter, CustomTypeDef,
+    CustomTypeId, EnumDef, EnumId, FieldDef, FunctionDef, FunctionId, MethodDef, NamePart,
+    PackageInfo, Path, PathSegment, Primitive, RecordDef, RecordId, ReturnDef, SourceContract,
+    StreamDef, StreamId, TraitDef, TraitId, TypeExpr, VariantPayload,
 };
 use serde::{Deserialize, Serialize};
 
@@ -60,6 +60,9 @@ pub enum SourceFragment {
         spelling: String,
         /// Methods to merge, with ids nested under the target's placeholder.
         methods: Vec<MethodDef>,
+        /// Associated constants, owned by the target once it resolves.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        constants: Vec<ConstantDef>,
     },
     /// An invocation the per-invocation capture cannot describe yet.
     ///
@@ -175,14 +178,17 @@ pub fn aggregate_records(
             SourceFragment::Constant(def) => contract.constants.push(def),
             SourceFragment::Custom(def) => contract.customs.push(def),
             SourceFragment::Methods {
-                target, methods, ..
-            } => method_blocks.push((target, methods)),
+                target,
+                methods,
+                constants,
+                ..
+            } => method_blocks.push((target, methods, constants)),
             SourceFragment::InternedStringPool { .. } | SourceFragment::Unsupported { .. } => {}
         }
     }
 
-    for (target, methods) in method_blocks {
-        merge_methods(&mut contract, target, methods)?;
+    for (target, methods, constants) in method_blocks {
+        merge_methods(&mut contract, target, methods, constants)?;
     }
 
     contract.records.sort_by(|a, b| a.id.cmp(&b.id));
@@ -200,10 +206,12 @@ fn merge_methods(
     contract: &mut SourceContract,
     target: TypeExpr,
     methods: Vec<MethodDef>,
+    constants: Vec<ConstantDef>,
 ) -> Result<(), SourceFragmentError> {
-    let (target_id, target_methods) = match &target {
+    let (target_id, owner, target_methods) = match &target {
         TypeExpr::Record { id, .. } => (
             id.as_str().to_owned(),
+            ConstantOwner::Record(id.clone()),
             contract
                 .records
                 .iter_mut()
@@ -212,6 +220,7 @@ fn merge_methods(
         ),
         TypeExpr::Enum { id, .. } => (
             id.as_str().to_owned(),
+            ConstantOwner::Enum(id.clone()),
             contract
                 .enums
                 .iter_mut()
@@ -234,6 +243,15 @@ fn merge_methods(
             method.id = boltffi_ast::MethodId::new(format!("{target_id}::{tail}"));
         }
         target_methods.push(method);
+    }
+    for mut constant in constants {
+        if let Some(rest) = constant.id.as_str().strip_prefix(SLOT_ID_PREFIX)
+            && let Some((_, tail)) = rest.split_once("::")
+        {
+            constant.id = ConstantId::new(format!("{target_id}::{tail}"));
+        }
+        constant.owner = Some(owner.clone());
+        contract.constants.push(constant);
     }
     Ok(())
 }
@@ -281,11 +299,15 @@ fn fragment_id(fragment: &SourceFragment, module: &str) -> String {
         SourceFragment::Custom(def) => def.id.as_str().to_owned(),
         SourceFragment::InternedStringPool { id, .. } => id.clone(),
         SourceFragment::Methods {
-            spelling, methods, ..
+            spelling,
+            methods,
+            constants,
+            ..
         } => {
             let names = methods
                 .iter()
                 .map(|method| method.name.spelling())
+                .chain(constants.iter().map(|constant| constant.name.spelling()))
                 .collect::<Vec<_>>()
                 .join(",");
             format!("{module}::impl {spelling}::{{{names}}}")
@@ -344,6 +366,11 @@ fn mint_self_ids(fragment: &mut SourceFragment, module: &str) {
         SourceFragment::Constant(def) => {
             if let Some(value) = minted(def.id.as_str(), module) {
                 def.id = ConstantId::new(value);
+            }
+            if let Some(ConstantOwner::Class(id)) = &mut def.owner
+                && let Some(value) = minted(id.as_str(), module)
+            {
+                *id = ClassId::new(value);
             }
         }
         SourceFragment::Custom(def) => {
@@ -422,10 +449,17 @@ fn resolve_fragment(
         SourceFragment::Custom(def) => resolve(&mut def.repr),
         SourceFragment::InternedStringPool { .. } => Ok(()),
         SourceFragment::Methods {
-            target, methods, ..
+            target,
+            methods,
+            constants,
+            ..
         } => {
             resolve(target)?;
-            resolve_methods(methods, &mut resolve)
+            resolve_methods(methods, &mut resolve)?;
+            for constant in constants {
+                resolve(&mut constant.type_expr)?;
+            }
+            Ok(())
         }
         SourceFragment::Unsupported { .. } => Ok(()),
     }
@@ -974,6 +1008,86 @@ mod tests {
                 TypeExpr::Record { id, .. } if id == &RecordId::new("demo::geometry::Point")
             ),
             "the item type resolves through its slot"
+        );
+    }
+
+    #[test]
+    fn merges_method_block_constants_into_their_resolved_owner() {
+        let mut constant = ConstantDef::new(
+            ConstantId::new(format!("{SLOT_ID_PREFIX}0::ORIGIN")),
+            name("ORIGIN"),
+            slot_leaf(0, "Point"),
+            boltffi_ast::ConstExpr::Raw("Point { x : 0.0 }".to_owned()),
+        );
+        constant.owner = Some(ConstantOwner::Record(RecordId::new(format!(
+            "{SLOT_ID_PREFIX}0"
+        ))));
+        let methods = raw(
+            "demo",
+            &[r#"{"id":"demo::geometry::Point"}"#],
+            serde_json::to_vec(&SourceFragment::Methods {
+                target: slot_leaf(0, "Point"),
+                spelling: "Point".to_owned(),
+                methods: Vec::new(),
+                constants: vec![constant],
+            })
+            .expect("fragment serializes"),
+        );
+
+        let contract =
+            aggregate_records(&[methods, point_record()], PackageInfo::new("demo", None))
+                .expect("records aggregate");
+
+        assert_eq!(contract.constants.len(), 1);
+        assert_eq!(
+            contract.constants[0].id,
+            ConstantId::new("demo::geometry::Point::ORIGIN"),
+            "the constant id rebases onto the resolved target"
+        );
+        assert_eq!(
+            contract.constants[0].owner,
+            Some(ConstantOwner::Record(RecordId::new(
+                "demo::geometry::Point"
+            ))),
+            "the provisional owner takes the resolved target's kind and id"
+        );
+        assert!(
+            matches!(
+                &contract.constants[0].type_expr,
+                TypeExpr::Record { id, .. } if id == &RecordId::new("demo::geometry::Point")
+            ),
+            "the declared type resolves through its slot"
+        );
+    }
+
+    #[test]
+    fn mints_class_constant_owners_from_the_module_path() {
+        let mut constant = ConstantDef::new(
+            ConstantId::new(format!("{SELF_ID}::Counter::MAX")),
+            name("MAX"),
+            TypeExpr::Primitive(Primitive::I32),
+            boltffi_ast::ConstExpr::Raw("9".to_owned()),
+        );
+        constant.owner = Some(ConstantOwner::Class(ClassId::new(format!(
+            "{SELF_ID}::Counter"
+        ))));
+        let record = raw(
+            "demo::api",
+            &[],
+            serde_json::to_vec(&SourceFragment::Constant(constant)).expect("fragment serializes"),
+        );
+
+        let contract = aggregate_records(&[record], PackageInfo::new("demo", None))
+            .expect("records aggregate");
+
+        assert_eq!(
+            contract.constants[0].id,
+            ConstantId::new("demo::api::Counter::MAX")
+        );
+        assert_eq!(
+            contract.constants[0].owner,
+            Some(ConstantOwner::Class(ClassId::new("demo::api::Counter"))),
+            "the class owner mints against the record's module path"
         );
     }
 

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -244,6 +244,7 @@ enum DeclaredKind {
     Enum,
     Class,
     Custom,
+    Trait,
 }
 
 #[derive(Debug, Default)]
@@ -258,8 +259,8 @@ fn declared_kind(fragment: &SourceFragment) -> Option<DeclaredKind> {
         SourceFragment::Enum(_) => Some(DeclaredKind::Enum),
         SourceFragment::Class(_) => Some(DeclaredKind::Class),
         SourceFragment::Custom(_) => Some(DeclaredKind::Custom),
+        SourceFragment::Trait(_) => Some(DeclaredKind::Trait),
         SourceFragment::Function(_)
-        | SourceFragment::Trait(_)
         | SourceFragment::Stream(_)
         | SourceFragment::Constant(_)
         | SourceFragment::InternedStringPool { .. }
@@ -519,8 +520,25 @@ fn resolve_expr(
         }
         TypeExpr::FnPtr(signature) => resolve_fn_sig(signature, slots, declared),
         TypeExpr::Dyn(bounds) | TypeExpr::ImplTrait(bounds) => {
-            if let boltffi_ast::BaseTrait::Function(function_trait) = &mut bounds.base {
-                resolve_fn_sig(&mut function_trait.signature, slots, declared)?;
+            match &mut bounds.base {
+                boltffi_ast::BaseTrait::Function(function_trait) => {
+                    resolve_fn_sig(&mut function_trait.signature, slots, declared)?;
+                }
+                boltffi_ast::BaseTrait::Named { id, .. } => {
+                    if let Some(index) = id.as_str().strip_prefix(SLOT_ID_PREFIX) {
+                        let TypeNode::Id { id: resolved } = slot_node(index, slots)? else {
+                            return Err(SourceFragmentError::UnresolvedReference {
+                                id: id.as_str().to_owned(),
+                            });
+                        };
+                        if declared.kinds.get(resolved) != Some(&DeclaredKind::Trait) {
+                            return Err(SourceFragmentError::UnresolvedReference {
+                                id: resolved.clone(),
+                            });
+                        }
+                        *id = boltffi_ast::TraitId::new(resolved.clone());
+                    }
+                }
             }
             Ok(())
         }
@@ -574,6 +592,9 @@ fn node_expr(
                 DeclaredKind::Class => TypeExpr::class(ClassId::new(id.clone()), path),
                 DeclaredKind::Custom => {
                     TypeExpr::custom(boltffi_ast::CustomTypeId::new(id.clone()), path)
+                }
+                DeclaredKind::Trait => {
+                    return Err(SourceFragmentError::UnresolvedReference { id: id.clone() });
                 }
             })
         }

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -869,6 +869,43 @@ mod tests {
     }
 
     #[test]
+    fn mints_stream_ids_and_owners() {
+        let mut stream = StreamDef::new(
+            StreamId::new(format!("{SELF_ID}::Engine::points")),
+            name("points"),
+            slot_leaf(0, "Point"),
+        );
+        stream.owner = Some(ClassId::new(format!("{SELF_ID}::Engine")));
+        let stream = raw(
+            "demo::runtime",
+            &[r#"{"id":"demo::geometry::Point"}"#],
+            serde_json::to_vec(&SourceFragment::Stream(stream)).expect("fragment serializes"),
+        );
+
+        let contract = aggregate_records(&[stream, point_record()], PackageInfo::new("demo", None))
+            .expect("records aggregate");
+
+        assert_eq!(contract.streams.len(), 1);
+        assert_eq!(
+            contract.streams[0].id,
+            StreamId::new("demo::runtime::Engine::points"),
+            "stream ids mint from the invocation's module path"
+        );
+        assert_eq!(
+            contract.streams[0].owner,
+            Some(ClassId::new("demo::runtime::Engine")),
+            "the owner placeholder mints against the same module"
+        );
+        assert!(
+            matches!(
+                &contract.streams[0].item_type,
+                TypeExpr::Record { id, .. } if id == &RecordId::new("demo::geometry::Point")
+            ),
+            "the item type resolves through its slot"
+        );
+    }
+
+    #[test]
     fn rejects_a_reference_no_record_declares() {
         let route = raw(
             "demo",

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -10,10 +10,10 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
 use boltffi_ast::{
-    ClassDef, ClassId, ConstantDef, ConstantId, CustomTypeDef, EnumDef, EnumId, FieldDef,
-    FunctionDef, FunctionId, MethodDef, NamePart, PackageInfo, Path, PathSegment, Primitive,
-    RecordDef, RecordId, ReturnDef, SourceContract, StreamDef, StreamId, TraitDef, TraitId,
-    TypeExpr, VariantPayload,
+    ClassDef, ClassId, ConstantDef, ConstantId, CustomTypeConverter, CustomTypeDef, CustomTypeId,
+    EnumDef, EnumId, FieldDef, FunctionDef, FunctionId, MethodDef, NamePart, PackageInfo, Path,
+    PathSegment, Primitive, RecordDef, RecordId, ReturnDef, SourceContract, StreamDef, StreamId,
+    TraitDef, TraitId, TypeExpr, VariantPayload,
 };
 use serde::{Deserialize, Serialize};
 
@@ -327,9 +327,31 @@ fn mint_self_ids(fragment: &mut SourceFragment, module: &str) {
                 def.id = ConstantId::new(value);
             }
         }
-        SourceFragment::Custom(_)
-        | SourceFragment::Methods { .. }
-        | SourceFragment::Unsupported { .. } => {}
+        SourceFragment::Custom(def) => {
+            if let Some(value) = minted(def.id.as_str(), module) {
+                def.id = CustomTypeId::new(value);
+            }
+            mint_converter_module(&mut def.converters.into_ffi, module);
+            mint_converter_module(&mut def.converters.try_from_ffi, module);
+        }
+        SourceFragment::Methods { .. } | SourceFragment::Unsupported { .. } => {}
+    }
+}
+
+fn mint_converter_module(converter: &mut CustomTypeConverter, module: &str) {
+    if let CustomTypeConverter::Path(path) = converter
+        && path
+            .segments
+            .first()
+            .is_some_and(|segment| segment.name.as_str() == SELF_ID)
+    {
+        let mut segments = module
+            .split("::")
+            .skip(1)
+            .map(PathSegment::new)
+            .collect::<Vec<_>>();
+        segments.extend(path.segments.drain(1..));
+        path.segments = segments;
     }
 }
 

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -45,6 +45,15 @@ pub enum SourceFragment {
     Constant(ConstantDef),
     /// A `custom_type!` registration.
     Custom(CustomTypeDef),
+    /// A `#[data(impl)]` methods block, merged into its target declaration.
+    Methods {
+        /// The impl target, as a slot-deferred reference until resolution.
+        target: TypeExpr,
+        /// The impl target's written spelling, part of the dedup key.
+        spelling: String,
+        /// Methods to merge, with ids nested under the target's placeholder.
+        methods: Vec<MethodDef>,
+    },
     /// An invocation the per-invocation capture cannot describe yet.
     ///
     /// Its presence means the crate's source records are incomplete; aggregation refuses
@@ -116,13 +125,13 @@ pub fn aggregate_records(
             })
             .collect::<Result<Vec<_>, _>>()?;
         mint_self_ids(&mut fragment, &record.module);
-        fragments.push((fragment, slots));
+        fragments.push((fragment, slots, record.module.clone()));
     }
 
     let mut kinds = HashMap::new();
     let mut unique: HashMap<String, (&SourceFragment, &[TypeNode])> = HashMap::new();
-    for (fragment, slots) in &fragments {
-        let id = fragment_id(fragment).to_owned();
+    for (fragment, slots, module) in &fragments {
+        let id = fragment_id(fragment, module);
         match unique.entry(id.clone()) {
             Entry::Vacant(entry) => {
                 entry.insert((fragment, slots));
@@ -139,8 +148,9 @@ pub fn aggregate_records(
 
     let mut contract = SourceContract::new(package);
     let mut seen = HashMap::new();
-    for (mut fragment, slots) in fragments {
-        let id = fragment_id(&fragment).to_owned();
+    let mut method_blocks = Vec::new();
+    for (mut fragment, slots, module) in fragments {
+        let id = fragment_id(&fragment, &module);
         if seen.insert(id, ()).is_some() {
             continue;
         }
@@ -154,8 +164,15 @@ pub fn aggregate_records(
             SourceFragment::Stream(def) => contract.streams.push(def),
             SourceFragment::Constant(def) => contract.constants.push(def),
             SourceFragment::Custom(def) => contract.customs.push(def),
+            SourceFragment::Methods {
+                target, methods, ..
+            } => method_blocks.push((target, methods)),
             SourceFragment::Unsupported { .. } => {}
         }
+    }
+
+    for (target, methods) in method_blocks {
+        merge_methods(&mut contract, target, methods)?;
     }
 
     contract.records.sort_by(|a, b| a.id.cmp(&b.id));
@@ -167,6 +184,48 @@ pub fn aggregate_records(
     contract.constants.sort_by(|a, b| a.id.cmp(&b.id));
     contract.customs.sort_by(|a, b| a.id.cmp(&b.id));
     Ok(contract)
+}
+
+fn merge_methods(
+    contract: &mut SourceContract,
+    target: TypeExpr,
+    methods: Vec<MethodDef>,
+) -> Result<(), SourceFragmentError> {
+    let (target_id, target_methods) = match &target {
+        TypeExpr::Record { id, .. } => (
+            id.as_str().to_owned(),
+            contract
+                .records
+                .iter_mut()
+                .find(|record| &record.id == id)
+                .map(|record| &mut record.methods),
+        ),
+        TypeExpr::Enum { id, .. } => (
+            id.as_str().to_owned(),
+            contract
+                .enums
+                .iter_mut()
+                .find(|declared| &declared.id == id)
+                .map(|declared| &mut declared.methods),
+        ),
+        _ => {
+            return Err(SourceFragmentError::UnresolvedReference {
+                id: "a methods block targets a non-data declaration".to_owned(),
+            });
+        }
+    };
+    let Some(target_methods) = target_methods else {
+        return Err(SourceFragmentError::UnresolvedReference { id: target_id });
+    };
+    for mut method in methods {
+        if let Some(rest) = method.id.as_str().strip_prefix(SLOT_ID_PREFIX) {
+            if let Some((_, tail)) = rest.split_once("::") {
+                method.id = boltffi_ast::MethodId::new(format!("{target_id}::{tail}"));
+            }
+        }
+        target_methods.push(method);
+    }
+    Ok(())
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -187,21 +246,32 @@ fn declared_kind(fragment: &SourceFragment) -> Option<DeclaredKind> {
         | SourceFragment::Trait(_)
         | SourceFragment::Stream(_)
         | SourceFragment::Constant(_)
+        | SourceFragment::Methods { .. }
         | SourceFragment::Unsupported { .. } => None,
     }
 }
 
-fn fragment_id(fragment: &SourceFragment) -> &str {
+fn fragment_id(fragment: &SourceFragment, module: &str) -> String {
     match fragment {
-        SourceFragment::Record(def) => def.id.as_str(),
-        SourceFragment::Enum(def) => def.id.as_str(),
-        SourceFragment::Function(def) => def.id.as_str(),
-        SourceFragment::Class(def) => def.id.as_str(),
-        SourceFragment::Trait(def) => def.id.as_str(),
-        SourceFragment::Stream(def) => def.id.as_str(),
-        SourceFragment::Constant(def) => def.id.as_str(),
-        SourceFragment::Custom(def) => def.id.as_str(),
-        SourceFragment::Unsupported { name, .. } => name,
+        SourceFragment::Record(def) => def.id.as_str().to_owned(),
+        SourceFragment::Enum(def) => def.id.as_str().to_owned(),
+        SourceFragment::Function(def) => def.id.as_str().to_owned(),
+        SourceFragment::Class(def) => def.id.as_str().to_owned(),
+        SourceFragment::Trait(def) => def.id.as_str().to_owned(),
+        SourceFragment::Stream(def) => def.id.as_str().to_owned(),
+        SourceFragment::Constant(def) => def.id.as_str().to_owned(),
+        SourceFragment::Custom(def) => def.id.as_str().to_owned(),
+        SourceFragment::Methods {
+            spelling, methods, ..
+        } => {
+            let names = methods
+                .iter()
+                .map(|method| method.name.spelling())
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{module}::impl {spelling}::{{{names}}}")
+        }
+        SourceFragment::Unsupported { name, .. } => name.clone(),
     }
 }
 
@@ -257,7 +327,9 @@ fn mint_self_ids(fragment: &mut SourceFragment, module: &str) {
                 def.id = ConstantId::new(value);
             }
         }
-        SourceFragment::Custom(_) | SourceFragment::Unsupported { .. } => {}
+        SourceFragment::Custom(_)
+        | SourceFragment::Methods { .. }
+        | SourceFragment::Unsupported { .. } => {}
     }
 }
 
@@ -302,6 +374,12 @@ fn resolve_fragment(
         SourceFragment::Stream(def) => resolve(&mut def.item_type),
         SourceFragment::Constant(def) => resolve(&mut def.type_expr),
         SourceFragment::Custom(def) => resolve(&mut def.repr),
+        SourceFragment::Methods {
+            target, methods, ..
+        } => {
+            resolve(target)?;
+            resolve_methods(methods, &mut resolve)
+        }
         SourceFragment::Unsupported { .. } => Ok(()),
     }
 }

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -45,6 +45,17 @@ pub enum SourceFragment {
     Constant(ConstantDef),
     /// A `custom_type!` registration.
     Custom(CustomTypeDef),
+    /// An invocation the per-invocation capture cannot describe yet.
+    ///
+    /// Its presence means the crate's source records are incomplete; aggregation refuses
+    /// the whole set so consumers fall back to the legacy path instead of shipping a
+    /// silently partial contract.
+    Unsupported {
+        /// Item name at the invocation site.
+        name: String,
+        /// Why the capture could not describe the item.
+        reason: String,
+    },
 }
 
 /// One resolved type node from a slot descriptor.
@@ -85,6 +96,13 @@ pub fn aggregate_records(
                 module: record.module.clone(),
                 message: error.to_string(),
             })?;
+        if let SourceFragment::Unsupported { name, reason } = &fragment {
+            return Err(SourceFragmentError::UnsupportedCapture {
+                module: record.module.clone(),
+                name: name.clone(),
+                reason: reason.clone(),
+            });
+        }
         let slots = record
             .slots
             .iter()
@@ -136,6 +154,7 @@ pub fn aggregate_records(
             SourceFragment::Stream(def) => contract.streams.push(def),
             SourceFragment::Constant(def) => contract.constants.push(def),
             SourceFragment::Custom(def) => contract.customs.push(def),
+            SourceFragment::Unsupported { .. } => {}
         }
     }
 
@@ -167,7 +186,8 @@ fn declared_kind(fragment: &SourceFragment) -> Option<DeclaredKind> {
         SourceFragment::Function(_)
         | SourceFragment::Trait(_)
         | SourceFragment::Stream(_)
-        | SourceFragment::Constant(_) => None,
+        | SourceFragment::Constant(_)
+        | SourceFragment::Unsupported { .. } => None,
     }
 }
 
@@ -181,6 +201,7 @@ fn fragment_id(fragment: &SourceFragment) -> &str {
         SourceFragment::Stream(def) => def.id.as_str(),
         SourceFragment::Constant(def) => def.id.as_str(),
         SourceFragment::Custom(def) => def.id.as_str(),
+        SourceFragment::Unsupported { name, .. } => name,
     }
 }
 
@@ -236,7 +257,7 @@ fn mint_self_ids(fragment: &mut SourceFragment, module: &str) {
                 def.id = ConstantId::new(value);
             }
         }
-        SourceFragment::Custom(_) => {}
+        SourceFragment::Custom(_) | SourceFragment::Unsupported { .. } => {}
     }
 }
 
@@ -281,6 +302,7 @@ fn resolve_fragment(
         SourceFragment::Stream(def) => resolve(&mut def.item_type),
         SourceFragment::Constant(def) => resolve(&mut def.type_expr),
         SourceFragment::Custom(def) => resolve(&mut def.repr),
+        SourceFragment::Unsupported { .. } => Ok(()),
     }
 }
 
@@ -550,6 +572,15 @@ pub enum SourceFragmentError {
         /// The conflicting canonical id.
         id: String,
     },
+    /// A record marks an invocation the capture cannot describe yet.
+    UnsupportedCapture {
+        /// Module path of the emitting invocation.
+        module: String,
+        /// Item name at the invocation site.
+        name: String,
+        /// Why the capture could not describe the item.
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for SourceFragmentError {
@@ -593,6 +624,14 @@ impl std::fmt::Display for SourceFragmentError {
             Self::DuplicateDeclaration { id } => write!(
                 formatter,
                 "two records declare `{id}` with different content"
+            ),
+            Self::UnsupportedCapture {
+                module,
+                name,
+                reason,
+            } => write!(
+                formatter,
+                "`{name}` in `{module}` is not captured per-invocation yet: {reason}"
             ),
         }
     }
@@ -776,6 +815,28 @@ mod tests {
             .expect_err("identical fragments with differing slots fail");
         assert!(
             matches!(error, SourceFragmentError::DuplicateDeclaration { id } if id == "demo::Route")
+        );
+    }
+
+    #[test]
+    fn refuses_a_set_with_an_unsupported_capture() {
+        let unsupported = raw(
+            "demo",
+            &[],
+            serde_json::to_vec(&SourceFragment::Unsupported {
+                name: "Listener".to_owned(),
+                reason: "callback traits are not captured yet".to_owned(),
+            })
+            .expect("fragment serializes"),
+        );
+
+        let error = aggregate_records(
+            &[point_record(), unsupported],
+            PackageInfo::new("demo", None),
+        )
+        .expect_err("incomplete capture refuses the whole set");
+        assert!(
+            matches!(error, SourceFragmentError::UnsupportedCapture { name, .. } if name == "Listener")
         );
     }
 

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -27,7 +27,7 @@ pub const SLOT_ID_PREFIX: &str = "$slot:";
 
 /// One declaration captured by one macro invocation.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum SourceFragment {
     /// A `#[data]` struct.
     Record(RecordDef),

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -179,16 +179,16 @@ pub fn aggregate_records(
             SourceFragment::Custom(def) => contract.customs.push(def),
             SourceFragment::Methods {
                 target,
+                spelling,
                 methods,
                 constants,
-                ..
-            } => method_blocks.push((target, methods, constants)),
+            } => method_blocks.push((target, spelling, methods, constants)),
             SourceFragment::InternedStringPool { .. } | SourceFragment::Unsupported { .. } => {}
         }
     }
 
-    for (target, methods, constants) in method_blocks {
-        merge_methods(&mut contract, target, methods, constants)?;
+    for (target, spelling, methods, constants) in method_blocks {
+        merge_methods(&mut contract, target, &spelling, methods, constants)?;
     }
 
     contract.records.sort_by(|a, b| a.id.cmp(&b.id));
@@ -205,6 +205,7 @@ pub fn aggregate_records(
 fn merge_methods(
     contract: &mut SourceContract,
     target: TypeExpr,
+    spelling: &str,
     methods: Vec<MethodDef>,
     constants: Vec<ConstantDef>,
 ) -> Result<(), SourceFragmentError> {
@@ -228,8 +229,8 @@ fn merge_methods(
                 .map(|declared| &mut declared.methods),
         ),
         _ => {
-            return Err(SourceFragmentError::UnresolvedReference {
-                id: "a methods block targets a non-data declaration".to_owned(),
+            return Err(SourceFragmentError::MethodsTargetNotData {
+                spelling: spelling.to_owned(),
             });
         }
     };
@@ -773,6 +774,11 @@ pub enum SourceFragmentError {
         /// Actual argument count.
         actual: usize,
     },
+    /// A methods block targets a declaration that is not a record or enum.
+    MethodsTargetNotData {
+        /// The impl target's written spelling.
+        spelling: String,
+    },
     /// Two records declare the same id with different content.
     DuplicateDeclaration {
         /// The conflicting canonical id.
@@ -826,6 +832,10 @@ impl std::fmt::Display for SourceFragmentError {
             } => write!(
                 formatter,
                 "slot shape `{shape}` expects {expected} arguments, found {actual}"
+            ),
+            Self::MethodsTargetNotData { spelling } => write!(
+                formatter,
+                "a methods block targets `{spelling}`, which is not a data record or enum"
             ),
             Self::DuplicateDeclaration { id } => write!(
                 formatter,

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -45,6 +45,13 @@ pub enum SourceFragment {
     Constant(ConstantDef),
     /// A `custom_type!` registration.
     Custom(CustomTypeDef),
+    /// An `interned_string_pool!` declaration; its values inline at every use site.
+    InternedStringPool {
+        /// Canonical pool id, written `$self::Name` until minting.
+        id: String,
+        /// Static values addressable by wire id, in declaration order.
+        values: Vec<String>,
+    },
     /// A `#[data(impl)]` methods block, merged into its target declaration.
     Methods {
         /// The impl target, as a slot-deferred reference until resolution.
@@ -128,7 +135,7 @@ pub fn aggregate_records(
         fragments.push((fragment, slots, record.module.clone()));
     }
 
-    let mut kinds = HashMap::new();
+    let mut declared = Declared::default();
     let mut unique: HashMap<String, (&SourceFragment, &[TypeNode])> = HashMap::new();
     for (fragment, slots, module) in &fragments {
         let id = fragment_id(fragment, module);
@@ -142,7 +149,10 @@ pub fn aggregate_records(
             }
         }
         if let Some(kind) = declared_kind(fragment) {
-            kinds.insert(id, kind);
+            declared.kinds.insert(id, kind);
+        }
+        if let SourceFragment::InternedStringPool { id, values } = fragment {
+            declared.pools.insert(id.clone(), values.clone());
         }
     }
 
@@ -154,7 +164,7 @@ pub fn aggregate_records(
         if seen.insert(id, ()).is_some() {
             continue;
         }
-        resolve_fragment(&mut fragment, &slots, &kinds)?;
+        resolve_fragment(&mut fragment, &slots, &declared)?;
         match fragment {
             SourceFragment::Record(def) => contract.records.push(def),
             SourceFragment::Enum(def) => contract.enums.push(def),
@@ -167,7 +177,7 @@ pub fn aggregate_records(
             SourceFragment::Methods {
                 target, methods, ..
             } => method_blocks.push((target, methods)),
-            SourceFragment::Unsupported { .. } => {}
+            SourceFragment::InternedStringPool { .. } | SourceFragment::Unsupported { .. } => {}
         }
     }
 
@@ -236,6 +246,12 @@ enum DeclaredKind {
     Custom,
 }
 
+#[derive(Debug, Default)]
+struct Declared {
+    kinds: HashMap<String, DeclaredKind>,
+    pools: HashMap<String, Vec<String>>,
+}
+
 fn declared_kind(fragment: &SourceFragment) -> Option<DeclaredKind> {
     match fragment {
         SourceFragment::Record(_) => Some(DeclaredKind::Record),
@@ -246,6 +262,7 @@ fn declared_kind(fragment: &SourceFragment) -> Option<DeclaredKind> {
         | SourceFragment::Trait(_)
         | SourceFragment::Stream(_)
         | SourceFragment::Constant(_)
+        | SourceFragment::InternedStringPool { .. }
         | SourceFragment::Methods { .. }
         | SourceFragment::Unsupported { .. } => None,
     }
@@ -261,6 +278,7 @@ fn fragment_id(fragment: &SourceFragment, module: &str) -> String {
         SourceFragment::Stream(def) => def.id.as_str().to_owned(),
         SourceFragment::Constant(def) => def.id.as_str().to_owned(),
         SourceFragment::Custom(def) => def.id.as_str().to_owned(),
+        SourceFragment::InternedStringPool { id, .. } => id.clone(),
         SourceFragment::Methods {
             spelling, methods, ..
         } => {
@@ -334,6 +352,11 @@ fn mint_self_ids(fragment: &mut SourceFragment, module: &str) {
             mint_converter_module(&mut def.converters.into_ffi, module);
             mint_converter_module(&mut def.converters.try_from_ffi, module);
         }
+        SourceFragment::InternedStringPool { id, .. } => {
+            if let Some(value) = minted(id, module) {
+                *id = value;
+            }
+        }
         SourceFragment::Methods { .. } | SourceFragment::Unsupported { .. } => {}
     }
 }
@@ -366,9 +389,9 @@ fn mint_methods(methods: &mut [MethodDef], prefix: &str) {
 fn resolve_fragment(
     fragment: &mut SourceFragment,
     slots: &[TypeNode],
-    kinds: &HashMap<String, DeclaredKind>,
+    declared: &Declared,
 ) -> Result<(), SourceFragmentError> {
-    let mut resolve = |expr: &mut TypeExpr| resolve_expr(expr, slots, kinds);
+    let mut resolve = |expr: &mut TypeExpr| resolve_expr(expr, slots, declared);
     match fragment {
         SourceFragment::Record(def) => {
             resolve_fields(&mut def.fields, &mut resolve)?;
@@ -396,6 +419,7 @@ fn resolve_fragment(
         SourceFragment::Stream(def) => resolve(&mut def.item_type),
         SourceFragment::Constant(def) => resolve(&mut def.type_expr),
         SourceFragment::Custom(def) => resolve(&mut def.repr),
+        SourceFragment::InternedStringPool { .. } => Ok(()),
         SourceFragment::Methods {
             target, methods, ..
         } => {
@@ -443,21 +467,33 @@ fn resolve_callable(
 fn resolve_expr(
     expr: &mut TypeExpr,
     slots: &[TypeNode],
-    kinds: &HashMap<String, DeclaredKind>,
+    declared: &Declared,
 ) -> Result<(), SourceFragmentError> {
     if let TypeExpr::Record { id, path } = expr
         && let Some(index) = id.as_str().strip_prefix(SLOT_ID_PREFIX)
     {
-        let index: usize = index
-            .parse()
-            .map_err(|_| SourceFragmentError::UnknownSlot {
-                slot: index.to_owned(),
-            })?;
-        let node = slots.get(index).ok_or(SourceFragmentError::MissingSlot {
-            index,
-            available: slots.len(),
-        })?;
-        *expr = node_expr(node, Some(path.clone()), kinds)?;
+        let node = slot_node(index, slots)?;
+        *expr = node_expr(node, Some(path.clone()), &declared.kinds)?;
+        return Ok(());
+    }
+    if let TypeExpr::InternedString {
+        pool_id,
+        static_values,
+        ..
+    } = expr
+        && let Some(index) = pool_id.strip_prefix(SLOT_ID_PREFIX)
+    {
+        let TypeNode::Id { id } = slot_node(index, slots)? else {
+            return Err(SourceFragmentError::UnresolvedReference {
+                id: pool_id.clone(),
+            });
+        };
+        let values = declared
+            .pools
+            .get(id)
+            .ok_or_else(|| SourceFragmentError::UnresolvedReference { id: id.clone() })?;
+        *pool_id = id.clone();
+        *static_values = values.clone();
         return Ok(());
     }
 
@@ -466,25 +502,25 @@ fn resolve_expr(
         | TypeExpr::Arc(inner)
         | TypeExpr::Vec(inner)
         | TypeExpr::Slice(inner)
-        | TypeExpr::Option(inner) => resolve_expr(inner, slots, kinds),
+        | TypeExpr::Option(inner) => resolve_expr(inner, slots, declared),
         TypeExpr::Result { ok, err } => {
-            resolve_expr(ok, slots, kinds)?;
-            resolve_expr(err, slots, kinds)
+            resolve_expr(ok, slots, declared)?;
+            resolve_expr(err, slots, declared)
         }
         TypeExpr::Map { key, value, .. } => {
-            resolve_expr(key, slots, kinds)?;
-            resolve_expr(value, slots, kinds)
+            resolve_expr(key, slots, declared)?;
+            resolve_expr(value, slots, declared)
         }
         TypeExpr::Tuple(elements) => {
             for element in elements {
-                resolve_expr(element, slots, kinds)?;
+                resolve_expr(element, slots, declared)?;
             }
             Ok(())
         }
-        TypeExpr::FnPtr(signature) => resolve_fn_sig(signature, slots, kinds),
+        TypeExpr::FnPtr(signature) => resolve_fn_sig(signature, slots, declared),
         TypeExpr::Dyn(bounds) | TypeExpr::ImplTrait(bounds) => {
             if let boltffi_ast::BaseTrait::Function(function_trait) = &mut bounds.base {
-                resolve_fn_sig(&mut function_trait.signature, slots, kinds)?;
+                resolve_fn_sig(&mut function_trait.signature, slots, declared)?;
             }
             Ok(())
         }
@@ -492,16 +528,31 @@ fn resolve_expr(
     }
 }
 
+fn slot_node<'slots>(
+    index: &str,
+    slots: &'slots [TypeNode],
+) -> Result<&'slots TypeNode, SourceFragmentError> {
+    let index: usize = index
+        .parse()
+        .map_err(|_| SourceFragmentError::UnknownSlot {
+            slot: index.to_owned(),
+        })?;
+    slots.get(index).ok_or(SourceFragmentError::MissingSlot {
+        index,
+        available: slots.len(),
+    })
+}
+
 fn resolve_fn_sig(
     signature: &mut boltffi_ast::FnSig,
     slots: &[TypeNode],
-    kinds: &HashMap<String, DeclaredKind>,
+    declared: &Declared,
 ) -> Result<(), SourceFragmentError> {
     for parameter in &mut signature.parameters {
-        resolve_expr(parameter, slots, kinds)?;
+        resolve_expr(parameter, slots, declared)?;
     }
     if let ReturnDef::Value(expr) = &mut signature.returns {
-        resolve_expr(expr, slots, kinds)?;
+        resolve_expr(expr, slots, declared)?;
     }
     Ok(())
 }
@@ -903,6 +954,54 @@ mod tests {
             ),
             "the item type resolves through its slot"
         );
+    }
+
+    #[test]
+    fn inlines_interned_string_pool_values_at_use_sites() {
+        let pool = raw(
+            "demo::pools",
+            &[],
+            serde_json::to_vec(&SourceFragment::InternedStringPool {
+                id: format!("{SELF_ID}::Browser"),
+                values: vec!["Chrome".to_owned(), "Firefox".to_owned()],
+            })
+            .expect("fragment serializes"),
+        );
+        let holder = raw(
+            "demo",
+            &[r#"{"id":"demo::pools::Browser"}"#],
+            record_fragment(vec![FieldDef::new(
+                name("browser"),
+                TypeExpr::interned_string(
+                    Path::single("InternedString"),
+                    format!("{SLOT_ID_PREFIX}0"),
+                    Path::single("Browser"),
+                    Vec::new(),
+                ),
+            )]),
+        );
+
+        let contract = aggregate_records(&[holder, pool], PackageInfo::new("demo", None))
+            .expect("records aggregate");
+
+        match &contract.records[0].fields[0].type_expr {
+            TypeExpr::InternedString {
+                pool_id,
+                static_values,
+                ..
+            } => {
+                assert_eq!(
+                    pool_id, "demo::pools::Browser",
+                    "the pool reference resolves through its slot"
+                );
+                assert_eq!(
+                    static_values,
+                    &["Chrome".to_owned(), "Firefox".to_owned()],
+                    "the declaring fragment's values inline at the use site"
+                );
+            }
+            other => panic!("interned string did not resolve: {other:?}"),
+        }
     }
 
     #[test]

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -218,10 +218,10 @@ fn merge_methods(
         return Err(SourceFragmentError::UnresolvedReference { id: target_id });
     };
     for mut method in methods {
-        if let Some(rest) = method.id.as_str().strip_prefix(SLOT_ID_PREFIX) {
-            if let Some((_, tail)) = rest.split_once("::") {
-                method.id = boltffi_ast::MethodId::new(format!("{target_id}::{tail}"));
-            }
+        if let Some(rest) = method.id.as_str().strip_prefix(SLOT_ID_PREFIX)
+            && let Some((_, tail)) = rest.split_once("::")
+        {
+            method.id = boltffi_ast::MethodId::new(format!("{target_id}::{tail}"));
         }
         target_methods.push(method);
     }

--- a/boltffi_core/src/lib.rs
+++ b/boltffi_core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod wire;
 
 pub use boltffi_macros::{
     Data, FfiType, custom_ffi, custom_type, data, default, error, export, ffi_export, ffi_stream,
-    ffi_trait, name, skip,
+    ffi_trait, name, scaffolding, skip,
 };
 
 /// Defines a static interned-string pool.

--- a/boltffi_core/tests/wire_records.rs
+++ b/boltffi_core/tests/wire_records.rs
@@ -3,7 +3,10 @@ use boltffi_macros::data;
 
 extern crate self as boltffi;
 
+boltffi_macros::scaffolding!();
+
 pub mod __private {
+    pub use boltffi_core::capture;
     pub use boltffi_core::{
         EventSubscription, FfiBuf, FfiSpan, FfiStatus, Passable, RustFutureContinuationCallback,
         RustFutureHandle, StreamContinuationCallback, StreamPollResult, SubscriptionHandle,

--- a/boltffi_macros/Cargo.toml
+++ b/boltffi_macros/Cargo.toml
@@ -21,6 +21,7 @@ boltffi_ffi_rules.workspace = true
 boltffi_ast.workspace = true
 boltffi_binding.workspace = true
 boltffi_scan.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 boltffi_bindgen.workspace = true

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -11,6 +11,17 @@ use boltffi_scan::{
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
 
+/// Resolves the facade crate's path at the invocation site, honoring renames.
+fn facade() -> TokenStream {
+    match proc_macro_crate::crate_name("boltffi") {
+        Ok(proc_macro_crate::FoundCrate::Name(name)) => {
+            let name = format_ident!("{name}");
+            quote! { ::#name }
+        }
+        _ => quote! { ::boltffi },
+    }
+}
+
 /// How an impl block relates to type identity at this entry point.
 pub(crate) enum ImplCapture {
     /// `#[export] impl` declares a class; the self type gets its identity here.
@@ -97,6 +108,30 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
     }
 }
 
+pub(crate) fn interned_string_pool_tokens(item: proc_macro::TokenStream) -> TokenStream {
+    if proc_macro_crate::crate_name("boltffi").is_err() {
+        return TokenStream::new();
+    }
+    match boltffi_scan::capture_interned_string_pool(proc_macro2::TokenStream::from(item)) {
+        Ok(pool) => {
+            let ident = format_ident!("{}", pool.name);
+            let identity = local_identity_tokens(&ident, &pool.name);
+            let record = record_tokens(
+                &SourceFragment::InternedStringPool {
+                    id: format!("$self::{}", pool.name),
+                    values: pool.values,
+                },
+                &[],
+            );
+            quote! {
+                #identity
+                #record
+            }
+        }
+        Err(error) => unsupported_tokens("interned_string_pool", &error.to_string()),
+    }
+}
+
 pub(crate) fn error_item_tokens(item: proc_macro::TokenStream) -> TokenStream {
     let Ok(item) = syn::parse::<syn::Item>(item) else {
         return TokenStream::new();
@@ -151,18 +186,19 @@ pub(crate) fn scaffolding_tokens() -> TokenStream {
 fn data_tokens(ident: &syn::Ident, fragment: SourceFragment, slots: &[syn::Path]) -> TokenStream {
     let name = ident.to_string();
     let record = record_tokens(&fragment, slots);
+    let facade = facade();
     quote! {
         const _: () = {
-            impl<Tag> ::boltffi::__private::capture::TypeInfo<Tag> for #ident {
+            impl<Tag> #facade::__private::capture::TypeInfo<Tag> for #ident {
                 const MODULE: &'static str = ::core::module_path!();
                 const NAME: &'static str = #name;
             }
 
-            impl<Tag> ::boltffi::__private::capture::TypeDesc<Tag> for #ident {
-                const DESC: ::boltffi::__private::capture::DescBuf =
-                    ::boltffi::__private::capture::DescBuf::named(
-                        <#ident as ::boltffi::__private::capture::TypeInfo<Tag>>::MODULE,
-                        <#ident as ::boltffi::__private::capture::TypeInfo<Tag>>::NAME,
+            impl<Tag> #facade::__private::capture::TypeDesc<Tag> for #ident {
+                const DESC: #facade::__private::capture::DescBuf =
+                    #facade::__private::capture::DescBuf::named(
+                        <#ident as #facade::__private::capture::TypeInfo<Tag>>::MODULE,
+                        <#ident as #facade::__private::capture::TypeInfo<Tag>>::NAME,
                     );
             }
         };
@@ -175,14 +211,15 @@ fn record_tokens(fragment: &SourceFragment, slots: &[syn::Path]) -> TokenStream 
         Ok(json) => Literal::byte_string(&json),
         Err(_) => return TokenStream::new(),
     };
+    let facade = facade();
     let descs = slots
         .iter()
         .enumerate()
         .map(|(index, path)| {
             let ident = format_ident!("DESC_{index}");
             quote! {
-                const #ident: &'static ::boltffi::__private::capture::DescBuf =
-                    &<#path as ::boltffi::__private::capture::TypeDesc<crate::__BoltffiTag>>::DESC;
+                const #ident: &'static #facade::__private::capture::DescBuf =
+                    &<#path as #facade::__private::capture::TypeDesc<crate::__BoltffiTag>>::DESC;
             }
         })
         .collect::<Vec<_>>();
@@ -198,7 +235,7 @@ fn record_tokens(fragment: &SourceFragment, slots: &[syn::Path]) -> TokenStream 
             #(#descs)*
             const SLOTS: &[&str] = &[#(#desc_refs),*];
             const JSON: &[u8] = #json;
-            const LEN: usize = ::boltffi::__private::capture::record_len(
+            const LEN: usize = #facade::__private::capture::record_len(
                 ::core::env!("CARGO_PKG_NAME"),
                 ::core::env!("CARGO_PKG_VERSION"),
                 ::core::module_path!(),
@@ -214,7 +251,7 @@ fn record_tokens(fragment: &SourceFragment, slots: &[syn::Path]) -> TokenStream 
                 unsafe(link_section = ".boltffisrc")
             )]
             #[used]
-            static RECORD: [u8; LEN] = ::boltffi::__private::capture::record(
+            static RECORD: [u8; LEN] = #facade::__private::capture::record(
                 ::core::env!("CARGO_PKG_NAME"),
                 ::core::env!("CARGO_PKG_VERSION"),
                 ::core::module_path!(),
@@ -255,16 +292,17 @@ pub(crate) fn custom_type_tokens(item: proc_macro::TokenStream) -> TokenStream {
         Ok(captured) => record_tokens(&SourceFragment::Custom(captured.def), &captured.slots),
         Err(error) => unsupported_tokens(&name, &error.to_string()),
     };
+    let facade = facade();
     quote! {
         const _: () = {
-            impl ::boltffi::__private::capture::TypeInfo<crate::__BoltffiTag> for #remote {
+            impl #facade::__private::capture::TypeInfo<crate::__BoltffiTag> for #remote {
                 const MODULE: &'static str = ::core::module_path!();
                 const NAME: &'static str = #name;
             }
 
-            impl ::boltffi::__private::capture::TypeDesc<crate::__BoltffiTag> for #remote {
-                const DESC: ::boltffi::__private::capture::DescBuf =
-                    ::boltffi::__private::capture::DescBuf::named(
+            impl #facade::__private::capture::TypeDesc<crate::__BoltffiTag> for #remote {
+                const DESC: #facade::__private::capture::DescBuf =
+                    #facade::__private::capture::DescBuf::named(
                         ::core::module_path!(),
                         #name,
                     );
@@ -275,18 +313,19 @@ pub(crate) fn custom_type_tokens(item: proc_macro::TokenStream) -> TokenStream {
 }
 
 fn local_identity_tokens<T: quote::ToTokens>(self_ty: &T, name: &str) -> TokenStream {
+    let facade = facade();
     quote! {
         const _: () = {
-            impl<Tag> ::boltffi::__private::capture::TypeInfo<Tag> for #self_ty {
+            impl<Tag> #facade::__private::capture::TypeInfo<Tag> for #self_ty {
                 const MODULE: &'static str = ::core::module_path!();
                 const NAME: &'static str = #name;
             }
 
-            impl<Tag> ::boltffi::__private::capture::TypeDesc<Tag> for #self_ty {
-                const DESC: ::boltffi::__private::capture::DescBuf =
-                    ::boltffi::__private::capture::DescBuf::named(
-                        <#self_ty as ::boltffi::__private::capture::TypeInfo<Tag>>::MODULE,
-                        <#self_ty as ::boltffi::__private::capture::TypeInfo<Tag>>::NAME,
+            impl<Tag> #facade::__private::capture::TypeDesc<Tag> for #self_ty {
+                const DESC: #facade::__private::capture::DescBuf =
+                    #facade::__private::capture::DescBuf::named(
+                        <#self_ty as #facade::__private::capture::TypeInfo<Tag>>::MODULE,
+                        <#self_ty as #facade::__private::capture::TypeInfo<Tag>>::NAME,
                     );
             }
         };

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -231,29 +231,31 @@ pub(crate) fn custom_ffi_tokens(item: proc_macro::TokenStream) -> TokenStream {
 }
 
 pub(crate) fn custom_type_tokens(item: proc_macro::TokenStream) -> TokenStream {
-    let Ok(spec) = crate::custom::r#type::parse_spec(item) else {
-        return unsupported_tokens(
-            "custom_type!",
-            "custom types are not captured per-invocation yet",
-        );
+    let Ok(spec) = crate::custom::r#type::parse_spec(item.clone()) else {
+        return unsupported_tokens("custom_type!", "custom_type! spec did not parse");
     };
     let remote = &spec.remote;
-    let name = type_leaf_name(remote).unwrap_or_else(|| spec.name.to_string());
-    let module = type_module_spelling(remote);
-    let unsupported = unsupported_tokens(&name, "custom types are not captured per-invocation yet");
+    let name = spec.name.to_string();
+    let record = match boltffi_scan::capture_custom(proc_macro2::TokenStream::from(item)) {
+        Ok(captured) => record_tokens(&SourceFragment::Custom(captured.def), &captured.slots),
+        Err(error) => unsupported_tokens(&name, &error.to_string()),
+    };
     quote! {
         const _: () = {
             impl ::boltffi::__private::capture::TypeInfo<crate::__BoltffiTag> for #remote {
-                const MODULE: &'static str = #module;
+                const MODULE: &'static str = ::core::module_path!();
                 const NAME: &'static str = #name;
             }
 
             impl ::boltffi::__private::capture::TypeDesc<crate::__BoltffiTag> for #remote {
                 const DESC: ::boltffi::__private::capture::DescBuf =
-                    ::boltffi::__private::capture::DescBuf::named(#module, #name);
+                    ::boltffi::__private::capture::DescBuf::named(
+                        ::core::module_path!(),
+                        #name,
+                    );
             }
         };
-        #unsupported
+        #record
     }
 }
 

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -51,8 +51,6 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
         syn::Item::Impl(item) => {
             let self_ty = &*item.self_ty;
             let name = type_leaf_name(self_ty).unwrap_or_else(|| "impl".to_owned());
-            let unsupported =
-                unsupported_tokens(&name, "impl blocks are not captured per-invocation yet");
             match impl_capture {
                 ImplCapture::Class => {
                     let identity = local_identity_tokens(self_ty, &name);

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -6,7 +6,7 @@
 use boltffi_binding::SourceFragment;
 use boltffi_scan::{
     capture_class, capture_constant, capture_enum, capture_function, capture_methods,
-    capture_struct, capture_trait,
+    capture_streams, capture_struct, capture_trait,
 };
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
@@ -54,22 +54,26 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
             match impl_capture {
                 ImplCapture::Class => {
                     let identity = local_identity_tokens(self_ty, &name);
-                    let record = if has_stream_methods(item) {
-                        unsupported_tokens(
-                            &name,
-                            "stream methods are not captured per-invocation yet",
-                        )
-                    } else {
-                        match capture_class(item) {
-                            Ok(captured) => {
-                                record_tokens(&SourceFragment::Class(captured.def), &captured.slots)
-                            }
-                            Err(error) => unsupported_tokens(&name, &error.to_string()),
+                    let record = match capture_class(item) {
+                        Ok(captured) => {
+                            record_tokens(&SourceFragment::Class(captured.def), &captured.slots)
                         }
+                        Err(error) => unsupported_tokens(&name, &error.to_string()),
+                    };
+                    let streams = match capture_streams(item) {
+                        Ok(captured) => captured
+                            .def
+                            .into_iter()
+                            .map(|stream| {
+                                record_tokens(&SourceFragment::Stream(stream), &captured.slots)
+                            })
+                            .collect::<TokenStream>(),
+                        Err(error) => unsupported_tokens(&name, &error.to_string()),
                     };
                     quote! {
                         #identity
                         #record
+                        #streams
                     }
                 }
                 ImplCapture::Methods => match capture_methods(item) {
@@ -91,20 +95,6 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
         },
         _ => TokenStream::new(),
     }
-}
-
-fn has_stream_methods(item: &syn::ItemImpl) -> bool {
-    item.items.iter().any(|member| {
-        matches!(
-            member,
-            syn::ImplItem::Fn(function) if function.attrs.iter().any(|attr| {
-                attr.path()
-                    .segments
-                    .last()
-                    .is_some_and(|segment| segment.ident == "ffi_stream")
-            })
-        )
-    })
 }
 
 fn data_unsupported_tokens(ident: &syn::Ident, reason: &str) -> TokenStream {

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -265,21 +265,18 @@ fn record_tokens(fragment: &SourceFragment, slots: &[syn::Path]) -> TokenStream 
 
 pub(crate) fn custom_ffi_tokens(item: proc_macro::TokenStream) -> TokenStream {
     let Ok(item) = syn::parse::<syn::ItemImpl>(item) else {
-        return unsupported_tokens(
-            "custom_ffi",
-            "custom FFI impls are not captured per-invocation yet",
-        );
+        return unsupported_tokens("custom_ffi", "custom_ffi impl did not parse");
     };
     let self_ty = &*item.self_ty;
     let name = type_leaf_name(self_ty).unwrap_or_else(|| "custom_ffi".to_owned());
     let identity = local_identity_tokens(self_ty, &name);
-    let unsupported = unsupported_tokens(
-        &name,
-        "custom FFI impls are not captured per-invocation yet",
-    );
+    let record = match boltffi_scan::capture_custom_ffi(&item) {
+        Ok(captured) => record_tokens(&SourceFragment::Custom(captured.def), &captured.slots),
+        Err(error) => unsupported_tokens(&name, &error.to_string()),
+    };
     quote! {
         #identity
-        #unsupported
+        #record
     }
 }
 

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -5,8 +5,9 @@
 
 use boltffi_binding::SourceFragment;
 use boltffi_scan::{
-    capture_class, capture_constant, capture_enum, capture_error_enum, capture_error_struct,
-    capture_function, capture_methods, capture_streams, capture_struct, capture_trait,
+    capture_class, capture_class_constants, capture_constant, capture_enum, capture_error_enum,
+    capture_error_struct, capture_function, capture_methods, capture_streams, capture_struct,
+    capture_trait,
 };
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
@@ -89,10 +90,21 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
                             .collect::<TokenStream>(),
                         Err(error) => unsupported_tokens(&name, &error.to_string()),
                     };
+                    let constants = match capture_class_constants(item) {
+                        Ok(captured) => captured
+                            .def
+                            .into_iter()
+                            .map(|constant| {
+                                record_tokens(&SourceFragment::Constant(constant), &captured.slots)
+                            })
+                            .collect::<TokenStream>(),
+                        Err(error) => unsupported_tokens(&name, &error.to_string()),
+                    };
                     quote! {
                         #identity
                         #record
                         #streams
+                        #constants
                     }
                 }
                 ImplCapture::Methods => match capture_methods(item) {
@@ -101,6 +113,7 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
                             target: captured.target,
                             spelling: captured.spelling,
                             methods: captured.methods,
+                            constants: captured.constants,
                         };
                         record_tokens(&fragment, &captured.slots)
                     }

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -273,11 +273,11 @@ fn record_tokens(fragment: &SourceFragment, slots: &[boltffi_scan::SlotSource]) 
                 JSON,
             );
             #[cfg_attr(
-                any(target_os = "macos", target_os = "ios"),
+                target_vendor = "apple",
                 unsafe(link_section = "__DATA,__boltffisrc")
             )]
             #[cfg_attr(
-                not(any(target_os = "macos", target_os = "ios")),
+                not(target_vendor = "apple"),
                 unsafe(link_section = ".boltffisrc")
             )]
             #[used]

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -5,8 +5,8 @@
 
 use boltffi_binding::SourceFragment;
 use boltffi_scan::{
-    capture_class, capture_constant, capture_enum, capture_function, capture_methods,
-    capture_streams, capture_struct, capture_trait,
+    capture_class, capture_constant, capture_enum, capture_error_enum, capture_error_struct,
+    capture_function, capture_methods, capture_streams, capture_struct, capture_trait,
 };
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
@@ -92,6 +92,31 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
         syn::Item::Const(item) => match capture_constant(item) {
             Ok(captured) => record_tokens(&SourceFragment::Constant(captured.def), &captured.slots),
             Err(error) => unsupported_tokens(&item.ident.to_string(), &error.to_string()),
+        },
+        _ => TokenStream::new(),
+    }
+}
+
+pub(crate) fn error_item_tokens(item: proc_macro::TokenStream) -> TokenStream {
+    let Ok(item) = syn::parse::<syn::Item>(item) else {
+        return TokenStream::new();
+    };
+    match &item {
+        syn::Item::Struct(item) => match capture_error_struct(item) {
+            Ok(captured) => data_tokens(
+                &item.ident,
+                SourceFragment::Record(captured.def),
+                &captured.slots,
+            ),
+            Err(error) => data_unsupported_tokens(&item.ident, &error.to_string()),
+        },
+        syn::Item::Enum(item) => match capture_error_enum(item) {
+            Ok(captured) => data_tokens(
+                &item.ident,
+                SourceFragment::Enum(captured.def),
+                &captured.slots,
+            ),
+            Err(error) => data_unsupported_tokens(&item.ident, &error.to_string()),
         },
         _ => TokenStream::new(),
     }

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -57,7 +57,14 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
             Err(error) => unsupported_tokens(&item.sig.ident.to_string(), &error.to_string()),
         },
         syn::Item::Trait(item) => match capture_trait(item) {
-            Ok(captured) => record_tokens(&SourceFragment::Trait(captured.def), &captured.slots),
+            Ok(captured) => {
+                let identity = trait_identity_tokens(item);
+                let record = record_tokens(&SourceFragment::Trait(captured.def), &captured.slots);
+                quote! {
+                    #identity
+                    #record
+                }
+            }
             Err(error) => unsupported_tokens(&item.ident.to_string(), &error.to_string()),
         },
         syn::Item::Impl(item) => {
@@ -184,7 +191,11 @@ pub(crate) fn scaffolding_tokens() -> TokenStream {
     }
 }
 
-fn data_tokens(ident: &syn::Ident, fragment: SourceFragment, slots: &[syn::Path]) -> TokenStream {
+fn data_tokens(
+    ident: &syn::Ident,
+    fragment: SourceFragment,
+    slots: &[boltffi_scan::SlotSource],
+) -> TokenStream {
     let name = ident.to_string();
     let record = record_tokens(&fragment, slots);
     let facade = facade();
@@ -207,7 +218,7 @@ fn data_tokens(ident: &syn::Ident, fragment: SourceFragment, slots: &[syn::Path]
     }
 }
 
-fn record_tokens(fragment: &SourceFragment, slots: &[syn::Path]) -> TokenStream {
+fn record_tokens(fragment: &SourceFragment, slots: &[boltffi_scan::SlotSource]) -> TokenStream {
     let json = match serde_json::to_vec(fragment) {
         Ok(json) => Literal::byte_string(&json),
         Err(_) => return TokenStream::new(),
@@ -216,11 +227,16 @@ fn record_tokens(fragment: &SourceFragment, slots: &[syn::Path]) -> TokenStream 
     let descs = slots
         .iter()
         .enumerate()
-        .map(|(index, path)| {
+        .map(|(index, source)| {
             let ident = format_ident!("DESC_{index}");
+            let desc = match source {
+                boltffi_scan::SlotSource::Type(ty) => quote! {
+                    &<#ty as #facade::__private::capture::TypeDesc<crate::__BoltffiTag>>::DESC
+                },
+                boltffi_scan::SlotSource::TraitValue(path) => quote! { &#path },
+            };
             quote! {
-                const #ident: &'static #facade::__private::capture::DescBuf =
-                    &<#path as #facade::__private::capture::TypeDesc<crate::__BoltffiTag>>::DESC;
+                const #ident: &'static #facade::__private::capture::DescBuf = #desc;
             }
         })
         .collect::<Vec<_>>();
@@ -307,6 +323,22 @@ pub(crate) fn custom_type_tokens(item: proc_macro::TokenStream) -> TokenStream {
             }
         };
         #record
+    }
+}
+
+/// A trait's descriptor lives in the value namespace under the trait's own
+/// name, so use sites reach it through the same written path as the bound —
+/// with no dyn-compatibility requirement on the trait.
+fn trait_identity_tokens(item: &syn::ItemTrait) -> TokenStream {
+    let vis = &item.vis;
+    let ident = &item.ident;
+    let name = ident.to_string();
+    let facade = facade();
+    quote! {
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        #vis const #ident: #facade::__private::capture::DescBuf =
+            #facade::__private::capture::DescBuf::named(::core::module_path!(), #name);
     }
 }
 

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -24,8 +24,9 @@ fn facade() -> TokenStream {
 
 /// How an impl block relates to type identity at this entry point.
 pub(crate) enum ImplCapture {
-    /// `#[export] impl` declares a class; the self type gets its identity here.
-    Class,
+    /// `#[export] impl` declares a class; the self type gets its identity here. Carries
+    /// the export marker's argument tokens for the thread-safety choice.
+    Class(TokenStream),
     /// `#[data(impl)]` adds methods to a type whose identity the `#[data]` site owns.
     Methods,
 }
@@ -63,9 +64,9 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
             let self_ty = &*item.self_ty;
             let name = type_leaf_name(self_ty).unwrap_or_else(|| "impl".to_owned());
             match impl_capture {
-                ImplCapture::Class => {
+                ImplCapture::Class(marker_args) => {
                     let identity = local_identity_tokens(self_ty, &name);
-                    let record = match capture_class(item) {
+                    let record = match capture_class(item, marker_args) {
                         Ok(captured) => {
                             record_tokens(&SourceFragment::Class(captured.def), &captured.slots)
                         }

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -288,16 +288,3 @@ fn type_leaf_name(ty: &syn::Type) -> Option<String> {
         _ => None,
     }
 }
-
-fn type_module_spelling(ty: &syn::Type) -> String {
-    let syn::Type::Path(path) = ty else {
-        return String::new();
-    };
-    let segments = path
-        .path
-        .segments
-        .iter()
-        .map(|segment| segment.ident.to_string())
-        .collect::<Vec<_>>();
-    segments[..segments.len().saturating_sub(1)].join("::")
-}

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -5,7 +5,8 @@
 
 use boltffi_binding::SourceFragment;
 use boltffi_scan::{
-    capture_class, capture_constant, capture_enum, capture_function, capture_struct, capture_trait,
+    capture_class, capture_constant, capture_enum, capture_function, capture_methods,
+    capture_struct, capture_trait,
 };
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
@@ -73,7 +74,17 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
                         #record
                     }
                 }
-                ImplCapture::Methods => unsupported,
+                ImplCapture::Methods => match capture_methods(item) {
+                    Ok(captured) => {
+                        let fragment = SourceFragment::Methods {
+                            target: captured.target,
+                            spelling: captured.spelling,
+                            methods: captured.methods,
+                        };
+                        record_tokens(&fragment, &captured.slots)
+                    }
+                    Err(error) => unsupported_tokens(&name, &error.to_string()),
+                },
             }
         }
         syn::Item::Const(item) => match capture_constant(item) {

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -1,0 +1,263 @@
+//! Per-invocation capture: every `#[data]`/`#[export]` expansion appends its own source
+//! record, so binding discovery reads what the compiler compiled instead of re-scanning
+//! source. Invocations the capture cannot describe yet emit an unsupported marker, which
+//! makes bindgen fall back to the legacy path rather than ship a partial contract.
+
+use boltffi_binding::SourceFragment;
+use boltffi_scan::{capture_enum, capture_function, capture_struct};
+use proc_macro2::{Literal, TokenStream};
+use quote::{format_ident, quote};
+
+/// How an impl block relates to type identity at this entry point.
+pub(crate) enum ImplCapture {
+    /// `#[export] impl` declares a class; the self type gets its identity here.
+    Class,
+    /// `#[data(impl)]` adds methods to a type whose identity the `#[data]` site owns.
+    Methods,
+}
+
+pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCapture) -> TokenStream {
+    let Ok(item) = syn::parse::<syn::Item>(item) else {
+        return TokenStream::new();
+    };
+    match &item {
+        syn::Item::Struct(item) => match capture_struct(item) {
+            Ok(captured) => data_tokens(
+                &item.ident,
+                SourceFragment::Record(captured.def),
+                &captured.slots,
+            ),
+            Err(error) => data_unsupported_tokens(&item.ident, &error.to_string()),
+        },
+        syn::Item::Enum(item) => match capture_enum(item) {
+            Ok(captured) => data_tokens(
+                &item.ident,
+                SourceFragment::Enum(captured.def),
+                &captured.slots,
+            ),
+            Err(error) => data_unsupported_tokens(&item.ident, &error.to_string()),
+        },
+        syn::Item::Fn(item) => match capture_function(item) {
+            Ok(captured) => record_tokens(&SourceFragment::Function(captured.def), &captured.slots),
+            Err(error) => unsupported_tokens(&item.sig.ident.to_string(), &error.to_string()),
+        },
+        syn::Item::Trait(item) => unsupported_tokens(
+            &item.ident.to_string(),
+            "callback traits are not captured per-invocation yet",
+        ),
+        syn::Item::Impl(item) => {
+            let self_ty = &*item.self_ty;
+            let name = type_leaf_name(self_ty).unwrap_or_else(|| "impl".to_owned());
+            let unsupported =
+                unsupported_tokens(&name, "impl blocks are not captured per-invocation yet");
+            match impl_capture {
+                ImplCapture::Class => {
+                    let identity = local_identity_tokens(self_ty, &name);
+                    quote! {
+                        #identity
+                        #unsupported
+                    }
+                }
+                ImplCapture::Methods => unsupported,
+            }
+        }
+        syn::Item::Const(item) => unsupported_tokens(
+            &item.ident.to_string(),
+            "constant exports are not captured per-invocation yet",
+        ),
+        _ => TokenStream::new(),
+    }
+}
+
+fn data_unsupported_tokens(ident: &syn::Ident, reason: &str) -> TokenStream {
+    let identity = local_identity_tokens(ident, &ident.to_string());
+    let unsupported = unsupported_tokens(&ident.to_string(), reason);
+    quote! {
+        #identity
+        #unsupported
+    }
+}
+
+pub(crate) fn unsupported_tokens(name: &str, reason: &str) -> TokenStream {
+    record_tokens(
+        &SourceFragment::Unsupported {
+            name: name.to_owned(),
+            reason: reason.to_owned(),
+        },
+        &[],
+    )
+}
+
+pub(crate) fn scaffolding_tokens() -> TokenStream {
+    quote! {
+        #[doc(hidden)]
+        pub enum __BoltffiTag {}
+    }
+}
+
+fn data_tokens(ident: &syn::Ident, fragment: SourceFragment, slots: &[syn::Path]) -> TokenStream {
+    let name = ident.to_string();
+    let record = record_tokens(&fragment, slots);
+    quote! {
+        const _: () = {
+            impl<Tag> ::boltffi::__private::capture::TypeInfo<Tag> for #ident {
+                const MODULE: &'static str = ::core::module_path!();
+                const NAME: &'static str = #name;
+            }
+
+            impl<Tag> ::boltffi::__private::capture::TypeDesc<Tag> for #ident {
+                const DESC: ::boltffi::__private::capture::DescBuf =
+                    ::boltffi::__private::capture::DescBuf::named(
+                        <#ident as ::boltffi::__private::capture::TypeInfo<Tag>>::MODULE,
+                        <#ident as ::boltffi::__private::capture::TypeInfo<Tag>>::NAME,
+                    );
+            }
+        };
+        #record
+    }
+}
+
+fn record_tokens(fragment: &SourceFragment, slots: &[syn::Path]) -> TokenStream {
+    let json = match serde_json::to_vec(fragment) {
+        Ok(json) => Literal::byte_string(&json),
+        Err(_) => return TokenStream::new(),
+    };
+    let descs = slots
+        .iter()
+        .enumerate()
+        .map(|(index, path)| {
+            let ident = format_ident!("DESC_{index}");
+            quote! {
+                const #ident: &'static ::boltffi::__private::capture::DescBuf =
+                    &<#path as ::boltffi::__private::capture::TypeDesc<crate::__BoltffiTag>>::DESC;
+            }
+        })
+        .collect::<Vec<_>>();
+    let desc_refs = (0..slots.len())
+        .map(|index| {
+            let ident = format_ident!("DESC_{index}");
+            quote! { #ident.as_str() }
+        })
+        .collect::<Vec<_>>();
+
+    quote! {
+        const _: () = {
+            #(#descs)*
+            const SLOTS: &[&str] = &[#(#desc_refs),*];
+            const JSON: &[u8] = #json;
+            const LEN: usize = ::boltffi::__private::capture::record_len(
+                ::core::env!("CARGO_PKG_NAME"),
+                ::core::env!("CARGO_PKG_VERSION"),
+                ::core::module_path!(),
+                SLOTS,
+                JSON,
+            );
+            #[cfg_attr(
+                any(target_os = "macos", target_os = "ios"),
+                unsafe(link_section = "__DATA,__boltffisrc")
+            )]
+            #[cfg_attr(
+                not(any(target_os = "macos", target_os = "ios")),
+                unsafe(link_section = ".boltffisrc")
+            )]
+            #[used]
+            static RECORD: [u8; LEN] = ::boltffi::__private::capture::record(
+                ::core::env!("CARGO_PKG_NAME"),
+                ::core::env!("CARGO_PKG_VERSION"),
+                ::core::module_path!(),
+                SLOTS,
+                JSON,
+            );
+        };
+    }
+}
+
+pub(crate) fn custom_ffi_tokens(item: proc_macro::TokenStream) -> TokenStream {
+    let Ok(item) = syn::parse::<syn::ItemImpl>(item) else {
+        return unsupported_tokens(
+            "custom_ffi",
+            "custom FFI impls are not captured per-invocation yet",
+        );
+    };
+    let self_ty = &*item.self_ty;
+    let name = type_leaf_name(self_ty).unwrap_or_else(|| "custom_ffi".to_owned());
+    let identity = local_identity_tokens(self_ty, &name);
+    let unsupported = unsupported_tokens(
+        &name,
+        "custom FFI impls are not captured per-invocation yet",
+    );
+    quote! {
+        #identity
+        #unsupported
+    }
+}
+
+pub(crate) fn custom_type_tokens(item: proc_macro::TokenStream) -> TokenStream {
+    let Ok(spec) = crate::custom::r#type::parse_spec(item) else {
+        return unsupported_tokens(
+            "custom_type!",
+            "custom types are not captured per-invocation yet",
+        );
+    };
+    let remote = &spec.remote;
+    let name = type_leaf_name(remote).unwrap_or_else(|| spec.name.to_string());
+    let module = type_module_spelling(remote);
+    let unsupported = unsupported_tokens(&name, "custom types are not captured per-invocation yet");
+    quote! {
+        const _: () = {
+            impl ::boltffi::__private::capture::TypeInfo<crate::__BoltffiTag> for #remote {
+                const MODULE: &'static str = #module;
+                const NAME: &'static str = #name;
+            }
+
+            impl ::boltffi::__private::capture::TypeDesc<crate::__BoltffiTag> for #remote {
+                const DESC: ::boltffi::__private::capture::DescBuf =
+                    ::boltffi::__private::capture::DescBuf::named(#module, #name);
+            }
+        };
+        #unsupported
+    }
+}
+
+fn local_identity_tokens<T: quote::ToTokens>(self_ty: &T, name: &str) -> TokenStream {
+    quote! {
+        const _: () = {
+            impl<Tag> ::boltffi::__private::capture::TypeInfo<Tag> for #self_ty {
+                const MODULE: &'static str = ::core::module_path!();
+                const NAME: &'static str = #name;
+            }
+
+            impl<Tag> ::boltffi::__private::capture::TypeDesc<Tag> for #self_ty {
+                const DESC: ::boltffi::__private::capture::DescBuf =
+                    ::boltffi::__private::capture::DescBuf::named(
+                        <#self_ty as ::boltffi::__private::capture::TypeInfo<Tag>>::MODULE,
+                        <#self_ty as ::boltffi::__private::capture::TypeInfo<Tag>>::NAME,
+                    );
+            }
+        };
+    }
+}
+
+fn type_leaf_name(ty: &syn::Type) -> Option<String> {
+    match ty {
+        syn::Type::Path(path) => path
+            .path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string()),
+        _ => None,
+    }
+}
+
+fn type_module_spelling(ty: &syn::Type) -> String {
+    let syn::Type::Path(path) = ty else {
+        return String::new();
+    };
+    let segments = path
+        .path
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect::<Vec<_>>();
+    segments[..segments.len().saturating_sub(1)].join("::")
+}

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -4,7 +4,9 @@
 //! makes bindgen fall back to the legacy path rather than ship a partial contract.
 
 use boltffi_binding::SourceFragment;
-use boltffi_scan::{capture_enum, capture_function, capture_struct};
+use boltffi_scan::{
+    capture_class, capture_constant, capture_enum, capture_function, capture_struct, capture_trait,
+};
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
 
@@ -41,10 +43,10 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
             Ok(captured) => record_tokens(&SourceFragment::Function(captured.def), &captured.slots),
             Err(error) => unsupported_tokens(&item.sig.ident.to_string(), &error.to_string()),
         },
-        syn::Item::Trait(item) => unsupported_tokens(
-            &item.ident.to_string(),
-            "callback traits are not captured per-invocation yet",
-        ),
+        syn::Item::Trait(item) => match capture_trait(item) {
+            Ok(captured) => record_tokens(&SourceFragment::Trait(captured.def), &captured.slots),
+            Err(error) => unsupported_tokens(&item.ident.to_string(), &error.to_string()),
+        },
         syn::Item::Impl(item) => {
             let self_ty = &*item.self_ty;
             let name = type_leaf_name(self_ty).unwrap_or_else(|| "impl".to_owned());
@@ -53,20 +55,47 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
             match impl_capture {
                 ImplCapture::Class => {
                     let identity = local_identity_tokens(self_ty, &name);
+                    let record = if has_stream_methods(item) {
+                        unsupported_tokens(
+                            &name,
+                            "stream methods are not captured per-invocation yet",
+                        )
+                    } else {
+                        match capture_class(item) {
+                            Ok(captured) => {
+                                record_tokens(&SourceFragment::Class(captured.def), &captured.slots)
+                            }
+                            Err(error) => unsupported_tokens(&name, &error.to_string()),
+                        }
+                    };
                     quote! {
                         #identity
-                        #unsupported
+                        #record
                     }
                 }
                 ImplCapture::Methods => unsupported,
             }
         }
-        syn::Item::Const(item) => unsupported_tokens(
-            &item.ident.to_string(),
-            "constant exports are not captured per-invocation yet",
-        ),
+        syn::Item::Const(item) => match capture_constant(item) {
+            Ok(captured) => record_tokens(&SourceFragment::Constant(captured.def), &captured.slots),
+            Err(error) => unsupported_tokens(&item.ident.to_string(), &error.to_string()),
+        },
         _ => TokenStream::new(),
     }
+}
+
+fn has_stream_methods(item: &syn::ItemImpl) -> bool {
+    item.items.iter().any(|member| {
+        matches!(
+            member,
+            syn::ImplItem::Fn(function) if function.attrs.iter().any(|attr| {
+                attr.path()
+                    .segments
+                    .last()
+                    .is_some_and(|segment| segment.ident == "ffi_stream")
+            })
+        )
+    })
 }
 
 fn data_unsupported_tokens(ident: &syn::Ident, reason: &str) -> TokenStream {

--- a/boltffi_macros/src/custom/type.rs
+++ b/boltffi_macros/src/custom/type.rs
@@ -3,9 +3,9 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse::Parse;
 
-struct CustomTypeSpec {
-    name: syn::Ident,
-    remote: syn::Type,
+pub(crate) struct CustomTypeSpec {
+    pub(crate) name: syn::Ident,
+    pub(crate) remote: syn::Type,
     repr: syn::Type,
     error: syn::Type,
     into_ffi: syn::Expr,
@@ -14,6 +14,10 @@ struct CustomTypeSpec {
 
 struct CustomTypeExpansion {
     spec: CustomTypeSpec,
+}
+
+pub(crate) fn parse_spec(item: TokenStream) -> syn::Result<CustomTypeSpec> {
+    syn::parse(item)
 }
 
 impl Parse for CustomTypeSpec {

--- a/boltffi_macros/src/experimental/expansion_build.rs
+++ b/boltffi_macros/src/experimental/expansion_build.rs
@@ -28,8 +28,12 @@ pub enum Item {
 
 static EMITTED: AtomicBool = AtomicBool::new(false);
 
+pub fn active() -> bool {
+    env::var_os(BINDING_EXPANSION_BUILD_ENV).is_some()
+}
+
 pub fn item() -> Item {
-    if env::var_os(BINDING_EXPANSION_BUILD_ENV).is_none() {
+    if !active() {
         return Item::Inactive;
     }
 

--- a/boltffi_macros/src/experimental/metadata_build.rs
+++ b/boltffi_macros/src/experimental/metadata_build.rs
@@ -24,8 +24,12 @@ pub enum Item {
 
 static EMITTED: AtomicBool = AtomicBool::new(false);
 
+pub fn active() -> bool {
+    env::var_os(BINDING_METADATA_BUILD_ENV).is_some()
+}
+
 pub fn item() -> Item {
-    if env::var_os(BINDING_METADATA_BUILD_ENV).is_none() {
+    if !active() {
         return Item::Inactive;
     }
 

--- a/boltffi_macros/src/lib.rs
+++ b/boltffi_macros/src/lib.rs
@@ -345,10 +345,14 @@ pub fn error(_attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_derive(Data)]
 pub fn derive_data(input: TokenStream) -> TokenStream {
     let expanded = proc_macro2::TokenStream::from(data::expansion::derive_data_impl(input));
-    let captured = capture::unsupported_tokens(
-        "derive(Data)",
-        "derived data is not captured per-invocation yet",
-    );
+    let captured = if experimental_build_active() {
+        proc_macro2::TokenStream::new()
+    } else {
+        capture::unsupported_tokens(
+            "derive(Data)",
+            "derived data is not captured per-invocation yet",
+        )
+    };
     TokenStream::from(quote! {
         #expanded
         #captured

--- a/boltffi_macros/src/lib.rs
+++ b/boltffi_macros/src/lib.rs
@@ -312,11 +312,20 @@ pub fn data(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn error(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    expand_or_experimental(
+    let captured = if experimental_build_active() {
+        proc_macro2::TokenStream::new()
+    } else {
+        capture::error_item_tokens(item.clone())
+    };
+    let expanded = proc_macro2::TokenStream::from(expand_without_capture(
         data::repr::materialize(item),
         data::expansion::data_impl,
         DependencyExpansion::Legacy,
-    )
+    ));
+    TokenStream::from(quote! {
+        #expanded
+        #captured
+    })
 }
 
 #[proc_macro_derive(Data)]

--- a/boltffi_macros/src/lib.rs
+++ b/boltffi_macros/src/lib.rs
@@ -39,7 +39,12 @@ fn expand_or_experimental(
     legacy: impl FnOnce(TokenStream) -> TokenStream,
     dependency: DependencyExpansion,
 ) -> TokenStream {
-    expand_with_capture(item, legacy, dependency, capture::ImplCapture::Class)
+    expand_with_capture(
+        item,
+        legacy,
+        dependency,
+        capture::ImplCapture::Class(proc_macro2::TokenStream::new()),
+    )
 }
 
 fn expand_with_capture(
@@ -371,10 +376,12 @@ pub fn export(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     if let Ok(item_impl) = syn::parse::<syn::ItemImpl>(item_clone.clone()) {
-        return expand_or_experimental(
+        let marker_args = proc_macro2::TokenStream::from(attr.clone());
+        return expand_with_capture(
             TokenStream::from(quote!(#item_impl)),
             |item| exports::methods::export_impl(attr, item),
             DependencyExpansion::Preserve,
+            capture::ImplCapture::Class(marker_args),
         );
     }
 

--- a/boltffi_macros/src/lib.rs
+++ b/boltffi_macros/src/lib.rs
@@ -289,7 +289,16 @@ pub fn scaffolding(item: TokenStream) -> TokenStream {
 
 #[proc_macro]
 pub fn interned_string_pool(item: TokenStream) -> TokenStream {
-    interned_string::interned_string_pool_impl(item)
+    let captured = if experimental_build_active() {
+        proc_macro2::TokenStream::new()
+    } else {
+        capture::interned_string_pool_tokens(item.clone())
+    };
+    let expanded = proc_macro2::TokenStream::from(interned_string::interned_string_pool_impl(item));
+    TokenStream::from(quote! {
+        #expanded
+        #captured
+    })
 }
 
 #[proc_macro_attribute]

--- a/boltffi_macros/src/lib.rs
+++ b/boltffi_macros/src/lib.rs
@@ -3,6 +3,7 @@ use quote::quote;
 use syn::{DeriveInput, ItemFn, parse_macro_input};
 
 mod callbacks;
+mod capture;
 mod custom;
 mod data;
 mod experimental;
@@ -34,6 +35,28 @@ pub fn derive_ffi_type(input: TokenStream) -> TokenStream {
 }
 
 fn expand_or_experimental(
+    item: TokenStream,
+    legacy: impl FnOnce(TokenStream) -> TokenStream,
+    dependency: DependencyExpansion,
+) -> TokenStream {
+    expand_with_capture(item, legacy, dependency, capture::ImplCapture::Class)
+}
+
+fn expand_with_capture(
+    item: TokenStream,
+    legacy: impl FnOnce(TokenStream) -> TokenStream,
+    dependency: DependencyExpansion,
+    impl_capture: capture::ImplCapture,
+) -> TokenStream {
+    let captured = capture::item_tokens(item.clone(), impl_capture);
+    let expanded = proc_macro2::TokenStream::from(expand_without_capture(item, legacy, dependency));
+    TokenStream::from(quote! {
+        #expanded
+        #captured
+    })
+}
+
+fn expand_without_capture(
     item: TokenStream,
     legacy: impl FnOnce(TokenStream) -> TokenStream,
     dependency: DependencyExpansion,
@@ -217,12 +240,35 @@ pub fn ffi_trait(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn custom_ffi(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    custom::ffi::custom_ffi_impl(item)
+    let captured = capture::custom_ffi_tokens(item.clone());
+    let expanded = proc_macro2::TokenStream::from(custom::ffi::custom_ffi_impl(item));
+    TokenStream::from(quote! {
+        #expanded
+        #captured
+    })
 }
 
 #[proc_macro]
 pub fn custom_type(item: TokenStream) -> TokenStream {
-    custom::r#type::custom_type_impl(item)
+    let captured = capture::custom_type_tokens(item.clone());
+    let expanded = proc_macro2::TokenStream::from(custom::r#type::custom_type_impl(item));
+    TokenStream::from(quote! {
+        #expanded
+        #captured
+    })
+}
+
+#[proc_macro]
+pub fn scaffolding(item: TokenStream) -> TokenStream {
+    if !item.is_empty() {
+        return syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "boltffi::scaffolding! takes no arguments",
+        )
+        .to_compile_error()
+        .into();
+    }
+    TokenStream::from(capture::scaffolding_tokens())
 }
 
 #[proc_macro]
@@ -234,10 +280,11 @@ pub fn interned_string_pool(item: TokenStream) -> TokenStream {
 pub fn data(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr_str = attr.to_string();
     if attr_str.trim() == "impl" {
-        return expand_or_experimental(
+        return expand_with_capture(
             item,
             data::expansion::data_impl_block,
             DependencyExpansion::Legacy,
+            capture::ImplCapture::Methods,
         );
     }
     expand_or_experimental(
@@ -258,7 +305,15 @@ pub fn error(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 #[proc_macro_derive(Data)]
 pub fn derive_data(input: TokenStream) -> TokenStream {
-    data::expansion::derive_data_impl(input)
+    let expanded = proc_macro2::TokenStream::from(data::expansion::derive_data_impl(input));
+    let captured = capture::unsupported_tokens(
+        "derive(Data)",
+        "derived data is not captured per-invocation yet",
+    );
+    TokenStream::from(quote! {
+        #expanded
+        #captured
+    })
 }
 
 #[proc_macro_attribute]

--- a/boltffi_macros/src/lib.rs
+++ b/boltffi_macros/src/lib.rs
@@ -48,7 +48,11 @@ fn expand_with_capture(
     dependency: DependencyExpansion,
     impl_capture: capture::ImplCapture,
 ) -> TokenStream {
-    let captured = capture::item_tokens(item.clone(), impl_capture);
+    let captured = if experimental_build_active() {
+        proc_macro2::TokenStream::new()
+    } else {
+        capture::item_tokens(item.clone(), impl_capture)
+    };
     let expanded = proc_macro2::TokenStream::from(expand_without_capture(item, legacy, dependency));
     TokenStream::from(quote! {
         #expanded
@@ -96,6 +100,10 @@ fn expand_without_capture(
         }
         experimental::metadata_build::Item::Error(tokens) => TokenStream::from(tokens),
     }
+}
+
+fn experimental_build_active() -> bool {
+    experimental::expansion_build::active() || experimental::metadata_build::active()
 }
 
 enum DependencyExpansion {
@@ -240,7 +248,11 @@ pub fn ffi_trait(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn custom_ffi(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let captured = capture::custom_ffi_tokens(item.clone());
+    let captured = if experimental_build_active() {
+        proc_macro2::TokenStream::new()
+    } else {
+        capture::custom_ffi_tokens(item.clone())
+    };
     let expanded = proc_macro2::TokenStream::from(custom::ffi::custom_ffi_impl(item));
     TokenStream::from(quote! {
         #expanded
@@ -250,7 +262,11 @@ pub fn custom_ffi(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 #[proc_macro]
 pub fn custom_type(item: TokenStream) -> TokenStream {
-    let captured = capture::custom_type_tokens(item.clone());
+    let captured = if experimental_build_active() {
+        proc_macro2::TokenStream::new()
+    } else {
+        capture::custom_type_tokens(item.clone())
+    };
     let expanded = proc_macro2::TokenStream::from(custom::r#type::custom_type_impl(item));
     TokenStream::from(quote! {
         #expanded

--- a/boltffi_macros/tests/fixtures/core_only_interned_string_pool/Cargo.lock
+++ b/boltffi_macros/tests/fixtures/core_only_interned_string_pool/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn",
 ]
 
@@ -413,9 +414,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -454,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -499,9 +500,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -588,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -680,6 +681,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2f034a4bebf216c9e4b7083603e024cf930873fd67830cfb083c9fa33129d9"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/boltffi_macros/tests/fixtures/renamed_core_only_interned_string_pool/Cargo.lock
+++ b/boltffi_macros/tests/fixtures/renamed_core_only_interned_string_pool/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn",
 ]
 
@@ -413,9 +414,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -454,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -499,9 +500,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -588,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -680,6 +681,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2f034a4bebf216c9e4b7083603e024cf930873fd67830cfb083c9fa33129d9"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/boltffi_macros/tests/fixtures/renamed_interned_string_pool/Cargo.lock
+++ b/boltffi_macros/tests/fixtures/renamed_interned_string_pool/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn",
 ]
 
@@ -421,9 +422,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -462,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -507,9 +508,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -596,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -688,6 +689,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2f034a4bebf216c9e4b7083603e024cf930873fd67830cfb083c9fa33129d9"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/boltffi_scan/src/capture.rs
+++ b/boltffi_scan/src/capture.rs
@@ -1,0 +1,174 @@
+//! Scans one macro invocation's item without whole-crate knowledge.
+//!
+//! Ids come out as `$self::Name` placeholders and every named type reference becomes a
+//! `$slot:N` leaf paired with the written path in [`CapturedItem::slots`], for the macro
+//! to project through the compiler at the invocation site.
+
+use boltffi_ast::{EnumDef, FunctionDef, RecordDef};
+
+use crate::declared_types::DeclaredTypes;
+use crate::path::{ModulePath, ModuleScope};
+use crate::{ScanError, items};
+
+/// One item scanned in deferred-resolution mode.
+pub struct CapturedItem<Def> {
+    /// The declaration with placeholder ids and slot leaves.
+    pub def: Def,
+    /// Written paths of the deferred references, in slot-index order.
+    pub slots: Vec<syn::Path>,
+}
+
+/// Captures a `#[data]` struct as a record definition.
+pub fn capture_struct(item: &syn::ItemStruct) -> Result<CapturedItem<RecordDef>, ScanError> {
+    captured(|scope, declared_types| items::record::scan_item(item, scope, declared_types))
+}
+
+/// Captures a `#[data]` enum as an enum definition.
+pub fn capture_enum(item: &syn::ItemEnum) -> Result<CapturedItem<EnumDef>, ScanError> {
+    captured(|scope, declared_types| items::enumeration::scan_item(item, scope, declared_types))
+}
+
+/// Captures an `#[export]` free function as a function definition.
+pub fn capture_function(item: &syn::ItemFn) -> Result<CapturedItem<FunctionDef>, ScanError> {
+    captured(|scope, declared_types| items::function::scan_item(item, scope, declared_types))
+}
+
+fn captured<Def>(
+    scan: impl FnOnce(&ModuleScope, &DeclaredTypes) -> Result<Def, ScanError>,
+) -> Result<CapturedItem<Def>, ScanError> {
+    let scope = ModuleScope::with_spans(ModulePath::root("$self"), &[], None);
+    let mut declared_types = DeclaredTypes::deferred();
+    let def = scan(&scope, &declared_types)?;
+    Ok(CapturedItem {
+        def,
+        slots: declared_types.take_slots(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use boltffi_ast::{ReturnDef, TypeExpr};
+    use quote::ToTokens;
+
+    use super::*;
+
+    #[test]
+    fn captures_a_struct_with_deferred_references() {
+        let item: syn::ItemStruct = syn::parse_quote! {
+            pub struct Route {
+                pub start: Point,
+                pub stops: Vec<geometry::Point>,
+                pub label: String,
+            }
+        };
+
+        let captured = capture_struct(&item).expect("struct captures");
+
+        assert_eq!(captured.def.id.as_str(), "$self::Route");
+        assert_eq!(
+            captured.slots.len(),
+            2,
+            "each distinct written path gets one slot"
+        );
+        assert_eq!(
+            captured.slots[0].to_token_stream().to_string(),
+            "Point",
+            "slots keep the written spelling"
+        );
+        assert_eq!(
+            captured.slots[1].to_token_stream().to_string(),
+            "geometry :: Point"
+        );
+        assert!(
+            matches!(
+                &captured.def.fields[0].type_expr,
+                TypeExpr::Record { id, .. } if id.as_str() == "$slot:0"
+            ),
+            "named references defer to their slot"
+        );
+        assert!(
+            matches!(
+                &captured.def.fields[1].type_expr,
+                TypeExpr::Vec(inner)
+                    if matches!(inner.as_ref(), TypeExpr::Record { id, .. } if id.as_str() == "$slot:1")
+            ),
+            "container spellings stay structural around the slot"
+        );
+        assert!(
+            matches!(&captured.def.fields[2].type_expr, TypeExpr::String),
+            "standard leaves never take a slot"
+        );
+    }
+
+    #[test]
+    fn captures_repeated_references_into_one_slot() {
+        let item: syn::ItemStruct = syn::parse_quote! {
+            pub struct Segment {
+                pub from: Point,
+                pub to: Point,
+            }
+        };
+
+        let captured = capture_struct(&item).expect("struct captures");
+
+        assert_eq!(captured.slots.len(), 1, "identical spellings share a slot");
+        assert!(
+            matches!(
+                &captured.def.fields[1].type_expr,
+                TypeExpr::Record { id, .. } if id.as_str() == "$slot:0"
+            ),
+            "the second reference reuses the first slot"
+        );
+    }
+
+    #[test]
+    fn captures_an_enum_with_payload_references() {
+        let item: syn::ItemEnum = syn::parse_quote! {
+            pub enum Shape {
+                Empty,
+                At(Point),
+            }
+        };
+
+        let captured = capture_enum(&item).expect("enum captures");
+
+        assert_eq!(captured.def.id.as_str(), "$self::Shape");
+        assert_eq!(captured.slots.len(), 1);
+    }
+
+    #[test]
+    fn captures_a_function_signature() {
+        let item: syn::ItemFn = syn::parse_quote! {
+            pub fn nearest(route: Route, count: u32) -> Option<Point> {
+                unimplemented!()
+            }
+        };
+
+        let captured = capture_function(&item).expect("function captures");
+
+        assert_eq!(captured.def.id.as_str(), "$self::nearest");
+        assert_eq!(captured.slots.len(), 2, "Route and Point defer");
+        assert!(
+            matches!(
+                &captured.def.returns,
+                ReturnDef::Value(TypeExpr::Option(inner))
+                    if matches!(inner.as_ref(), TypeExpr::Record { id, .. } if id.as_str() == "$slot:1")
+            ),
+            "the return type defers through the option"
+        );
+    }
+
+    #[test]
+    fn rejects_generics_loudly() {
+        let item: syn::ItemStruct = syn::parse_quote! {
+            pub struct Wrapper<T> {
+                pub inner: T,
+            }
+        };
+
+        assert!(
+            capture_struct(&item).is_err(),
+            "generic items stay unsupported"
+        );
+    }
+}

--- a/boltffi_scan/src/capture.rs
+++ b/boltffi_scan/src/capture.rs
@@ -13,12 +13,30 @@ use crate::declared_types::DeclaredTypes;
 use crate::path::{ModulePath, ModuleScope};
 use crate::{ScanError, items};
 
+/// One deferred reference, in the form the record emitter projects it through.
+pub enum SlotSource {
+    /// A type whose descriptor comes from its `TypeDesc` impl.
+    Type(Box<syn::Type>),
+    /// A trait bound whose descriptor is the value-namespace const the trait's
+    /// definition site emits under the trait's own name.
+    TraitValue(syn::Path),
+}
+
+impl quote::ToTokens for SlotSource {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            Self::Type(ty) => ty.to_tokens(tokens),
+            Self::TraitValue(path) => path.to_tokens(tokens),
+        }
+    }
+}
+
 /// One item scanned in deferred-resolution mode.
 pub struct CapturedItem<Def> {
     /// The declaration with placeholder ids and slot leaves.
     pub def: Def,
-    /// Written paths of the deferred references, in slot-index order.
-    pub slots: Vec<syn::Path>,
+    /// Written references, in slot-index order.
+    pub slots: Vec<SlotSource>,
 }
 
 /// Captures a `#[data]` struct as a record definition.
@@ -122,8 +140,8 @@ pub struct CapturedMethods {
     pub spelling: String,
     /// The block's methods, with ids nested under the target's slot placeholder.
     pub methods: Vec<MethodDef>,
-    /// Written paths of the deferred references, in slot-index order.
-    pub slots: Vec<syn::Path>,
+    /// Written references, in slot-index order.
+    pub slots: Vec<SlotSource>,
 }
 
 /// Captures a `#[data(impl)]` methods block against its slot-deferred target.
@@ -213,6 +231,65 @@ mod tests {
         assert!(
             matches!(&captured.def.fields[2].type_expr, TypeExpr::String),
             "standard leaves never take a slot"
+        );
+    }
+
+    #[test]
+    fn captures_trait_bounds_as_value_namespace_slots() {
+        let item: syn::ItemFn = syn::parse_quote! {
+            pub fn apply(callback: impl ValueCallback, boxed: Box<dyn ValueCallback + Send>) -> i32 {
+                0
+            }
+        };
+
+        let captured = capture_function(&item).expect("function captures");
+
+        assert_eq!(
+            captured.slots.len(),
+            1,
+            "impl and dyn references to one trait share a slot"
+        );
+        assert!(
+            matches!(&captured.slots[0], SlotSource::TraitValue(path)
+                if path.to_token_stream().to_string() == "ValueCallback"),
+            "trait slots reference the descriptor const by the written path"
+        );
+        assert!(
+            matches!(
+                &captured.def.parameters[0].type_expr,
+                TypeExpr::ImplTrait(bounds)
+                    if matches!(
+                        &bounds.base,
+                        boltffi_ast::BaseTrait::Named { id, .. } if id.as_str() == "$slot:0"
+                    )
+            ),
+            "the impl-Trait base defers to the trait slot"
+        );
+    }
+
+    #[test]
+    fn captures_generic_remote_paths_as_whole_type_slots() {
+        let item: syn::ItemFn = syn::parse_quote! {
+            pub fn width(span: Range<u32>) -> u32 {
+                0
+            }
+        };
+
+        let captured = capture_function(&item).expect("function captures");
+
+        assert_eq!(captured.slots.len(), 1);
+        assert!(
+            matches!(&captured.slots[0], SlotSource::Type(ty)
+                if ty.to_token_stream().to_string() == "Range < u32 >"),
+            "the generic path defers whole, compiler-resolved at the custom's impl"
+        );
+        assert!(
+            matches!(
+                &captured.def.parameters[0].type_expr,
+                TypeExpr::Record { id, path }
+                    if id.as_str() == "$slot:0" && path.last().is_some_and(|segment| segment.name.as_str() == "Range")
+            ),
+            "the provisional leaf carries the argument-less written path"
         );
     }
 

--- a/boltffi_scan/src/capture.rs
+++ b/boltffi_scan/src/capture.rs
@@ -5,7 +5,7 @@
 //! to project through the compiler at the invocation site.
 
 use boltffi_ast::{
-    ClassDef, ClassId, ConstantDef, ConstantOwner, CustomTypeDef, EnumDef, FunctionDef, MethodDef,
+    ClassDef, ConstantDef, ConstantOwner, CustomTypeDef, EnumDef, FunctionDef, MethodDef,
     RecordDef, RecordId, StreamDef, TraitDef, TypeExpr,
 };
 
@@ -87,10 +87,7 @@ pub fn capture_class_constants(
     item: &syn::ItemImpl,
 ) -> Result<CapturedItem<Vec<ConstantDef>>, ScanError> {
     captured(|scope, declared_types| {
-        let target = crate::impl_target::Target::class(item)?;
-        let spelling = target.spelling();
-        let leaf = spelling.rsplit("::").next().unwrap_or(spelling);
-        let owner = ConstantOwner::Class(ClassId::new(scope.path().qualified(leaf)));
+        let owner = ConstantOwner::Class(items::class::resolve_id(item, scope, declared_types)?);
         items::constant::scan_associated_in_impl(item, &owner, scope, declared_types)
     })
 }
@@ -648,6 +645,26 @@ mod tests {
         assert!(
             capture_struct(&item).is_err(),
             "generic items stay unsupported"
+        );
+    }
+
+    #[test]
+    fn rejects_qualified_class_impl_targets_loudly() {
+        let item: syn::ItemImpl = syn::parse_quote! {
+            impl crate::runtime::Engine {
+                pub const LIMIT: u32 = 4;
+
+                pub fn start(&self) {}
+            }
+        };
+
+        let Err(error) = capture_class(&item, proc_macro2::TokenStream::new()) else {
+            panic!("the invocation module cannot mint another module's class id");
+        };
+        assert!(error.to_string().contains("crate::runtime::Engine"));
+        assert!(
+            capture_class_constants(&item).is_err(),
+            "constants refuse the same target"
         );
     }
 }

--- a/boltffi_scan/src/capture.rs
+++ b/boltffi_scan/src/capture.rs
@@ -86,6 +86,25 @@ pub fn capture_custom_ffi(item: &syn::ItemImpl) -> Result<CapturedItem<CustomTyp
     })
 }
 
+/// One `interned_string_pool!` declaration, captured from its invocation tokens.
+pub struct CapturedPool {
+    /// The pool type's declared name.
+    pub name: String,
+    /// Static values addressable by wire id, in declaration order.
+    pub values: Vec<String>,
+}
+
+/// Captures an `interned_string_pool!` invocation's declaration tokens.
+pub fn capture_interned_string_pool(
+    tokens: proc_macro2::TokenStream,
+) -> Result<CapturedPool, ScanError> {
+    let spec = items::interned_string_pool::Spec::parse_tokens(tokens)?;
+    Ok(CapturedPool {
+        name: spec.name().to_string(),
+        values: spec.values().to_vec(),
+    })
+}
+
 /// Methods captured from one `#[data(impl)]` block, targeting a slot-deferred type.
 pub struct CapturedMethods {
     /// The impl target as a slot-deferred type expression.
@@ -385,6 +404,46 @@ mod tests {
 
         assert_eq!(captured.def.id.as_str(), "$self::LIMIT");
         assert!(captured.slots.is_empty());
+    }
+
+    #[test]
+    fn captures_an_interned_string_pool_declaration() {
+        let captured = capture_interned_string_pool(quote::quote! {
+            pub Browser {
+                CHROME = "Chrome",
+                FIREFOX = "Firefox",
+            }
+        })
+        .expect("pool captures");
+
+        assert_eq!(captured.name, "Browser");
+        assert_eq!(captured.values, ["Chrome", "Firefox"]);
+    }
+
+    #[test]
+    fn captures_interned_string_references_with_deferred_pools() {
+        let item: syn::ItemFn = syn::parse_quote! {
+            pub fn browser(name: InternedString<Browser>) -> u32 {
+                unimplemented!()
+            }
+        };
+
+        let captured = capture_function(&item).expect("function captures");
+
+        assert_eq!(captured.slots.len(), 1, "the pool reference takes the slot");
+        assert_eq!(
+            captured.slots[0].to_token_stream().to_string(),
+            "Browser",
+            "the slot holds the pool's written path, not InternedString"
+        );
+        assert!(
+            matches!(
+                &captured.def.parameters[0].type_expr,
+                TypeExpr::InternedString { pool_id, static_values, .. }
+                    if pool_id == "$slot:0" && static_values.is_empty()
+            ),
+            "the pool defers to its slot with values left for aggregation"
+        );
     }
 
     #[test]

--- a/boltffi_scan/src/capture.rs
+++ b/boltffi_scan/src/capture.rs
@@ -4,7 +4,9 @@
 //! `$slot:N` leaf paired with the written path in [`CapturedItem::slots`], for the macro
 //! to project through the compiler at the invocation site.
 
-use boltffi_ast::{ClassDef, ConstantDef, EnumDef, FunctionDef, RecordDef, TraitDef};
+use boltffi_ast::{
+    ClassDef, ConstantDef, EnumDef, FunctionDef, MethodDef, RecordDef, TraitDef, TypeExpr,
+};
 
 use crate::declared_types::DeclaredTypes;
 use crate::path::{ModulePath, ModuleScope};
@@ -46,6 +48,41 @@ pub fn capture_constant(item: &syn::ItemConst) -> Result<CapturedItem<ConstantDe
 /// Captures an exported callback trait as a trait definition.
 pub fn capture_trait(item: &syn::ItemTrait) -> Result<CapturedItem<TraitDef>, ScanError> {
     captured(|scope, declared_types| items::callback::scan_item(item, scope, declared_types))
+}
+
+/// Methods captured from one `#[data(impl)]` block, targeting a slot-deferred type.
+pub struct CapturedMethods {
+    /// The impl target as a slot-deferred type expression.
+    pub target: TypeExpr,
+    /// The impl target's written spelling, for stable dedup keys.
+    pub spelling: String,
+    /// The block's methods, with ids nested under the target's slot placeholder.
+    pub methods: Vec<MethodDef>,
+    /// Written paths of the deferred references, in slot-index order.
+    pub slots: Vec<syn::Path>,
+}
+
+/// Captures a `#[data(impl)]` methods block against its slot-deferred target.
+pub fn capture_methods(item: &syn::ItemImpl) -> Result<CapturedMethods, ScanError> {
+    let scope = ModuleScope::with_spans(ModulePath::root("$self"), &[], None);
+    let mut declared_types = DeclaredTypes::deferred();
+    let scanner = crate::type_expr::Scanner::new(&declared_types, &scope);
+    let target = scanner.scan(&item.self_ty)?;
+    let parent = match &target {
+        TypeExpr::Record { id, .. } => id.as_str().to_owned(),
+        _ => return Err(ScanError::unsupported_type(&item.self_ty)),
+    };
+    let methods = items::impl_methods::scan_value_methods(item, &parent, &scope, &declared_types)?;
+    let spelling = crate::spelling::path(&match &*item.self_ty {
+        syn::Type::Path(path) => path.path.clone(),
+        _ => return Err(ScanError::unsupported_type(&item.self_ty)),
+    });
+    Ok(CapturedMethods {
+        target,
+        spelling,
+        methods,
+        slots: declared_types.take_slots(),
+    })
 }
 
 fn captured<Def>(

--- a/boltffi_scan/src/capture.rs
+++ b/boltffi_scan/src/capture.rs
@@ -5,8 +5,8 @@
 //! to project through the compiler at the invocation site.
 
 use boltffi_ast::{
-    ClassDef, ConstantDef, CustomTypeDef, EnumDef, FunctionDef, MethodDef, RecordDef, StreamDef,
-    TraitDef, TypeExpr,
+    ClassDef, ClassId, ConstantDef, ConstantOwner, CustomTypeDef, EnumDef, FunctionDef, MethodDef,
+    RecordDef, RecordId, StreamDef, TraitDef, TypeExpr,
 };
 
 use crate::declared_types::DeclaredTypes;
@@ -82,6 +82,19 @@ pub fn capture_class(
     })
 }
 
+/// Captures the associated constants of an `#[export] impl` block as constant definitions.
+pub fn capture_class_constants(
+    item: &syn::ItemImpl,
+) -> Result<CapturedItem<Vec<ConstantDef>>, ScanError> {
+    captured(|scope, declared_types| {
+        let target = crate::impl_target::Target::class(item)?;
+        let spelling = target.spelling();
+        let leaf = spelling.rsplit("::").next().unwrap_or(spelling);
+        let owner = ConstantOwner::Class(ClassId::new(scope.path().qualified(leaf)));
+        items::constant::scan_associated_in_impl(item, &owner, scope, declared_types)
+    })
+}
+
 /// Captures the `#[ffi_stream]` methods of an `#[export] impl` block as stream definitions.
 pub fn capture_streams(item: &syn::ItemImpl) -> Result<CapturedItem<Vec<StreamDef>>, ScanError> {
     captured(|scope, declared_types| items::stream::scan_item(item, scope, declared_types))
@@ -140,6 +153,9 @@ pub struct CapturedMethods {
     pub spelling: String,
     /// The block's methods, with ids nested under the target's slot placeholder.
     pub methods: Vec<MethodDef>,
+    /// The block's associated constants, with ids nested under the target's slot
+    /// placeholder and a provisional owner replaced when the target resolves.
+    pub constants: Vec<ConstantDef>,
     /// Written references, in slot-index order.
     pub slots: Vec<SlotSource>,
 }
@@ -155,6 +171,9 @@ pub fn capture_methods(item: &syn::ItemImpl) -> Result<CapturedMethods, ScanErro
         _ => return Err(ScanError::unsupported_type(&item.self_ty)),
     };
     let methods = items::impl_methods::scan_value_methods(item, &parent, &scope, &declared_types)?;
+    let owner = ConstantOwner::Record(RecordId::new(parent));
+    let constants =
+        items::constant::scan_associated_in_impl(item, &owner, &scope, &declared_types)?;
     let spelling = crate::spelling::path(&match &*item.self_ty {
         syn::Type::Path(path) => path.path.clone(),
         _ => return Err(ScanError::unsupported_type(&item.self_ty)),
@@ -163,6 +182,7 @@ pub fn capture_methods(item: &syn::ItemImpl) -> Result<CapturedMethods, ScanErro
         target,
         spelling,
         methods,
+        constants,
         slots: declared_types.take_slots(),
     })
 }
@@ -501,6 +521,68 @@ mod tests {
 
         assert_eq!(captured.def.id.as_str(), "$self::Listener");
         assert_eq!(captured.def.methods.len(), 1);
+    }
+
+    #[test]
+    fn captures_associated_constants_under_the_target_placeholder() {
+        let item: syn::ItemImpl = syn::parse_quote! {
+            impl Point {
+                pub const ORIGIN: Point = Point { x: 0.0 };
+                pub const UNIT: Self = Point { x: 1.0 };
+                const PRIVATE: f64 = 0.5;
+                #[skip]
+                pub const HIDDEN: f64 = 0.25;
+
+                pub fn doubled(&self) -> Point {
+                    unimplemented!()
+                }
+            }
+        };
+
+        let captured = capture_methods(&item).expect("methods block captures");
+
+        assert_eq!(
+            captured.constants.len(),
+            2,
+            "private and skipped constants stay out"
+        );
+        assert_eq!(captured.constants[0].id.as_str(), "$slot:0::ORIGIN");
+        assert!(
+            matches!(
+                &captured.constants[0].type_expr,
+                TypeExpr::Record { id, .. } if id.as_str() == "$slot:0"
+            ),
+            "the declared type defers to the target's slot"
+        );
+        assert!(
+            matches!(&captured.constants[1].type_expr, TypeExpr::SelfType),
+            "Self stays a self type"
+        );
+    }
+
+    #[test]
+    fn captures_class_constants_with_the_class_owner() {
+        let item: syn::ItemImpl = syn::parse_quote! {
+            impl Counter {
+                pub const MAX: i32 = 9;
+
+                pub fn new() -> Self {
+                    unimplemented!()
+                }
+            }
+        };
+
+        let captured = capture_class_constants(&item).expect("class constants capture");
+
+        assert_eq!(captured.def.len(), 1);
+        assert_eq!(captured.def[0].id.as_str(), "$self::Counter::MAX");
+        assert!(
+            matches!(
+                &captured.def[0].owner,
+                Some(ConstantOwner::Class(id)) if id.as_str() == "$self::Counter"
+            ),
+            "the owner carries the class placeholder for minting"
+        );
     }
 
     #[test]

--- a/boltffi_scan/src/capture.rs
+++ b/boltffi_scan/src/capture.rs
@@ -5,8 +5,8 @@
 //! to project through the compiler at the invocation site.
 
 use boltffi_ast::{
-    ClassDef, ConstantDef, CustomTypeDef, EnumDef, FunctionDef, MethodDef, RecordDef, TraitDef,
-    TypeExpr,
+    ClassDef, ConstantDef, CustomTypeDef, EnumDef, FunctionDef, MethodDef, RecordDef, StreamDef,
+    TraitDef, TypeExpr,
 };
 
 use crate::declared_types::DeclaredTypes;
@@ -39,6 +39,11 @@ pub fn capture_function(item: &syn::ItemFn) -> Result<CapturedItem<FunctionDef>,
 /// Captures an `#[export] impl` block as a class definition.
 pub fn capture_class(item: &syn::ItemImpl) -> Result<CapturedItem<ClassDef>, ScanError> {
     captured(|scope, declared_types| items::class::scan_item(item, scope, declared_types))
+}
+
+/// Captures the `#[ffi_stream]` methods of an `#[export] impl` block as stream definitions.
+pub fn capture_streams(item: &syn::ItemImpl) -> Result<CapturedItem<Vec<StreamDef>>, ScanError> {
+    captured(|scope, declared_types| items::stream::scan_item(item, scope, declared_types))
 }
 
 /// Captures an `#[export]` constant as a constant definition.
@@ -249,6 +254,76 @@ mod tests {
             captured.def.methods[0].id.as_str(),
             "$self::Counter::new",
             "method ids nest under the class placeholder"
+        );
+    }
+
+    #[test]
+    fn captures_stream_methods_with_deferred_item_types() {
+        let item: syn::ItemImpl = syn::parse_quote! {
+            impl Engine {
+                pub fn start(&self) {}
+
+                #[ffi_stream(item = Point, mode = "batch")]
+                pub fn points(&self) -> Arc<EventSubscription<Point>> {
+                    unimplemented!()
+                }
+            }
+        };
+
+        let captured = capture_streams(&item).expect("streams capture");
+
+        assert_eq!(captured.def.len(), 1, "only stream methods produce streams");
+        assert_eq!(captured.def[0].id.as_str(), "$self::Engine::points");
+        assert_eq!(
+            captured.def[0].owner.as_ref().map(|owner| owner.as_str()),
+            Some("$self::Engine")
+        );
+        assert_eq!(captured.def[0].mode, boltffi_ast::StreamMode::Batch);
+        assert!(
+            matches!(
+                &captured.def[0].item_type,
+                TypeExpr::Record { id, .. } if id.as_str() == "$slot:0"
+            ),
+            "the item type defers to its slot"
+        );
+        assert_eq!(
+            captured.slots.len(),
+            1,
+            "the runtime wrapper types never take slots"
+        );
+    }
+
+    #[test]
+    fn captures_stream_methods_with_qualified_runtime_types() {
+        let item: syn::ItemImpl = syn::parse_quote! {
+            impl Engine {
+                #[ffi_stream(item = i32)]
+                pub fn values(&self) -> std::sync::Arc<boltffi::EventSubscription<i32>> {
+                    unimplemented!()
+                }
+            }
+        };
+
+        let captured = capture_streams(&item).expect("streams capture");
+
+        assert_eq!(captured.def.len(), 1);
+        assert!(matches!(&captured.def[0].item_type, TypeExpr::Primitive(_)));
+    }
+
+    #[test]
+    fn rejects_stream_methods_without_subscription_returns() {
+        let item: syn::ItemImpl = syn::parse_quote! {
+            impl Engine {
+                #[ffi_stream(item = i32)]
+                pub fn values(&self) -> i32 {
+                    unimplemented!()
+                }
+            }
+        };
+
+        assert!(
+            capture_streams(&item).is_err(),
+            "the subscription return shape stays required"
         );
     }
 

--- a/boltffi_scan/src/capture.rs
+++ b/boltffi_scan/src/capture.rs
@@ -31,6 +31,20 @@ pub fn capture_enum(item: &syn::ItemEnum) -> Result<CapturedItem<EnumDef>, ScanE
     captured(|scope, declared_types| items::enumeration::scan_item(item, scope, declared_types))
 }
 
+/// Captures an `#[error]` struct as a record definition carrying the error marker.
+pub fn capture_error_struct(item: &syn::ItemStruct) -> Result<CapturedItem<RecordDef>, ScanError> {
+    let mut captured = capture_struct(item)?;
+    crate::marker::Marker::Error.append_value_attrs(&mut captured.def.user_attrs);
+    Ok(captured)
+}
+
+/// Captures an `#[error]` enum as an enum definition carrying the error marker.
+pub fn capture_error_enum(item: &syn::ItemEnum) -> Result<CapturedItem<EnumDef>, ScanError> {
+    let mut captured = capture_enum(item)?;
+    crate::marker::Marker::Error.append_value_attrs(&mut captured.def.user_attrs);
+    Ok(captured)
+}
+
 /// Captures an `#[export]` free function as a function definition.
 pub fn capture_function(item: &syn::ItemFn) -> Result<CapturedItem<FunctionDef>, ScanError> {
     captured(|scope, declared_types| items::function::scan_item(item, scope, declared_types))
@@ -208,6 +222,26 @@ mod tests {
 
         assert_eq!(captured.def.id.as_str(), "$self::Shape");
         assert_eq!(captured.slots.len(), 1);
+    }
+
+    #[test]
+    fn captures_error_items_with_the_error_marker() {
+        let item: syn::ItemEnum = syn::parse_quote! {
+            pub enum MathError {
+                DivisionByZero,
+            }
+        };
+
+        let captured = capture_error_enum(&item).expect("error enum captures");
+
+        assert!(
+            captured.def.user_attrs.iter().any(|attr| {
+                attr.path
+                    .last()
+                    .is_some_and(|segment| segment.name.as_str() == "error")
+            }),
+            "the error marker rides as a user attr"
+        );
     }
 
     #[test]

--- a/boltffi_scan/src/capture.rs
+++ b/boltffi_scan/src/capture.rs
@@ -51,8 +51,17 @@ pub fn capture_function(item: &syn::ItemFn) -> Result<CapturedItem<FunctionDef>,
 }
 
 /// Captures an `#[export] impl` block as a class definition.
-pub fn capture_class(item: &syn::ItemImpl) -> Result<CapturedItem<ClassDef>, ScanError> {
-    captured(|scope, declared_types| items::class::scan_item(item, scope, declared_types))
+///
+/// The `marker_args` parameter is the export marker's argument tokens, which carry the
+/// class thread-safety choice.
+pub fn capture_class(
+    item: &syn::ItemImpl,
+    marker_args: proc_macro2::TokenStream,
+) -> Result<CapturedItem<ClassDef>, ScanError> {
+    let thread_safety = crate::marker::export_marker_from_args(marker_args)?.class_thread_safety();
+    captured(|scope, declared_types| {
+        items::class::scan_item(item, scope, declared_types, thread_safety)
+    })
 }
 
 /// Captures the `#[ffi_stream]` methods of an `#[export] impl` block as stream definitions.
@@ -299,7 +308,8 @@ mod tests {
             }
         };
 
-        let captured = capture_class(&item).expect("class impl captures");
+        let captured =
+            capture_class(&item, proc_macro2::TokenStream::new()).expect("class impl captures");
 
         assert_eq!(captured.def.id.as_str(), "$self::Counter");
         assert_eq!(captured.def.methods.len(), 2);
@@ -307,6 +317,28 @@ mod tests {
             captured.def.methods[0].id.as_str(),
             "$self::Counter::new",
             "method ids nest under the class placeholder"
+        );
+        assert_eq!(
+            captured.def.thread_safety,
+            boltffi_ast::ClassThreadSafety::default()
+        );
+    }
+
+    #[test]
+    fn captures_single_threaded_class_thread_safety() {
+        let item: syn::ItemImpl = syn::parse_quote! {
+            impl Counter {
+                pub fn bump(&mut self) {}
+            }
+        };
+
+        let captured =
+            capture_class(&item, quote::quote!(single_threaded)).expect("class impl captures");
+
+        assert_eq!(
+            captured.def.thread_safety,
+            boltffi_ast::ClassThreadSafety::UnsafeSingleThreaded,
+            "the export marker's thread-safety choice rides the fragment"
         );
     }
 

--- a/boltffi_scan/src/capture.rs
+++ b/boltffi_scan/src/capture.rs
@@ -4,7 +4,7 @@
 //! `$slot:N` leaf paired with the written path in [`CapturedItem::slots`], for the macro
 //! to project through the compiler at the invocation site.
 
-use boltffi_ast::{EnumDef, FunctionDef, RecordDef};
+use boltffi_ast::{ClassDef, ConstantDef, EnumDef, FunctionDef, RecordDef, TraitDef};
 
 use crate::declared_types::DeclaredTypes;
 use crate::path::{ModulePath, ModuleScope};
@@ -31,6 +31,21 @@ pub fn capture_enum(item: &syn::ItemEnum) -> Result<CapturedItem<EnumDef>, ScanE
 /// Captures an `#[export]` free function as a function definition.
 pub fn capture_function(item: &syn::ItemFn) -> Result<CapturedItem<FunctionDef>, ScanError> {
     captured(|scope, declared_types| items::function::scan_item(item, scope, declared_types))
+}
+
+/// Captures an `#[export] impl` block as a class definition.
+pub fn capture_class(item: &syn::ItemImpl) -> Result<CapturedItem<ClassDef>, ScanError> {
+    captured(|scope, declared_types| items::class::scan_item(item, scope, declared_types))
+}
+
+/// Captures an `#[export]` constant as a constant definition.
+pub fn capture_constant(item: &syn::ItemConst) -> Result<CapturedItem<ConstantDef>, ScanError> {
+    captured(|scope, declared_types| items::constant::scan_item(item, scope, declared_types))
+}
+
+/// Captures an exported callback trait as a trait definition.
+pub fn capture_trait(item: &syn::ItemTrait) -> Result<CapturedItem<TraitDef>, ScanError> {
+    captured(|scope, declared_types| items::callback::scan_item(item, scope, declared_types))
 }
 
 fn captured<Def>(
@@ -156,6 +171,57 @@ mod tests {
             ),
             "the return type defers through the option"
         );
+    }
+
+    #[test]
+    fn captures_a_class_impl_with_methods() {
+        let item: syn::ItemImpl = syn::parse_quote! {
+            impl Counter {
+                pub fn new(initial: i32) -> Self {
+                    unimplemented!()
+                }
+
+                pub fn add(&self, amount: i32) -> i32 {
+                    unimplemented!()
+                }
+            }
+        };
+
+        let captured = capture_class(&item).expect("class impl captures");
+
+        assert_eq!(captured.def.id.as_str(), "$self::Counter");
+        assert_eq!(captured.def.methods.len(), 2);
+        assert_eq!(
+            captured.def.methods[0].id.as_str(),
+            "$self::Counter::new",
+            "method ids nest under the class placeholder"
+        );
+    }
+
+    #[test]
+    fn captures_a_callback_trait() {
+        let item: syn::ItemTrait = syn::parse_quote! {
+            pub trait Listener {
+                fn on_event(&self, message: String);
+            }
+        };
+
+        let captured = capture_trait(&item).expect("trait captures");
+
+        assert_eq!(captured.def.id.as_str(), "$self::Listener");
+        assert_eq!(captured.def.methods.len(), 1);
+    }
+
+    #[test]
+    fn captures_a_constant() {
+        let item: syn::ItemConst = syn::parse_quote! {
+            pub const LIMIT: u32 = 42;
+        };
+
+        let captured = capture_constant(&item).expect("constant captures");
+
+        assert_eq!(captured.def.id.as_str(), "$self::LIMIT");
+        assert!(captured.slots.is_empty());
     }
 
     #[test]

--- a/boltffi_scan/src/capture.rs
+++ b/boltffi_scan/src/capture.rs
@@ -5,7 +5,8 @@
 //! to project through the compiler at the invocation site.
 
 use boltffi_ast::{
-    ClassDef, ConstantDef, EnumDef, FunctionDef, MethodDef, RecordDef, TraitDef, TypeExpr,
+    ClassDef, ConstantDef, CustomTypeDef, EnumDef, FunctionDef, MethodDef, RecordDef, TraitDef,
+    TypeExpr,
 };
 
 use crate::declared_types::DeclaredTypes;
@@ -48,6 +49,22 @@ pub fn capture_constant(item: &syn::ItemConst) -> Result<CapturedItem<ConstantDe
 /// Captures an exported callback trait as a trait definition.
 pub fn capture_trait(item: &syn::ItemTrait) -> Result<CapturedItem<TraitDef>, ScanError> {
     captured(|scope, declared_types| items::callback::scan_item(item, scope, declared_types))
+}
+
+/// Captures a `custom_type!` invocation's spec tokens as a custom type definition.
+pub fn capture_custom(
+    tokens: proc_macro2::TokenStream,
+) -> Result<CapturedItem<CustomTypeDef>, ScanError> {
+    captured(|scope, declared_types| {
+        items::custom_type::scan_macro_tokens(tokens.clone(), scope, declared_types)
+    })
+}
+
+/// Captures a `#[custom_ffi]` trait impl as a custom type definition.
+pub fn capture_custom_ffi(item: &syn::ItemImpl) -> Result<CapturedItem<CustomTypeDef>, ScanError> {
+    captured(|scope, declared_types| {
+        items::custom_type::scan_trait_impl_item(item, scope, declared_types)
+    })
 }
 
 /// Methods captured from one `#[data(impl)]` block, targeting a slot-deferred type.

--- a/boltffi_scan/src/declared_types.rs
+++ b/boltffi_scan/src/declared_types.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
 use boltffi_ast::{ClassId, CustomRemoteType, CustomTypeId, EnumId, RecordId, TraitId};
@@ -34,9 +35,50 @@ pub(super) struct DeclaredTypes {
     custom_by_remote_shape: HashMap<String, CustomRemoteShapeMatch>,
     interned_string_pools: HashMap<String, Vec<String>>,
     source_types: TypeNamespace,
+    deferred_slots: Option<RefCell<SlotTable>>,
+}
+
+/// Named type references collected while scanning in deferred-resolution mode.
+#[derive(Default)]
+struct SlotTable {
+    paths: Vec<syn::Path>,
+    by_spelling: HashMap<String, usize>,
 }
 
 impl DeclaredTypes {
+    /// Creates an empty registry that defers every named reference to a slot,
+    /// for scanning one macro invocation without whole-crate knowledge.
+    pub(super) fn deferred() -> Self {
+        Self {
+            deferred_slots: Some(RefCell::default()),
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn is_deferred(&self) -> bool {
+        self.deferred_slots.is_some()
+    }
+
+    pub(super) fn defer_slot(&self, path: &syn::Path) -> Option<usize> {
+        let slots = self.deferred_slots.as_ref()?;
+        let mut slots = slots.borrow_mut();
+        let spelling = spelling::path(path);
+        if let Some(index) = slots.by_spelling.get(&spelling) {
+            return Some(*index);
+        }
+        let index = slots.paths.len();
+        slots.paths.push(path.clone());
+        slots.by_spelling.insert(spelling, index);
+        Some(index)
+    }
+
+    pub(super) fn take_slots(&mut self) -> Vec<syn::Path> {
+        self.deferred_slots
+            .take()
+            .map(|slots| slots.into_inner().paths)
+            .unwrap_or_default()
+    }
+
     #[cfg(test)]
     pub(super) fn new() -> Self {
         Self::default()

--- a/boltffi_scan/src/declared_types.rs
+++ b/boltffi_scan/src/declared_types.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 
 use boltffi_ast::{ClassId, CustomRemoteType, CustomTypeId, EnumId, RecordId, TraitId};
 
+use crate::capture::SlotSource;
 use crate::impl_target;
 use crate::items;
 use crate::marked::MarkedItems;
@@ -41,7 +42,7 @@ pub(super) struct DeclaredTypes {
 /// Named type references collected while scanning in deferred-resolution mode.
 #[derive(Default)]
 struct SlotTable {
-    paths: Vec<syn::Path>,
+    sources: Vec<SlotSource>,
     by_spelling: HashMap<String, usize>,
 }
 
@@ -60,22 +61,42 @@ impl DeclaredTypes {
     }
 
     pub(super) fn defer_slot(&self, path: &syn::Path) -> Option<usize> {
+        self.defer_slot_keyed(spelling::path(path), || {
+            SlotSource::Type(Box::new(syn::Type::Path(syn::TypePath {
+                qself: None,
+                path: path.clone(),
+            })))
+        })
+    }
+
+    /// Defers a trait bound's path as a value-namespace slot, so the descriptor
+    /// resolves through the const the trait's definition site emits.
+    pub(super) fn defer_trait_slot(&self, path: &syn::Path) -> Option<usize> {
+        self.defer_slot_keyed(format!("trait {}", spelling::path(path)), || {
+            SlotSource::TraitValue(path.clone())
+        })
+    }
+
+    fn defer_slot_keyed(
+        &self,
+        spelling: String,
+        source: impl FnOnce() -> SlotSource,
+    ) -> Option<usize> {
         let slots = self.deferred_slots.as_ref()?;
         let mut slots = slots.borrow_mut();
-        let spelling = spelling::path(path);
         if let Some(index) = slots.by_spelling.get(&spelling) {
             return Some(*index);
         }
-        let index = slots.paths.len();
-        slots.paths.push(path.clone());
+        let index = slots.sources.len();
+        slots.sources.push(source());
         slots.by_spelling.insert(spelling, index);
         Some(index)
     }
 
-    pub(super) fn take_slots(&mut self) -> Vec<syn::Path> {
+    pub(super) fn take_slots(&mut self) -> Vec<SlotSource> {
         self.deferred_slots
             .take()
-            .map(|slots| slots.into_inner().paths)
+            .map(|slots| slots.into_inner().sources)
             .unwrap_or_default()
     }
 

--- a/boltffi_scan/src/error.rs
+++ b/boltffi_scan/src/error.rs
@@ -62,6 +62,9 @@ pub enum ScanError {
     UnsupportedClassImplShape {
         target: String,
     },
+    UnsupportedCapturedClassImpl {
+        target: String,
+    },
     UnsupportedGenerics {
         item: String,
     },
@@ -191,6 +194,13 @@ impl fmt::Display for ScanError {
                 write!(
                     formatter,
                     "exported class impl `{target}` cannot implement a trait"
+                )
+            }
+            Self::UnsupportedCapturedClassImpl { target } => {
+                write!(
+                    formatter,
+                    "class impl target `{target}` is not captured per invocation; \
+                     export the class as a bare name from its type's module"
                 )
             }
             Self::UnsupportedGenerics { item } => {
@@ -354,6 +364,14 @@ mod tests {
             }
             .to_string(),
             "exported class impl `Engine` cannot implement a trait"
+        );
+        assert_eq!(
+            ScanError::UnsupportedCapturedClassImpl {
+                target: "crate::runtime::Engine".to_owned()
+            }
+            .to_string(),
+            "class impl target `crate::runtime::Engine` is not captured per invocation; \
+             export the class as a bare name from its type's module"
         );
         assert_eq!(
             ScanError::UnsupportedGenerics {

--- a/boltffi_scan/src/items/callback.rs
+++ b/boltffi_scan/src/items/callback.rs
@@ -17,6 +17,14 @@ pub fn scan(
     build(marked.item(), marked.scope(), declared_types)
 }
 
+pub(crate) fn scan_item(
+    item: &syn::ItemTrait,
+    scope: &ModuleScope,
+    declared_types: &DeclaredTypes,
+) -> Result<TraitDef, ScanError> {
+    build(item, scope, declared_types)
+}
+
 fn build(
     item: &syn::ItemTrait,
     scope: &ModuleScope,

--- a/boltffi_scan/src/items/class.rs
+++ b/boltffi_scan/src/items/class.rs
@@ -41,6 +41,14 @@ pub fn scan(
         })
 }
 
+pub(crate) fn scan_item(
+    item: &syn::ItemImpl,
+    scope: &ModuleScope,
+    declared_types: &DeclaredTypes,
+) -> Result<ClassDef, ScanError> {
+    build(item, scope, declared_types, ClassThreadSafety::default())
+}
+
 fn build(
     item: &syn::ItemImpl,
     scope: &ModuleScope,
@@ -78,6 +86,11 @@ fn resolve_target_id(
     scope: &ModuleScope,
     declared_types: &DeclaredTypes,
 ) -> Result<ClassId, ScanError> {
+    if declared_types.is_deferred() {
+        let spelling = target.spelling();
+        let leaf = spelling.rsplit("::").next().unwrap_or(spelling);
+        return Ok(ClassId::new(scope.path().qualified(leaf)));
+    }
     let path = declared_types
         .resolve_impl_target(scope, target)?
         .ok_or_else(|| ScanError::UnsupportedClassImpl {

--- a/boltffi_scan/src/items/class.rs
+++ b/boltffi_scan/src/items/class.rs
@@ -45,8 +45,9 @@ pub(crate) fn scan_item(
     item: &syn::ItemImpl,
     scope: &ModuleScope,
     declared_types: &DeclaredTypes,
+    thread_safety: ClassThreadSafety,
 ) -> Result<ClassDef, ScanError> {
-    build(item, scope, declared_types, ClassThreadSafety::default())
+    build(item, scope, declared_types, thread_safety)
 }
 
 fn build(

--- a/boltffi_scan/src/items/class.rs
+++ b/boltffi_scan/src/items/class.rs
@@ -73,7 +73,7 @@ fn build(
     Ok(class)
 }
 
-pub(super) fn resolve_id(
+pub(crate) fn resolve_id(
     item: &syn::ItemImpl,
     scope: &ModuleScope,
     declared_types: &DeclaredTypes,
@@ -88,9 +88,16 @@ fn resolve_target_id(
     declared_types: &DeclaredTypes,
 ) -> Result<ClassId, ScanError> {
     if declared_types.is_deferred() {
-        let spelling = target.spelling();
-        let leaf = spelling.rsplit("::").next().unwrap_or(spelling);
-        return Ok(ClassId::new(scope.path().qualified(leaf)));
+        let bare = target
+            .path()
+            .filter(|path| path.leading_colon.is_none() && path.segments.len() == 1);
+        let Some(path) = bare else {
+            return Err(ScanError::UnsupportedCapturedClassImpl {
+                target: target.spelling().to_owned(),
+            });
+        };
+        let leaf = path.segments[0].ident.to_string();
+        return Ok(ClassId::new(scope.path().qualified(&leaf)));
     }
     let path = declared_types
         .resolve_impl_target(scope, target)?

--- a/boltffi_scan/src/items/constant.rs
+++ b/boltffi_scan/src/items/constant.rs
@@ -135,6 +135,23 @@ where
         })
 }
 
+pub(crate) fn scan_associated_in_impl(
+    item: &syn::ItemImpl,
+    owner: &ConstantOwner,
+    scope: &ModuleScope,
+    declared_types: &DeclaredTypes,
+) -> Result<Vec<ConstantDef>, ScanError> {
+    item.items
+        .iter()
+        .filter_map(|item| match item {
+            syn::ImplItem::Const(constant) => {
+                scan_associated_constant(constant, owner.clone(), scope, declared_types).transpose()
+            }
+            _ => None,
+        })
+        .collect()
+}
+
 fn scan_associated_constant(
     constant: &syn::ImplItemConst,
     owner: ConstantOwner,

--- a/boltffi_scan/src/items/constant.rs
+++ b/boltffi_scan/src/items/constant.rs
@@ -26,6 +26,14 @@ pub fn scan(
     build_item(marked.item(), marked.scope(), declared_types)
 }
 
+pub(crate) fn scan_item(
+    item: &syn::ItemConst,
+    scope: &ModuleScope,
+    declared_types: &DeclaredTypes,
+) -> Result<ConstantDef, ScanError> {
+    build_item(item, scope, declared_types)
+}
+
 fn build_item(
     item: &syn::ItemConst,
     scope: &ModuleScope,

--- a/boltffi_scan/src/items/custom_type.rs
+++ b/boltffi_scan/src/items/custom_type.rs
@@ -40,6 +40,53 @@ pub fn scan(
     Ok(custom)
 }
 
+pub(crate) fn scan_macro_tokens(
+    tokens: proc_macro2::TokenStream,
+    scope: &ModuleScope,
+    declared_types: &DeclaredTypes,
+) -> Result<CustomTypeDef, ScanError> {
+    let spec = syn::parse2::<ParsedSpec>(tokens)
+        .map_err(invalid_custom_type)
+        .and_then(Spec::from_parsed)?;
+    build_from_spec(&spec, scope, declared_types)
+}
+
+pub(crate) fn scan_trait_impl_item(
+    item: &syn::ItemImpl,
+    scope: &ModuleScope,
+    declared_types: &DeclaredTypes,
+) -> Result<CustomTypeDef, ScanError> {
+    let spec = Spec::parse_trait_impl(item)?;
+    build_from_spec(&spec, scope, declared_types)
+}
+
+fn build_from_spec(
+    spec: &Spec,
+    scope: &ModuleScope,
+    declared_types: &DeclaredTypes,
+) -> Result<CustomTypeDef, ScanError> {
+    let custom_name = name::source(spec.name());
+    let custom_id = CustomTypeId::new(scope.path().qualified(&spec.name().to_string()));
+    let mut converters = spec.converters(scope.path());
+    mark_deferred_module(&mut converters.into_ffi);
+    mark_deferred_module(&mut converters.try_from_ffi);
+    let scanner = Scanner::new(declared_types, scope);
+    Ok(CustomTypeDef::new(
+        custom_id,
+        custom_name,
+        spec.remote_type().clone(),
+        scanner.scan(spec.repr())?,
+        spec.error().cloned(),
+        converters,
+    ))
+}
+
+fn mark_deferred_module(converter: &mut boltffi_ast::CustomTypeConverter) {
+    if let boltffi_ast::CustomTypeConverter::Path(path) = converter {
+        path.segments.insert(0, PathSegment::new("$self"));
+    }
+}
+
 pub struct Spec {
     visibility: Option<syn::Visibility>,
     name: syn::Ident,

--- a/boltffi_scan/src/items/enumeration.rs
+++ b/boltffi_scan/src/items/enumeration.rs
@@ -19,6 +19,14 @@ pub fn scan(
     Ok(enumeration)
 }
 
+pub(crate) fn scan_item(
+    item: &syn::ItemEnum,
+    scope: &ModuleScope,
+    declared_types: &DeclaredTypes,
+) -> Result<EnumDef, ScanError> {
+    build(item, scope, declared_types)
+}
+
 fn build(
     item: &syn::ItemEnum,
     scope: &ModuleScope,

--- a/boltffi_scan/src/items/function.rs
+++ b/boltffi_scan/src/items/function.rs
@@ -16,6 +16,14 @@ pub fn scan(
     build(marked.item(), marked.scope(), declared_types)
 }
 
+pub(crate) fn scan_item(
+    item: &syn::ItemFn,
+    scope: &ModuleScope,
+    declared_types: &DeclaredTypes,
+) -> Result<FunctionDef, ScanError> {
+    build(item, scope, declared_types)
+}
+
 fn build(
     item: &syn::ItemFn,
     scope: &ModuleScope,

--- a/boltffi_scan/src/items/impl_methods.rs
+++ b/boltffi_scan/src/items/impl_methods.rs
@@ -17,6 +17,15 @@ pub(super) fn class_methods(
     scan(item, parent, scope, declared_types, StreamMethods::Separate)
 }
 
+pub(crate) fn scan_value_methods(
+    item: &syn::ItemImpl,
+    parent: &str,
+    scope: &ModuleScope,
+    declared_types: &DeclaredTypes,
+) -> Result<Vec<MethodDef>, ScanError> {
+    value_methods(item, parent, scope, declared_types)
+}
+
 pub(super) fn value_methods(
     item: &syn::ItemImpl,
     parent: &str,

--- a/boltffi_scan/src/items/interned_string_pool.rs
+++ b/boltffi_scan/src/items/interned_string_pool.rs
@@ -25,7 +25,7 @@ impl Spec {
         Self::parse_tokens(marked.item().mac.tokens.clone())
     }
 
-    fn parse_tokens(tokens: proc_macro2::TokenStream) -> Result<Self, ScanError> {
+    pub(crate) fn parse_tokens(tokens: proc_macro2::TokenStream) -> Result<Self, ScanError> {
         let parsed =
             syn::parse2::<ParsedSpec>(tokens).map_err(|err| ScanError::InvalidCustomType {
                 message: format!("invalid interned_string_pool invocation: {err}"),

--- a/boltffi_scan/src/items/mod.rs
+++ b/boltffi_scan/src/items/mod.rs
@@ -9,7 +9,7 @@ pub(super) mod interned_string_pool;
 pub(super) mod record;
 pub(super) mod stream;
 
-mod impl_methods;
+pub(crate) mod impl_methods;
 mod signature;
 
 pub(super) fn misplaced_stream_marker(

--- a/boltffi_scan/src/items/record.rs
+++ b/boltffi_scan/src/items/record.rs
@@ -17,6 +17,14 @@ pub fn scan(
     Ok(record)
 }
 
+pub(crate) fn scan_item(
+    item: &syn::ItemStruct,
+    scope: &ModuleScope,
+    declared_types: &DeclaredTypes,
+) -> Result<RecordDef, ScanError> {
+    build(item, scope, declared_types)
+}
+
 fn build(
     item: &syn::ItemStruct,
     scope: &ModuleScope,

--- a/boltffi_scan/src/items/stream.rs
+++ b/boltffi_scan/src/items/stream.rs
@@ -125,16 +125,20 @@ fn block_streams(
     marked: &Marked<'_, syn::ItemImpl>,
     declared_types: &DeclaredTypes,
 ) -> Result<Vec<StreamDef>, ScanError> {
-    let owner = class::resolve_id(marked.item(), marked.scope(), declared_types)?;
-    let scanner = Scanner::new(declared_types, marked.scope());
-    marked
-        .item()
-        .items
+    scan_item(marked.item(), marked.scope(), declared_types)
+}
+
+pub(crate) fn scan_item(
+    item: &syn::ItemImpl,
+    scope: &ModuleScope,
+    declared_types: &DeclaredTypes,
+) -> Result<Vec<StreamDef>, ScanError> {
+    let owner = class::resolve_id(item, scope, declared_types)?;
+    let scanner = Scanner::new(declared_types, scope);
+    item.items
         .iter()
         .filter_map(|item| match item {
-            syn::ImplItem::Fn(method) => {
-                method_stream(method, &owner, marked.scope(), &scanner).transpose()
-            }
+            syn::ImplItem::Fn(method) => method_stream(method, &owner, scope, &scanner).transpose(),
             _ => None,
         })
         .collect()
@@ -189,7 +193,7 @@ fn validate(
             "`{item}` must be a public `&self` method with no parameters"
         )));
     }
-    let returned = subscription_item(&method.sig.output, scope, &item)?;
+    let returned = subscription_item(&method.sig.output, scope, &item, scanner.is_deferred())?;
     let declared_item = StreamItem::from_boundary(scanner.scan(attribute.item())?);
     let returned_item = scanner.scan(returned)?;
     if declared_item.storage() != &returned_item {
@@ -250,6 +254,7 @@ fn subscription_item<'source>(
     output: &'source syn::ReturnType,
     scope: &ModuleScope,
     item: &str,
+    deferred: bool,
 ) -> Result<&'source syn::Type, ScanError> {
     let syn::ReturnType::Type(_, ty) = output else {
         return Err(Attribute::invalid(format!(
@@ -259,7 +264,12 @@ fn subscription_item<'source>(
     let outer = path_type(ty).ok_or_else(|| {
         Attribute::invalid(format!("`{item}` must return Arc<EventSubscription<T>>"))
     })?;
-    if !matches_path(scope, &outer.path, &["std::sync::Arc", "alloc::sync::Arc"]) {
+    if !matches_path(
+        scope,
+        &outer.path,
+        &["std::sync::Arc", "alloc::sync::Arc"],
+        deferred,
+    ) {
         return Err(Attribute::invalid(format!(
             "`{item}` must return Arc<EventSubscription<T>>"
         )));
@@ -276,6 +286,7 @@ fn subscription_item<'source>(
             "boltffi::EventSubscription",
             "boltffi_core::EventSubscription",
         ],
+        deferred,
     ) {
         return Err(Attribute::invalid(format!(
             "`{item}` must return Arc<EventSubscription<T>>"
@@ -306,7 +317,10 @@ fn generic_type_argument(path: &syn::TypePath) -> Option<&syn::Type> {
     }
 }
 
-fn matches_path(scope: &ModuleScope, path: &syn::Path, qualified: &[&str]) -> bool {
+fn matches_path(scope: &ModuleScope, path: &syn::Path, qualified: &[&str], deferred: bool) -> bool {
+    if deferred {
+        return suffix_matches(path, qualified);
+    }
     match scope.expand(path) {
         PathExpansion::Imported { path, .. } | PathExpansion::Qualified(path) => {
             qualified.iter().any(|candidate| path == *candidate)
@@ -320,6 +334,23 @@ fn matches_path(scope: &ModuleScope, path: &syn::Path, qualified: &[&str]) -> bo
         }),
         PathExpansion::Ambiguous | PathExpansion::Unsupported => false,
     }
+}
+
+fn suffix_matches(path: &syn::Path, qualified: &[&str]) -> bool {
+    let written = path
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect::<Vec<_>>();
+    qualified.iter().any(|candidate| {
+        let segments = candidate.split("::").collect::<Vec<_>>();
+        written.len() <= segments.len()
+            && written
+                .iter()
+                .rev()
+                .zip(segments.iter().rev())
+                .all(|(written, segment)| written == segment)
+    })
 }
 
 fn raw_path(path: &syn::Path) -> Option<String> {

--- a/boltffi_scan/src/lib.rs
+++ b/boltffi_scan/src/lib.rs
@@ -21,9 +21,9 @@ mod unsupported;
 mod visibility;
 
 pub use capture::{
-    CapturedItem, CapturedMethods, capture_class, capture_constant, capture_custom,
+    CapturedItem, CapturedMethods, CapturedPool, capture_class, capture_constant, capture_custom,
     capture_custom_ffi, capture_enum, capture_error_enum, capture_error_struct, capture_function,
-    capture_methods, capture_streams, capture_struct, capture_trait,
+    capture_interned_string_pool, capture_methods, capture_streams, capture_struct, capture_trait,
 };
 pub use cfg::ActiveCfg;
 pub use error::ScanError;

--- a/boltffi_scan/src/lib.rs
+++ b/boltffi_scan/src/lib.rs
@@ -21,8 +21,9 @@ mod unsupported;
 mod visibility;
 
 pub use capture::{
-    CapturedItem, CapturedMethods, capture_class, capture_constant, capture_enum, capture_function,
-    capture_methods, capture_struct, capture_trait,
+    CapturedItem, CapturedMethods, capture_class, capture_constant, capture_custom,
+    capture_custom_ffi, capture_enum, capture_function, capture_methods, capture_struct,
+    capture_trait,
 };
 pub use cfg::ActiveCfg;
 pub use error::ScanError;

--- a/boltffi_scan/src/lib.rs
+++ b/boltffi_scan/src/lib.rs
@@ -22,8 +22,8 @@ mod visibility;
 
 pub use capture::{
     CapturedItem, CapturedMethods, capture_class, capture_constant, capture_custom,
-    capture_custom_ffi, capture_enum, capture_function, capture_methods, capture_streams,
-    capture_struct, capture_trait,
+    capture_custom_ffi, capture_enum, capture_error_enum, capture_error_struct, capture_function,
+    capture_methods, capture_streams, capture_struct, capture_trait,
 };
 pub use cfg::ActiveCfg;
 pub use error::ScanError;

--- a/boltffi_scan/src/lib.rs
+++ b/boltffi_scan/src/lib.rs
@@ -21,10 +21,10 @@ mod unsupported;
 mod visibility;
 
 pub use capture::{
-    CapturedItem, CapturedMethods, CapturedPool, SlotSource, capture_class, capture_constant,
-    capture_custom, capture_custom_ffi, capture_enum, capture_error_enum, capture_error_struct,
-    capture_function, capture_interned_string_pool, capture_methods, capture_streams,
-    capture_struct, capture_trait,
+    CapturedItem, CapturedMethods, CapturedPool, SlotSource, capture_class,
+    capture_class_constants, capture_constant, capture_custom, capture_custom_ffi, capture_enum,
+    capture_error_enum, capture_error_struct, capture_function, capture_interned_string_pool,
+    capture_methods, capture_streams, capture_struct, capture_trait,
 };
 pub use cfg::ActiveCfg;
 pub use error::ScanError;

--- a/boltffi_scan/src/lib.rs
+++ b/boltffi_scan/src/lib.rs
@@ -21,8 +21,8 @@ mod unsupported;
 mod visibility;
 
 pub use capture::{
-    CapturedItem, capture_class, capture_constant, capture_enum, capture_function, capture_struct,
-    capture_trait,
+    CapturedItem, CapturedMethods, capture_class, capture_constant, capture_enum, capture_function,
+    capture_methods, capture_struct, capture_trait,
 };
 pub use cfg::ActiveCfg;
 pub use error::ScanError;

--- a/boltffi_scan/src/lib.rs
+++ b/boltffi_scan/src/lib.rs
@@ -20,7 +20,10 @@ pub(crate) mod type_expr;
 mod unsupported;
 mod visibility;
 
-pub use capture::{CapturedItem, capture_enum, capture_function, capture_struct};
+pub use capture::{
+    CapturedItem, capture_class, capture_constant, capture_enum, capture_function, capture_struct,
+    capture_trait,
+};
 pub use cfg::ActiveCfg;
 pub use error::ScanError;
 pub use input::ScanInput;

--- a/boltffi_scan/src/lib.rs
+++ b/boltffi_scan/src/lib.rs
@@ -21,9 +21,10 @@ mod unsupported;
 mod visibility;
 
 pub use capture::{
-    CapturedItem, CapturedMethods, CapturedPool, capture_class, capture_constant, capture_custom,
-    capture_custom_ffi, capture_enum, capture_error_enum, capture_error_struct, capture_function,
-    capture_interned_string_pool, capture_methods, capture_streams, capture_struct, capture_trait,
+    CapturedItem, CapturedMethods, CapturedPool, SlotSource, capture_class, capture_constant,
+    capture_custom, capture_custom_ffi, capture_enum, capture_error_enum, capture_error_struct,
+    capture_function, capture_interned_string_pool, capture_methods, capture_streams,
+    capture_struct, capture_trait,
 };
 pub use cfg::ActiveCfg;
 pub use error::ScanError;

--- a/boltffi_scan/src/lib.rs
+++ b/boltffi_scan/src/lib.rs
@@ -22,8 +22,8 @@ mod visibility;
 
 pub use capture::{
     CapturedItem, CapturedMethods, capture_class, capture_constant, capture_custom,
-    capture_custom_ffi, capture_enum, capture_function, capture_methods, capture_struct,
-    capture_trait,
+    capture_custom_ffi, capture_enum, capture_function, capture_methods, capture_streams,
+    capture_struct, capture_trait,
 };
 pub use cfg::ActiveCfg;
 pub use error::ScanError;

--- a/boltffi_scan/src/lib.rs
+++ b/boltffi_scan/src/lib.rs
@@ -1,4 +1,5 @@
 mod attributes;
+mod capture;
 mod cfg;
 mod const_expr;
 mod declared_types;
@@ -19,6 +20,7 @@ pub(crate) mod type_expr;
 mod unsupported;
 mod visibility;
 
+pub use capture::{CapturedItem, capture_enum, capture_function, capture_struct};
 pub use cfg::ActiveCfg;
 pub use error::ScanError;
 pub use input::ScanInput;

--- a/boltffi_scan/src/marker.rs
+++ b/boltffi_scan/src/marker.rs
@@ -174,6 +174,19 @@ fn marker_name(attr: &syn::Attribute) -> Option<String> {
     }
 }
 
+pub(crate) fn export_marker_from_args(
+    tokens: proc_macro2::TokenStream,
+) -> Result<ExportMarker, ScanError> {
+    if tokens.is_empty() {
+        return Ok(ExportMarker::default());
+    }
+    syn::parse::Parser::parse2(parse_export_args, tokens.clone()).map_err(|_| {
+        ScanError::InvalidMarker {
+            attribute: format!("export({tokens})"),
+        }
+    })
+}
+
 fn invalid(attr: &syn::Attribute) -> ScanError {
     ScanError::InvalidMarker {
         attribute: crate::spelling::attr(attr),

--- a/boltffi_scan/src/type_expr.rs
+++ b/boltffi_scan/src/type_expr.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use boltffi_ast::{
     AdditionalBound, BaseTrait, BuiltinType, ConstExpr, CustomTypeId, FnSig, FnTrait, FnTraitKind,
     GenericArgument, MapKind, NamePart, Path, PathRoot, PathSegment, Primitive, RecordId,
-    ReturnDef, TraitBounds, TypeExpr,
+    ReturnDef, TraitBounds, TraitId, TypeExpr,
 };
 use quote::ToTokens;
 
@@ -202,6 +202,12 @@ impl<'a> Scanner<'a> {
             .iter()
             .any(|segment| !matches!(segment.arguments, syn::PathArguments::None))
         {
+            if let Some(index) = self.declared_types.defer_slot(&type_path.path) {
+                return Ok(TypeExpr::record(
+                    RecordId::new(format!("$slot:{index}")),
+                    ast_path_without_arguments(&type_path.path),
+                ));
+            }
             return Err(ScanError::unsupported_type(source));
         }
         let Some(segment) = type_path.path.segments.last() else {
@@ -363,7 +369,16 @@ impl<'a> Scanner<'a> {
         }
         let path = ast_path(&bound.path, self)?;
         if self.declared_types.is_deferred() {
-            return Ok(None);
+            if is_auto_trait_path(&bound.path) {
+                return Ok(None);
+            }
+            let Some(index) = self.declared_types.defer_trait_slot(&bound.path) else {
+                return Ok(None);
+            };
+            return Ok(Some(BaseTrait::Named {
+                id: TraitId::new(format!("$slot:{index}")),
+                path,
+            }));
         }
         match self
             .declared_types
@@ -547,6 +562,17 @@ pub fn unwrapped(ty: &syn::Type) -> &syn::Type {
 
 fn is_unit(ty: &syn::Type) -> bool {
     matches!(unwrapped(ty), syn::Type::Tuple(tuple) if tuple.elems.is_empty())
+}
+
+/// Whether a bound path names a well-known auto trait, which stays an
+/// additional bound instead of becoming a deferred base-trait slot.
+fn is_auto_trait_path(path: &syn::Path) -> bool {
+    path.segments.last().is_some_and(|segment| {
+        matches!(
+            segment.ident.to_string().as_str(),
+            "Send" | "Sync" | "Unpin"
+        )
+    })
 }
 
 fn ast_path(path: &syn::Path, scanner: &Scanner<'_>) -> Result<Path, ScanError> {

--- a/boltffi_scan/src/type_expr.rs
+++ b/boltffi_scan/src/type_expr.rs
@@ -2,8 +2,8 @@ use std::num::NonZeroUsize;
 
 use boltffi_ast::{
     AdditionalBound, BaseTrait, BuiltinType, ConstExpr, CustomTypeId, FnSig, FnTrait, FnTraitKind,
-    GenericArgument, MapKind, NamePart, Path, PathRoot, PathSegment, Primitive, ReturnDef,
-    TraitBounds, TypeExpr,
+    GenericArgument, MapKind, NamePart, Path, PathRoot, PathSegment, Primitive, RecordId,
+    ReturnDef, TraitBounds, TypeExpr,
 };
 use quote::ToTokens;
 
@@ -163,6 +163,11 @@ impl<'a> Scanner<'a> {
         let Some(standard_type) = StandardType::from_leaf(&segment.ident.to_string()) else {
             return Ok(None);
         };
+        if self.declared_types.is_deferred() {
+            return Ok(standard_type
+                .accepts_path(&path_without_arguments(&type_path.path))
+                .then_some(standard_type));
+        }
         match self
             .declared_types
             .resolve_type_in_scope(self.scope, &type_path.path)?
@@ -209,6 +214,12 @@ impl<'a> Scanner<'a> {
             return Ok(TypeExpr::Primitive(primitive));
         }
         let path = ast_path(&type_path.path, self)?;
+        if let Some(index) = self.declared_types.defer_slot(&type_path.path) {
+            return Ok(TypeExpr::record(
+                RecordId::new(format!("$slot:{index}")),
+                path,
+            ));
+        }
         match self
             .declared_types
             .resolve_type_in_scope(self.scope, &type_path.path)?
@@ -347,6 +358,9 @@ impl<'a> Scanner<'a> {
             return Ok(None);
         }
         let path = ast_path(&bound.path, self)?;
+        if self.declared_types.is_deferred() {
+            return Ok(None);
+        }
         match self
             .declared_types
             .resolve_type_in_scope(self.scope, &bound.path)?
@@ -428,6 +442,9 @@ impl<'a> Scanner<'a> {
         segment: &syn::PathSegment,
         source: &syn::Type,
     ) -> Result<TypeExpr, ScanError> {
+        if self.declared_types.is_deferred() {
+            return Err(ScanError::unsupported_type(source));
+        }
         let pool = self.single_type_argument(segment, source)?;
         let syn::Type::Path(pool_path) = unwrapped(pool) else {
             return Err(ScanError::unsupported_type(source));
@@ -500,6 +517,9 @@ impl<'a> Scanner<'a> {
     }
 
     fn custom_remote(&self, ty: &syn::Type) -> Result<Option<&CustomTypeId>, ScanError> {
+        if self.declared_types.is_deferred() {
+            return Ok(None);
+        }
         if self.can_resolve_custom_remote(ty)? {
             self.declared_types.resolve_custom_remote(self.scope, ty)
         } else {

--- a/boltffi_scan/src/type_expr.rs
+++ b/boltffi_scan/src/type_expr.rs
@@ -28,6 +28,10 @@ impl<'a> Scanner<'a> {
         self.scope
     }
 
+    pub(crate) fn is_deferred(&self) -> bool {
+        self.declared_types.is_deferred()
+    }
+
     pub fn scan(&self, ty: &syn::Type) -> Result<TypeExpr, ScanError> {
         let unwrapped = unwrapped(ty);
         if let Some(custom) = self.custom_remote(unwrapped)? {

--- a/boltffi_scan/src/type_expr.rs
+++ b/boltffi_scan/src/type_expr.rs
@@ -446,9 +446,6 @@ impl<'a> Scanner<'a> {
         segment: &syn::PathSegment,
         source: &syn::Type,
     ) -> Result<TypeExpr, ScanError> {
-        if self.declared_types.is_deferred() {
-            return Err(ScanError::unsupported_type(source));
-        }
         let pool = self.single_type_argument(segment, source)?;
         let syn::Type::Path(pool_path) = unwrapped(pool) else {
             return Err(ScanError::unsupported_type(source));
@@ -461,6 +458,14 @@ impl<'a> Scanner<'a> {
                 .any(|segment| !matches!(segment.arguments, syn::PathArguments::None))
         {
             return Err(ScanError::unsupported_type(source));
+        }
+        if let Some(index) = self.declared_types.defer_slot(&pool_path.path) {
+            return Ok(TypeExpr::interned_string(
+                interned_string_base_path(&type_path.path),
+                format!("$slot:{index}"),
+                ast_path_without_arguments(&pool_path.path),
+                Vec::new(),
+            ));
         }
         let (pool_canonical_path, static_values) = self
             .declared_types

--- a/boltffi_tests/src/lib.rs
+++ b/boltffi_tests/src/lib.rs
@@ -4,6 +4,8 @@
 
 use boltffi::*;
 
+scaffolding!();
+
 #[data]
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub struct FixturePoint {

--- a/examples/demo/multicrate_model/src/lib.rs
+++ b/examples/demo/multicrate_model/src/lib.rs
@@ -1,4 +1,6 @@
 use boltffi::*;
+
+scaffolding!();
 use std::sync::atomic::{AtomicI32, Ordering};
 
 #[data]

--- a/examples/demo/multicrate_session/src/lib.rs
+++ b/examples/demo/multicrate_session/src/lib.rs
@@ -1,4 +1,6 @@
 use boltffi::*;
+
+scaffolding!();
 use std::sync::Mutex;
 
 pub use demo_multicrate_model::{

--- a/examples/demo/src/lib.rs
+++ b/examples/demo/src/lib.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
 
+boltffi::scaffolding!();
+
 pub mod async_fns;
 pub mod builtins;
 pub mod bytes;


### PR DESCRIPTION
Second slice of #665: every macro entry point now emits its per-invocation record. Bindgen still lowers the legacy envelope — the discovery flip is the next slice.

- `boltffi_scan`: deferred-resolution capture — each invocation describes the item it sees, writing `$slot:N` for every named type reference plus a slot table of written paths:

  ```rust
  #[data]
  pub struct Route { start: Point }
  // fragment: { start: $slot:0 } + slots [Point]
  // <Point as TypeDesc<Tag>>::DESC resolves the slot at Point's own definition site
  ```

- `boltffi_macros`: capture on `#[data]`, `#[data(impl)]`, `#[export]` (fn / impl / trait / const), `#[error]`, `custom_type!`, `custom_ffi`, streams, and `interned_string_pool!`; `boltffi::scaffolding!()` provides the per-crate anchor tag. Anything capture cannot describe emits an unsupported marker so aggregation refuses the whole set and consumers keep the legacy path.
- `boltffi_binding`: aggregation extensions — `#[data(impl)]` method blocks and associated constants merge into their slot-resolved targets, pools inline at use sites, incomplete sets are refused.
- `boltffi_bindgen`: `read_source` runs a plain cargo build (metadata env gates scrubbed) and reads records from every artifact; end-to-end tests prove the records of the macro fixture lower **decl-for-decl equal** to the legacy scanner, on native and wasm32 artifacts.

One reviewer thread from #725 resolved itself while testing: split `#[export] impl` blocks for one class never compiled (the expansion emits `boltffi_{class}_free` per block — E0428 on main today), so aggregation keeps the loud duplicate error instead of growing an unreachable merge.

Part of #665. Next: the discovery flip.
