### PR TITLE
fix(wasm): detach the reader lent to a nested packed read

### DIFF
--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -1140,6 +1140,7 @@ export class BoltFFIModule {
       try {
         return read(reader);
       } finally {
+        reader.invalidate();
         if (!empty) this.freePacked(pointer, length);
       }
     }

--- a/runtime/typescript/test/packed-buffer.test.ts
+++ b/runtime/typescript/test/packed-buffer.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { WireReader } from "../src/wire.js";
+import { createFakeModule } from "./support/fake-module.js";
+
+/**
+ * `readPackedBuffer` lends a reader memory that is freed the moment the
+ * callback returns, so a reader that outlives the callback must not be able to
+ * read. The pooled reader is detached on the way out; the reader handed to a
+ * nested call has to be detached too, or it keeps pointing at freed memory.
+ */
+describe("readPackedBuffer detaches the reader it lends", () => {
+  const payload = (): Uint8Array => {
+    const bytes = new Uint8Array(8);
+    new DataView(bytes.buffer).setUint32(0, 0x1234, true);
+    new DataView(bytes.buffer).setUint32(4, 0x5678, true);
+    return bytes;
+  };
+
+  it("detaches the pooled reader", () => {
+    const fake = createFakeModule();
+    let escaped: WireReader | undefined;
+
+    const value = fake.module.readPackedBuffer(fake.pack(payload()), (reader) => {
+      escaped = reader;
+      return reader.readU32();
+    });
+
+    expect(value).toBe(0x1234);
+    expect(() => escaped!.readU32()).toThrow(RangeError);
+  });
+
+  it("detaches the reader handed to a nested call", () => {
+    const fake = createFakeModule();
+    let escapedInner: WireReader | undefined;
+
+    const value = fake.module.readPackedBuffer(fake.pack(payload()), (outer) => {
+      const inner = fake.module.readPackedBuffer(fake.pack(payload()), (reader) => {
+        escapedInner = reader;
+        return reader.readU32();
+      });
+      // The outer reader must survive the nested call untouched.
+      return inner + outer.readU32();
+    });
+
+    expect(value).toBe(0x1234 * 2);
+    expect(escapedInner).toBeDefined();
+    expect(escapedInner).not.toBe(undefined);
+    expect(() => escapedInner!.readU32()).toThrow(RangeError);
+  });
+
+  it("frees both payloads when a call nests", () => {
+    const fake = createFakeModule();
+
+    fake.module.readPackedBuffer(fake.pack(payload()), (outer) => {
+      fake.module.readPackedBuffer(fake.pack(payload()), (inner) => inner.readU32());
+      return outer.readU32();
+    });
+
+    expect(fake.freed).toHaveLength(2);
+  });
+
+  it("gives a nested call its own reader rather than resetting the outer one", () => {
+    const fake = createFakeModule();
+
+    const value = fake.module.readPackedBuffer(fake.pack(payload()), (outer) => {
+      const inner = fake.module.readPackedBuffer(fake.pack(payload()), (r) => r.readU32());
+      // Would read the nested payload's second word if the reader were shared.
+      return `${inner}:${outer.readU32()}:${outer.readU32()}`;
+    });
+
+    expect(value).toBe(`${0x1234}:${0x1234}:${0x5678}`);
+  });
+});

