### PR TITLE
perf(wasm): copy byte and string returns once

### DIFF
--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -1080,13 +1080,13 @@ export class BoltFFIModule {
       throw new Error("Invalid packed wire string");
     }
     try {
+      const bytes = this.getBytes();
       const payloadLength = this.getView().getUint32(pointer, true);
-      if (payloadLength !== length - 4) {
+      if (payloadLength !== length - 4 || pointer + length > bytes.length) {
         throw new Error("Invalid packed wire string length");
       }
-      return this._decoder.decode(
-        new Uint8Array(this._memory.buffer, pointer + 4, payloadLength)
-      );
+      const start = pointer + 4;
+      return this._decoder.decode(bytes.subarray(start, start + payloadLength));
     } finally {
       this.freePacked(pointer, length);
     }
@@ -1098,11 +1098,14 @@ export class BoltFFIModule {
       throw new Error("Invalid packed wire bytes");
     }
     try {
+      const bytes = this.getBytes();
       const payloadLength = this.getView().getUint32(pointer, true);
-      if (payloadLength !== length - 4) {
+      if (payloadLength !== length - 4 || pointer + length > bytes.length) {
         throw new Error("Invalid packed wire bytes length");
       }
-      return new Uint8Array(this._memory.buffer, pointer + 4, payloadLength).slice();
+      const start = pointer + 4;
+      // One allocation: building a view and then copying it made two.
+      return bytes.slice(start, start + payloadLength);
     } finally {
       this.freePacked(pointer, length);
     }

--- a/runtime/typescript/test/packed-wire.test.ts
+++ b/runtime/typescript/test/packed-wire.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { createFakeModule } from "./support/fake-module.js";
+
+/**
+ * Wire bytes and strings arrive as a 4-byte length followed by the payload.
+ * The value handed back must own its bytes, because the payload is freed
+ * before the caller ever sees it, and a length that does not describe the
+ * region must be rejected rather than silently truncated.
+ */
+function wireBytes(payload: Uint8Array): Uint8Array {
+  const framed = new Uint8Array(4 + payload.length);
+  new DataView(framed.buffer).setUint32(0, payload.length, true);
+  framed.set(payload, 4);
+  return framed;
+}
+
+describe("takePackedWireBytes", () => {
+  it("returns bytes that do not alias wasm memory", () => {
+    const fake = createFakeModule();
+    const packed = fake.pack(wireBytes(new Uint8Array([1, 2, 3, 4])));
+    const { pointer, length } = { pointer: Number(packed & 0xffff_ffffn), length: Number(packed >> 32n) };
+
+    const value = fake.module.takePackedWireBytes(packed);
+    fake.scribble(pointer, length);
+
+    expect(Array.from(value)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("frees the payload", () => {
+    const fake = createFakeModule();
+    fake.module.takePackedWireBytes(fake.pack(wireBytes(new Uint8Array([9]))));
+    expect(fake.freed).toHaveLength(1);
+  });
+
+  it("returns an empty array for an empty payload", () => {
+    const fake = createFakeModule();
+    const value = fake.module.takePackedWireBytes(fake.pack(wireBytes(new Uint8Array(0))));
+    expect(value).toHaveLength(0);
+  });
+
+  it("rejects a length that disagrees with the frame", () => {
+    const fake = createFakeModule();
+    const framed = wireBytes(new Uint8Array([1, 2, 3]));
+    const packed = fake.pack(framed);
+    const pointer = Number(packed & 0xffff_ffffn);
+
+    // Frame says 3 bytes of payload, packed length claims one more.
+    expect(() => fake.module.takePackedWireBytes(fake.packRaw(pointer, framed.length + 1)))
+      .toThrow(/Invalid packed wire bytes/);
+  });
+
+  it("rejects a payload that runs past the end of memory", () => {
+    const fake = createFakeModule();
+    const size = fake.memory.buffer.byteLength;
+    const pointer = size - 16;
+    const view = new DataView(fake.memory.buffer);
+    view.setUint32(pointer, 1_000_000, true);
+
+    // `slice` would clamp here and hand back a short array; it must throw.
+    expect(() => fake.module.takePackedWireBytes(fake.packRaw(pointer, 1_000_004)))
+      .toThrow(/Invalid packed wire bytes/);
+  });
+});
+
+describe("takePackedWireString", () => {
+  const encode = (text: string): Uint8Array => wireBytes(new TextEncoder().encode(text));
+
+  it("decodes and frees", () => {
+    const fake = createFakeModule();
+    const value = fake.module.takePackedWireString(fake.pack(encode("olá mundo")));
+    expect(value).toBe("olá mundo");
+    expect(fake.freed).toHaveLength(1);
+  });
+
+  it("rejects a length that disagrees with the frame", () => {
+    const fake = createFakeModule();
+    const framed = encode("abc");
+    const pointer = Number(fake.pack(framed) & 0xffff_ffffn);
+
+    expect(() => fake.module.takePackedWireString(fake.packRaw(pointer, framed.length + 1)))
+      .toThrow(/Invalid packed wire string/);
+  });
+
+  it("rejects a payload that runs past the end of memory", () => {
+    const fake = createFakeModule();
+    const pointer = fake.memory.buffer.byteLength - 16;
+    new DataView(fake.memory.buffer).setUint32(pointer, 1_000_000, true);
+
+    expect(() => fake.module.takePackedWireString(fake.packRaw(pointer, 1_000_004)))
+      .toThrow(/Invalid packed wire string/);
+  });
+});

--- a/runtime/typescript/test/support/fake-module.ts
+++ b/runtime/typescript/test/support/fake-module.ts
@@ -1,0 +1,64 @@
+import { AsyncFutureManager, BoltFFIModule } from "../../src/module.js";
+import { StreamPollManager } from "../../src/stream.js";
+
+/**
+ * A `BoltFFIModule` over a plain `WebAssembly.Memory` and a bump allocator, so
+ * the packed-return paths can be tested without building a wasm module.
+ *
+ * Frees are recorded rather than reclaimed: most of these tests are about a
+ * payload having been released, and nothing still pointing at it afterwards.
+ */
+export interface FakeModule {
+  module: BoltFFIModule;
+  memory: WebAssembly.Memory;
+  /** Every `(pointer, length)` released through the packed-return free. */
+  freed: Array<{ pointer: number; length: number }>;
+  /** Copies `bytes` into wasm memory and returns the packed pointer/length. */
+  pack(bytes: Uint8Array): bigint;
+  /** Builds a packed value by hand, to exercise malformed payloads. */
+  packRaw(pointer: number, length: number): bigint;
+  /** Overwrites a region, standing in for the allocator reusing it. */
+  scribble(pointer: number, length: number): void;
+}
+
+export function createFakeModule(pages = 1): FakeModule {
+  const memory = new WebAssembly.Memory({ initial: pages });
+  const freed: FakeModule["freed"] = [];
+  let bump = 64; // leave the return slot at 0 alone
+
+  const exports = {
+    memory,
+    boltffi_wasm_return_slot_addr: () => 0,
+    boltffi_wasm_alloc: (size: number) => {
+      const pointer = bump;
+      bump = (bump + size + 7) & ~7;
+      if (bump > memory.buffer.byteLength) {
+        memory.grow(Math.ceil((bump - memory.buffer.byteLength) / 65536) + 1);
+      }
+      return pointer;
+    },
+    boltffi_wasm_free: () => {},
+    boltffi_wasm_free_string_return: (pointer: number, length: number) => {
+      freed.push({ pointer, length });
+    },
+  };
+
+  const module = new BoltFFIModule(
+    { exports } as unknown as WebAssembly.Instance,
+    new AsyncFutureManager(),
+    new StreamPollManager()
+  );
+
+  const packRaw = (pointer: number, length: number): bigint =>
+    (BigInt(length) << 32n) | BigInt(pointer);
+  const pack = (bytes: Uint8Array): bigint => {
+    const pointer = exports.boltffi_wasm_alloc(bytes.length);
+    new Uint8Array(memory.buffer).set(bytes, pointer);
+    return packRaw(pointer, bytes.length);
+  };
+  const scribble = (pointer: number, length: number): void => {
+    new Uint8Array(memory.buffer).fill(0xff, pointer, pointer + length);
+  };
+
+  return { module, memory, freed, pack, packRaw, scribble };
+}


### PR DESCRIPTION
`takePackedWireBytes` built a view over wasm memory and then copied it:

```ts
return new Uint8Array(this._memory.buffer, pointer + 4, payloadLength).slice();
```

That is two typed arrays per call, plus a `.buffer` accessor read. Slicing the cached whole-memory array does it in one.

| 16-byte payload | cost |
| --- | ---: |
| `new Uint8Array(mem.buffer, off, n).slice()` | 48.78 ns |
| `cached.slice(off, off + n)` | **31.50 ns** |
| `cached.subarray(off, off + n).slice()` | 51.56 ns |

The saving is fixed rather than proportional — 1.55x at 16 bytes, 1.04x at 1 KiB, 1.05x at 64 KiB — so it shows up where payloads are small and disappears into the memcpy where they are large. `subarray().slice()` is worth mentioning only because it looks like an improvement and is not: it is the same two allocations.

`takePackedWireString` had the same shape and gets the same treatment.

## The part that is not a pure speedup

`slice(a, b)` **clamps** where the view constructor **threw**. A packed length that runs past the end of memory used to fail loudly; without care it would have started returning a short array instead. Both paths now check the payload against the end of memory explicitly, alongside the existing frame-length check.

I would rather this be reviewed as a behaviour change than slipped in as a detail. It is the reason the diff is larger than the optimisation warrants.

## Numbers

Allocation against `main`, per path:

| path | bytes/call | scavenges per 200k calls |
| --- | --- | --- |
| echo bytes | 480.1 → **376.8** (−22%) | 46 → **35** |
| encode a record | 480.7 → **376.4** (−22%) | 46 → **36** |
| decode a record | 575.0 → 572.4 (unchanged) | 55 → 55 |

Decode not moving is the expected result — it returns a record, not bytes — and is useful as a negative control that the change does what it says and nothing else.

### On the CPU number

I am deliberately not quoting an end-to-end timing. My machine was loaded (loadavg 12–33) and, measured there, this branch and even a pure bug-fix branch both showed ~8% swings on `decode`, a path neither of them touches. That is noise, and it is larger than this change's effect. The 48.78 → 31.50 ns above comes from an in-process A/B of the two expressions, which is sound; the whole-call figure is not, on this hardware, and I would rather say so than publish a number I would have to walk back.

## Testing

- New `packed-wire.test.ts`: bytes that do not alias wasm memory after the payload is scribbled over, the payload being freed, empty payloads, a frame length that disagrees with the packed length, and a payload running past the end of memory. Same set for the string path.
- New `test/support/fake-module.ts` builds a `BoltFFIModule` over a plain `WebAssembly.Memory` and a bump allocator. There was no way to test these paths without a wasm build before, which is why the bounds regression above would have been easy to miss.
- I checked the bounds tests fail without the check: with it removed, both "runs past the end of memory" cases fail.
- Runtime suite, 124 tests. `examples/platforms/wasm` acceptance suite passes.
- No Rust changes in this PR.
