### PR TITLE
fix: close the `close()` race with an in-flight call counter

### DIFF
--- a/boltffi_backend/src/core/error.rs
+++ b/boltffi_backend/src/core/error.rs
@@ -204,6 +204,14 @@ pub enum BackendError {
         /// Generated Java name used more than once.
         name: String,
     },
+    /// Two generated C# declarations require the same name in one scope.
+    #[error("csharp name collision in {scope}: `{name}` is already used")]
+    CSharpNameCollision {
+        /// C# scope where the collision was found.
+        scope: String,
+        /// Generated C# name used more than once.
+        name: String,
+    },
     /// A backend template failed to render.
     #[error("template rendering failed: {message}")]
     Template {

--- a/boltffi_backend/src/target/csharp/mod.rs
+++ b/boltffi_backend/src/target/csharp/mod.rs
@@ -262,7 +262,7 @@ mod tests {
     use boltffi_ast::PackageInfo;
     use boltffi_binding::{Bindings, Native, lower};
 
-    use crate::{GeneratedOutput, Target, bridge::c::CBridge};
+    use crate::{GeneratedOutput, Target, bridge::c::CBridge, core::Error};
 
     use super::{CSharpCustomMapping, CSharpHost};
 
@@ -1257,6 +1257,59 @@ mod tests {
         assert!(!class.contains("BoltFfiNew"));
         assert!(!class.contains(".TakeHandle()"));
         assert!(output.diagnostics().is_empty());
+    }
+
+    #[test]
+    fn csharp_target_retains_async_class_receivers_until_future_free() {
+        let bindings = bindings(
+            r#"
+            pub struct Worker;
+
+            #[export]
+            impl Worker {
+                pub fn new() -> Self { Self }
+                pub async fn run(&self, value: i32) -> i32 { value }
+            }
+            "#,
+        );
+        let output = target(CSharpHost::new())
+            .render(&bindings)
+            .expect("async class method should render");
+
+        let class = file(&output, "Worker.cs");
+        assert!(class.contains(
+            "ulong boltffiReceiver = BoltffiRetain();\n                    try\n                    {\n                        return NativeMethods.NativeWorkerRun(boltffiReceiver, value);\n                    }\n                    catch\n                    {\n                        BoltffiRelease();\n                        throw;\n                    }"
+        ));
+        assert!(class.contains(
+            "boltffiFuture =>\n                {\n                    NativeMethods.NativeWorkerRunFree(boltffiFuture);\n                    BoltffiRelease();\n                }"
+        ));
+        assert!(output.diagnostics().is_empty());
+    }
+
+    #[test]
+    fn csharp_target_rejects_class_methods_colliding_with_lifecycle_helpers() {
+        let bindings = bindings(
+            r#"
+            pub struct Resource;
+
+            #[export]
+            impl Resource {
+                pub fn new() -> Self { Self }
+                pub fn boltffi_retain(&self) {}
+            }
+            "#,
+        );
+        let error = target(CSharpHost::new())
+            .render(&bindings)
+            .expect_err("class lifecycle helpers must retain their generated names");
+
+        assert_eq!(
+            error,
+            Error::CSharpNameCollision {
+                scope: "Resource".to_owned(),
+                name: "BoltffiRetain".to_owned(),
+            }
+        );
     }
 
     #[test]

--- a/boltffi_backend/src/target/csharp/mod.rs
+++ b/boltffi_backend/src/target/csharp/mod.rs
@@ -1216,7 +1216,11 @@ mod tests {
         assert!(class.contains("public int Get()"));
         assert!(class.contains("public void Increment()"));
         assert!(class.contains("public static int Add(int a, int b)"));
-        assert!(class.contains("ThrowIfDisposed();"));
+        assert!(class.contains("private ulong BoltffiRetain()"));
+        assert!(class.contains("private void BoltffiRelease()"));
+        assert!(class.contains("ulong boltffiReceiver = BoltffiRetain();"));
+        assert!(class.contains("BoltffiRelease();"));
+        assert!(class.contains("NativeMethods.NativeCounterRelease(RawHandle);"));
         assert!(class.contains("~Counter() => Release();"));
 
         let module = file(&output, "Demo.cs");

--- a/boltffi_backend/src/target/csharp/render/class.rs
+++ b/boltffi_backend/src/target/csharp/render/class.rs
@@ -100,6 +100,7 @@ impl Class {
                 Err(error) => collect_diagnostic(&mut diagnostics, "method", method.name(), error)?,
             }
         }
+        validate_reserved_members(&name, &methods)?;
         let constants = AssociatedConstants::from_owner(
             ConstantOwner::Class(declaration.id()),
             &namespace,
@@ -145,6 +146,25 @@ impl Class {
             .try_fold(emitted, |emitted, function| function.add_support(emitted))?;
         self.constants.add_support(emitted)
     }
+}
+
+/// Rejects methods that would duplicate a generated helper. The retain and
+/// release helpers only collide at zero parameters; `RawHandle` is a property,
+/// which C# rejects alongside a method of any arity.
+fn validate_reserved_members(scope: &Identifier, methods: &[Function]) -> Result<()> {
+    methods
+        .iter()
+        .find(|method| {
+            method.name.as_str() == "RawHandle"
+                || (method.parameters.is_empty()
+                    && ["BoltffiRetain", "BoltffiRelease"].contains(&method.name.as_str()))
+        })
+        .map_or(Ok(()), |method| {
+            Err(Error::CSharpNameCollision {
+                scope: scope.to_string(),
+                name: method.name.to_string(),
+            })
+        })
 }
 
 fn collect_diagnostic(

--- a/boltffi_backend/src/target/csharp/render/mod.rs
+++ b/boltffi_backend/src/target/csharp/render/mod.rs
@@ -488,6 +488,7 @@ impl Function {
             context,
         )?;
         requires_wire_runtime |= encoded_error.is_some();
+        let mut receiver_guard = None;
 
         if let Some(receive) = callable.receiver() {
             let group =
@@ -523,6 +524,7 @@ impl Function {
             return_after_status = receiver.return_after_status;
             encoded_writeback = receiver.encoded_writeback;
             setup.extend(receiver.setup);
+            receiver_guard = receiver.guard;
             requires_wire_runtime |= receiver.requires_wire_runtime;
         }
 
@@ -1316,8 +1318,10 @@ impl Function {
                 encoded_writeback.as_ref(),
                 encoded_error.as_ref(),
                 handle_return.as_ref(),
+                receiver_guard.as_ref(),
             )?),
             None => (!setup.is_empty()
+                || receiver_guard.is_some()
                 || encoded_return.is_some()
                 || encoded_writeback.is_some()
                 || encoded_error.is_some()
@@ -1334,6 +1338,7 @@ impl Function {
                     encoded_error.as_ref(),
                     handle_return.as_ref(),
                     &parameter_writebacks,
+                    receiver_guard.as_ref(),
                 )
             })
             .transpose()?,
@@ -1623,6 +1628,7 @@ fn render_callable_body(
     encoded_error: Option<&EncodedError>,
     handle_return: Option<&HandleReturn>,
     parameter_writebacks: &[MutableParameterWriteback],
+    guard: Option<&ReceiverGuard>,
 ) -> Result<Statement> {
     let mut lines = setup.iter().map(ToString::to_string).collect::<Vec<_>>();
     if let Some(error) = encoded_error {
@@ -1640,7 +1646,7 @@ fn render_callable_body(
         } else if let Some(value) = return_after_status {
             lines.push(format!("return {value};"));
         }
-        return Ok(Statement::new(indent(&lines.join("\n"), 12)));
+        return finish_callable_body(lines, guard);
     }
 
     if let Some(handle) = handle_return {
@@ -1650,7 +1656,7 @@ fn render_callable_body(
             handle.native_type,
             handle_value_expression(handle.ty.clone(), &local, handle.nullable, handle.callback,),
         ));
-        return Ok(Statement::new(indent(&lines.join("\n"), 12)));
+        return finish_callable_body(lines, guard);
     }
 
     match encoded_return {
@@ -1672,7 +1678,21 @@ fn render_callable_body(
         }
         None => lines.push(format!("return {invocation};")),
     }
-    Ok(Statement::new(indent(&lines.join("\n"), 12)))
+    finish_callable_body(lines, guard)
+}
+
+fn finish_callable_body(lines: Vec<String>, guard: Option<&ReceiverGuard>) -> Result<Statement> {
+    let body = lines.join("\n");
+    let body = match guard {
+        Some(guard) => format!(
+            "{}\ntry\n{{\n{}\n}}\nfinally\n{{\n{}\n}}",
+            guard.retain,
+            indent(&body, 4),
+            indent(&guard.release.to_string(), 4),
+        ),
+        None => body,
+    };
+    Ok(Statement::new(indent(&body, 12)))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1689,6 +1709,7 @@ fn render_async_body(
     encoded_writeback: Option<&EncodedReturn>,
     encoded_error: Option<&EncodedError>,
     handle_return: Option<&HandleReturn>,
+    guard: Option<&ReceiverGuard>,
 ) -> Result<Statement> {
     if encoded_writeback.is_some() {
         return unsupported("mutable encoded value in async function");
@@ -1770,9 +1791,16 @@ fn render_async_body(
         true => "CallAsyncVoid".to_owned(),
         false => format!("CallAsync<{public_return_type}>"),
     };
+    let create = match guard {
+        Some(guard) => format!(
+            "() =>\n    {{\n        {}\n        try\n        {{\n            return {start};\n        }}\n        finally\n        {{\n            {}\n        }}\n    }}",
+            guard.retain, guard.release,
+        ),
+        None => format!("() => {start}"),
+    };
     let mut lines = setup.iter().map(ToString::to_string).collect::<Vec<_>>();
     lines.push(format!(
-        "return BoltFFIAsync.{call}(\n    () => {start},\n    NativeMethods.{},\n    {future} =>\n    {{\n{}\n    }},\n    NativeMethods.{},\n    NativeMethods.{},\n    cancellationToken);",
+        "return BoltFFIAsync.{call}(\n    {create},\n    NativeMethods.{},\n    {future} =>\n    {{\n{}\n    }},\n    NativeMethods.{},\n    NativeMethods.{},\n    cancellationToken);",
         asynchronous.poll_name,
         indent(&completion.join("\n"), 8),
         asynchronous.cancel_name,
@@ -1824,7 +1852,16 @@ struct LoweredReceiver {
     return_after_status: Option<Expression>,
     encoded_writeback: Option<EncodedReturn>,
     setup: Vec<Statement>,
+    guard: Option<ReceiverGuard>,
     requires_wire_runtime: bool,
+}
+
+/// In-flight guard for class receivers: retain declares the handle local and
+/// increments the call counter, release decrements it and frees the native
+/// allocation once the counter drains after `Dispose()`.
+struct ReceiverGuard {
+    retain: Statement,
+    release: Statement,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1882,6 +1919,7 @@ fn lower_receiver(
                 return_after_status: Some(Expression::identifier(output_name)),
                 encoded_writeback: None,
                 setup: Vec::new(),
+                guard: None,
                 requires_wire_runtime: false,
             })
         }
@@ -1903,6 +1941,7 @@ fn lower_receiver(
                 return_after_status: None,
                 encoded_writeback: None,
                 setup: Vec::new(),
+                guard: None,
                 requires_wire_runtime: false,
             })
         }
@@ -1934,10 +1973,17 @@ fn lower_class_receiver(
             array_out: false,
             byte_array: false,
         }],
-        arguments: vec![Expression::new("this.Handle")],
+        arguments: vec![Expression::new("boltffiReceiver")],
         return_after_status: None,
         encoded_writeback: None,
-        setup: vec![Statement::new("ThrowIfDisposed();")],
+        setup: Vec::new(),
+        guard: Some(ReceiverGuard {
+            retain: Statement::new(format!(
+                "{} boltffiReceiver = BoltffiRetain();",
+                handle_carrier_type(carrier)?
+            )),
+            release: Statement::new("BoltffiRelease();"),
+        }),
         requires_wire_runtime: false,
     })
 }
