### PR TITLE
Env-gated per-invocation function wrappers through FfiCross

### DIFF
--- a/boltffi_ast/src/callable.rs
+++ b/boltffi_ast/src/callable.rs
@@ -186,6 +186,12 @@ pub struct FunctionDef {
     /// Span available during macro expansion.
     #[serde(default, skip_serializing, skip_deserializing)]
     pub source_span: Option<SourceSpan>,
+    /// Native wrapper symbol minted at the macro invocation, when one was emitted.
+    ///
+    /// Per-invocation capture records carry the symbol here because the invocation site
+    /// is the only place that knows the exported wrapper's link name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native_symbol: Option<String>,
 }
 
 impl FunctionDef {
@@ -209,6 +215,7 @@ impl FunctionDef {
             user_attrs: Vec::new(),
             source: Source::exported(),
             source_span: None,
+            native_symbol: None,
         }
     }
 }

--- a/boltffi_core/src/capture/cross.rs
+++ b/boltffi_core/src/capture/cross.rs
@@ -1,9 +1,10 @@
 use std::collections::{BTreeMap, HashMap};
+use std::time::{Duration, SystemTime};
 
 use crate::safety::PANIC_STATUS;
 use crate::status::{FfiStatus, set_last_error};
 use crate::types::FfiBuf;
-use crate::wire::{WireDecode, WireEncode};
+use crate::wire::{DecodeError, WireDecode, WireEncode};
 
 /// A value's ABI at a per-invocation wrapper boundary: itself when direct, an owned
 /// [`FfiBuf`] when encoded. One value per parameter, so wrapper arity never depends on
@@ -19,7 +20,7 @@ pub trait FfiCross<Tag>: Sized {
     /// Converts an owned value into its crossing representation.
     fn lower(self) -> Self::Ffi;
     /// Reconstructs an owned value from its crossing representation.
-    fn lift(ffi: Self::Ffi) -> Self;
+    fn lift(ffi: Self::Ffi) -> Result<Self, DecodeError>;
     /// The value returned beside a panic status; never valid to read.
     fn poisoned() -> Self::Ffi;
 }
@@ -34,6 +35,19 @@ pub unsafe fn note_panic(status: *mut FfiStatus, panic: Box<dyn std::any::Any + 
     set_last_error(panic_message(panic));
     if !status.is_null() {
         unsafe { *status = PANIC_STATUS };
+    }
+}
+
+/// Records a failed argument lift: stores the decode error as the last error and writes
+/// [`FfiStatus::INVALID_ARG`] through the out-parameter when one was supplied.
+///
+/// # Safety
+///
+/// `status` must be null or valid for writes.
+pub unsafe fn note_invalid_arg(status: *mut FfiStatus, error: DecodeError) {
+    set_last_error(error.to_string());
+    if !status.is_null() {
+        unsafe { *status = FfiStatus::INVALID_ARG };
     }
 }
 
