### PR TITLE
perf(wasm): build short ascii strings from their char codes

### DIFF
--- a/runtime/typescript/src/wire.ts
+++ b/runtime/typescript/src/wire.ts
@@ -1,6 +1,10 @@
 const UTF8_DECODER = new TextDecoder("utf-8");
 const EMPTY_VIEW = new DataView(new ArrayBuffer(0));
 const UTF8_ENCODER = new TextEncoder();
+// 16 is where the two curves cross: below it building the string wins on time,
+// above it TextDecoder does. Allocation favours the fast path at every length.
+const ASCII_FAST_PATH_LIMIT = 16;
+const ASCII_SCRATCH: number[] = [];
 
 type TypedArrayConstructor<T extends ArrayBufferView> = {
   new (buffer: ArrayBufferLike, byteOffset: number, length: number): T;
@@ -20,6 +24,8 @@ export class WireReader {
    * else — scalars, strings, `readBytes` — already produces owned values.
    */
   private borrowed: boolean;
+  private bytes: Uint8Array | null = null;
+  private bufferRef: ArrayBuffer;
 
   /**
    * The view spans exactly the payload, so `offset` is relative to it and any
@@ -38,6 +44,7 @@ export class WireReader {
         : new DataView(buffer, offset, length);
     this.offset = 0;
     this.borrowed = borrowed;
+    this.bufferRef = buffer;
   }
 
   /** Points an existing reader at another payload, reusing the instance. */
@@ -50,6 +57,10 @@ export class WireReader {
     this.view = new DataView(buffer, offset, length);
     this.offset = 0;
     this.borrowed = borrowed;
+    if (this.bufferRef !== buffer) {
+      this.bufferRef = buffer;
+      this.bytes = null;
+    }
     return this;
   }
 
@@ -157,8 +168,36 @@ export class WireReader {
 
   readString(): string {
     const len = this.readU32();
-    const bytes = new Uint8Array(this.view.buffer, this.take(len), len);
-    return UTF8_DECODER.decode(bytes);
+    const start = this.take(len);
+    // Short ASCII strings are cheaper to build from their char codes than to
+    // decode, on both time and allocation. Every code has to be passed at
+    // once: appending one at a time builds a cons-string chain that allocates
+    // more than TextDecoder does.
+    if (len <= ASCII_FAST_PATH_LIMIT) {
+      const bytes = this.asBytes();
+      const scratch = ASCII_SCRATCH;
+      let i = 0;
+      for (; i < len; i++) {
+        const byte = bytes[start + i]!;
+        if (byte > 0x7f) break;
+        scratch[i] = byte;
+      }
+      if (i === len) {
+        scratch.length = len;
+        return String.fromCharCode.apply(null, scratch);
+      }
+    }
+    return UTF8_DECODER.decode(new Uint8Array(this.view.buffer, start, len));
+  }
+
+  /** Whole-buffer view of the reader's memory, for the fast path above. */
+  private asBytes(): Uint8Array {
+    let bytes = this.bytes;
+    if (bytes === null || bytes.byteLength === 0) {
+      bytes = new Uint8Array(this.bufferRef);
+      this.bytes = bytes;
+    }
+    return bytes;
   }
 
   readBytes(): Uint8Array {

--- a/runtime/typescript/test/ascii-string.test.ts
+++ b/runtime/typescript/test/ascii-string.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { WireReader, WireWriter } from "../src/wire.js";
+
+/**
+ * Short ASCII strings take a fast path that builds the string from its char
+ * codes instead of decoding it. It must be indistinguishable from
+ * `TextDecoder` for every input, so these tests are equivalence tests: the
+ * threshold and the bail-out are where a divergence would hide.
+ */
+const roundtrip = (value: string): string => {
+  const writer = new WireWriter();
+  writer.writeString(value);
+  const bytes = writer.getBytes();
+  return new WireReader(bytes.buffer, bytes.byteOffset, false).readString();
+};
+
+describe("readString", () => {
+  it("matches across and around the threshold", () => {
+    for (const len of [0, 1, 2, 8, 15, 16, 17, 24, 64, 200, 1000]) {
+      const value = "a".repeat(len);
+      expect(roundtrip(value), `${len} bytes`).toBe(value);
+    }
+  });
+
+  it("falls back when any byte is above ascii", () => {
+    for (const value of ["ç", "ça", "aç", "aça", "ção", "áéíóúàèìòù", "日本語", "🎉"]) {
+      expect(roundtrip(value), value).toBe(value);
+    }
+  });
+
+  it("bails out wherever the multi-byte sequence sits", () => {
+    // Start, middle and end of a string short enough to enter the fast path.
+    expect(roundtrip("çaaaaaaa")).toBe("çaaaaaaa");
+    expect(roundtrip("aaaaçaaa")).toBe("aaaaçaaa");
+    expect(roundtrip("aaaaaaaç")).toBe("aaaaaaaç");
+  });
+
+  it("handles a multi-byte sequence straddling the threshold", () => {
+    // 14 ascii + 2 bytes lands exactly on the limit and must bail on the last
+    // character; 15 + 2 exceeds it and never enters the fast path at all.
+    expect(roundtrip("a".repeat(14) + "ç")).toBe("a".repeat(14) + "ç");
+    expect(roundtrip("a".repeat(15) + "ç")).toBe("a".repeat(15) + "ç");
+  });
+
+  it("preserves every ascii code point", () => {
+    let value = "";
+    for (let code = 0; code < 128; code++) value += String.fromCharCode(code);
+    // Longer than the fast path, so also read it in short slices.
+    expect(roundtrip(value)).toBe(value);
+    for (let start = 0; start < 128; start += 8) {
+      const chunk = value.slice(start, start + 8);
+      expect(roundtrip(chunk), `codes ${start}..${start + 8}`).toBe(chunk);
+    }
+  });
+
+  it("does not carry the scratch buffer between reads", () => {
+    const writer = new WireWriter();
+    writer.writeString("abcdefgh");
+    writer.writeString("xy");
+    writer.writeString("");
+    writer.writeString("zzz");
+    const bytes = writer.getBytes();
+    const reader = new WireReader(bytes.buffer, bytes.byteOffset, false);
+
+    expect(reader.readString()).toBe("abcdefgh");
+    expect(reader.readString()).toBe("xy");
+    expect(reader.readString()).toBe("");
+    expect(reader.readString()).toBe("zzz");
+  });
+
+  it("re-reads after being pointed at another buffer", () => {
+    const first = new WireWriter();
+    first.writeString("first");
+    const second = new WireWriter();
+    second.writeString("second");
+    const firstBytes = first.getBytes();
+    const secondBytes = second.getBytes();
+
+    const reader = new WireReader(firstBytes.buffer, firstBytes.byteOffset, false);
+    expect(reader.readString()).toBe("first");
+
+    reader.reset(secondBytes.buffer, secondBytes.byteOffset, secondBytes.byteLength, false);
+    expect(reader.readString()).toBe("second");
+  });
+});

--- a/runtime/typescript/test/support/fake-module.ts
+++ b/runtime/typescript/test/support/fake-module.ts
@@ -1,0 +1,64 @@
+import { AsyncFutureManager, BoltFFIModule } from "../../src/module.js";
+import { StreamPollManager } from "../../src/stream.js";
+
+/**
+ * A `BoltFFIModule` over a plain `WebAssembly.Memory` and a bump allocator, so
+ * the packed-return paths can be tested without building a wasm module.
+ *
+ * Frees are recorded rather than reclaimed: most of these tests are about a
+ * payload having been released, and nothing still pointing at it afterwards.
+ */
+export interface FakeModule {
+  module: BoltFFIModule;
+  memory: WebAssembly.Memory;
+  /** Every `(pointer, length)` released through the packed-return free. */
+  freed: Array<{ pointer: number; length: number }>;
+  /** Copies `bytes` into wasm memory and returns the packed pointer/length. */
+  pack(bytes: Uint8Array): bigint;
+  /** Builds a packed value by hand, to exercise malformed payloads. */
+  packRaw(pointer: number, length: number): bigint;
+  /** Overwrites a region, standing in for the allocator reusing it. */
+  scribble(pointer: number, length: number): void;
+}
+
+export function createFakeModule(pages = 1): FakeModule {
+  const memory = new WebAssembly.Memory({ initial: pages });
+  const freed: FakeModule["freed"] = [];
+  let bump = 64; // leave the return slot at 0 alone
+
+  const exports = {
+    memory,
+    boltffi_wasm_return_slot_addr: () => 0,
+    boltffi_wasm_alloc: (size: number) => {
+      const pointer = bump;
+      bump = (bump + size + 7) & ~7;
+      if (bump > memory.buffer.byteLength) {
+        memory.grow(Math.ceil((bump - memory.buffer.byteLength) / 65536) + 1);
+      }
+      return pointer;
+    },
+    boltffi_wasm_free: () => {},
+    boltffi_wasm_free_string_return: (pointer: number, length: number) => {
+      freed.push({ pointer, length });
+    },
+  };
+
+  const module = new BoltFFIModule(
+    { exports } as unknown as WebAssembly.Instance,
+    new AsyncFutureManager(),
+    new StreamPollManager()
+  );
+
+  const packRaw = (pointer: number, length: number): bigint =>
+    (BigInt(length) << 32n) | BigInt(pointer);
+  const pack = (bytes: Uint8Array): bigint => {
+    const pointer = exports.boltffi_wasm_alloc(bytes.length);
+    new Uint8Array(memory.buffer).set(bytes, pointer);
+    return packRaw(pointer, bytes.length);
+  };
+  const scribble = (pointer: number, length: number): void => {
+    new Uint8Array(memory.buffer).fill(0xff, pointer, pointer + length);
+  };
+
+  return { module, memory, freed, pack, packRaw, scribble };
+}


### PR DESCRIPTION
Decoding a 7-byte record tag through `TextDecoder` costs ~80ns and ~129 bytes of allocation. Building it from its char codes instead costs ~37ns and ~24 bytes.

| 7-byte tag | time | bytes |
| --- | ---: | ---: |
| `TextDecoder.decode` | 79.9 ns | 128.7 B |
| `fromCharCode.apply` over a reused array | **36.5 ns** | **24.0 B** |

## The obvious implementation is the wrong one

Appending one character at a time is what this change looks like it should be, and it is a trap. It builds a cons-string chain — one intermediate string per character:

| 32-byte tag | time | bytes |
| --- | ---: | ---: |
| `TextDecoder.decode` | 77.4 ns | 152.2 B |
| `out += fromCharCode(b)` | **196.9 ns** | **939.4 B** |
| `fromCharCode.apply` over a reused array | 121.3 ns | 47.8 B |

At 32 bytes the append form is **2.5x slower than the code it replaces and allocates six times as much**. The first version of this change was written that way, and only the allocation profile caught it. Passing every code at once is the whole point.

Spreading a subarray (`fromCharCode(...bytes)`) is worse again: 235 ns and 747 B at 7 bytes.

## Why the threshold is 16

| len | `TextDecoder` | fast path | speed | bytes |
| ---: | --- | --- | ---: | ---: |
| 2 | 72.8 ns / 128 B | 30.5 ns / 24 B | 2.38x | 5.34x |
| 8 | 79.9 ns / 129 B | 49.7 ns / 24 B | 1.61x | 5.36x |
| 12 | 76.3 ns / 136 B | 59.5 ns / 32 B | 1.28x | 4.25x |
| 16 | 80.4 ns / 136 B | 70.6 ns / 32 B | 1.14x | 4.23x |
| 24 | 78.2 ns / 144 B | 113.2 ns / 40 B | 0.69x | 3.59x |
| 32 | 75.5 ns / 153 B | 132.3 ns / 48 B | 0.57x | 3.17x |

16 is where the time curves cross. Allocation favours the fast path at every length, but time is the binding constraint, so the shorter threshold wins.

Two honest caveats on that number. It comes from benchmarking the two string-building strategies in isolation, not `readString` itself, so it omits `take()`, `asBytes()` and the branch — and at 16 the advantage is only 1.14x, which is inside the error that omission could carry. 16 is a conservative choice rather than a precisely located optimum. Anyone who wants to argue for 12 has a case.

## Correctness

The fast path bails to `TextDecoder` on the first byte above 0x7f, so it never sees a multi-byte sequence. Nothing observable distinguishes the two paths — that is the contract, and the tests are equivalence tests against it.

## Numbers

Allocation against `main`, per path:

| path | bytes/call | scavenges per 200k calls |
| --- | --- | --- |
| decode a record | 575.0 → **463.5** (−19%) | 55 → **45** |
| echo bytes | 480.1 → 480.5 (unchanged) | 46 → 46 |
| encode a record | 480.7 → 481.5 (unchanged) | 46 → 46 |

Echo and encode not moving is expected — neither reads a string — and serves as a negative control.

### On the CPU number

The per-strategy timings above come from in-process A/B measurement and are sound. I am not quoting a whole-call figure: my machine was loaded (loadavg 12–33), and measured there, sibling branches showed ~8% swings on paths they do not touch. That noise is larger than this change's end-to-end effect, so a number would be misleading. Please run it yourself if the allocation figures are not enough.

## Testing

New `ascii-string.test.ts`, all equivalence against `TextDecoder`:

- every length across and around the threshold (0, 1, 2, 8, 15, 16, 17, 24, 64, 200, 1000)
- non-ASCII bail-out with the multi-byte sequence at the start, the middle and the end
- a sequence straddling the threshold: 14 ASCII + 2 bytes lands exactly on the limit and must bail on the last character; 15 + 2 never enters the fast path
- all 128 ASCII code points, read whole and in short slices
- back-to-back reads sharing the scratch array, including an empty string between them
- a reader pointed at a second buffer, which fails without the cache invalidation

Runtime suite, 123 tests. `examples/platforms/wasm` acceptance suite passes. No Rust changes in this PR.

Touches `wire.ts` in the same region as #740; whichever lands second needs a trivial rebase.
