### PR TITLE
bindgen: lower per-invocation source records ahead of the legacy envelope

### DIFF
--- a/boltffi_bindgen/src/generate.rs
+++ b/boltffi_bindgen/src/generate.rs
@@ -15,7 +15,10 @@ use boltffi_backend::target::{
     typescript::TypeScriptHost,
 };
 use boltffi_backend::{CustomTypeMapping, GeneratedOutput, Target as BackendTarget};
-use boltffi_binding::{BindingMetadataSurface, Bindings, Native, Surface, Wasm32};
+use boltffi_binding::{
+    BindingMetadataSurface, Bindings, LowerError, Native, SourceFragmentError, Surface,
+    SurfaceLower, Wasm32, aggregate_records, lower,
+};
 use thiserror::Error;
 
 use crate::metadata::{BindingMetadataBuild, BindingMetadataBuildError};
@@ -723,10 +726,18 @@ impl Generation {
             .collect()
     }
 
-    fn bindings<S: Surface>(&self) -> Result<Bindings<S>, GenerationError> {
+    fn bindings<S: Surface + SurfaceLower>(&self) -> Result<Bindings<S>, GenerationError> {
         let surface = self
             .binding_surface
             .unwrap_or_else(|| BindingMetadataSurface::from_target_triple(self.triple.as_deref()));
+        let source = self.metadata_build().read_source()?;
+        if !source.source_records.is_empty() {
+            match aggregate_records(&source.source_records, source.package) {
+                Ok(contract) => return lower::<S>(&contract).map_err(GenerationError::Lower),
+                Err(error) if falls_back_to_envelope(&error) => {}
+                Err(error) => return Err(GenerationError::SourceAggregation(error)),
+            }
+        }
         self.metadata_build()
             .read()?
             .into_iter()
@@ -767,6 +778,12 @@ pub enum GenerationError {
         /// Surface selected from the target triple.
         surface: BindingMetadataSurface,
     },
+    /// Per-invocation source records did not aggregate into one contract.
+    #[error("aggregate per-invocation source records: {0}")]
+    SourceAggregation(SourceFragmentError),
+    /// The aggregated source contract failed to lower.
+    #[error("lower aggregated source contract: {0}")]
+    Lower(LowerError),
     /// The target backend failed to render the bindings.
     #[error("render bindings: {0}")]
     Render(boltffi_backend::Error),
@@ -790,6 +807,16 @@ pub enum GenerationError {
         /// Filesystem error.
         source: std::io::Error,
     },
+}
+
+/// Unsupported captures and unresolved references mean capture could not see
+/// the whole surface; the legacy whole-crate scan still can.
+fn falls_back_to_envelope(error: &SourceFragmentError) -> bool {
+    matches!(
+        error,
+        SourceFragmentError::UnsupportedCapture { .. }
+            | SourceFragmentError::UnresolvedReference { .. }
+    )
 }
 
 fn write_file(path: &Path, contents: &str) -> Result<(), GenerationError> {
@@ -1372,5 +1399,31 @@ mod tests {
         );
         assert!(jni.contains("_result = boltffi_function_demo_signed_read(value);"));
         assert!(jni.contains("_result = boltffi_function_demo_wide_read(value);"));
+    }
+
+    #[test]
+    fn capture_gaps_fall_back_to_the_envelope_path() {
+        assert!(falls_back_to_envelope(
+            &SourceFragmentError::UnsupportedCapture {
+                module: "demo".to_owned(),
+                name: "Engine".to_owned(),
+                reason: "trait impls are not captured".to_owned(),
+            }
+        ));
+        assert!(falls_back_to_envelope(
+            &SourceFragmentError::UnresolvedReference {
+                id: "demo::Missing".to_owned(),
+            }
+        ));
+        assert!(!falls_back_to_envelope(
+            &SourceFragmentError::DuplicateDeclaration {
+                id: "demo::Route".to_owned(),
+            }
+        ));
+        assert!(!falls_back_to_envelope(
+            &SourceFragmentError::MethodsTargetNotData {
+                spelling: "Engine".to_owned(),
+            }
+        ));
     }
 }

