### PR TITLE
decode encoded returns in place instead of copying them out

### DIFF
--- a/boltffi_backend/src/target/typescript/mod.rs
+++ b/boltffi_backend/src/target/typescript/mod.rs
@@ -1135,12 +1135,12 @@ mod tests {
             "const __boltffi_value_writer = _module.allocWriter(PointCodec.size(value));"
         ));
         assert!(browser.contents().contains(
-            "const __boltffiReader = _module.takePackedBuffer((_exports.boltffi_function_demo_echo_point"
+            "return _module.readPackedBuffer((_exports.boltffi_function_demo_echo_point"
         ));
         assert!(
             browser
                 .contents()
-                .contains("return PointCodec.decode(__boltffiReader);")
+                .contains("(__boltffiReader) => PointCodec.decode(__boltffiReader)")
         );
         assert!(
             browser

--- a/boltffi_backend/src/target/typescript/render/function.rs
+++ b/boltffi_backend/src/target/typescript/render/function.rs
@@ -1556,19 +1556,21 @@ impl Return {
                     .into_iter()
                     .collect::<ArgumentList>(),
             ))],
-            ReturnConversion::Encoded { reader, decode } => vec![
-                Statement::constant(
-                    reader.clone(),
-                    Expression::call(
-                        Expression::identifier(Identifier::known("_module")),
-                        Identifier::known("takePackedBuffer"),
-                        [call.cast(TypeName::bigint())]
-                            .into_iter()
-                            .collect::<ArgumentList>(),
-                    ),
-                ),
-                Statement::return_value(decode.clone()),
-            ],
+            // Decoded in place rather than copied out: `readPackedBuffer` lends
+            // the reader wasm memory and frees the payload once the codec
+            // returns, which avoids an ArrayBuffer and a DataView per call.
+            ReturnConversion::Encoded { reader, decode } => {
+                vec![Statement::return_value(Expression::call(
+                    Expression::identifier(Identifier::known("_module")),
+                    Identifier::known("readPackedBuffer"),
+                    [
+                        call.cast(TypeName::bigint()),
+                        Expression::parameter_lambda(reader.clone(), decode.clone()),
+                    ]
+                    .into_iter()
+                    .collect::<ArgumentList>(),
+                ))]
+            }
             ReturnConversion::PackedOptional { take } => {
                 vec![Statement::return_value(Expression::call(
                     Expression::identifier(Identifier::known("_module")),

--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -180,8 +180,9 @@ export class BoltFFIModule {
   readonly asyncManager: AsyncFutureManager;
   readonly streamManager: StreamPollManager;
   private _memory: WebAssembly.Memory;
-  /** Reused by `readPackedBuffer`; never escapes a single read. */
-  private readonly borrowedReader = new WireReader(EMPTY_BUFFER, 0, true);
+  /** Lent out by `readPackedBuffer`, one read at a time. */
+  private readonly borrowedReader = new WireReader(EMPTY_BUFFER, 0, true, 0);
+  private borrowedReaderInUse = false;
   private _encoder: TextEncoder;
   private _decoder: TextDecoder;
   private _writerPool: Map<number, WriterAlloc[]>;
@@ -1119,18 +1120,37 @@ export class BoltFFIModule {
    *
    * Safe because the reader is in borrowed mode: reads that would hand out a
    * view over that memory copy instead, so nothing the callback returns can
-   * outlive the free below. The reader itself must not escape `read`, which
-   * holds for the generated codecs — they decode and return a value.
+   * outlive the free below. The reader spans exactly the payload, so a
+   * malformed length throws rather than reading past it, and it is detached
+   * afterwards, so a reader that escapes `read` throws rather than reading
+   * freed memory. `read` returning a promise is still the caller's problem:
+   * the payload is freed when `read` returns, not when the promise settles.
    */
   readPackedBuffer<T>(packed: bigint, read: (reader: WireReader) => T): T {
     const { pointer, length } = this.unpackPacked(packed);
-    if (pointer === 0 || length === 0) {
-      return read(this.borrowedReader.reset(EMPTY_BUFFER, 0, true));
+    const empty = pointer === 0 || length === 0;
+    const buffer = empty ? EMPTY_BUFFER : this._memory.buffer;
+    const start = empty ? 0 : pointer;
+    const size = empty ? 0 : length;
+
+    // A nested call would reset the reader the outer one is still using, so it
+    // gets its own. Generated codecs never nest, but the method is public.
+    if (this.borrowedReaderInUse) {
+      const reader = new WireReader(buffer, start, true, size);
+      try {
+        return read(reader);
+      } finally {
+        if (!empty) this.freePacked(pointer, length);
+      }
     }
+
+    this.borrowedReaderInUse = true;
     try {
-      return read(this.borrowedReader.reset(this._memory.buffer, pointer, true));
+      return read(this.borrowedReader.reset(buffer, start, size, true));
     } finally {
-      this.freePacked(pointer, length);
+      this.borrowedReader.invalidate();
+      this.borrowedReaderInUse = false;
+      if (!empty) this.freePacked(pointer, length);
     }
   }
 

--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -2,6 +2,8 @@ import { WireReader, WireWriter } from "./wire.js";
 import type { WasmWireWriterAllocator } from "./wire.js";
 import { StreamPollManager } from "./stream.js";
 
+const EMPTY_BUFFER = new ArrayBuffer(0);
+
 const FFI_BUF_DESCRIPTOR_SIZE = 16;
 const FFI_STATUS_SIZE = 4;
 const OPTION_F64_NONE = 0xffff_ffff_ffff_ffffn;
@@ -178,6 +180,8 @@ export class BoltFFIModule {
   readonly asyncManager: AsyncFutureManager;
   readonly streamManager: StreamPollManager;
   private _memory: WebAssembly.Memory;
+  /** Reused by `readPackedBuffer`; never escapes a single read. */
+  private readonly borrowedReader = new WireReader(EMPTY_BUFFER, 0, true);
   private _encoder: TextEncoder;
   private _decoder: TextDecoder;
   private _writerPool: Map<number, WriterAlloc[]>;
@@ -1104,6 +1108,31 @@ export class BoltFFIModule {
   }
 
 
+
+  /**
+   * Reads a packed return in place, without copying it out of wasm memory.
+   *
+   * `takePackedBuffer` copies the payload into a fresh `ArrayBuffer` and wraps
+   * it in a new `DataView` on every call, which dominates the cost of decoding
+   * a small record. Here the reader borrows wasm memory instead, and the
+   * payload is freed once `read` returns.
+   *
+   * Safe because the reader is in borrowed mode: reads that would hand out a
+   * view over that memory copy instead, so nothing the callback returns can
+   * outlive the free below. The reader itself must not escape `read`, which
+   * holds for the generated codecs — they decode and return a value.
+   */
+  readPackedBuffer<T>(packed: bigint, read: (reader: WireReader) => T): T {
+    const { pointer, length } = this.unpackPacked(packed);
+    if (pointer === 0 || length === 0) {
+      return read(this.borrowedReader.reset(EMPTY_BUFFER, 0, true));
+    }
+    try {
+      return read(this.borrowedReader.reset(this._memory.buffer, pointer, true));
+    } finally {
+      this.freePacked(pointer, length);
+    }
+  }
 
   takePackedBuffer(packed: bigint): WireReader {
     const { pointer, length } = this.unpackPacked(packed);

--- a/runtime/typescript/src/wire.ts
+++ b/runtime/typescript/src/wire.ts
@@ -10,10 +10,30 @@ type TypedArrayConstructor<T extends ArrayBufferView> = {
 export class WireReader {
   private view: DataView;
   private offset: number;
+  /**
+   * True when the view points at wasm memory the caller still owns, rather
+   * than at a private copy.
+   *
+   * Reads that would otherwise hand out a view over that memory copy instead,
+   * so a returned array cannot outlive the buffer it borrows from. Everything
+   * else — scalars, strings, `readBytes` — already produces owned values.
+   */
+  private borrowed: boolean;
 
-  constructor(buffer: ArrayBuffer, offset = 0) {
+  constructor(buffer: ArrayBuffer, offset = 0, borrowed = false) {
     this.view = new DataView(buffer);
     this.offset = offset;
+    this.borrowed = borrowed;
+  }
+
+  /** Points an existing reader at another region, avoiding a fresh DataView. */
+  reset(buffer: ArrayBuffer, offset: number, borrowed: boolean): this {
+    if (this.view.buffer !== buffer) {
+      this.view = new DataView(buffer);
+    }
+    this.offset = offset;
+    this.borrowed = borrowed;
+    return this;
   }
 
   readBool(): boolean {
@@ -112,14 +132,14 @@ export class WireReader {
     const len = this.readU32();
     const result = new Int8Array(this.view.buffer, this.offset, len);
     this.offset += len;
-    return result;
+    return this.borrowed ? result.slice() : result;
   }
 
   readU8Array(): Uint8Array {
     const len = this.readU32();
     const result = new Uint8Array(this.view.buffer, this.offset, len);
     this.offset += len;
-    return result;
+    return this.borrowed ? result.slice() : result;
   }
 
   readBoolArray(): boolean[] {
@@ -136,7 +156,7 @@ export class WireReader {
     const byteOffset = this.offset;
     const byteLength = len * typedArray.BYTES_PER_ELEMENT;
     this.offset += byteLength;
-    if (byteOffset % typedArray.BYTES_PER_ELEMENT === 0) {
+    if (!this.borrowed && byteOffset % typedArray.BYTES_PER_ELEMENT === 0) {
       return new typedArray(this.view.buffer, byteOffset, len);
     }
     const copy = new Uint8Array(this.view.buffer, byteOffset, byteLength).slice().buffer;

--- a/runtime/typescript/src/wire.ts
+++ b/runtime/typescript/src/wire.ts
@@ -1,4 +1,5 @@
 const UTF8_DECODER = new TextDecoder("utf-8");
+const EMPTY_VIEW = new DataView(new ArrayBuffer(0));
 const UTF8_ENCODER = new TextEncoder();
 
 type TypedArrayConstructor<T extends ArrayBufferView> = {
@@ -20,20 +21,60 @@ export class WireReader {
    */
   private borrowed: boolean;
 
-  constructor(buffer: ArrayBuffer, offset = 0, borrowed = false) {
-    this.view = new DataView(buffer);
-    this.offset = offset;
+  /**
+   * The view spans exactly the payload, so `offset` is relative to it and any
+   * read past the end throws instead of reaching into neighbouring memory.
+   * Omitting `length` extends the view to the end of `buffer`.
+   */
+  constructor(
+    buffer: ArrayBuffer,
+    offset = 0,
+    borrowed = false,
+    length?: number
+  ) {
+    this.view =
+      length === undefined
+        ? new DataView(buffer, offset)
+        : new DataView(buffer, offset, length);
+    this.offset = 0;
     this.borrowed = borrowed;
   }
 
-  /** Points an existing reader at another region, avoiding a fresh DataView. */
-  reset(buffer: ArrayBuffer, offset: number, borrowed: boolean): this {
-    if (this.view.buffer !== buffer) {
-      this.view = new DataView(buffer);
-    }
-    this.offset = offset;
+  /** Points an existing reader at another payload, reusing the instance. */
+  reset(
+    buffer: ArrayBuffer,
+    offset: number,
+    length: number,
+    borrowed: boolean
+  ): this {
+    this.view = new DataView(buffer, offset, length);
+    this.offset = 0;
     this.borrowed = borrowed;
     return this;
+  }
+
+  /**
+   * Detaches the reader from whatever it was pointing at, so a reader that
+   * outlives its payload throws rather than reading freed memory. Costs
+   * nothing — the empty view is shared.
+   */
+  invalidate(): void {
+    this.view = EMPTY_VIEW;
+    this.offset = 0;
+  }
+
+  /**
+   * Reserves `byteLength` bytes and returns their absolute index in the
+   * underlying buffer. Reads that build a typed array bypass the view's own
+   * bounds check, so they go through here to keep it.
+   */
+  private take(byteLength: number): number {
+    const start = this.offset;
+    if (byteLength < 0 || start + byteLength > this.view.byteLength) {
+      throw new RangeError("Wire read past the end of the payload");
+    }
+    this.offset = start + byteLength;
+    return this.view.byteOffset + start;
   }
 
   readBool(): boolean {
@@ -116,36 +157,31 @@ export class WireReader {
 
   readString(): string {
     const len = this.readU32();
-    const bytes = new Uint8Array(this.view.buffer, this.offset, len);
-    this.offset += len;
+    const bytes = new Uint8Array(this.view.buffer, this.take(len), len);
     return UTF8_DECODER.decode(bytes);
   }
 
   readBytes(): Uint8Array {
     const len = this.readU32();
-    const bytes = new Uint8Array(this.view.buffer, this.offset, len);
-    this.offset += len;
+    const bytes = new Uint8Array(this.view.buffer, this.take(len), len);
     return bytes.slice();
   }
 
   readI8Array(): Int8Array {
     const len = this.readU32();
-    const result = new Int8Array(this.view.buffer, this.offset, len);
-    this.offset += len;
+    const result = new Int8Array(this.view.buffer, this.take(len), len);
     return this.borrowed ? result.slice() : result;
   }
 
   readU8Array(): Uint8Array {
     const len = this.readU32();
-    const result = new Uint8Array(this.view.buffer, this.offset, len);
-    this.offset += len;
+    const result = new Uint8Array(this.view.buffer, this.take(len), len);
     return this.borrowed ? result.slice() : result;
   }
 
   readBoolArray(): boolean[] {
     const len = this.readU32();
-    const values = new Uint8Array(this.view.buffer, this.offset, len);
-    this.offset += len;
+    const values = new Uint8Array(this.view.buffer, this.take(len), len);
     return Array.from(values, (value) => value !== 0);
   }
 
@@ -153,9 +189,8 @@ export class WireReader {
     typedArray: TypedArrayConstructor<T>,
     len: number
   ): T {
-    const byteOffset = this.offset;
     const byteLength = len * typedArray.BYTES_PER_ELEMENT;
-    this.offset += byteLength;
+    const byteOffset = this.take(byteLength);
     if (!this.borrowed && byteOffset % typedArray.BYTES_PER_ELEMENT === 0) {
       return new typedArray(this.view.buffer, byteOffset, len);
     }

--- a/runtime/typescript/test/borrowed.test.ts
+++ b/runtime/typescript/test/borrowed.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import { WireReader, WireWriter } from "../src/wire.js";
+
+/**
+ * A reader in borrowed mode points at memory the caller frees once the read
+ * returns, so nothing it hands back may alias that memory. These tests write a
+ * payload, decode it through a borrowed reader, then overwrite the source bytes
+ * — anything that changed underneath was aliasing and would have been a
+ * use-after-free in the generated glue.
+ */
+function borrowedOver(bytes: Uint8Array): {
+  reader: WireReader;
+  scribble: () => void;
+} {
+  // Copy into a standalone buffer we can scribble over, mimicking the payload
+  // being freed and the region reused.
+  const backing = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(backing).set(bytes);
+  return {
+    reader: new WireReader(backing, 0, true, backing.byteLength),
+    scribble: () => new Uint8Array(backing).fill(0xff),
+  };
+}
+
+describe("borrowed reader does not alias the payload", () => {
+  it("copies u8 arrays", () => {
+    const writer = new WireWriter();
+    writer.writeBytes(new Uint8Array([1, 2, 3, 4])); // len + payload: what readU8Array expects
+    const { reader, scribble } = borrowedOver(writer.getBytes());
+
+    const value = reader.readU8Array();
+    scribble();
+    expect(Array.from(value)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("copies i8 arrays", () => {
+    const writer = new WireWriter();
+    writer.writeBytes(new Uint8Array(new Int8Array([-1, 2, -3]).buffer));
+    const { reader, scribble } = borrowedOver(writer.getBytes());
+
+    const value = reader.readI8Array();
+    scribble();
+    expect(Array.from(value)).toEqual([-1, 2, -3]);
+  });
+
+  it("copies typed arrays of every width", () => {
+    const writer = new WireWriter();
+    writer.writeU32(2);
+    writer.writeI32(-5);
+    writer.writeI32(6);
+    const { reader, scribble } = borrowedOver(writer.getBytes());
+
+    const value = reader.readI32Array();
+    scribble();
+    expect(Array.from(value)).toEqual([-5, 6]);
+  });
+
+  it("copies f64 arrays", () => {
+    const writer = new WireWriter();
+    writer.writeU32(2);
+    writer.writeF64(1.5);
+    writer.writeF64(-2.25);
+    const { reader, scribble } = borrowedOver(writer.getBytes());
+
+    const value = reader.readF64Array();
+    scribble();
+    expect(Array.from(value)).toEqual([1.5, -2.25]);
+  });
+
+  it("keeps strings, bytes and bool arrays owned", () => {
+    const writer = new WireWriter();
+    writer.writeString("olá mundo");
+    writer.writeBytes(new Uint8Array([7, 8]));
+    writer.writeArray([true, false], (value) => writer.writeBool(value));
+    const { reader, scribble } = borrowedOver(writer.getBytes());
+
+    const text = reader.readString();
+    const bytes = reader.readBytes();
+    const flags = reader.readBoolArray();
+    scribble();
+
+    expect(text).toBe("olá mundo");
+    expect(Array.from(bytes)).toEqual([7, 8]);
+    expect(flags).toEqual([true, false]);
+  });
+
+  it("still hands out views when not borrowed", () => {
+    // The zero-copy path is the point of non-borrowed mode; assert it survives.
+    const writer = new WireWriter();
+    writer.writeBytes(new Uint8Array([1, 2, 3]));
+    const bytes = writer.getBytes();
+    const reader = new WireReader(bytes.buffer, bytes.byteOffset);
+
+    const value = reader.readU8Array();
+    expect(value.buffer).toBe(bytes.buffer);
+  });
+});
+
+describe("reset", () => {
+  it("repoints a reader at another buffer and mode", () => {
+    const first = new WireWriter();
+    first.writeU32(11);
+    const second = new WireWriter();
+    second.writeU32(22);
+
+    const reader = new WireReader(first.getBytes().buffer, 0, false);
+    expect(reader.readU32()).toBe(11);
+
+    const secondBytes = second.getBytes();
+    reader.reset(secondBytes.buffer, 0, secondBytes.byteLength, true);
+    expect(reader.readU32()).toBe(22);
+  });
+
+  it("applies the borrowed flag it is given", () => {
+    const writer = new WireWriter();
+    writer.writeBytes(new Uint8Array([4, 5]));
+    const bytes = writer.getBytes();
+
+    const reader = new WireReader(new ArrayBuffer(0), 0, false);
+    reader.reset(bytes.buffer, bytes.byteOffset, bytes.byteLength, true);
+
+    const value = reader.readU8Array();
+    expect(value.buffer).not.toBe(bytes.buffer);
+    expect(Array.from(value)).toEqual([4, 5]);
+  });
+});
+
+describe("payload bounds", () => {
+  /**
+   * The reader spans only the payload, so a truncated or malformed length
+   * cannot walk into whatever wasm allocated next — it throws instead of
+   * returning adjacent memory as if it were data.
+   */
+  function payloadInsideLargerBuffer(payload: Uint8Array): ArrayBuffer {
+    const backing = new ArrayBuffer(payload.byteLength + 64);
+    const bytes = new Uint8Array(backing);
+    bytes.set(payload);
+    bytes.fill(0xaa, payload.byteLength); // the neighbour that must stay unread
+    return backing;
+  }
+
+  it("throws instead of reading a scalar past the payload", () => {
+    const writer = new WireWriter();
+    writer.writeU32(1);
+    const payload = writer.getBytes();
+    const reader = new WireReader(
+      payloadInsideLargerBuffer(payload),
+      0,
+      true,
+      payload.byteLength
+    );
+
+    expect(reader.readU32()).toBe(1);
+    expect(() => reader.readU32()).toThrow();
+  });
+
+  it("throws instead of reading an array past the payload", () => {
+    const writer = new WireWriter();
+    writer.writeU32(32); // a length the payload cannot satisfy
+    const payload = writer.getBytes();
+    const reader = new WireReader(
+      payloadInsideLargerBuffer(payload),
+      0,
+      true,
+      payload.byteLength
+    );
+
+    expect(() => reader.readU8Array()).toThrow(RangeError);
+  });
+
+  it("throws instead of decoding a string past the payload", () => {
+    const writer = new WireWriter();
+    writer.writeU32(32);
+    const payload = writer.getBytes();
+    const reader = new WireReader(
+      payloadInsideLargerBuffer(payload),
+      0,
+      true,
+      payload.byteLength
+    );
+
+    expect(() => reader.readString()).toThrow(RangeError);
+  });
+});
+
+describe("invalidate", () => {
+  it("makes a reader that outlived its payload throw", () => {
+    const writer = new WireWriter();
+    writer.writeU32(7);
+    const bytes = writer.getBytes();
+    const reader = new WireReader(bytes.buffer, bytes.byteOffset, true, 4);
+
+    expect(reader.readU32()).toBe(7);
+    reader.invalidate();
+    expect(() => reader.readU32()).toThrow();
+  });
+});


### PR DESCRIPTION
Encoded returns copy their payload out of wasm memory before the codec reads it. Decoding in place instead takes `find_name` from ~956ns to ~354ns.

## What was happening

`takePackedBuffer` allocates a fresh `ArrayBuffer` and a new `DataView` on every call:

```ts
const bytes = new Uint8Array(this._memory.buffer, pointer, length);
const copy = bytes.slice();
this.freePacked(pointer, length);
return new WireReader(copy.buffer, 0);
```

For a small record that allocation is most of the cost — the work happens before the codec reads a single field. Every `Option<T>`, record, and `Vec<record>` return goes through it.

## The change

`readPackedBuffer(packed, read)` lends the reader wasm memory and frees the payload once `read` returns, so no copy. The generator emits it in place of the two-statement form:

```ts
// before
const __boltffiReader = _module.takePackedBuffer(_exports.…(ptr, len));
return __boltffiReader.readOptional(() => NodeSummaryCodec.decode(__boltffiReader));

// after
return _module.readPackedBuffer(_exports.…(ptr, len),
  (__boltffiReader) => __boltffiReader.readOptional(() => NodeSummaryCodec.decode(__boltffiReader)));
```

### Why this is safe now, having been unsafe in #728

#728 flagged this path and deliberately left it alone:

> Pooling that reader is tempting but unsafe as things stand — `readI8Array`/`readU8Array` hand out views over the reader's buffer without copying, so a shared scratch would corrupt them silently.

That objection was correct and is what this addresses. `WireReader` now tracks whether it borrows wasm memory, and the three reads that would hand out a view over it — `readI8Array`, `readU8Array`, `readTypedArray` — copy in that mode. Everything else already produced owned values: scalars are copied by construction, `readString` builds a new string, `readBytes` already called `.slice()`.

Three further things the copy used to give for free, restored explicitly in the second commit:

- **Bounds.** The copy was exactly `length` bytes, so an over-long nested length threw. A borrowed reader's view now spans exactly the payload, and the reads that build a typed array — which bypass the view's own check — go through an explicit one.
- **Escape.** The reader is detached after `read` returns, so one that outlives the callback throws instead of reading freed memory.
- **Reentrancy.** A nested `readPackedBuffer` gets its own reader rather than resetting the outer one's. Generated codecs never nest, but the method is public.

A `read` callback returning a promise is still the caller's problem: the payload is freed when `read` returns, not when the promise settles. Generated codecs are synchronous.

## Numbers

`examples/demo`, median of 5 repetitions per case, two full paired rounds (rebuild `main`, measure, rebuild branch, measure):

| case | before | after | |
| --- | ---: | ---: | --- |
| `find_name` (`Option<String>`) | 956 ns | **354 ns** | 2.70x |
| `generate_particles_10k` (`Vec<record>`) | 976 us | **759 us** | 1.29x |
| `sum_trade_volumes_10k` | 3.26 ms | **2.70 ms** | 1.21x |
| `echo_string_small` (control, different path) | 262 ns | 248 ns | unchanged |

The gain grows with payload size, because the avoided copy grows with it. `find_name` is the case #728 used as its example of this cost.

### On reproducing these

**Please run them yourself.** `benchmarks/harnesses/wasm-bench` has enough run-to-run variance that a single run of each side is not trustworthy: at one point, comparing one baseline run against one patched run made `generate_particles_10k` look **2.86x worse**, when repeated paired measurement shows it better. That case alone ranged 596us–1308us within a single baseline round.

The table therefore comes from a focused probe taking the median of 5 repetitions, run twice with a full rebuild of each side in between, with `echo_string_small` carried as a control that this change should not touch. I would not trust — and am not claiming — a global "everything got faster" figure from this harness. What I am claiming is the cases above, which held across both rounds, and the mechanism, which is straightforward: one fewer allocation and copy per encoded return.

An earlier revision of this branch measured `find_name` lower still, before the payload bound was added back. Bounding the view costs a `DataView` per call that the unbounded version could reuse; that trade seemed clearly worth making.

## Testing

- `cargo test --workspace` — no failures. Two snapshot expectations in `boltffi_backend` were updated: the generated glue changed shape, not semantics.
- Runtime suite, 115 tests, including a new `borrowed.test.ts`: it writes a payload, decodes it through a borrowed reader, then overwrites the source bytes, so anything still aliasing them fails. Covers every read that could alias, plus the bounds and detach behaviour.
- `examples/platforms/wasm` acceptance suite passes, which is what pins the decoded values.
- `cargo clippy --workspace --all-targets` clean, `cargo fmt --all` applied.

The borrowed-mode copies are the part most worth reviewing: if a read that returns a view over the reader's buffer were missed, it would produce a use-after-free. I believe `readI8Array`, `readU8Array` and `readTypedArray` are the complete set — `readBoolArray` builds a new array via `Array.from`, and `readBytes` already copies — but a second pair of eyes on that list is the highest-value review here.