@@ -2054,6 +2100,7 @@ fn lower_encoded_receiver(
         return_after_status: None,
         encoded_writeback,
         setup,
+        guard: None,
         requires_wire_runtime: true,
     })
 }

--- a/boltffi_backend/src/target/csharp/render/mod.rs
+++ b/boltffi_backend/src/target/csharp/render/mod.rs
@@ -1793,18 +1793,24 @@ fn render_async_body(
     };
     let create = match guard {
         Some(guard) => format!(
-            "() =>\n    {{\n        {}\n        try\n        {{\n            return {start};\n        }}\n        finally\n        {{\n            {}\n        }}\n    }}",
+            "() =>\n    {{\n        {}\n        try\n        {{\n            return {start};\n        }}\n        catch\n        {{\n            {}\n            throw;\n        }}\n    }}",
             guard.retain, guard.release,
         ),
         None => format!("() => {start}"),
     };
+    let free = match guard {
+        Some(guard) => format!(
+            "{future} =>\n    {{\n        NativeMethods.{}({future});\n        {}\n    }}",
+            asynchronous.free_name, guard.release,
+        ),
+        None => format!("NativeMethods.{}", asynchronous.free_name),
+    };
     let mut lines = setup.iter().map(ToString::to_string).collect::<Vec<_>>();
     lines.push(format!(
-        "return BoltFFIAsync.{call}(\n    {create},\n    NativeMethods.{},\n    {future} =>\n    {{\n{}\n    }},\n    NativeMethods.{},\n    NativeMethods.{},\n    cancellationToken);",
+        "return BoltFFIAsync.{call}(\n    {create},\n    NativeMethods.{},\n    {future} =>\n    {{\n{}\n    }},\n    NativeMethods.{},\n    {free},\n    cancellationToken);",
         asynchronous.poll_name,
         indent(&completion.join("\n"), 8),
         asynchronous.cancel_name,
-        asynchronous.free_name,
     ));
     Ok(Statement::new(indent(&lines.join("\n"), 12)))
 }

--- a/boltffi_backend/src/target/java/render/call/asynchronous.rs
+++ b/boltffi_backend/src/target/java/render/call/asynchronous.rs
@@ -2,10 +2,7 @@ use super::*;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AsyncCall {
-    create_acquire: Vec<Statement>,
-    create_prepare: Vec<Statement>,
-    create: Expression,
-    create_cleanup: Vec<Statement>,
+    create_body: Vec<Statement>,
     poll: Expression,
     complete: Vec<Statement>,
     cancel: Expression,
@@ -101,40 +98,11 @@ impl AsyncCall {
             vec![Statement::throw_value(failure_call)],
         )];
         Ok(Self {
-            create_acquire: arguments
-                .receiver
-                .into_iter()
-                .flat_map(|receiver| receiver.native.acquire.iter().cloned())
-                .chain(
-                    arguments
-                        .parameters
-                        .iter()
-                        .flat_map(|parameter| parameter.native.acquire.iter().cloned()),
-                )
-                .collect(),
-            create_prepare: arguments
-                .receiver
-                .into_iter()
-                .flat_map(|receiver| receiver.native.prepare.iter().cloned())
-                .chain(
-                    arguments
-                        .parameters
-                        .iter()
-                        .flat_map(|parameter| parameter.native.prepare.iter().cloned()),
-                )
-                .collect(),
-            create,
-            create_cleanup: arguments
-                .parameters
-                .iter()
-                .flat_map(|parameter| parameter.native.cleanup.iter().cloned())
-                .chain(
-                    arguments
-                        .receiver
-                        .into_iter()
-                        .flat_map(|receiver| receiver.native.cleanup.iter().cloned()),
-                )
-                .collect(),
+            create_body: guarded_body(
+                arguments.receiver,
+                arguments.parameters,
+                vec![Statement::return_value(create)],
+            ),
             poll: poll.call(scope.native_owner, [future.clone(), continuation])?,
             complete: complete_body,
             cancel: cancel.call(scope.native_owner, [future.clone()])?,
@@ -143,24 +111,8 @@ impl AsyncCall {
         })
     }
 