--- a/boltffi_bindgen/src/generate.rs
+++ b/boltffi_bindgen/src/generate.rs
@@ -727,17 +727,17 @@ impl Generation {
     }
 
     fn bindings<S: Surface + SurfaceLower>(&self) -> Result<Bindings<S>, GenerationError> {
-        let surface = self
-            .binding_surface
-            .unwrap_or_else(|| BindingMetadataSurface::from_target_triple(self.triple.as_deref()));
         let source = self.metadata_build().read_source()?;
-        if !source.source_records.is_empty() {
+        if records_cover_the_root(&source.source_records, &source.package) {
             match aggregate_records(&source.source_records, source.package) {
                 Ok(contract) => return lower::<S>(&contract).map_err(GenerationError::Lower),
                 Err(error) if falls_back_to_envelope(&error) => {}
                 Err(error) => return Err(GenerationError::SourceAggregation(error)),
             }
         }
+        let surface = self
+            .binding_surface
+            .unwrap_or_else(|| BindingMetadataSurface::from_target_triple(self.triple.as_deref()));
         self.metadata_build()
             .read()?
             .into_iter()
@@ -809,13 +809,23 @@ pub enum GenerationError {
     },
 }
 
-/// Unsupported captures and unresolved references mean capture could not see
-/// the whole surface; the legacy whole-crate scan still can.
+/// The records path covers only surfaces the root package emitted itself;
+/// dependency records mean a multi-crate surface the legacy scan still owns.
+fn records_cover_the_root(
+    records: &[boltffi_binding::RawSourceRecord],
+    package: &boltffi_ast::PackageInfo,
+) -> bool {
+    !records.is_empty() && records.iter().all(|record| record.package == *package)
+}
+
+/// Unsupported captures, unresolved references, and shadowed builtins mean
+/// capture could not see the whole surface; the legacy whole-crate scan still can.
 fn falls_back_to_envelope(error: &SourceFragmentError) -> bool {
     matches!(
         error,
         SourceFragmentError::UnsupportedCapture { .. }
             | SourceFragmentError::UnresolvedReference { .. }
+            | SourceFragmentError::ShadowedBuiltin { .. }
     )
 }
 
@@ -1415,6 +1425,11 @@ mod tests {
                 id: "demo::Missing".to_owned(),
             }
         ));
+        assert!(falls_back_to_envelope(
+            &SourceFragmentError::ShadowedBuiltin {
+                name: "Duration".to_owned(),
+            }
+        ));
         assert!(!falls_back_to_envelope(
             &SourceFragmentError::DuplicateDeclaration {
                 id: "demo::Route".to_owned(),
@@ -1425,5 +1440,30 @@ mod tests {
                 spelling: "Engine".to_owned(),
             }
         ));
+    }
+
+    #[test]
+    fn only_root_owned_record_sets_take_the_records_path() {
+        let root = boltffi_ast::PackageInfo::new("demo", None);
+        let record = |package: &str| boltffi_binding::RawSourceRecord {
+            package: boltffi_ast::PackageInfo::new(package, None),
+            module: package.to_owned(),
+            slots: Vec::new(),
+            json: Vec::new(),
+        };
+
+        assert!(records_cover_the_root(&[record("demo")], &root));
+        assert!(
+            !records_cover_the_root(&[], &root),
+            "an envelope-only root has no records to prefer"
+        );
+        assert!(
+            !records_cover_the_root(&[record("helper")], &root),
+            "dependency records without the root mean the root did not emit"
+        );
+        assert!(
+            !records_cover_the_root(&[record("demo"), record("helper")], &root),
+            "a dependency surface is still the legacy scan's to scope"
+        );
     }
 }