--- a/runtime/typescript/test/support/fake-module.ts
+++ b/runtime/typescript/test/support/fake-module.ts
@@ -1,0 +1,64 @@
+import { AsyncFutureManager, BoltFFIModule } from "../../src/module.js";
+import { StreamPollManager } from "../../src/stream.js";
+
+/**
+ * A `BoltFFIModule` over a plain `WebAssembly.Memory` and a bump allocator, so
+ * the packed-return paths can be tested without building a wasm module.
+ *
+ * Frees are recorded rather than reclaimed: most of these tests are about a
+ * payload having been released, and nothing still pointing at it afterwards.
+ */
+export interface FakeModule {
+  module: BoltFFIModule;
+  memory: WebAssembly.Memory;
+  /** Every `(pointer, length)` released through the packed-return free. */
+  freed: Array<{ pointer: number; length: number }>;
+  /** Copies `bytes` into wasm memory and returns the packed pointer/length. */
+  pack(bytes: Uint8Array): bigint;
+  /** Builds a packed value by hand, to exercise malformed payloads. */
+  packRaw(pointer: number, length: number): bigint;
+  /** Overwrites a region, standing in for the allocator reusing it. */
+  scribble(pointer: number, length: number): void;
+}
+
+export function createFakeModule(pages = 1): FakeModule {
+  const memory = new WebAssembly.Memory({ initial: pages });
+  const freed: FakeModule["freed"] = [];
+  let bump = 64; // leave the return slot at 0 alone
+
+  const exports = {
+    memory,
+    boltffi_wasm_return_slot_addr: () => 0,
+    boltffi_wasm_alloc: (size: number) => {
+      const pointer = bump;
+      bump = (bump + size + 7) & ~7;
+      if (bump > memory.buffer.byteLength) {
+        memory.grow(Math.ceil((bump - memory.buffer.byteLength) / 65536) + 1);
+      }
+      return pointer;
+    },
+    boltffi_wasm_free: () => {},
+    boltffi_wasm_free_string_return: (pointer: number, length: number) => {
+      freed.push({ pointer, length });
+    },
+  };
+
+  const module = new BoltFFIModule(
+    { exports } as unknown as WebAssembly.Instance,
+    new AsyncFutureManager(),
+    new StreamPollManager()
+  );
+
+  const packRaw = (pointer: number, length: number): bigint =>
+    (BigInt(length) << 32n) | BigInt(pointer);
+  const pack = (bytes: Uint8Array): bigint => {
+    const pointer = exports.boltffi_wasm_alloc(bytes.length);
+    new Uint8Array(memory.buffer).set(bytes, pointer);
+    return packRaw(pointer, bytes.length);
+  };
+  const scribble = (pointer: number, length: number): void => {
+    new Uint8Array(memory.buffer).fill(0xff, pointer, pointer + length);
+  };
+
+  return { module, memory, freed, pack, packRaw, scribble };
+}


### PR DESCRIPTION
`readPackedBuffer` frees its payload as soon as the read callback returns, and detaches the pooled reader on the way out so that a reader which escapes the callback throws instead of reading freed memory.

The reader built for a **nested** call was dropped without that detach:

```ts
if (this.borrowedReaderInUse) {
  const reader = new WireReader(buffer, start, true, size);
  try {
    return read(reader);
  } finally {
    if (!empty) this.freePacked(pointer, length);   // reader still live
  }
}
```

So the guarantee held for one call depth and not the next. A reader that escapes a nested read points at memory the allocator is free to hand out again, and reads it without complaint.

Generated codecs never nest, so this is not reachable from generated glue today — but `readPackedBuffer` is public, and the pooled path goes to the trouble of detaching precisely because "the callback will not keep the reader" is not something the method can enforce.

One line. The interesting part is the test.

## Testing

This is the first test to touch `readPackedBuffer` at all, because there was no way to construct a `BoltFFIModule` without a wasm build. This PR adds `test/support/fake-module.ts`, which backs one with a plain `WebAssembly.Memory` and a bump allocator, and records frees rather than reclaiming them so a test can assert a payload was released.

`packed-buffer.test.ts` covers:

- the pooled reader is detached after the call (the existing guarantee, previously untested)
- the reader lent to a nested call is detached too — **this is the fix, and the test fails without it**
- both payloads are freed when a call nests
- a nested call gets its own reader rather than resetting the outer one's, checked by reading past the point where a shared reader would have been rewound

No behaviour change on any path that does not nest, and the allocation profile confirms it: decode 575.0 → 574.9 bytes/call, echo 480.1 → 481.6, encode 480.7 → 478.5, scavenge counts unchanged. A bug fix should be free, and this one is.

Runtime suite, 120 tests; `examples/platforms/wasm` acceptance suite passes.

The fixture is also what makes the sibling PRs' tests possible, so it will appear in more than one of them; whichever lands first, the others drop their copy on rebase.