@@ -55,8 +69,8 @@ macro_rules! direct_cross {
                 fn lower(self) -> Self {
                     self
                 }
-                fn lift(ffi: Self) -> Self {
-                    ffi
+                fn lift(ffi: Self) -> Result<Self, DecodeError> {
+                    Ok(ffi)
                 }
                 fn poisoned() -> Self {
                     $poisoned
@@ -88,9 +102,8 @@ macro_rules! encoded_cross {
                     FfiBuf::wire_encode(&self)
                 }
 
-                fn lift(ffi: FfiBuf) -> Self {
+                fn lift(ffi: FfiBuf) -> Result<Self, DecodeError> {
                     crate::wire::decode(unsafe { ffi.as_byte_slice() })
-                        .expect("wire decode failed at the FFI boundary")
                 }
 
                 fn poisoned() -> FfiBuf {
@@ -101,7 +114,13 @@ macro_rules! encoded_cross {
     };
 }
 
-encoded_cross!(String);
+encoded_cross!(String, Duration, SystemTime);
+
+#[cfg(feature = "uuid")]
+encoded_cross!(uuid::Uuid);
+
+#[cfg(feature = "url")]
+encoded_cross!(url::Url);
 
 macro_rules! encoded_cross_generic {
     ($({$($generics:tt)*} $ty:ty),* $(,)?) => {
@@ -116,9 +135,8 @@ macro_rules! encoded_cross_generic {
                     FfiBuf::wire_encode(&self)
                 }
 
-                fn lift(ffi: FfiBuf) -> Self {
+                fn lift(ffi: FfiBuf) -> Result<Self, DecodeError> {
                     crate::wire::decode(unsafe { ffi.as_byte_slice() })
-                        .expect("wire decode failed at the FFI boundary")
                 }
 
                 fn poisoned() -> FfiBuf {
@@ -136,6 +154,18 @@ encoded_cross_generic!(
     {K, V} HashMap<K, V>,
     {K, V} BTreeMap<K, V>,
     {T, E} Result<T, E>,
+    {A} (A,),
+    {A, B} (A, B),
+    {A, B, C} (A, B, C),
+    {A, B, C, D} (A, B, C, D),
+    {A, B, C, D, E} (A, B, C, D, E),
+    {A, B, C, D, E, F} (A, B, C, D, E, F),
+    {A, B, C, D, E, F, G} (A, B, C, D, E, F, G),
+    {A, B, C, D, E, F, G, H} (A, B, C, D, E, F, G, H),
+    {A, B, C, D, E, F, G, H, I} (A, B, C, D, E, F, G, H, I),
+    {A, B, C, D, E, F, G, H, I, J} (A, B, C, D, E, F, G, H, I, J),
+    {A, B, C, D, E, F, G, H, I, J, K} (A, B, C, D, E, F, G, H, I, J, K),
+    {A, B, C, D, E, F, G, H, I, J, K, L} (A, B, C, D, E, F, G, H, I, J, K, L),
 );
 
 #[cfg(test)]
@@ -147,14 +177,14 @@ mod tests {
     extern "C" fn probe_direct(
         value: <f64 as FfiCross<ProbeTag>>::Ffi,
     ) -> <f64 as FfiCross<ProbeTag>>::Ffi {
-        let lifted = <f64 as FfiCross<ProbeTag>>::lift(value);
+        let lifted = <f64 as FfiCross<ProbeTag>>::lift(value).expect("direct lift is infallible");
         <f64 as FfiCross<ProbeTag>>::lower(lifted + 1.0)
     }
 
     extern "C" fn probe_encoded(
         value: <String as FfiCross<ProbeTag>>::Ffi,
     ) -> <String as FfiCross<ProbeTag>>::Ffi {
-        let lifted = <String as FfiCross<ProbeTag>>::lift(value);
+        let lifted = <String as FfiCross<ProbeTag>>::lift(value).expect("probe bytes decode");
         <String as FfiCross<ProbeTag>>::lower(format!("{lifted}!"))
     }
 
@@ -168,7 +198,7 @@ mod tests {
 
         let encoded = probe_encoded(<String as FfiCross<ProbeTag>>::lower("hey".to_owned()));
         assert_eq!(
-            <String as FfiCross<ProbeTag>>::lift(encoded),
+            <String as FfiCross<ProbeTag>>::lift(encoded).expect("probe bytes decode"),
             "hey!",
             "encoded values cross as owned buffers"
         );
@@ -180,8 +210,25 @@ mod tests {
         let lifted =
             <Vec<Option<String>> as FfiCross<ProbeTag>>::lift(<Vec<Option<String>> as FfiCross<
                 ProbeTag,
-            >>::lower(values.clone()));
+            >>::lower(values.clone()))
+            .expect("probe bytes decode");
         assert_eq!(lifted, values, "containers compose in the byte encoding");
+    }
+
+    #[test]
+    fn builtins_round_trip_through_the_wire_encoding() {
+        let duration = Duration::from_millis(1500);
+        let lifted = <Duration as FfiCross<ProbeTag>>::lift(
+            <Duration as FfiCross<ProbeTag>>::lower(duration),
+        )
+        .expect("probe bytes decode");
+        assert_eq!(lifted, duration, "builtins cross as encoded buffers");
+    }
+
+    #[test]
+    fn a_malformed_buffer_lifts_to_a_decode_error() {
+        <String as FfiCross<ProbeTag>>::lift(FfiBuf::from_vec(vec![0xFF, 0xFF, 0xFF]))
+            .expect_err("truncated bytes refuse to lift");
     }
 
     #[test]
@@ -196,6 +243,23 @@ mod tests {
             crate::status::take_last_error().as_deref(),
             Some("boom"),
             "the panic message lands in the last error"
+        );
+    }
+
+    #[test]
+    fn a_noted_invalid_arg_sets_the_status_and_last_error() {
+        let error = <String as FfiCross<ProbeTag>>::lift(FfiBuf::from_vec(vec![0xFF]))
+            .expect_err("truncated bytes refuse to lift");
+        let mut status = FfiStatus::OK;
+        unsafe { note_invalid_arg(&mut status, error) };
+        assert_eq!(
+            status,
+            FfiStatus::INVALID_ARG,
+            "the out-parameter takes the invalid-argument status"
+        );
+        assert!(
+            crate::status::take_last_error().is_some(),
+            "the decode error lands in the last error"
         );
     }
 }

--- a/boltffi_core/src/capture/cross.rs
+++ b/boltffi_core/src/capture/cross.rs
@@ -1,0 +1,201 @@
+use std::collections::{BTreeMap, HashMap};
+
+use crate::safety::PANIC_STATUS;
+use crate::status::{FfiStatus, set_last_error};
+use crate::types::FfiBuf;
+use crate::wire::{WireDecode, WireEncode};
+
+/// A value's ABI at a per-invocation wrapper boundary: itself when direct, an owned
+/// [`FfiBuf`] when encoded. One value per parameter, so wrapper arity never depends on
+/// knowledge only the referenced type's definition site has.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` cannot cross the FFI boundary by value",
+    label = "cannot cross by value",
+    note = "annotate `{Self}` with `#[data]`, or use a supported primitive or container"
+)]
+pub trait FfiCross<Tag>: Sized {
+    /// The `extern "C"` type this value crosses as.
+    type Ffi;
+    /// Converts an owned value into its crossing representation.
+    fn lower(self) -> Self::Ffi;
+    /// Reconstructs an owned value from its crossing representation.
+    fn lift(ffi: Self::Ffi) -> Self;
+    /// The value returned beside a panic status; never valid to read.
+    fn poisoned() -> Self::Ffi;
+}
+
+/// Records a caught wrapper panic: stores the message as the last error and writes
+/// [`PANIC_STATUS`] through the out-parameter when one was supplied.
+///
+/// # Safety
+///
+/// `status` must be null or valid for writes.
+pub unsafe fn note_panic(status: *mut FfiStatus, panic: Box<dyn std::any::Any + Send>) {
+    set_last_error(panic_message(panic));
+    if !status.is_null() {
+        unsafe { *status = PANIC_STATUS };
+    }
+}
+
+fn panic_message(panic: Box<dyn std::any::Any + Send>) -> String {
+    match panic.downcast_ref::<&str>() {
+        Some(message) => (*message).to_owned(),
+        None => match panic.downcast::<String>() {
+            Ok(message) => *message,
+            Err(_) => "panic payload is not a string".to_owned(),
+        },
+    }
+}
+
+macro_rules! direct_cross {
+    ($($ty:ty => $poisoned:expr),* $(,)?) => {
+        $(
+            impl<Tag> FfiCross<Tag> for $ty {
+                type Ffi = Self;
+                fn lower(self) -> Self {
+                    self
+                }
+                fn lift(ffi: Self) -> Self {
+                    ffi
+                }
+                fn poisoned() -> Self {
+                    $poisoned
+                }
+            }
+        )*
+    };
+}
+
+direct_cross!(
+    u8 => 0, u16 => 0, u32 => 0, u64 => 0,
+    i8 => 0, i16 => 0, i32 => 0, i64 => 0,
+    usize => 0, isize => 0,
+    f32 => 0.0, f64 => 0.0,
+    bool => false,
+    () => (),
+);
+
+macro_rules! encoded_cross {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl<Tag> FfiCross<Tag> for $ty
+            where
+                Self: WireEncode + WireDecode,
+            {
+                type Ffi = FfiBuf;
+
+                fn lower(self) -> FfiBuf {
+                    FfiBuf::wire_encode(&self)
+                }
+
+                fn lift(ffi: FfiBuf) -> Self {
+                    crate::wire::decode(unsafe { ffi.as_byte_slice() })
+                        .expect("wire decode failed at the FFI boundary")
+                }
+
+                fn poisoned() -> FfiBuf {
+                    FfiBuf::empty()
+                }
+            }
+        )*
+    };
+}
+
+encoded_cross!(String);
+
+macro_rules! encoded_cross_generic {
+    ($({$($generics:tt)*} $ty:ty),* $(,)?) => {
+        $(
+            impl<Tag, $($generics)*> FfiCross<Tag> for $ty
+            where
+                Self: WireEncode + WireDecode,
+            {
+                type Ffi = FfiBuf;
+
+                fn lower(self) -> FfiBuf {
+                    FfiBuf::wire_encode(&self)
+                }
+
+                fn lift(ffi: FfiBuf) -> Self {
+                    crate::wire::decode(unsafe { ffi.as_byte_slice() })
+                        .expect("wire decode failed at the FFI boundary")
+                }
+
+                fn poisoned() -> FfiBuf {
+                    FfiBuf::empty()
+                }
+            }
+        )*
+    };
+}
+
+encoded_cross_generic!(
+    {T} Vec<T>,
+    {T} Option<T>,
+    {T} Box<T>,
+    {K, V} HashMap<K, V>,
+    {K, V} BTreeMap<K, V>,
+    {T, E} Result<T, E>,
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct ProbeTag;
+
+    extern "C" fn probe_direct(
+        value: <f64 as FfiCross<ProbeTag>>::Ffi,
+    ) -> <f64 as FfiCross<ProbeTag>>::Ffi {
+        let lifted = <f64 as FfiCross<ProbeTag>>::lift(value);
+        <f64 as FfiCross<ProbeTag>>::lower(lifted + 1.0)
+    }
+
+    extern "C" fn probe_encoded(
+        value: <String as FfiCross<ProbeTag>>::Ffi,
+    ) -> <String as FfiCross<ProbeTag>>::Ffi {
+        let lifted = <String as FfiCross<ProbeTag>>::lift(value);
+        <String as FfiCross<ProbeTag>>::lower(format!("{lifted}!"))
+    }
+
+    #[test]
+    fn extern_signatures_project_through_the_crossing() {
+        assert_eq!(
+            probe_direct(<f64 as FfiCross<ProbeTag>>::lower(1.5)),
+            2.5,
+            "direct values cross as themselves"
+        );
+
+        let encoded = probe_encoded(<String as FfiCross<ProbeTag>>::lower("hey".to_owned()));
+        assert_eq!(
+            <String as FfiCross<ProbeTag>>::lift(encoded),
+            "hey!",
+            "encoded values cross as owned buffers"
+        );
+    }
+
+    #[test]
+    fn containers_round_trip_through_the_wire_encoding() {
+        let values = vec![Some("ab".to_owned()), None];
+        let lifted =
+            <Vec<Option<String>> as FfiCross<ProbeTag>>::lift(<Vec<Option<String>> as FfiCross<
+                ProbeTag,
+            >>::lower(values.clone()));
+        assert_eq!(lifted, values, "containers compose in the byte encoding");
+    }
+
+    #[test]
+    fn a_noted_panic_sets_the_status_and_last_error() {
+        let mut status = FfiStatus::OK;
+        unsafe { note_panic(&mut status, Box::new("boom".to_owned())) };
+        assert_eq!(
+            status, PANIC_STATUS,
+            "the out-parameter takes the panic status"
+        );
+        assert_eq!(
+            crate::status::take_last_error().as_deref(),
+            Some("boom"),
+            "the panic message lands in the last error"
+        );
+    }
+}

--- a/boltffi_core/src/capture/mod.rs
+++ b/boltffi_core/src/capture/mod.rs
@@ -5,7 +5,7 @@ mod cross;
 mod record;
 mod type_info;
 
-pub use cross::{FfiCross, note_panic};
+pub use cross::{FfiCross, note_invalid_arg, note_panic};
 pub use record::{
     SOURCE_RECORD_MAGIC, SOURCE_SECTION_MACH_O, SOURCE_SECTION_MACH_O_NAME, SOURCE_SECTION_OBJECT,
     record, record_len,

--- a/boltffi_core/src/capture/mod.rs
+++ b/boltffi_core/src/capture/mod.rs
@@ -1,9 +1,11 @@
 //! Per-invocation metadata capture: each `#[data]`/`#[export]` expansion emits its own
 //! link-section record, built in const context so type references resolve through rustc.
 
+mod cross;
 mod record;
 mod type_info;
 
+pub use cross::{FfiCross, note_panic};
 pub use record::{
     SOURCE_RECORD_MAGIC, SOURCE_SECTION_MACH_O, SOURCE_SECTION_MACH_O_NAME, SOURCE_SECTION_OBJECT,
     record, record_len,

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -297,6 +297,17 @@ fn wrapper_tokens(
         }
     };
 
+    for parameter in &def.parameters {
+        if !wrapper_crossable(&parameter.type_expr) {
+            return Err("a parameter type has no FfiCross crossing yet");
+        }
+    }
+    if let boltffi_ast::ReturnDef::Value(returns) = &def.returns
+        && !wrapper_crossable(returns)
+    {
+        return Err("the return type has no FfiCross crossing yet");
+    }
+
     let ident = &item.sig.ident;
     let symbol = invocation_symbol(&ident.to_string());
     def.native_symbol = Some(symbol.clone());
@@ -314,13 +325,24 @@ fn wrapper_tokens(
             if !__boltffi_status.is_null() {
                 unsafe { *__boltffi_status = #facade::__private::FfiStatus::OK };
             }
-            match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(move || {
-                let __boltffi_ret = #ident(
-                    #(<#types as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::lift(#names)),*
-                );
-                <#return_type as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::lower(__boltffi_ret)
-            })) {
-                Ok(value) => value,
+            match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(
+                move || -> ::core::result::Result<
+                    <#return_type as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::Ffi,
+                    #facade::__private::wire::DecodeError,
+                > {
+                    let __boltffi_ret = #ident(
+                        #(<#types as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::lift(#names)?),*
+                    );
+                    ::core::result::Result::Ok(
+                        <#return_type as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::lower(__boltffi_ret)
+                    )
+                }
+            )) {
+                Ok(::core::result::Result::Ok(value)) => value,
+                Ok(::core::result::Result::Err(error)) => {
+                    unsafe { #facade::__private::capture::note_invalid_arg(__boltffi_status, error) };
+                    <#return_type as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::poisoned()
+                }
                 Err(panic) => {
                     unsafe { #facade::__private::capture::note_panic(__boltffi_status, panic) };
                     <#return_type as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::poisoned()
@@ -335,6 +357,30 @@ fn crossing_unsupported(ty: &syn::Type) -> bool {
         ty,
         syn::Type::Reference(_) | syn::Type::ImplTrait(_) | syn::Type::Ptr(_)
     )
+}
+
+/// Whether every type reached by this expression has an `FfiCross` impl the wrapper can
+/// name: core's primitives, builtins, and containers, plus the impls `#[data]` sites
+/// emit. Everything else refuses so the crate falls back instead of failing to compile —
+/// including all custom types, since the function site cannot tell a `custom_ffi` local
+/// (which has an impl) from a `custom_type!` remote (which the orphan rule keeps bare).
+fn wrapper_crossable(type_expr: &boltffi_ast::TypeExpr) -> bool {
+    use boltffi_ast::TypeExpr;
+    match type_expr {
+        TypeExpr::Primitive(_)
+        | TypeExpr::Unit
+        | TypeExpr::String
+        | TypeExpr::Builtin(_)
+        | TypeExpr::Record { .. }
+        | TypeExpr::Enum { .. } => true,
+        TypeExpr::Boxed(inner) | TypeExpr::Vec(inner) | TypeExpr::Option(inner) => {
+            wrapper_crossable(inner)
+        }
+        TypeExpr::Result { ok, err } => wrapper_crossable(ok) && wrapper_crossable(err),
+        TypeExpr::Map { key, value, .. } => wrapper_crossable(key) && wrapper_crossable(value),
+        TypeExpr::Tuple(items) => items.iter().all(wrapper_crossable),
+        _ => false,
+    }
 }
 
 fn invocation_symbol(item: &str) -> String {
@@ -523,9 +569,10 @@ fn wire_cross_tokens<T: quote::ToTokens>(self_ty: &T) -> TokenStream {
                 #facade::__private::FfiBuf::wire_encode(&self)
             }
 
-            fn lift(ffi: #facade::__private::FfiBuf) -> Self {
+            fn lift(
+                ffi: #facade::__private::FfiBuf,
+            ) -> ::core::result::Result<Self, #facade::__private::wire::DecodeError> {
                 #facade::__private::wire::decode(unsafe { ffi.as_byte_slice() })
-                    .expect("wire decode failed at the FFI boundary")
             }
 
             fn poisoned() -> #facade::__private::FfiBuf {
@@ -543,5 +590,29 @@ fn type_leaf_name(ty: &syn::Type) -> Option<String> {
             .last()
             .map(|segment| segment.ident.to_string()),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use boltffi_ast::{BuiltinType, TypeExpr};
+
+    use super::wrapper_crossable;
+
+    #[test]
+    fn wrapper_crossability_follows_ffi_cross_coverage() {
+        assert!(
+            wrapper_crossable(&TypeExpr::Builtin(BuiltinType::Duration)),
+            "builtins have core crossings"
+        );
+        assert!(
+            wrapper_crossable(&TypeExpr::Vec(Box::new(TypeExpr::String))),
+            "containers cross when their elements do"
+        );
+        assert!(!wrapper_crossable(&TypeExpr::Str), "borrowed types refuse");
+        assert!(
+            !wrapper_crossable(&TypeExpr::Vec(Box::new(TypeExpr::Str))),
+            "containers refuse when their elements do"
+        );
     }
 }

--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -54,7 +54,24 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
             Err(error) => data_unsupported_tokens(&item.ident, &error.to_string()),
         },
         syn::Item::Fn(item) => match capture_function(item) {
-            Ok(captured) => record_tokens(&SourceFragment::Function(captured.def), &captured.slots),
+            Ok(mut captured) => {
+                let wrapper = if wrappers_enabled() {
+                    match wrapper_tokens(item, &mut captured.def) {
+                        Ok(wrapper) => wrapper,
+                        Err(reason) => {
+                            return unsupported_tokens(&item.sig.ident.to_string(), reason);
+                        }
+                    }
+                } else {
+                    TokenStream::new()
+                };
+                let record =
+                    record_tokens(&SourceFragment::Function(captured.def), &captured.slots);
+                quote! {
+                    #wrapper
+                    #record
+                }
+            }
             Err(error) => unsupported_tokens(&item.sig.ident.to_string(), &error.to_string()),
         },
         syn::Item::Trait(item) => match capture_trait(item) {
@@ -73,7 +90,7 @@ pub(crate) fn item_tokens(item: proc_macro::TokenStream, impl_capture: ImplCaptu
             let name = type_leaf_name(self_ty).unwrap_or_else(|| "impl".to_owned());
             match impl_capture {
                 ImplCapture::Class(marker_args) => {
-                    let identity = local_identity_tokens(self_ty, &name);
+                    let identity = local_identity_tokens(self_ty, &name, LocalCrossing::None);
                     let record = match capture_class(item, marker_args) {
                         Ok(captured) => {
                             record_tokens(&SourceFragment::Class(captured.def), &captured.slots)
@@ -136,7 +153,7 @@ pub(crate) fn interned_string_pool_tokens(item: proc_macro::TokenStream) -> Toke
     match boltffi_scan::capture_interned_string_pool(proc_macro2::TokenStream::from(item)) {
         Ok(pool) => {
             let ident = format_ident!("{}", pool.name);
-            let identity = local_identity_tokens(&ident, &pool.name);
+            let identity = local_identity_tokens(&ident, &pool.name, LocalCrossing::None);
             let record = record_tokens(
                 &SourceFragment::InternedStringPool {
                     id: format!("$self::{}", pool.name),
@@ -179,7 +196,7 @@ pub(crate) fn error_item_tokens(item: proc_macro::TokenStream) -> TokenStream {
 }
 
 fn data_unsupported_tokens(ident: &syn::Ident, reason: &str) -> TokenStream {
-    let identity = local_identity_tokens(ident, &ident.to_string());
+    let identity = local_identity_tokens(ident, &ident.to_string(), LocalCrossing::Wire);
     let unsupported = unsupported_tokens(&ident.to_string(), reason);
     quote! {
         #identity
@@ -211,6 +228,7 @@ fn data_tokens(
 ) -> TokenStream {
     let name = ident.to_string();
     let record = record_tokens(&fragment, slots);
+    let cross = wire_cross_tokens(ident);
     let facade = facade();
     quote! {
         const _: () = {
@@ -226,9 +244,113 @@ fn data_tokens(
                         <#ident as #facade::__private::capture::TypeInfo<Tag>>::NAME,
                     );
             }
+
+            #cross
         };
         #record
     }
+}
+
+/// Read at expansion time; cargo does not fingerprint the variable, so toggling it
+/// only takes effect on a fresh build of the affected crates.
+fn wrappers_enabled() -> bool {
+    std::env::var_os("BOLTFFI_CAPTURE_WRAPPERS").is_some()
+}
+
+fn wrapper_tokens(
+    item: &syn::ItemFn,
+    def: &mut boltffi_ast::FunctionDef,
+) -> Result<TokenStream, &'static str> {
+    if !item.sig.generics.params.is_empty() {
+        return Err("generic functions have no per-invocation wrapper");
+    }
+    if item.sig.asyncness.is_some() {
+        return Err("async functions have no per-invocation wrapper yet");
+    }
+    if item.sig.variadic.is_some() || item.sig.abi.is_some() {
+        return Err("extern or variadic functions have no per-invocation wrapper");
+    }
+
+    let mut names = Vec::new();
+    let mut types = Vec::new();
+    for input in &item.sig.inputs {
+        let syn::FnArg::Typed(typed) = input else {
+            return Err("methods have no per-invocation wrapper yet");
+        };
+        let syn::Pat::Ident(pat) = &*typed.pat else {
+            return Err("pattern parameters have no per-invocation wrapper");
+        };
+        if crossing_unsupported(&typed.ty) {
+            return Err("borrowed or impl-trait parameters have no per-invocation wrapper yet");
+        }
+        names.push(pat.ident.clone());
+        types.push((*typed.ty).clone());
+    }
+
+    let return_type = match &item.sig.output {
+        syn::ReturnType::Default => syn::parse_quote!(()),
+        syn::ReturnType::Type(_, ty) => {
+            if crossing_unsupported(ty) {
+                return Err("borrowed returns have no per-invocation wrapper yet");
+            }
+            (**ty).clone()
+        }
+    };
+
+    let ident = &item.sig.ident;
+    let symbol = invocation_symbol(&ident.to_string());
+    def.native_symbol = Some(symbol.clone());
+    let symbol_ident = quote::format_ident!("{symbol}");
+    let facade = facade();
+
+    Ok(quote! {
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        #[allow(clippy::missing_safety_doc)]
+        pub unsafe extern "C" fn #symbol_ident(
+            #(#names: <#types as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::Ffi,)*
+            __boltffi_status: *mut #facade::__private::FfiStatus,
+        ) -> <#return_type as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::Ffi {
+            if !__boltffi_status.is_null() {
+                unsafe { *__boltffi_status = #facade::__private::FfiStatus::OK };
+            }
+            match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(move || {
+                let __boltffi_ret = #ident(
+                    #(<#types as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::lift(#names)),*
+                );
+                <#return_type as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::lower(__boltffi_ret)
+            })) {
+                Ok(value) => value,
+                Err(panic) => {
+                    unsafe { #facade::__private::capture::note_panic(__boltffi_status, panic) };
+                    <#return_type as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::poisoned()
+                }
+            }
+        }
+    })
+}
+
+fn crossing_unsupported(ty: &syn::Type) -> bool {
+    matches!(
+        ty,
+        syn::Type::Reference(_) | syn::Type::ImplTrait(_) | syn::Type::Ptr(_)
+    )
+}
+
+fn invocation_symbol(item: &str) -> String {
+    let span = proc_macro::Span::call_site();
+    let crate_name = std::env::var("CARGO_CRATE_NAME").unwrap_or_else(|_| "unknown".to_owned());
+    let position = format!("{}:{}:{}", span.file(), span.line(), span.column());
+    format!("boltffi_inv_{crate_name}_{item}_{:08x}", fnv1a(&position))
+}
+
+fn fnv1a(input: &str) -> u32 {
+    let mut hash: u32 = 0x811c9dc5;
+    for byte in input.bytes() {
+        hash ^= u32::from(byte);
+        hash = hash.wrapping_mul(0x01000193);
+    }
+    hash
 }
 
 fn record_tokens(fragment: &SourceFragment, slots: &[boltffi_scan::SlotSource]) -> TokenStream {
@@ -298,7 +420,7 @@ pub(crate) fn custom_ffi_tokens(item: proc_macro::TokenStream) -> TokenStream {
     };
     let self_ty = &*item.self_ty;
     let name = type_leaf_name(self_ty).unwrap_or_else(|| "custom_ffi".to_owned());
-    let identity = local_identity_tokens(self_ty, &name);
+    let identity = local_identity_tokens(self_ty, &name, LocalCrossing::Wire);
     let record = match boltffi_scan::capture_custom_ffi(&item) {
         Ok(captured) => record_tokens(&SourceFragment::Custom(captured.def), &captured.slots),
         Err(error) => unsupported_tokens(&name, &error.to_string()),
@@ -355,7 +477,21 @@ fn trait_identity_tokens(item: &syn::ItemTrait) -> TokenStream {
     }
 }
 
-fn local_identity_tokens<T: quote::ToTokens>(self_ty: &T, name: &str) -> TokenStream {
+/// Whether an identity site also gets a wire-encoded [`FfiCross`] impl.
+enum LocalCrossing {
+    Wire,
+    None,
+}
+
+fn local_identity_tokens<T: quote::ToTokens>(
+    self_ty: &T,
+    name: &str,
+    crossing: LocalCrossing,
+) -> TokenStream {
+    let cross = match crossing {
+        LocalCrossing::Wire => wire_cross_tokens(self_ty),
+        LocalCrossing::None => TokenStream::new(),
+    };
     let facade = facade();
     quote! {
         const _: () = {
@@ -371,7 +507,31 @@ fn local_identity_tokens<T: quote::ToTokens>(self_ty: &T, name: &str) -> TokenSt
                         <#self_ty as #facade::__private::capture::TypeInfo<Tag>>::NAME,
                     );
             }
+
+            #cross
         };
+    }
+}
+
+fn wire_cross_tokens<T: quote::ToTokens>(self_ty: &T) -> TokenStream {
+    let facade = facade();
+    quote! {
+        impl<Tag> #facade::__private::capture::FfiCross<Tag> for #self_ty {
+            type Ffi = #facade::__private::FfiBuf;
+
+            fn lower(self) -> #facade::__private::FfiBuf {
+                #facade::__private::FfiBuf::wire_encode(&self)
+            }
+
+            fn lift(ffi: #facade::__private::FfiBuf) -> Self {
+                #facade::__private::wire::decode(unsafe { ffi.as_byte_slice() })
+                    .expect("wire decode failed at the FFI boundary")
+            }
+
+            fn poisoned() -> #facade::__private::FfiBuf {
+                #facade::__private::FfiBuf::empty()
+            }
+        }
     }
 }
 

--- a/boltffi_tests/Cargo.toml
+++ b/boltffi_tests/Cargo.toml
@@ -21,8 +21,10 @@ quote.workspace = true
 boltffi_core.workspace = true
 boltffi_ast.workspace = true
 boltffi_backend.workspace = true
+boltffi_bindgen.workspace = true
 boltffi_binding.workspace = true
 boltffi_scan.workspace = true
+libloading = "0.8"
 syn.workspace = true
 
 [lints]

--- a/boltffi_tests/tests/capture_wrappers.rs
+++ b/boltffi_tests/tests/capture_wrappers.rs
@@ -7,7 +7,7 @@
 use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use boltffi_bindgen::metadata::BindingMetadataBuild;
 use boltffi_core::FfiStatus;
@@ -42,6 +42,11 @@ pub fn shift(point: Point, by: f64) -> Point {
 #[export]
 pub fn shout(value: String) -> String {
     value.to_uppercase()
+}
+
+#[export]
+pub fn until(deadline: std::time::Duration) -> u64 {
+    deadline.as_millis() as u64
 }
 
 #[export]
@@ -175,6 +180,30 @@ fn wrappers_are_called_through_their_record_carried_symbols() {
     let shouted = unsafe { shout(wire_string("hey"), &mut status) };
     assert_eq!(status, FfiStatus::OK);
     assert_eq!(unwire_string(shouted), "HEY", "strings round-trip");
+
+    let mut status = FfiStatus::OK;
+    let refused = unsafe { shout(FfiBuf::from_vec(vec![0xFF, 0xFF, 0xFF]), &mut status) };
+    assert_eq!(
+        status,
+        FfiStatus::INVALID_ARG,
+        "malformed bytes report the invalid-argument status"
+    );
+    assert!(
+        unsafe { refused.as_byte_slice() }.is_empty(),
+        "the refused return is the empty buffer"
+    );
+
+    let until: libloading::Symbol<'_, unsafe extern "C" fn(FfiBuf, *mut FfiStatus) -> u64> =
+        unsafe { library.get(symbol("until").as_bytes()) }.expect("until symbol resolves");
+    let mut status = FfiStatus::OK;
+    let millis = unsafe {
+        until(
+            FfiBuf::wire_encode(&Duration::from_millis(1500)),
+            &mut status,
+        )
+    };
+    assert_eq!(status, FfiStatus::OK);
+    assert_eq!(millis, 1500, "builtins cross as encoded buffers");
 
     let boom: libloading::Symbol<'_, unsafe extern "C" fn(bool, *mut FfiStatus) -> f64> =
         unsafe { library.get(symbol("boom").as_bytes()) }.expect("boom symbol resolves");

--- a/boltffi_tests/tests/capture_wrappers.rs
+++ b/boltffi_tests/tests/capture_wrappers.rs
@@ -1,0 +1,200 @@
+//! Calls per-invocation wrappers through symbols read from their own source records.
+//!
+//! A fixture cdylib compiles with `BOLTFFI_CAPTURE_WRAPPERS` set, its records are
+//! aggregated, and every call goes through the record-carried symbol — the acceptance
+//! shape RFC #665 prototyped.
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use boltffi_bindgen::metadata::BindingMetadataBuild;
+use boltffi_core::FfiStatus;
+use boltffi_core::safety::PANIC_STATUS;
+use boltffi_core::types::FfiBuf;
+
+const FIXTURE_SOURCE: &str = r#"
+use boltffi::*;
+
+scaffolding!();
+
+#[data]
+#[derive(Clone, Copy)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[export]
+pub fn add(a: f64, b: f64) -> f64 {
+    a + b
+}
+
+#[export]
+pub fn shift(point: Point, by: f64) -> Point {
+    Point {
+        x: point.x + by,
+        y: point.y + by,
+    }
+}
+
+#[export]
+pub fn shout(value: String) -> String {
+    value.to_uppercase()
+}
+
+#[export]
+pub fn boom(trigger: bool) -> f64 {
+    if trigger {
+        panic!("wrapper caught this");
+    }
+    1.0
+}
+"#;
+
+struct FixtureCrate {
+    root: PathBuf,
+    manifest: PathBuf,
+}
+
+impl FixtureCrate {
+    fn write() -> Self {
+        static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+        let root = std::env::temp_dir().join(format!(
+            "boltffi-capture-wrappers-{}-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time after unix epoch")
+                .as_nanos(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let source_dir = root.join("src");
+        fs::create_dir_all(&source_dir).expect("create fixture source dir");
+        let manifest = root.join("Cargo.toml");
+        let boltffi = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("workspace root")
+            .join("boltffi");
+        fs::write(
+            &manifest,
+            format!(
+                "[package]\nname = \"capture_fixture\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[lib]\ncrate-type = [\"cdylib\"]\npath = \"src/lib.rs\"\n\n[dependencies]\nboltffi = {{ path = \"{}\" }}\n",
+                boltffi.display()
+            ),
+        )
+        .expect("write fixture manifest");
+        fs::write(source_dir.join("lib.rs"), FIXTURE_SOURCE).expect("write fixture source");
+        Self { root, manifest }
+    }
+}
+
+impl Drop for FixtureCrate {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn wire_string(value: &str) -> FfiBuf {
+    FfiBuf::wire_encode(&value.to_owned())
+}
+
+fn unwire_string(buf: FfiBuf) -> String {
+    boltffi_core::wire::decode(unsafe { buf.as_byte_slice() }).expect("string decodes")
+}
+
+#[test]
+fn wrappers_are_called_through_their_record_carried_symbols() {
+    let fixture = FixtureCrate::write();
+
+    let source = BindingMetadataBuild::new(&fixture.manifest)
+        .cargo_environment([("BOLTFFI_CAPTURE_WRAPPERS", "1")])
+        .read_source()
+        .expect("fixture source metadata reads");
+    let contract =
+        boltffi_binding::aggregate_records(&source.source_records, source.package.clone())
+            .expect("fixture records aggregate");
+
+    let symbol = |name: &str| {
+        contract
+            .functions
+            .iter()
+            .find(|function| function.id.as_str() == format!("capture_fixture::{name}"))
+            .unwrap_or_else(|| panic!("function `{name}` is captured"))
+            .native_symbol
+            .clone()
+            .unwrap_or_else(|| panic!("function `{name}` carries its wrapper symbol"))
+    };
+
+    let library_path = source
+        .artifacts
+        .iter()
+        .find(|path| {
+            matches!(
+                path.extension().and_then(|ext| ext.to_str()),
+                Some("dylib" | "so" | "dll")
+            ) && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains("capture_fixture"))
+        })
+        .expect("the fixture produced a loadable library")
+        .clone();
+    let library = unsafe { libloading::Library::new(&library_path) }.expect("fixture loads");
+
+    let add: libloading::Symbol<'_, unsafe extern "C" fn(f64, f64, *mut FfiStatus) -> f64> =
+        unsafe { library.get(symbol("add").as_bytes()) }.expect("add symbol resolves");
+    let mut status = FfiStatus::OK;
+    let sum = unsafe { add(2.0, 40.0, &mut status) };
+    assert_eq!(sum, 42.0, "direct values cross by value");
+    assert_eq!(status, FfiStatus::OK);
+
+    let shift: libloading::Symbol<'_, unsafe extern "C" fn(FfiBuf, f64, *mut FfiStatus) -> FfiBuf> =
+        unsafe { library.get(symbol("shift").as_bytes()) }.expect("shift symbol resolves");
+    let point = FfiBuf::from_vec([1.5f64.to_le_bytes(), 2.5f64.to_le_bytes()].concat());
+    let mut status = FfiStatus::OK;
+    let shifted = unsafe { shift(point, 10.0, &mut status) };
+    assert_eq!(status, FfiStatus::OK);
+    let bytes = unsafe { shifted.as_byte_slice() };
+    assert_eq!(
+        bytes.len(),
+        16,
+        "a blittable point crosses as raw field bytes"
+    );
+    let x = f64::from_le_bytes(bytes[..8].try_into().expect("f64 width"));
+    let y = f64::from_le_bytes(bytes[8..].try_into().expect("f64 width"));
+    assert_eq!(
+        (x, y),
+        (11.5, 12.5),
+        "records cross as wire-encoded buffers"
+    );
+
+    let shout: libloading::Symbol<'_, unsafe extern "C" fn(FfiBuf, *mut FfiStatus) -> FfiBuf> =
+        unsafe { library.get(symbol("shout").as_bytes()) }.expect("shout symbol resolves");
+    let mut status = FfiStatus::OK;
+    let shouted = unsafe { shout(wire_string("hey"), &mut status) };
+    assert_eq!(status, FfiStatus::OK);
+    assert_eq!(unwire_string(shouted), "HEY", "strings round-trip");
+
+    let boom: libloading::Symbol<'_, unsafe extern "C" fn(bool, *mut FfiStatus) -> f64> =
+        unsafe { library.get(symbol("boom").as_bytes()) }.expect("boom symbol resolves");
+    let mut status = FfiStatus::OK;
+    let poisoned = unsafe { boom(true, &mut status) };
+    assert_eq!(
+        status, PANIC_STATUS,
+        "a caught panic writes the panic status through the out-parameter"
+    );
+    assert_eq!(
+        poisoned, 0.0,
+        "the poisoned return is the type's zero value"
+    );
+
+    let mut status = FfiStatus::OK;
+    let calm = unsafe { boom(false, &mut status) };
+    assert_eq!(
+        status,
+        FfiStatus::OK,
+        "the wrapper resets the status on entry"
+    );
+    assert_eq!(calm, 1.0);
+}


### PR DESCRIPTION
Starts the wrapper ABI half of RFC #665: an env-gated `FfiCross` crossing for plain functions, minted at the macro invocation and carried on the source record.

With `BOLTFFI_CAPTURE_WRAPPERS` set, every `#[export] fn` also expands to an `extern "C"` wrapper whose symbol only the invocation site knows:

```rust
#[export]
pub fn shift(point: Point, by: f64) -> Point { ... }

// expands (gated) to:
pub unsafe extern "C" fn boltffi_inv_mycrate_shift_1a2b3c4d(
    point: <Point as FfiCross<crate::__BoltffiTag>>::Ffi,  // FfiBuf, wire-encoded
    by: f64,                                               // direct
    status: *mut FfiStatus,                                // panic protocol
) -> FfiBuf
```

- `FfiCross<Tag>` keeps wrapper arity independent of the referenced type's definition site: direct types cross as themselves, encoded types as one owned `FfiBuf` each. Malformed argument bytes lift to a decode error and report `INVALID_ARG`; panics are caught and report `PANIC_STATUS`. Both set the last error and return the type's poisoned value.
- `Result` returns follow the same rule: the whole `Result` crosses in the buffer and the status stays transport-only. Generated bindings decode and raise at the flip, through the value-position `Result` codecs every backend already ships — no error out-channel in the wrapper ABI.
- `#[data]` sites emit the wire `FfiCross` impl for their own type (inert until a wrapper references it); `custom_ffi` sites do the same for their local self type.
- The record's `FunctionDef` gains `native_symbol` (serde-skipped when absent), so bindgen can reach the wrapper through the record instead of deriving a name — the lowering flip that consumes it lands later in this series.
- Unsupported shapes refuse loudly at expansion → unsupported marker → the crate falls back to the legacy path. That covers signature shapes (async, generics, borrows, methods) and, via the captured type expressions, every type without an `FfiCross` impl (classes, interned strings, custom types — `custom_type!` remotes can never get one under the orphan rule). Async graduates later in this series.

Without the env var no wrappers or symbols are emitted and records are unchanged; the wire `FfiCross` impls above are the only new compiled surface, inert until a wrapper references them.

Known caveat: the gate is read at macro expansion and cargo does not fingerprint the variable, so toggling `BOLTFFI_CAPTURE_WRAPPERS` takes effect on a fresh build of the affected crates.