--- a/boltffi_bindgen/src/metadata.rs
+++ b/boltffi_bindgen/src/metadata.rs
@@ -113,8 +113,9 @@ impl BindingMetadataBuild {
             .map_err(BindingMetadataBuildError::Metadata)
     }
 
-    /// Runs a plain Cargo build (no metadata env gates) and reads per-invocation source
-    /// records from every reported artifact, dependency crates included.
+    /// Runs a Cargo build with the metadata cfgs but none of the env gates, and reads
+    /// per-invocation source records from every reported artifact, dependency crates
+    /// included.
     pub fn read_source(&self) -> Result<SourceMetadata, BindingMetadataBuildError> {
         let cargo_args = self
             .cargo_args
@@ -455,7 +456,23 @@ impl<'build> CargoBuild<'build> {
     }
 
     fn plain_command(self) -> Command {
-        self.base_command()
+        let mut command = self.base_command();
+        self.metadata_cfgs(&mut command);
+        command
+    }
+
+    /// Both builds compile the root crate with the metadata cfgs, so cfg-gated
+    /// exports surface identically; only the env gates separate them.
+    fn metadata_cfgs(&self, command: &mut Command) {
+        let surface = self.build.surface.unwrap_or_else(|| {
+            BindingMetadataSurface::from_target_triple(self.build.target.as_deref())
+        });
+        command
+            .arg("--")
+            .arg("--cfg")
+            .arg("boltffi_metadata")
+            .arg("--cfg")
+            .arg(format!("boltffi_binding_surface_{}", surface.as_str()));
     }
 
     fn base_command(&self) -> Command {
@@ -500,6 +517,7 @@ impl<'build> CargoBuild<'build> {
             BindingMetadataSurface::from_target_triple(self.build.target.as_deref())
         });
         let mut command = self.base_command();
+        self.metadata_cfgs(&mut command);
         command.env(BINDING_METADATA_BUILD_ENV, "1");
         command.env(BINDING_METADATA_SOURCE_ENV, self.source_root.path());
         command.env(BINDING_METADATA_SURFACE_ENV, surface.as_str());
@@ -510,12 +528,6 @@ impl<'build> CargoBuild<'build> {
         if let Some(root) = self.manifest.path().parent() {
             command.env(BINDING_METADATA_ROOT_ENV, root);
         }
-        command
-            .arg("--")
-            .arg("--cfg")
-            .arg("boltffi_metadata")
-            .arg("--cfg")
-            .arg(format!("boltffi_binding_surface_{}", surface.as_str()));
         command
     }
 }
@@ -1105,6 +1117,30 @@ mod tests {
     }
 
     #[test]