-    pub fn create_acquire(&self) -> &[Statement] {
-        &self.create_acquire
-    }
-
-    pub fn create_prepare(&self) -> &[Statement] {
-        &self.create_prepare
-    }
-
-    pub fn create(&self) -> &Expression {
-        &self.create
-    }
-
-    pub fn create_cleanup(&self) -> &[Statement] {
-        &self.create_cleanup
-    }
-
-    pub fn has_create_cleanup(&self) -> bool {
-        !self.create_cleanup.is_empty()
+    pub fn create_body(&self) -> &[Statement] {
+        &self.create_body
     }
 
     pub fn poll(&self) -> &Expression {

--- a/boltffi_backend/src/target/java/render/call/asynchronous.rs
+++ b/boltffi_backend/src/target/java/render/call/asynchronous.rs
@@ -6,7 +6,7 @@ pub struct AsyncCall {
     poll: Expression,
     complete: Vec<Statement>,
     cancel: Expression,
-    free: Expression,
+    free_body: Vec<Statement>,
     native_methods: Vec<Method>,
 }
 
@@ -97,16 +97,27 @@ impl AsyncCall {
             failure,
             vec![Statement::throw_value(failure_call)],
         )];
+        let free_body = std::iter::once(Statement::expression(
+            free.call(scope.native_owner, [future.clone()])?,
+        ))
+        .chain(
+            arguments
+                .receiver
+                .iter()
+                .flat_map(|receiver| receiver.native.cleanup.iter().cloned()),
+        )
+        .collect();
         Ok(Self {
-            create_body: guarded_body(
+            create_body: guarded_create_body(
                 arguments.receiver,
                 arguments.parameters,
                 vec![Statement::return_value(create)],
+                scope.version,
             ),
             poll: poll.call(scope.native_owner, [future.clone(), continuation])?,
             complete: complete_body,
-            cancel: cancel.call(scope.native_owner, [future.clone()])?,
-            free: free.call(scope.native_owner, [future])?,
+            cancel: cancel.call(scope.native_owner, [future])?,
+            free_body,
             native_methods: vec![start, poll, complete, cancel, free, panic_message],
         })
     }
@@ -127,8 +138,8 @@ impl AsyncCall {
         &self.cancel
     }
 
-    pub fn free(&self) -> &Expression {
-        &self.free
+    pub fn free_body(&self) -> &[Statement] {
+        &self.free_body
     }
 
     pub fn native_methods(&self) -> &[Method] {

--- a/boltffi_backend/src/target/java/render/call/mod.rs
+++ b/boltffi_backend/src/target/java/render/call/mod.rs
@@ -825,6 +825,65 @@ fn guarded_body(
     parameters: &[BoundParameter],
     success: Vec<Statement>,
 ) -> Vec<Statement> {
+    let guarded = parameter_guarded(receiver, parameters, success);
+    let cleanup = receiver
+        .iter()
+        .flat_map(|receiver| receiver.native.cleanup.iter().cloned())
+        .collect::<Vec<_>>();
+    let guarded = match cleanup.is_empty() {
+        true => guarded,
+        false => vec![Statement::try_finally(guarded, cleanup)],
+    };
+    receiver
+        .iter()
+        .flat_map(|receiver| receiver.native.acquire.iter().cloned())
+        .chain(guarded)
+        .collect()
+}
+
+/// Guards async future creation: the receiver's retain is released only when
+/// creation throws, since on success the future's free hook releases it.
+fn guarded_create_body(
+    receiver: Option<&Receiver>,
+    parameters: &[BoundParameter],
+    success: Vec<Statement>,
+    version: JavaVersion,
+) -> Vec<Statement> {
+    let guarded = parameter_guarded(receiver, parameters, success);
+    let cleanup = receiver
+        .iter()
+        .flat_map(|receiver| receiver.native.cleanup.iter().cloned())
+        .collect::<Vec<_>>();
+    let guarded = match cleanup.is_empty() {
+        true => guarded,
+        false => {
+            let failure = Identifier::known("__boltffi_failure");
+            let recovery = cleanup
+                .into_iter()
+                .chain([Statement::throw_value(Expression::identifier(
+                    failure.clone(),
+                ))])
+                .collect();
+            vec![Statement::try_catch(
+                guarded,
+                TypeName::named(TypeIdentifier::known("Throwable", version)),
+                failure,
+                recovery,
+            )]
+        }
+    };
+    receiver
+        .iter()
+        .flat_map(|receiver| receiver.native.acquire.iter().cloned())
+        .chain(guarded)
+        .collect()
+}
+
+fn parameter_guarded(
+    receiver: Option<&Receiver>,
+    parameters: &[BoundParameter],
+    success: Vec<Statement>,
+) -> Vec<Statement> {
     let protected = receiver
         .iter()
         .flat_map(|receiver| receiver.native.prepare.iter().cloned())
@@ -843,23 +902,10 @@ fn guarded_body(
         true => protected,
         false => vec![Statement::try_finally(protected, cleanup)],
     };
-    let guarded = parameters
+    parameters
         .iter()
         .flat_map(|parameter| parameter.native.acquire.iter().cloned())
         .chain(protected)
-        .collect::<Vec<_>>();
-    let cleanup = receiver
-        .iter()
-        .flat_map(|receiver| receiver.native.cleanup.iter().cloned())
-        .collect::<Vec<_>>();
-    let guarded = match cleanup.is_empty() {
-        true => guarded,
-        false => vec![Statement::try_finally(guarded, cleanup)],
-    };
-    receiver
-        .iter()
-        .flat_map(|receiver| receiver.native.acquire.iter().cloned())
-        .chain(guarded)
         .collect()
 }
 

--- a/boltffi_backend/src/target/java/render/call/mod.rs
+++ b/boltffi_backend/src/target/java/render/call/mod.rs
@@ -521,39 +521,7 @@ impl Call {
             scope.package,
             scope.return_context,
         )?;
-        let protected = receiver
-            .iter()
-            .flat_map(|receiver| receiver.native.prepare.iter().cloned())
-            .chain(
-                parameters
-                    .iter()
-                    .flat_map(|parameter| parameter.native.prepare.iter().cloned()),
-            )
-            .chain(success)
-            .collect::<Vec<_>>();
-        let cleanup = parameters
-            .iter()
-            .flat_map(|parameter| parameter.native.cleanup.iter().cloned())
-            .chain(
-                receiver
-                    .iter()
-                    .flat_map(|receiver| receiver.native.cleanup.iter().cloned()),
-            )
-            .collect::<Vec<_>>();
-        let protected = match cleanup.is_empty() {
-            true => protected,
-            false => vec![Statement::try_finally(protected, cleanup)],
-        };
-        let body = receiver
-            .iter()
-            .flat_map(|receiver| receiver.native.acquire.iter().cloned())
-            .chain(
-                parameters
-                    .iter()
-                    .flat_map(|parameter| parameter.native.acquire.iter().cloned()),
-            )
-            .chain(protected)
-            .collect();
+        let body = guarded_body(receiver.as_ref(), &parameters, success);
         Ok(Self {
             signature: CallSignature::new(
                 name,
@@ -848,6 +816,51 @@ impl NativeArgument {
             runtime: RuntimeRequirement::Wire,
         }
     }
+}
+
+/// Nests the receiver's cleanup around the parameter acquires so a throwing
+/// parameter acquire cannot leak the receiver's in-flight retain.
+fn guarded_body(
+    receiver: Option<&Receiver>,
+    parameters: &[BoundParameter],
+    success: Vec<Statement>,
+) -> Vec<Statement> {
+    let protected = receiver
+        .iter()
+        .flat_map(|receiver| receiver.native.prepare.iter().cloned())
+        .chain(
+            parameters
+                .iter()
+                .flat_map(|parameter| parameter.native.prepare.iter().cloned()),
+        )
+        .chain(success)
+        .collect::<Vec<_>>();
+    let cleanup = parameters
+        .iter()
+        .flat_map(|parameter| parameter.native.cleanup.iter().cloned())
+        .collect::<Vec<_>>();
+    let protected = match cleanup.is_empty() {
+        true => protected,
+        false => vec![Statement::try_finally(protected, cleanup)],
+    };
+    let guarded = parameters
+        .iter()
+        .flat_map(|parameter| parameter.native.acquire.iter().cloned())
+        .chain(protected)
+        .collect::<Vec<_>>();
+    let cleanup = receiver
+        .iter()
+        .flat_map(|receiver| receiver.native.cleanup.iter().cloned())
+        .collect::<Vec<_>>();
+    let guarded = match cleanup.is_empty() {
+        true => guarded,
+        false => vec![Statement::try_finally(guarded, cleanup)],
+    };
+    receiver
+        .iter()
+        .flat_map(|receiver| receiver.native.acquire.iter().cloned())
+        .chain(guarded)
+        .collect()
 }
 
 impl RuntimeRequirement {
@@ -1408,13 +1421,26 @@ impl Receiver {
         carrier: native::HandleCarrier,
         receive: Receive,
     ) -> Result<Self> {
-        Primitive::from_handle_carrier(carrier)?;
+        let primitive = Primitive::from_handle_carrier(carrier)?;
+        let retained = Identifier::known("__boltffi_receiver");
         match receive {
             Receive::ByRef | Receive::ByMutRef => Ok(Self {
                 ty,
-                native: NativeArgument::direct(
-                    Expression::this().call(Identifier::known("rawHandle"), Default::default()),
-                ),
+                native: NativeArgument {
+                    acquire: vec![Statement::value(
+                        TypeName::primitive(primitive),
+                        retained.clone(),
+                        Expression::this()
+                            .call(Identifier::known("boltffiRetain"), Default::default()),
+                    )],
+                    prepare: Vec::new(),
+                    expressions: vec![Expression::identifier(retained)],
+                    cleanup: vec![Statement::expression(
+                        Expression::this()
+                            .call(Identifier::known("boltffiRelease"), Default::default()),
+                    )],
+                    runtime: RuntimeRequirement::None,
+                },
                 mutation: None,
                 support: ReceiverSupport::Handle(carrier),
             }),

--- a/boltffi_backend/src/target/java/render/class.rs
+++ b/boltffi_backend/src/target/java/render/class.rs
@@ -274,7 +274,7 @@ impl Class {
     }
 
     pub fn signatures(&self) -> Vec<ErasedSignature> {
-        ["close", "rawHandle"]
+        ["close", "rawHandle", "boltffiRetain", "boltffiRelease"]
             .into_iter()
             .map(|name| ErasedSignature::new(Identifier::known(name), []))
             .chain(

--- a/boltffi_backend/src/target/kotlin/render/class.rs
+++ b/boltffi_backend/src/target/kotlin/render/class.rs
@@ -49,7 +49,9 @@ pub struct Initializer {
 struct ConstructorSignature(Vec<String>);
 
 /// Handle read through the generated closed-check accessor. Check-then-act:
-/// a `close()` racing the native call is not covered.
+/// a `close()` racing the native call is not covered. Receivers instead go
+/// through the generated `boltffiRetain()`/`boltffiRelease()` in-flight
+/// counter, which defers the native free past the racing call.
 fn guarded_handle(receiver: impl fmt::Display, presence: HandlePresence) -> Result<Expression> {
     let accessor = Identifier::parse("boltffiHandle")?;
     match presence {
@@ -84,14 +86,16 @@ impl Class {
         let name = Self::type_name(decl.name())?;
         let instance_methods = Self::methods(
             decl.methods(),
-            Some(guarded_handle("this", HandlePresence::Required)?),
+            Some(Expression::identifier(Identifier::parse(
+                "__boltffi_receiver",
+            )?)),
             host,
             bridge,
             context,
         )?;
         validate_reserved_members(
             &name,
-            &["close", "boltffiHandle"],
+            &["close", "boltffiHandle", "boltffiRetain", "boltffiRelease"],
             instance_methods
                 .iter()
                 .filter(|method| method.parameters().is_empty())

--- a/boltffi_backend/templates/target/csharp/class.cs
+++ b/boltffi_backend/templates/target/csharp/class.cs
@@ -8,8 +8,20 @@ namespace {{ class.namespace }}
 {{ class.documentation }}    public sealed class {{ class.name }} : global::System.IDisposable
     {
         private long handle;
+        private long calls = 1;
+        private int closed;
 
-        internal {{ class.carrier_type }} Handle => unchecked(({{ class.carrier_type }})(ulong)global::System.Threading.Interlocked.Read(ref handle));
+        private {{ class.carrier_type }} RawHandle => unchecked(({{ class.carrier_type }})(ulong)global::System.Threading.Interlocked.Read(ref handle));
+
+        internal {{ class.carrier_type }} Handle
+        {
+            get
+            {
+                if (global::System.Threading.Volatile.Read(ref closed) != 0)
+                    throw new global::System.ObjectDisposedException(nameof({{ class.name }}));
+                return RawHandle;
+            }
+        }
 
         internal {{ class.name }}({{ class.carrier_type }} handle)
         {
@@ -27,18 +39,37 @@ namespace {{ class.namespace }}
 {% endfor %}{% for function in class.methods %}
 {% include "target/csharp/function.cs" %}
 {% endfor %}
-        private {{ class.carrier_type }} TakeHandle() => unchecked(({{ class.carrier_type }})(ulong)global::System.Threading.Interlocked.Exchange(ref handle, 0));
-
-        private void ThrowIfDisposed()
+        private {{ class.carrier_type }} TakeHandle()
         {
-            if (global::System.Threading.Interlocked.Read(ref handle) == 0)
-                throw new global::System.ObjectDisposedException(nameof({{ class.name }}));
+            global::System.Threading.Interlocked.Exchange(ref closed, 1);
+            global::System.Threading.Interlocked.Exchange(ref calls, 0);
+            return RawHandle;
+        }
+
+        private {{ class.carrier_type }} BoltffiRetain()
+        {
+            while (true)
+            {
+                if (global::System.Threading.Volatile.Read(ref closed) != 0)
+                    throw new global::System.ObjectDisposedException(nameof({{ class.name }}));
+                long calls = global::System.Threading.Interlocked.Read(ref this.calls);
+                if (calls == 0)
+                    throw new global::System.ObjectDisposedException(nameof({{ class.name }}));
+                if (global::System.Threading.Interlocked.CompareExchange(ref this.calls, calls + 1, calls) == calls)
+                    return RawHandle;
+            }
+        }
+
+        private void BoltffiRelease()
+        {
+            if (global::System.Threading.Interlocked.Decrement(ref calls) == 0)
+                NativeMethods.{{ class.release_name }}(RawHandle);
         }
 
         private void Release()
         {
-            {{ class.carrier_type }} released = unchecked(({{ class.carrier_type }})(ulong)global::System.Threading.Interlocked.Exchange(ref handle, 0));
-            if (released != 0) NativeMethods.{{ class.release_name }}(released);
+            if (global::System.Threading.Interlocked.Exchange(ref closed, 1) == 0)
+                BoltffiRelease();
         }
 
         ~{{ class.name }}() => Release();

--- a/boltffi_backend/templates/target/java/call/asynchronous.java
+++ b/boltffi_backend/templates/target/java/call/asynchronous.java
@@ -1,15 +1,7 @@
 {% if let Some(asynchronous) = call.async_call() %}        return BoltFfiAsync.call(
             () -> {
-{% for statement in asynchronous.create_acquire() %}                {{ statement }}
-{% endfor %}{% if asynchronous.has_create_cleanup() %}                try {
-{% for statement in asynchronous.create_prepare() %}                    {{ statement }}
-{% endfor %}                    return {{ asynchronous.create() }};
-                } finally {
-{% for statement in asynchronous.create_cleanup() %}                    {{ statement }}
-{% endfor %}                }
-{% else %}{% for statement in asynchronous.create_prepare() %}                {{ statement }}
-{% endfor %}                return {{ asynchronous.create() }};
-{% endif %}            },
+{% for statement in asynchronous.create_body() %}                {{ statement }}
+{% endfor %}            },
             (future, continuation) -> {{ asynchronous.poll() }},
             (future) -> {
 {% for statement in asynchronous.complete() %}                {{ statement }}

--- a/boltffi_backend/templates/target/java/call/asynchronous.java
+++ b/boltffi_backend/templates/target/java/call/asynchronous.java
@@ -7,6 +7,8 @@
 {% for statement in asynchronous.complete() %}                {{ statement }}
 {% endfor %}            },
             (future) -> {{ asynchronous.cancel() }},
-            (future) -> {{ asynchronous.free() }}
+            (future) -> {
+{% for statement in asynchronous.free_body() %}                {{ statement }}
+{% endfor %}            }
         );
 {% endif %}

--- a/boltffi_backend/templates/target/java/class.java
+++ b/boltffi_backend/templates/target/java/class.java
@@ -1,10 +1,12 @@
 package {{ package }};
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 {% if let Some(doc) = class.doc() %}{{ doc }}
 {% endif %}public final class {{ class.name() }} implements AutoCloseable {
     private final {{ class.handle() }} handle;
+    private final AtomicLong calls = new AtomicLong(1L);
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
     {{ class.name() }}({{ class.handle() }} handle) {
@@ -27,10 +29,25 @@ import java.util.concurrent.atomic.AtomicBoolean;
         return handle;
     }
 
+    {{ class.handle() }} boltffiRetain() {
+        while (true) {
+            if (closed.get()) throw new IllegalStateException("{{ class.name() }} is closed");
+            long calls = this.calls.get();
+            if (calls == 0L) throw new IllegalStateException("{{ class.name() }} is closed");
+            if (this.calls.compareAndSet(calls, calls + 1L)) return handle;
+        }
+    }
+
+    void boltffiRelease() {
+        if (calls.decrementAndGet() == 0L) {
+            {{ class.release() }}
+        }
+    }
+
     @Override
     public void close() {
         if (!closed.compareAndSet(false, true)) return;
-        {{ class.release() }}
+        boltffiRelease();
     }
 {% for call in class.factories() %}
 {% include "target/java/call/initializer.java" %}

--- a/boltffi_backend/templates/target/kotlin/class.kt
+++ b/boltffi_backend/templates/target/kotlin/class.kt
@@ -1,15 +1,31 @@
 {{ class.documentation() }}class {{ class.name() }} internal constructor(internal val handle: Long) : AutoCloseable {
+    private val __boltffi_calls = java.util.concurrent.atomic.AtomicLong(1L)
     private val __boltffi_closed = java.util.concurrent.atomic.AtomicBoolean(false)
 
     override fun close() {
         if (__boltffi_closed.compareAndSet(false, true)) {
-            Native.{{ class.release() }}(handle)
+            boltffiRelease()
         }
     }
 
     internal fun boltffiHandle(): Long {
         check(!__boltffi_closed.get()) { "{{ class.name() }} is closed" }
         return handle
+    }
+
+    internal fun boltffiRetain(): Long {
+        while (true) {
+            check(!__boltffi_closed.get()) { "{{ class.name() }} is closed" }
+            val calls = __boltffi_calls.get()
+            check(calls != 0L) { "{{ class.name() }} is closed" }
+            if (__boltffi_calls.compareAndSet(calls, calls + 1L)) return handle
+        }
+    }
+
+    internal fun boltffiRelease() {
+        if (__boltffi_calls.decrementAndGet() == 0L) {
+            Native.{{ class.release() }}(handle)
+        }
     }
 {%- for initializer in class.initializers() %}
 {%- if initializer.constructor() %}
@@ -146,20 +162,25 @@
         boltffiCallAsync(
 {%- endif %}
             createFuture = {
-{%- for statement in async_call.create_setup() %}
-                {{ statement }}
-{%- endfor %}
-{%- if async_call.has_create_cleanup() %}
+                val __boltffi_receiver = boltffiRetain()
                 try {
-                    {{ async_call.create() }}
-                } finally {
-{%- for statement in async_call.create_cleanup() %}
+{%- for statement in async_call.create_setup() %}
                     {{ statement }}
 {%- endfor %}
-                }
+{%- if async_call.has_create_cleanup() %}
+                    try {
+                        {{ async_call.create() }}
+                    } finally {
+{%- for statement in async_call.create_cleanup() %}
+                        {{ statement }}
+{%- endfor %}
+                    }
 {%- else %}
-                {{ async_call.create() }}
+                    {{ async_call.create() }}
 {%- endif %}
+                } finally {
+                    boltffiRelease()
+                }
             },
             poll = { future, contHandle -> Native.{{ async_call.poll() }}(future, contHandle) },
             complete = { future ->
@@ -171,24 +192,29 @@
             cancel = { future -> Native.{{ async_call.cancel() }}(future) },
         )
 {%- else %}
+        val __boltffi_receiver = boltffiRetain()
+        try {
 {%- for statement in method.setup() %}
-        {{ statement }}
+            {{ statement }}
 {%- endfor %}
 {%- if method.has_cleanup() %}
-        try {
+            try {
 {%- for statement in method.call() %}
-            {{ statement }}
+                {{ statement }}
 {%- endfor %}
-        } finally {
+            } finally {
 {%- for statement in method.cleanup() %}
-            {{ statement }}
+                {{ statement }}
 {%- endfor %}
-        }
+            }
 {%- else %}
 {%- for statement in method.call() %}
-        {{ statement }}
+            {{ statement }}
 {%- endfor %}
 {%- endif %}
+        } finally {
+            boltffiRelease()
+        }
 {%- endif %}
     }
 {%- endfor %}

--- a/boltffi_backend/templates/target/kotlin/class.kt
+++ b/boltffi_backend/templates/target/kotlin/class.kt
@@ -178,8 +178,9 @@
 {%- else %}
                     {{ async_call.create() }}
 {%- endif %}
-                } finally {
+                } catch (__boltffi_failure: Throwable) {
                     boltffiRelease()
+                    throw __boltffi_failure
                 }
             },
             poll = { future, contHandle -> Native.{{ async_call.poll() }}(future, contHandle) },
@@ -188,7 +189,10 @@
                 {{ statement }}
 {%- endfor %}
             },
-            free = { future -> Native.{{ async_call.free() }}(future) },
+            free = { future ->
+                Native.{{ async_call.free() }}(future)
+                boltffiRelease()
+            },
             cancel = { future -> Native.{{ async_call.cancel() }}(future) },
         )
 {%- else %}

--- a/boltffi_backend/tests/java.rs
+++ b/boltffi_backend/tests/java.rs
@@ -336,6 +336,10 @@ const CLASSES: &str = r#"
         pub fn get(&self) -> i32 { self.value }
 
         pub fn set(&mut self, value: i32) { self.value = value; }
+
+        pub fn label(&self, prefix: String) -> String {
+            format!("{prefix}{}", self.value)
+        }
     }
 
     pub struct FallibleOnly {
@@ -1532,9 +1536,19 @@ fn java_target_renders_class_ownership_and_handle_calls_from_binding_ir() {
     );
     assert!(counter.contains("public int get()"));
     assert!(counter.contains("public void set(int value)"));
+    assert!(counter.contains("long boltffiRetain()"));
+    assert!(counter.contains("void boltffiRelease()"));
+    assert!(counter.contains("if (calls.decrementAndGet() == 0L) {"));
+    assert!(counter.contains("long __boltffi_receiver = this.boltffiRetain();"));
     assert!(
-        counter.contains("Native.boltffi_method_class_demo_counter_set(this.rawHandle(), value);")
+        counter
+            .contains("Native.boltffi_method_class_demo_counter_set(__boltffi_receiver, value);")
     );
+    assert!(counter.contains("public String label(String prefix)"));
+    assert!(counter.contains(
+        "long __boltffi_receiver = this.boltffiRetain();\n        try {\n    WireLease __boltffi_prefix_wire = WireWriterPool.acquire(WireSizes.string(prefix));"
+    ));
+    assert!(counter.contains("    } finally {\n        __boltffi_prefix_wire.close();\n    }\n} finally {\n    this.boltffiRelease();\n}"));
 
     assert!(fallible.contains("public FallibleOnly(String name)"));
     assert!(fallible.contains("private static long __boltffiCreateHandle0(String name)"));
@@ -1549,7 +1563,7 @@ fn java_target_renders_class_ownership_and_handle_calls_from_binding_ir() {
     );
     assert!(factory.contains("public Counter maybe(int value)"));
     assert!(factory.contains(
-        "long __boltffi_handle = Native.boltffi_method_class_demo_factory_maybe(this.rawHandle(), value);"
+        "long __boltffi_handle = Native.boltffi_method_class_demo_factory_maybe(__boltffi_receiver, value);"
     ));
     assert!(
         factory.contains("return (__boltffi_handle == 0L ? null : new Counter(__boltffi_handle));")
@@ -1990,7 +2004,8 @@ fn java_target_renders_async_functions_and_methods_from_poll_handle_protocols() 
     assert!(
         worker.contains("public java.util.concurrent.CompletableFuture<Integer> run(int value)")
     );
-    assert!(worker.contains("this.rawHandle()"));
+    assert!(worker.contains("long __boltffi_receiver = this.boltffiRetain();"));
+    assert!(worker.contains("this.boltffiRelease();"));
     assert!(output.coverage().unsupported().is_empty());
 }
 

--- a/boltffi_backend/tests/java.rs
+++ b/boltffi_backend/tests/java.rs
@@ -2004,8 +2004,12 @@ fn java_target_renders_async_functions_and_methods_from_poll_handle_protocols() 
     assert!(
         worker.contains("public java.util.concurrent.CompletableFuture<Integer> run(int value)")
     );
-    assert!(worker.contains("long __boltffi_receiver = this.boltffiRetain();"));
-    assert!(worker.contains("this.boltffiRelease();"));
+    assert!(worker.contains(
+        "long __boltffi_receiver = this.boltffiRetain();\n                try {\n    return Native.boltffi_method_class_demo_worker_run(__boltffi_receiver, value);\n} catch (Throwable __boltffi_failure) {\n    this.boltffiRelease();\n    throw __boltffi_failure;\n}"
+    ));
+    assert!(worker.contains(
+        "(future) -> {\n                Native.boltffi_async_method_class_demo_worker_run_free(future);\n                this.boltffiRelease();\n            }"
+    ));
     assert!(output.coverage().unsupported().is_empty());
 }
 

--- a/boltffi_backend/tests/kotlin/exports.rs
+++ b/boltffi_backend/tests/kotlin/exports.rs
@@ -179,9 +179,9 @@ fn kotlin_target_renders_class_handles_and_associated_callables() {
 
     assert!(rendered.contains("internal fun boltffiHandle(): Long {"));
     assert!(rendered.contains("check(!__boltffi_closed.get()) { \"Engine is closed\" }"));
-    assert!(
-        rendered.contains("Native.boltffi_method_class_demo_engine_value(this.boltffiHandle())")
-    );
+    assert!(rendered.contains("internal fun boltffiRetain(): Long {"));
+    assert!(rendered.contains("internal fun boltffiRelease() {"));
+    assert!(rendered.contains("Native.boltffi_method_class_demo_engine_value(__boltffi_receiver)"));
     assert!(!rendered.contains("this.handle"));
     assert!(rendered.contains("other.boltffiHandle()"));
     assert!(rendered.contains("other?.boltffiHandle() ?: 0L"));

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_preserves_rust_pascal_type_spelling.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_preserves_rust_pascal_type_spelling.snap
@@ -14,17 +14,33 @@ private object Native {
 }
 
 class GPSSimulator internal constructor(internal val handle: Long) : AutoCloseable {
+    private val __boltffi_calls = java.util.concurrent.atomic.AtomicLong(1L)
     private val __boltffi_closed = java.util.concurrent.atomic.AtomicBoolean(false)
 
     override fun close() {
         if (__boltffi_closed.compareAndSet(false, true)) {
-            Native.boltffi_release_class_demo_gps_simulator(handle)
+            boltffiRelease()
         }
     }
 
     internal fun boltffiHandle(): Long {
         check(!__boltffi_closed.get()) { "GPSSimulator is closed" }
         return handle
+    }
+
+    internal fun boltffiRetain(): Long {
+        while (true) {
+            check(!__boltffi_closed.get()) { "GPSSimulator is closed" }
+            val calls = __boltffi_calls.get()
+            check(calls != 0L) { "GPSSimulator is closed" }
+            if (__boltffi_calls.compareAndSet(calls, calls + 1L)) return handle
+        }
+    }
+
+    internal fun boltffiRelease() {
+        if (__boltffi_calls.decrementAndGet() == 0L) {
+            Native.boltffi_release_class_demo_gps_simulator(handle)
+        }
     }
 
     constructor(enabled: Boolean) : this(new(enabled).handle)
@@ -36,6 +52,11 @@ class GPSSimulator internal constructor(internal val handle: Long) : AutoCloseab
     }
 
     fun enabled(): Boolean {
-        return Native.boltffi_method_class_demo_gps_simulator_enabled(this.boltffiHandle())
+        val __boltffi_receiver = boltffiRetain()
+        try {
+            return Native.boltffi_method_class_demo_gps_simulator_enabled(__boltffi_receiver)
+        } finally {
+            boltffiRelease()
+        }
     }
 }

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_async_class_methods.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_async_class_methods.snap
@@ -25,17 +25,33 @@ private object Native {
 }
 
 class Engine internal constructor(internal val handle: Long) : AutoCloseable {
+    private val __boltffi_calls = java.util.concurrent.atomic.AtomicLong(1L)
     private val __boltffi_closed = java.util.concurrent.atomic.AtomicBoolean(false)
 
     override fun close() {
         if (__boltffi_closed.compareAndSet(false, true)) {
-            Native.boltffi_release_class_demo_engine(handle)
+            boltffiRelease()
         }
     }
 
     internal fun boltffiHandle(): Long {
         check(!__boltffi_closed.get()) { "Engine is closed" }
         return handle
+    }
+
+    internal fun boltffiRetain(): Long {
+        while (true) {
+            check(!__boltffi_closed.get()) { "Engine is closed" }
+            val calls = __boltffi_calls.get()
+            check(calls != 0L) { "Engine is closed" }
+            if (__boltffi_calls.compareAndSet(calls, calls + 1L)) return handle
+        }
+    }
+
+    internal fun boltffiRelease() {
+        if (__boltffi_calls.decrementAndGet() == 0L) {
+            Native.boltffi_release_class_demo_engine(handle)
+        }
     }
 
     constructor() : this(new().handle)
@@ -49,7 +65,12 @@ class Engine internal constructor(internal val handle: Long) : AutoCloseable {
     suspend fun compute(value: UInt): UInt {
         return boltffiCallAsync(
             createFuture = {
-                Native.boltffi_method_class_demo_engine_compute(this.boltffiHandle(), value.toInt())
+                val __boltffi_receiver = boltffiRetain()
+                try {
+                    Native.boltffi_method_class_demo_engine_compute(__boltffi_receiver, value.toInt())
+                } finally {
+                    boltffiRelease()
+                }
             },
             poll = { future, contHandle -> Native.boltffi_async_method_class_demo_engine_compute_poll(future, contHandle) },
             complete = { future ->

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_async_class_methods.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_async_class_methods.snap
@@ -68,15 +68,19 @@ class Engine internal constructor(internal val handle: Long) : AutoCloseable {
                 val __boltffi_receiver = boltffiRetain()
                 try {
                     Native.boltffi_method_class_demo_engine_compute(__boltffi_receiver, value.toInt())
-                } finally {
+                } catch (__boltffi_failure: Throwable) {
                     boltffiRelease()
+                    throw __boltffi_failure
                 }
             },
             poll = { future, contHandle -> Native.boltffi_async_method_class_demo_engine_compute_poll(future, contHandle) },
             complete = { future ->
                 Native.boltffi_async_method_class_demo_engine_compute_complete(future).toUInt()
             },
-            free = { future -> Native.boltffi_async_method_class_demo_engine_compute_free(future) },
+            free = { future ->
+                Native.boltffi_async_method_class_demo_engine_compute_free(future)
+                boltffiRelease()
+            },
             cancel = { future -> Native.boltffi_async_method_class_demo_engine_compute_cancel(future) },
         )
     }

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_async_initializers_as_suspend_factories.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_async_initializers_as_suspend_factories.snap
@@ -26,17 +26,33 @@ private object Native {
 }
 
 class Client internal constructor(internal val handle: Long) : AutoCloseable {
+    private val __boltffi_calls = java.util.concurrent.atomic.AtomicLong(1L)
     private val __boltffi_closed = java.util.concurrent.atomic.AtomicBoolean(false)
 
     override fun close() {
         if (__boltffi_closed.compareAndSet(false, true)) {
-            Native.boltffi_release_class_demo_client(handle)
+            boltffiRelease()
         }
     }
 
     internal fun boltffiHandle(): Long {
         check(!__boltffi_closed.get()) { "Client is closed" }
         return handle
+    }
+
+    internal fun boltffiRetain(): Long {
+        while (true) {
+            check(!__boltffi_closed.get()) { "Client is closed" }
+            val calls = __boltffi_calls.get()
+            check(calls != 0L) { "Client is closed" }
+            if (__boltffi_calls.compareAndSet(calls, calls + 1L)) return handle
+        }
+    }
+
+    internal fun boltffiRelease() {
+        if (__boltffi_calls.decrementAndGet() == 0L) {
+            Native.boltffi_release_class_demo_client(handle)
+        }
     }
 
     constructor() : this(new().handle)
@@ -61,6 +77,11 @@ class Client internal constructor(internal val handle: Long) : AutoCloseable {
     }
 
     fun port(): UInt {
-        return Native.boltffi_method_class_demo_client_port(this.boltffiHandle()).toUInt()
+        val __boltffi_receiver = boltffiRetain()
+        try {
+            return Native.boltffi_method_class_demo_client_port(__boltffi_receiver).toUInt()
+        } finally {
+            boltffiRelease()
+        }
     }
 }

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_class_handles_and_associated_callables.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_class_handles_and_associated_callables.snap
@@ -17,17 +17,33 @@ private object Native {
 }
 
 class Engine internal constructor(internal val handle: Long) : AutoCloseable {
+    private val __boltffi_calls = java.util.concurrent.atomic.AtomicLong(1L)
     private val __boltffi_closed = java.util.concurrent.atomic.AtomicBoolean(false)
 
     override fun close() {
         if (__boltffi_closed.compareAndSet(false, true)) {
-            Native.boltffi_release_class_demo_engine(handle)
+            boltffiRelease()
         }
     }
 
     internal fun boltffiHandle(): Long {
         check(!__boltffi_closed.get()) { "Engine is closed" }
         return handle
+    }
+
+    internal fun boltffiRetain(): Long {
+        while (true) {
+            check(!__boltffi_closed.get()) { "Engine is closed" }
+            val calls = __boltffi_calls.get()
+            check(calls != 0L) { "Engine is closed" }
+            if (__boltffi_calls.compareAndSet(calls, calls + 1L)) return handle
+        }
+    }
+
+    internal fun boltffiRelease() {
+        if (__boltffi_calls.decrementAndGet() == 0L) {
+            Native.boltffi_release_class_demo_engine(handle)
+        }
     }
 
     constructor(value: Int) : this(new(value).handle)
@@ -42,15 +58,30 @@ class Engine internal constructor(internal val handle: Long) : AutoCloseable {
     }
 
     fun value(): Int {
-        return Native.boltffi_method_class_demo_engine_value(this.boltffiHandle())
+        val __boltffi_receiver = boltffiRetain()
+        try {
+            return Native.boltffi_method_class_demo_engine_value(__boltffi_receiver)
+        } finally {
+            boltffiRelease()
+        }
     }
 
     fun swap(other: Engine): Engine {
-        return Engine(Native.boltffi_method_class_demo_engine_swap(this.boltffiHandle(), other.boltffiHandle()))
+        val __boltffi_receiver = boltffiRetain()
+        try {
+            return Engine(Native.boltffi_method_class_demo_engine_swap(__boltffi_receiver, other.boltffiHandle()))
+        } finally {
+            boltffiRelease()
+        }
     }
 
     fun maybeSwap(other: Engine?): Engine? {
-        val __boltffi_handle = Native.boltffi_method_class_demo_engine_maybe_swap(this.boltffiHandle(), other?.boltffiHandle() ?: 0L)
-        return if (__boltffi_handle == 0L) null else Engine(__boltffi_handle)
+        val __boltffi_receiver = boltffiRetain()
+        try {
+            val __boltffi_handle = Native.boltffi_method_class_demo_engine_maybe_swap(__boltffi_receiver, other?.boltffiHandle() ?: 0L)
+            return if (__boltffi_handle == 0L) null else Engine(__boltffi_handle)
+        } finally {
+            boltffiRelease()
+        }
     }
 }

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_companion_factory_style.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_companion_factory_style.snap
@@ -17,17 +17,33 @@ private object Native {
 }
 
 class Engine internal constructor(internal val handle: Long) : AutoCloseable {
+    private val __boltffi_calls = java.util.concurrent.atomic.AtomicLong(1L)
     private val __boltffi_closed = java.util.concurrent.atomic.AtomicBoolean(false)
 
     override fun close() {
         if (__boltffi_closed.compareAndSet(false, true)) {
-            Native.boltffi_release_class_demo_engine(handle)
+            boltffiRelease()
         }
     }
 
     internal fun boltffiHandle(): Long {
         check(!__boltffi_closed.get()) { "Engine is closed" }
         return handle
+    }
+
+    internal fun boltffiRetain(): Long {
+        while (true) {
+            check(!__boltffi_closed.get()) { "Engine is closed" }
+            val calls = __boltffi_calls.get()
+            check(calls != 0L) { "Engine is closed" }
+            if (__boltffi_calls.compareAndSet(calls, calls + 1L)) return handle
+        }
+    }
+
+    internal fun boltffiRelease() {
+        if (__boltffi_calls.decrementAndGet() == 0L) {
+            Native.boltffi_release_class_demo_engine(handle)
+        }
     }
 
     companion object {
@@ -40,15 +56,30 @@ class Engine internal constructor(internal val handle: Long) : AutoCloseable {
     }
 
     fun value(): Int {
-        return Native.boltffi_method_class_demo_engine_value(this.boltffiHandle())
+        val __boltffi_receiver = boltffiRetain()
+        try {
+            return Native.boltffi_method_class_demo_engine_value(__boltffi_receiver)
+        } finally {
+            boltffiRelease()
+        }
     }
 
     fun swap(other: Engine): Engine {
-        return Engine(Native.boltffi_method_class_demo_engine_swap(this.boltffiHandle(), other.boltffiHandle()))
+        val __boltffi_receiver = boltffiRetain()
+        try {
+            return Engine(Native.boltffi_method_class_demo_engine_swap(__boltffi_receiver, other.boltffiHandle()))
+        } finally {
+            boltffiRelease()
+        }
     }
 
     fun maybeSwap(other: Engine?): Engine? {
-        val __boltffi_handle = Native.boltffi_method_class_demo_engine_maybe_swap(this.boltffiHandle(), other?.boltffiHandle() ?: 0L)
-        return if (__boltffi_handle == 0L) null else Engine(__boltffi_handle)
+        val __boltffi_receiver = boltffiRetain()
+        try {
+            val __boltffi_handle = Native.boltffi_method_class_demo_engine_maybe_swap(__boltffi_receiver, other?.boltffiHandle() ?: 0L)
+            return if (__boltffi_handle == 0L) null else Engine(__boltffi_handle)
+        } finally {
+            boltffiRelease()
+        }
     }
 }

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_kdoc_for_documented_classes_and_data_enums.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_renders_kdoc_for_documented_classes_and_data_enums.snap
@@ -138,17 +138,33 @@ sealed class Outline {
  * A counter owned by Rust.
  */
 class Counter internal constructor(internal val handle: Long) : AutoCloseable {
+    private val __boltffi_calls = java.util.concurrent.atomic.AtomicLong(1L)
     private val __boltffi_closed = java.util.concurrent.atomic.AtomicBoolean(false)
 
     override fun close() {
         if (__boltffi_closed.compareAndSet(false, true)) {
-            Native.boltffi_release_class_demo_counter(handle)
+            boltffiRelease()
         }
     }
 
     internal fun boltffiHandle(): Long {
         check(!__boltffi_closed.get()) { "Counter is closed" }
         return handle
+    }
+
+    internal fun boltffiRetain(): Long {
+        while (true) {
+            check(!__boltffi_closed.get()) { "Counter is closed" }
+            val calls = __boltffi_calls.get()
+            check(calls != 0L) { "Counter is closed" }
+            if (__boltffi_calls.compareAndSet(calls, calls + 1L)) return handle
+        }
+    }
+
+    internal fun boltffiRelease() {
+        if (__boltffi_calls.decrementAndGet() == 0L) {
+            Native.boltffi_release_class_demo_counter(handle)
+        }
     }
 
     /**
@@ -180,7 +196,12 @@ class Counter internal constructor(internal val handle: Long) : AutoCloseable {
      * Returns the current value.
      */
     fun value(): Long {
-        return Native.boltffi_method_class_demo_counter_value(this.boltffiHandle())
+        val __boltffi_receiver = boltffiRetain()
+        try {
+            return Native.boltffi_method_class_demo_counter_value(__boltffi_receiver)
+        } finally {
+            boltffiRelease()
+        }
     }
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__stream__kotlin_target_renders_stream_protocols.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__stream__kotlin_target_renders_stream_protocols.snap
@@ -83,17 +83,33 @@ data class Point(
 }
 
 class Engine internal constructor(internal val handle: Long) : AutoCloseable {
+    private val __boltffi_calls = java.util.concurrent.atomic.AtomicLong(1L)
     private val __boltffi_closed = java.util.concurrent.atomic.AtomicBoolean(false)
 
     override fun close() {
         if (__boltffi_closed.compareAndSet(false, true)) {
-            Native.boltffi_release_class_demo_engine(handle)
+            boltffiRelease()
         }
     }
 
     internal fun boltffiHandle(): Long {
         check(!__boltffi_closed.get()) { "Engine is closed" }
         return handle
+    }
+
+    internal fun boltffiRetain(): Long {
+        while (true) {
+            check(!__boltffi_closed.get()) { "Engine is closed" }
+            val calls = __boltffi_calls.get()
+            check(calls != 0L) { "Engine is closed" }
+            if (__boltffi_calls.compareAndSet(calls, calls + 1L)) return handle
+        }
+    }
+
+    internal fun boltffiRelease() {
+        if (__boltffi_calls.decrementAndGet() == 0L) {
+            Native.boltffi_release_class_demo_engine(handle)
+        }
     }
 }
 

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__stream__kotlin_target_renders_stream_runtime.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__stream__kotlin_target_renders_stream_runtime.snap
@@ -1004,17 +1004,33 @@ data class Point(
 }
 
 class Engine internal constructor(internal val handle: Long) : AutoCloseable {
+    private val __boltffi_calls = java.util.concurrent.atomic.AtomicLong(1L)
     private val __boltffi_closed = java.util.concurrent.atomic.AtomicBoolean(false)
 
     override fun close() {
         if (__boltffi_closed.compareAndSet(false, true)) {
-            Native.boltffi_release_class_demo_engine(handle)
+            boltffiRelease()
         }
     }
 
     internal fun boltffiHandle(): Long {
         check(!__boltffi_closed.get()) { "Engine is closed" }
         return handle
+    }
+
+    internal fun boltffiRetain(): Long {
+        while (true) {
+            check(!__boltffi_closed.get()) { "Engine is closed" }
+            val calls = __boltffi_calls.get()
+            check(calls != 0L) { "Engine is closed" }
+            if (__boltffi_calls.compareAndSet(calls, calls + 1L)) return handle
+        }
+    }
+
+    internal fun boltffiRelease() {
+        if (__boltffi_calls.decrementAndGet() == 0L) {
+            Native.boltffi_release_class_demo_engine(handle)
+        }
     }
 }
 

--- a/examples/demo/src/classes/close_guard.rs
+++ b/examples/demo/src/classes/close_guard.rs
@@ -26,11 +26,6 @@ impl GuardedCounter {
             details = "Swift releases class handles in deinit; there is no user-facing close() after which a call could be rejected."
         ),
         exclude(
-            typescript,
-            reason = ExclusionReason::ImplementationGap,
-            details = "TypeScript releases class handles through FinalizationRegistry; there is no user-facing close() after which a call could be rejected."
-        ),
-        exclude(
             python,
             reason = ExclusionReason::ImplementationGap,
             details = "Python releases class handles in __del__; there is no user-facing close() after which a call could be rejected."
@@ -54,7 +49,7 @@ impl GuardedCounter {
         exclude(
             typescript,
             reason = ExclusionReason::ImplementationGap,
-            details = "TypeScript releases class handles through FinalizationRegistry; there is no user-facing close() to race against an in-flight call."
+            details = "JavaScript is single-threaded, so dispose() cannot race an in-flight call from another thread; the deferred-free scenario cannot be expressed."
         ),
         exclude(
             python,

--- a/examples/demo/src/classes/close_guard.rs
+++ b/examples/demo/src/classes/close_guard.rs
@@ -1,0 +1,71 @@
+use std::sync::Mutex;
+
+use boltffi::*;
+
+/// A counter whose gated method holds the native call in flight inside a
+/// caller-supplied callback, so tests can race `close()` against it.
+pub struct GuardedCounter {
+    value: Mutex<i32>,
+}
+
+#[export]
+impl GuardedCounter {
+    pub fn new(initial: i32) -> Self {
+        Self {
+            value: Mutex::new(initial),
+        }
+    }
+
+    #[demo_bench_macros::demo_case(
+        "classes.close_guard.guarded_counter.increment.should_reject_calls_after_close",
+        justification = "Ensure a closed class handle rejects further method calls with the language-native closed-object error instead of reaching the freed native object.",
+        directions = "Construct `classes::close_guard::GuardedCounter` through the generated binding, close it, and assert a subsequent `increment` call raises the language-native closed-object error.",
+        exclude(
+            swift,
+            reason = ExclusionReason::ImplementationGap,
+            details = "Swift releases class handles in deinit; there is no user-facing close() after which a call could be rejected."
+        ),
+        exclude(
+            typescript,
+            reason = ExclusionReason::ImplementationGap,
+            details = "TypeScript releases class handles through FinalizationRegistry; there is no user-facing close() after which a call could be rejected."
+        ),
+        exclude(
+            python,
+            reason = ExclusionReason::ImplementationGap,
+            details = "Python releases class handles in __del__; there is no user-facing close() after which a call could be rejected."
+        )
+    )]
+    pub fn increment(&self) -> i32 {
+        let mut guard = self.value.lock().unwrap();
+        *guard += 1;
+        *guard
+    }
+
+    #[demo_bench_macros::demo_case(
+        "classes.close_guard.guarded_counter.increment_through_gate.should_complete_in_flight_call_when_closed",
+        justification = "Ensure close() during an in-flight method call defers freeing the native object until the call completes, so the call finishes against live memory and only later calls fail (issue #664).",
+        directions = "Call `classes::close_guard::GuardedCounter::increment_through_gate` on one thread, block inside the gate callback, close the handle from a second thread, release the gate, and assert the in-flight call returns the correct value while a subsequent call raises the language-native closed-object error.",
+        exclude(
+            swift,
+            reason = ExclusionReason::ImplementationGap,
+            details = "Swift releases class handles in deinit; there is no user-facing close() to race against an in-flight call."
+        ),
+        exclude(
+            typescript,
+            reason = ExclusionReason::ImplementationGap,
+            details = "TypeScript releases class handles through FinalizationRegistry; there is no user-facing close() to race against an in-flight call."
+        ),
+        exclude(
+            python,
+            reason = ExclusionReason::ImplementationGap,
+            details = "Python releases class handles in __del__; there is no user-facing close() to race against an in-flight call."
+        )
+    )]
+    pub fn increment_through_gate(&self, gate: impl Fn(i32) -> i32) -> i32 {
+        let delta = gate(*self.value.lock().unwrap());
+        let mut guard = self.value.lock().unwrap();
+        *guard += delta;
+        *guard
+    }
+}

--- a/examples/demo/src/classes/mod.rs
+++ b/examples/demo/src/classes/mod.rs
@@ -2,6 +2,7 @@
 pub mod async_factory;
 pub mod async_methods;
 pub mod borrowed;
+pub mod close_guard;
 pub mod constructor_matrix;
 pub mod constructors;
 pub mod methods;
@@ -14,6 +15,7 @@ pub mod unsafe_single_threaded;
 pub use async_factory::*;
 pub use async_methods::*;
 pub use borrowed::*;
+pub use close_guard::*;
 pub use constructor_matrix::*;
 pub use constructors::*;
 pub use methods::*;

--- a/examples/platforms/apple/Tests/DemoConsumerTests/RustSwiftSurfaceContractTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/RustSwiftSurfaceContractTests.swift
@@ -570,6 +570,7 @@ private let rustToSwiftCoverageFile: [String: String] = [
     "callbacks/sync_traits.rs": "callbacks/SyncTraitsTests.swift",
     "classes/async_methods.rs": "classes/AsyncMethodsTests.swift",
     "classes/borrowed.rs": "classes/BorrowedTests.swift",
+    "classes/close_guard.rs": "classes/CloseGuardTests.swift",
     "classes/constructor_matrix.rs": "classes/ConstructorCoverageMatrixTests.swift",
     "classes/constructors.rs": "classes/ConstructorsTests.swift",
     "classes/methods.rs": "classes/MethodsTests.swift",

--- a/examples/platforms/apple/Tests/DemoConsumerTests/classes/CloseGuardTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/classes/CloseGuardTests.swift
@@ -1,0 +1,10 @@
+import Demo
+import XCTest
+
+final class CloseGuardTests: DemoTestCase {
+    func testGuardedCounterMethods() {
+        let counter = GuardedCounter(initial: 1)
+        XCTAssertEqual(counter.increment(), 2)
+        XCTAssertEqual(counter.incrementThroughGate(gate: { $0 + 5 }), 9)
+    }
+}

--- a/examples/platforms/csharp/DemoTest/Program.cs
+++ b/examples/platforms/csharp/DemoTest/Program.cs
@@ -52,6 +52,7 @@ public static class DemoTest
             TestOptionsWithVec();
             TestMultiCrateExports();
             TestClasses();
+            TestCloseGuard();
             TestResultFunctions();
             TestResultClassMethods();
             TestResultEnumErrors();
@@ -2942,6 +2943,52 @@ public static class DemoTest
         {
             consumer.SetProvider(new DataProviderImpl());
             Require(consumer.ComputeSum() == 10UL, "stored DataProvider callback");
+        }
+
+        Console.WriteLine("  PASS\n");
+    }
+
+    private static void TestCloseGuard()
+    {
+        Console.WriteLine("Testing class close guard (GuardedCounter)...");
+
+        DemoCase("case:classes.close_guard.guarded_counter.increment.should_reject_calls_after_close");
+        var counter = new GuardedCounter(1);
+        Require(counter.Increment() == 2, "GuardedCounter.Increment before Dispose");
+        counter.Dispose();
+        try
+        {
+            counter.Increment();
+            Require(false, "GuardedCounter.Increment after Dispose should throw");
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        DemoCase("case:classes.close_guard.guarded_counter.increment_through_gate.should_complete_in_flight_call_when_closed");
+        var gated = new GuardedCounter(10);
+        using var entered = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+        int result = 0;
+        var caller = new Thread(() => result = gated.IncrementThroughGate(observed =>
+        {
+            entered.Set();
+            release.Wait();
+            return observed + 5;
+        }));
+        caller.Start();
+        Require(entered.Wait(TimeSpan.FromSeconds(5)), "gate was not entered");
+        gated.Dispose();
+        release.Set();
+        caller.Join();
+        Require(result == 25, "GuardedCounter.IncrementThroughGate result");
+        try
+        {
+            gated.Increment();
+            Require(false, "GuardedCounter.Increment after in-flight Dispose should throw");
+        }
+        catch (ObjectDisposedException)
+        {
         }
 
         Console.WriteLine("  PASS\n");

--- a/examples/platforms/java/DemoTest.java
+++ b/examples/platforms/java/DemoTest.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public final class DemoTest {
     private static String currentDemoCase = null;
@@ -53,6 +55,7 @@ public final class DemoTest {
             testRecordsWithVecs();
             testMultiCrateExports();
             testInventoryConstructors();
+            testGuardedCounterCloseGuard();
             testConstructorCoverageMatrix();
             testClosures();
             testSyncCallbacks();
@@ -1614,6 +1617,50 @@ public final class DemoTest {
             assert false : "Inventory.tryNew(0) should fail";
         } catch (RuntimeException expected) {
             assert expected.getMessage().contains("Factory constructor failed") : "Inventory.tryNew(0) error";
+        }
+
+        System.out.println("  PASS\n");
+    }
+
+    private static void testGuardedCounterCloseGuard() throws InterruptedException {
+        System.out.println("Testing class close guard (GuardedCounter)...");
+
+        demoCase("case:classes.close_guard.guarded_counter.increment.should_reject_calls_after_close");
+        GuardedCounter counter = new GuardedCounter(1);
+        assert counter.increment() == 2 : "GuardedCounter.increment before close";
+        counter.close();
+        try {
+            counter.increment();
+            assert false : "GuardedCounter.increment after close should fail";
+        } catch (IllegalStateException expected) {
+            assert expected.getMessage().contains("GuardedCounter is closed") : "GuardedCounter closed error";
+        }
+
+        demoCase("case:classes.close_guard.guarded_counter.increment_through_gate.should_complete_in_flight_call_when_closed");
+        GuardedCounter gated = new GuardedCounter(10);
+        CountDownLatch entered = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        int[] result = new int[1];
+        Thread caller = new Thread(() -> result[0] = gated.incrementThroughGate(observed -> {
+            entered.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException error) {
+                throw new IllegalStateException(error);
+            }
+            return observed + 5;
+        }));
+        caller.start();
+        assert entered.await(5, TimeUnit.SECONDS) : "gate was not entered";
+        gated.close();
+        release.countDown();
+        caller.join();
+        assert result[0] == 25 : "GuardedCounter.incrementThroughGate result";
+        try {
+            gated.increment();
+            assert false : "GuardedCounter.increment after in-flight close should fail";
+        } catch (IllegalStateException expected) {
+            assert expected.getMessage().contains("GuardedCounter is closed") : "GuardedCounter closed error";
         }
 
         System.out.println("  PASS\n");

--- a/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoClassesAndStreamsTest.kt
+++ b/examples/platforms/kotlin/src/test/kotlin/com/boltffi/demo/DemoClassesAndStreamsTest.kt
@@ -212,4 +212,43 @@ class DemoClassesAndStreamsTest {
             }
         }
     }
+
+    @Test
+    fun guardedCounterRejectsCallsAfterClose() {
+        demoCase("case:classes.close_guard.guarded_counter.increment.should_reject_calls_after_close")
+        val counter = GuardedCounter(1)
+        assertEquals(2, counter.increment())
+        counter.close()
+        assertMessageContains(
+            assertFailsWith<IllegalStateException> { counter.increment() },
+            "GuardedCounter is closed",
+        )
+    }
+
+    @Test
+    fun guardedCounterCompletesInFlightCallWhenClosed() {
+        demoCase("case:classes.close_guard.guarded_counter.increment_through_gate.should_complete_in_flight_call_when_closed")
+        val counter = GuardedCounter(10)
+        val entered = java.util.concurrent.CountDownLatch(1)
+        val release = java.util.concurrent.CountDownLatch(1)
+        var result = 0
+        val caller = kotlin.concurrent.thread {
+            result = counter.incrementThroughGate(
+                ClosureI32ToI32 { observed ->
+                    entered.countDown()
+                    release.await()
+                    observed + 5
+                },
+            )
+        }
+        assert(entered.await(5, java.util.concurrent.TimeUnit.SECONDS)) { "gate was not entered" }
+        counter.close()
+        release.countDown()
+        caller.join()
+        assertEquals(25, result)
+        assertMessageContains(
+            assertFailsWith<IllegalStateException> { counter.increment() },
+            "GuardedCounter is closed",
+        )
+    }
 }

--- a/examples/platforms/wasm/test.mjs
+++ b/examples/platforms/wasm/test.mjs
@@ -10,6 +10,7 @@ const suiteModules = [
   "./tests/callbacks/closures.test.mjs",
   "./tests/callbacks/sync_traits.test.mjs",
   "./tests/classes/async_methods.test.mjs",
+  "./tests/classes/close_guard.test.mjs",
   "./tests/classes/constructor_matrix.test.mjs",
   "./tests/classes/constructors.test.mjs",
   "./tests/classes/methods.test.mjs",

--- a/examples/platforms/wasm/tests/classes/close_guard.test.mjs
+++ b/examples/platforms/wasm/tests/classes/close_guard.test.mjs
@@ -1,0 +1,13 @@
+import { assert, assertThrowsWithMessage, demo } from "../support/index.mjs";
+
+export async function run() {
+  demoCase("case:classes.close_guard.guarded_counter.increment.should_reject_calls_after_close");
+  const counter = demo.GuardedCounter.new(1);
+  assert.equal(counter.increment(), 2);
+  counter.dispose();
+  assertThrowsWithMessage(() => counter.increment(), "GuardedCounter has been disposed");
+
+  const gated = demo.GuardedCounter.new(10);
+  assert.equal(gated.incrementThroughGate((observed) => observed + 5), 25);
+  gated.dispose();
+}


### PR DESCRIPTION
## Summary

#663 made sequential use-after-close fail deterministically, but the guard is check-then-act, so a call racing `close()` can still reach freed memory:

```text
thread A: 
  engine.value()             
thread B:
  boltffiHandle()      // check passes
  engine.close()   // frees the native allocation
  Native..._value(h)   // undefined behavior
```

Class objects in the Kotlin, Java, and C# backends now carry an atomic call counter (starting at 1) next to the closed flag. Method entry retains the receiver (CAS increment, throwing once closed), method exit releases it, and `close()`/`Dispose()` flips the flag and drops the initial reference — whoever decrements to zero, the closer or the last in-flight call, performs the native free:

```kotlin
 fun value(): Int {
-    return Native.boltffi_method_class_demo_engine_value(this.boltffiHandle())
+    val __boltffi_receiver = boltffiRetain()
+    try {
+        return Native.boltffi_method_class_demo_engine_value(__boltffi_receiver)
+    } finally {
+        boltffiRelease()
+    }
 }
```

`close()` never blocks, and calls after `close()` throw the same exception as today — #663's sequential guarantee is unchanged. What changes is the race: the native free is deferred until the last in-flight call exits, so a call that overlaps `close()` completes against a live handle. This is the same shape UniFFI generates for its object bindings.

Async methods hold the retain for the future's whole lifetime — the native future captures a borrow of the receiver and dereferences it on every poll, so the release runs in the future's free hook (or immediately, when creation throws). Handle reads outside the receiver position — parameters, stream subscriptions, callback lowering — keep the existing check-then-act guard; the C# `Handle` property now throws `ObjectDisposedException` once disposed, matching the Kotlin/Java parameter behavior.

## Changes

- Kotlin/Java class templates: add `__boltffi_calls` / `boltffiRetain()` / `boltffiRelease()`, route `close()` through the counter, and wrap instance-method bodies in retain/release.
- Java call bodies nest parameter acquires inside the receiver guard, so a throwing acquire (e.g. a null argument hit during wire sizing) cannot leak the retain and pin the native allocation past `close()`.
- Async class methods release the retain in the future's free hook instead of after creation, and a throwing creation releases it on the spot — `close()` during a pending future no longer frees the allocation out from under later polls.
- The C# class renderer rejects exported methods that would collide with the generated `BoltffiRetain`/`BoltffiRelease`/`RawHandle` members, matching the Kotlin/Java reserved-name checks.
- C# class template: same protocol (`BoltffiRetain`/`BoltffiRelease`); `Release()` (dispose and finalizer path) flips the closed flag and drops the initial reference, and `Handle` throws once disposed.
- Backend renderers pass the receiver through the retained local instead of re-reading the handle per call.
- Snapshot coverage for the retain/release shape across sync, async, factory, and stream-owning classes in all three backends.