+    fn cargo_build_refuses_a_shadowed_builtin_so_bindgen_falls_back() {
+        if cfg!(miri) {
+            return;
+        }
+
+        let fixture = FixtureCrate::with_shadowed_builtin();
+
+        let source = BindingMetadataBuild::new(fixture.manifest())
+            .read_source()
+            .expect("cargo source metadata read");
+
+        let error =
+            boltffi_binding::aggregate_records(&source.source_records, source.package.clone())
+                .expect_err("a declared Duration makes the builtin spelling ambiguous");
+        assert!(
+            matches!(
+                error,
+                boltffi_binding::SourceFragmentError::ShadowedBuiltin { ref name } if name == "Duration"
+            ),
+            "aggregation refuses the set instead of guessing, got: {error}"
+        );
+    }
+
+    #[test]
     fn cargo_build_aggregates_macro_emitted_source_records() {
         if cfg!(miri) {
             return;
@@ -1630,6 +1666,10 @@ mod tests {
             Self::write(Source::with_boltffi_macros(), Dependency::Boltffi)
         }
 
+        fn with_shadowed_builtin() -> Self {
+            Self::write(Source::with_shadowed_builtin(), Dependency::Boltffi)
+        }
+
         fn with_feature_gated_boltffi_macros() -> Self {
             let root = temp_root("boltffi-bindgen-cargo-metadata");
             let source_dir = root.join("src");
@@ -1763,6 +1803,32 @@ pub fn view() -> CoreFfi {
     impl Source {
         fn with_metadata(envelope: &BindingMetadataEnvelope) -> Self {
             Self::with_metadata_and_body(envelope, "pub fn exported() -> u32 { 1 }\n")
+        }
+
+        fn with_shadowed_builtin() -> Self {
+            Self {
+                code: r#"
+boltffi::scaffolding!();
+
+pub mod timing {
+    use boltffi::data;
+
+    #[data]
+    #[derive(Clone, Copy)]
+    pub struct Duration {
+        pub millis: u64,
+    }
+
+    #[data]
+    #[derive(Clone, Copy)]
+    pub struct Sample {
+        pub own: Duration,
+        pub wall: std::time::Duration,
+    }
+}
+"#
+                .to_owned(),
+            }
         }
 
         fn with_boltffi_macros() -> Self {

--- a/boltffi_binding/src/ir/source_fragment.rs
+++ b/boltffi_binding/src/ir/source_fragment.rs
@@ -6,14 +6,15 @@
 //! whose id is `$slot:N`, replaced here by the type node the referenced type's own
 //! definition site resolved through rustc.
 
-use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 
 use boltffi_ast::{
-    ClassDef, ClassId, ConstantDef, ConstantId, ConstantOwner, CustomTypeConverter, CustomTypeDef,
-    CustomTypeId, EnumDef, EnumId, FieldDef, FunctionDef, FunctionId, MethodDef, NamePart,
-    PackageInfo, Path, PathSegment, Primitive, RecordDef, RecordId, ReturnDef, SourceContract,
-    StreamDef, StreamId, TraitDef, TraitId, TypeExpr, VariantPayload,
+    BuiltinType, ClassDef, ClassId, ConstantDef, ConstantId, ConstantOwner, CustomRemoteType,
+    CustomTypeConverter, CustomTypeDef, CustomTypeId, EnumDef, EnumId, FieldDef, FunctionDef,
+    FunctionId, MethodDef, NamePart, PackageInfo, Path, PathSegment, Primitive, RecordDef,
+    RecordId, ReturnDef, SourceContract, StreamDef, StreamId, TraitDef, TraitId, TypeExpr,
+    VariantPayload,
 };
 use serde::{Deserialize, Serialize};
 
@@ -151,6 +152,9 @@ pub fn aggregate_records(
                 return Err(SourceFragmentError::DuplicateDeclaration { id });
             }
         }
+        if let Some(name) = shadowed_builtin(fragment, &id) {
+            declared.shadowed.insert(name);
+        }
         if let Some(kind) = declared_kind(fragment) {
             declared.kinds.insert(id, kind);
         }
@@ -270,6 +274,23 @@ enum DeclaredKind {
 struct Declared {
     kinds: HashMap<String, DeclaredKind>,
     pools: HashMap<String, Vec<String>>,
+    shadowed: HashSet<String>,
+}
+
+/// A declaration or custom remote whose unqualified name matches a builtin makes
+/// that builtin's spelling ambiguous at every use site.
+fn shadowed_builtin(fragment: &SourceFragment, id: &str) -> Option<String> {
+    let name = match fragment {
+        SourceFragment::Record(_) | SourceFragment::Enum(_) | SourceFragment::Class(_) => {
+            id.rsplit("::").next().unwrap_or(id)
+        }
+        SourceFragment::Custom(def) => match &def.remote {
+            CustomRemoteType::Path(path) => path.segments.last()?.name.as_str(),
+            CustomRemoteType::Tuple(_) => return None,
+        },
+        _ => return None,
+    };
+    builtin_leaf(name).map(|_| name.to_owned())
 }
 
 fn declared_kind(fragment: &SourceFragment) -> Option<DeclaredKind> {
@@ -554,6 +575,15 @@ fn resolve_expr(
             Ok(())
         }
         TypeExpr::FnPtr(signature) => resolve_fn_sig(signature, slots, declared),
+        TypeExpr::Builtin(builtin) => {
+            let name = builtin.type_id();
+            if declared.shadowed.contains(name) {
+                return Err(SourceFragmentError::ShadowedBuiltin {
+                    name: name.to_owned(),
+                });
+            }
+            Ok(())
+        }
         TypeExpr::Dyn(bounds) | TypeExpr::ImplTrait(bounds) => {
             match &mut bounds.base {
                 boltffi_ast::BaseTrait::Function(function_trait) => {
@@ -672,15 +702,23 @@ fn leaf_expr(name: &str) -> Result<TypeExpr, SourceFragmentError> {
     if let Some(primitive) = primitive {
         return Ok(TypeExpr::Primitive(primitive));
     }
-    match name {
-        "String" => Ok(TypeExpr::String),
-        "Duration" => Ok(TypeExpr::builtin(boltffi_ast::BuiltinType::Duration)),
-        "SystemTime" => Ok(TypeExpr::builtin(boltffi_ast::BuiltinType::SystemTime)),
-        "Uuid" => Ok(TypeExpr::builtin(boltffi_ast::BuiltinType::Uuid)),
-        "Url" => Ok(TypeExpr::builtin(boltffi_ast::BuiltinType::Url)),
-        _ => Err(SourceFragmentError::UnknownLeaf {
+    if name == "String" {
+        return Ok(TypeExpr::String);
+    }
+    builtin_leaf(name)
+        .map(TypeExpr::builtin)
+        .ok_or_else(|| SourceFragmentError::UnknownLeaf {
             name: name.to_owned(),
-        }),
+        })
+}
+
+fn builtin_leaf(name: &str) -> Option<BuiltinType> {
+    match name {
+        "Duration" => Some(BuiltinType::Duration),
+        "SystemTime" => Some(BuiltinType::SystemTime),
+        "Uuid" => Some(BuiltinType::Uuid),
+        "Url" => Some(BuiltinType::Url),
+        _ => None,
     }
 }
 
@@ -784,6 +822,14 @@ pub enum SourceFragmentError {
         /// The conflicting canonical id.
         id: String,
     },
+    /// A builtin-named leaf collides with a same-named declaration or custom remote.
+    ///
+    /// Spelling cannot tell the two apart at a use site; the whole-crate scan can,
+    /// so consumers fall back to the legacy path.
+    ShadowedBuiltin {
+        /// The contested builtin name.
+        name: String,
+    },
     /// A record marks an invocation the capture cannot describe yet.
     UnsupportedCapture {
         /// Module path of the emitting invocation.
@@ -840,6 +886,10 @@ impl std::fmt::Display for SourceFragmentError {
             Self::DuplicateDeclaration { id } => write!(
                 formatter,
                 "two records declare `{id}` with different content"
+            ),
+            Self::ShadowedBuiltin { name } => write!(
+                formatter,
+                "builtin `{name}` is shadowed by a declaration of the same name"
             ),
             Self::UnsupportedCapture {
                 module,
@@ -898,6 +948,93 @@ mod tests {
             &[],
             serde_json::to_vec(&SourceFragment::Record(def)).expect("fragment serializes"),
         )
+    }
+
+    fn duration_field_record() -> RawSourceRecord {
+        raw(
+            "demo",
+            &[],
+            record_fragment(vec![FieldDef::new(
+                name("wall"),
+                TypeExpr::builtin(BuiltinType::Duration),
+            )]),
+        )
+    }
+
+    #[test]
+    fn an_unshadowed_builtin_leaf_aggregates() {
+        let contract =
+            aggregate_records(&[duration_field_record()], PackageInfo::new("demo", None))
+                .expect("records aggregate");
+
+        assert!(matches!(
+            contract.records[0].fields[0].type_expr,
+            TypeExpr::Builtin(BuiltinType::Duration)
+        ));
+    }
+
+    #[test]
+    fn a_declared_type_shadowing_a_builtin_refuses_aggregation() {
+        let mut shadow = RecordDef::new(
+            RecordId::new(format!("{SELF_ID}::Duration")),
+            name("Duration"),
+        );
+        shadow.fields = vec![FieldDef::new(
+            name("millis"),
+            TypeExpr::Primitive(Primitive::U64),
+        )];
+        let shadow = raw(
+            "demo::timing",
+            &[],
+            serde_json::to_vec(&SourceFragment::Record(shadow)).expect("fragment serializes"),
+        );
+
+        let error = aggregate_records(
+            &[shadow, duration_field_record()],
+            PackageInfo::new("demo", None),
+        )
+        .expect_err("the builtin spelling is ambiguous");
+
+        assert!(matches!(
+            error,
+            SourceFragmentError::ShadowedBuiltin { name } if name == "Duration"
+        ));
+    }
+
+    #[test]
+    fn a_custom_remote_shadowing_a_builtin_refuses_aggregation() {
+        let converter = || CustomTypeConverter::path(boltffi_ast::Path::single("instant_into_ffi"));
+        let custom = CustomTypeDef::new(
+            CustomTypeId::new(format!("{SELF_ID}::FixtureInstant")),
+            name("FixtureInstant"),
+            CustomRemoteType::path(boltffi_ast::CustomRemotePath::new(
+                boltffi_ast::PathRoot::Relative,
+                vec![
+                    boltffi_ast::CustomRemotePathSegment::new("std"),
+                    boltffi_ast::CustomRemotePathSegment::new("time"),
+                    boltffi_ast::CustomRemotePathSegment::new("Duration"),
+                ],
+            )),
+            TypeExpr::Primitive(Primitive::I64),
+            None,
+            boltffi_ast::CustomTypeConverters::new(converter(), converter()),
+        );
+        let custom = raw(
+            "demo::customs",
+            &[],
+            serde_json::to_vec(&SourceFragment::Custom(custom)).expect("fragment serializes"),
+        );
+
+        let error = aggregate_records(
+            &[custom, duration_field_record()],
+            PackageInfo::new("demo", None),
+        )
+        .expect_err("the remote's builtin spelling is ambiguous");
+
+        assert!(matches!(
+            error,
+            SourceFragmentError::ShadowedBuiltin { name } if name == "Duration"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
When a plain build surfaces source records owned entirely by the root package, `Generation::bindings` aggregates and lowers them directly; the env-gated envelope build runs only when no root-owned records surface or aggregation reports a capture gap (`UnsupportedCapture`, `UnresolvedReference`, `ShadowedBuiltin`). Other aggregation failures are genuine contract errors and surface as such. The plain build carries the same metadata cfgs as the envelope build, so cfg-gated exports surface identically on both paths.

Spelling cannot tell a bare `Duration` apart from a declared type or custom remote of the same name, so aggregation refuses such sets and the whole-crate scan — which resolves imports — decides:

```rust
#[data]
pub struct Duration { pub millis: u64 }

#[data]
pub struct Sample {
    pub own: Duration,             // the legacy scan binds crate::timing::Duration
    pub wall: std::time::Duration, // and keeps the builtin here
}
```

Compiler-arbitrated resolution through `TypeDesc` impls on the builtin remotes was tried and withdrawn: a blanket impl collides (E0119) with the impl `custom_type!` emits for a custom-mapped builtin remote.

The scan-vs-records lowering equivalence test on the macro fixture is the acceptance gate.

Still deferred, tracked for the series: dependency surfaces (any dependency-contributed record set falls back wholesale until the dependency-visibility question settles), and imported-bare-name class identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code) and a human
