### PR TITLE
perf(wasm): stop paying per-call costs at the wasm boundary

### DIFF
--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -4,6 +4,10 @@ import { StreamPollManager } from "./stream.js";
 
 const EMPTY_BUFFER = new ArrayBuffer(0);
 
+const LITTLE_ENDIAN = new Uint8Array(new Uint32Array([1]).buffer)[0] === 1;
+const PACKED_LOW = LITTLE_ENDIAN ? 0 : 1;
+const PACKED_HIGH = LITTLE_ENDIAN ? 1 : 0;
+
 const FFI_BUF_DESCRIPTOR_SIZE = 16;
 const FFI_STATUS_SIZE = 4;
 const OPTION_F64_NONE = 0xffff_ffff_ffff_ffffn;
@@ -197,6 +201,11 @@ export class BoltFFIModule {
   private _cachedF32: Float32Array | null = null;
   private _cachedF64: Float64Array | null = null;
   private _cachedView: DataView | null = null;
+  private _viewProbe: Uint8Array | null = null;
+  private _memoryBuffer: ArrayBuffer | null = null;
+  private _packedStorage = new ArrayBuffer(8);
+  private _packedBits = new BigUint64Array(this._packedStorage);
+  private _packedHalves = new Uint32Array(this._packedStorage);
   private _optionF64Storage = new ArrayBuffer(8);
   private _optionF64Bits = new BigUint64Array(this._optionF64Storage);
   private _optionF64Values = new Float64Array(this._optionF64Storage);
@@ -286,80 +295,134 @@ export class BoltFFIModule {
   }
 
   private getView(): DataView {
-    if (this._cachedView === null || this._cachedView.buffer !== this._memory.buffer) {
-      this._cachedView = new DataView(this._memory.buffer);
+    // `DataView.byteLength` throws when detached instead of reporting 0, so
+    // this cache cannot test itself and carries a probe.
+    const probe = this._viewProbe;
+    if (probe !== null && probe.byteLength !== 0) {
+      return this._cachedView as DataView;
     }
-    return this._cachedView;
+    const buffer = this._memory.buffer;
+    const remapped = new DataView(buffer);
+    this._cachedView = remapped;
+    this._viewProbe = new Uint8Array(buffer);
+    return remapped;
+  }
+
+  /** `memory.buffer` is an accessor; this is a field read behind a cheap check. */
+  private memoryBuffer(): ArrayBuffer {
+    this.getBytes();
+    return this._memoryBuffer as ArrayBuffer;
   }
 
   private getBytes(): Uint8Array {
-    if (this._cachedU8 === null || this._cachedU8.buffer !== this._memory.buffer) {
-      this._cachedU8 = new Uint8Array(this._memory.buffer);
+    const cached = this._cachedU8;
+    if (cached !== null && cached.byteLength !== 0) {
+      return cached;
     }
-    return this._cachedU8;
+    const buffer = this._memory.buffer;
+    const remapped = new Uint8Array(buffer);
+    this._cachedU8 = remapped;
+    this._memoryBuffer = buffer;
+    return remapped;
   }
 
   private getI8(): Int8Array {
-    if (this._cachedI8 === null || this._cachedI8.buffer !== this._memory.buffer) {
-      this._cachedI8 = new Int8Array(this._memory.buffer);
+    const cached = this._cachedI8;
+    if (cached !== null && cached.byteLength !== 0) {
+      return cached;
     }
-    return this._cachedI8;
+    const buffer = this._memory.buffer;
+    const remapped = new Int8Array(buffer);
+    this._cachedI8 = remapped;
+    return remapped;
   }
 
   private getI16(): Int16Array {
-    if (this._cachedI16 === null || this._cachedI16.buffer !== this._memory.buffer) {
-      this._cachedI16 = new Int16Array(this._memory.buffer);
+    const cached = this._cachedI16;
+    if (cached !== null && cached.byteLength !== 0) {
+      return cached;
     }
-    return this._cachedI16;
+    const buffer = this._memory.buffer;
+    const remapped = new Int16Array(buffer);
+    this._cachedI16 = remapped;
+    return remapped;
   }
 
   private getU16(): Uint16Array {
-    if (this._cachedU16 === null || this._cachedU16.buffer !== this._memory.buffer) {
-      this._cachedU16 = new Uint16Array(this._memory.buffer);
+    const cached = this._cachedU16;
+    if (cached !== null && cached.byteLength !== 0) {
+      return cached;
     }
-    return this._cachedU16;
+    const buffer = this._memory.buffer;
+    const remapped = new Uint16Array(buffer);
+    this._cachedU16 = remapped;
+    return remapped;
   }
 
   private getI32(): Int32Array {
-    if (this._cachedI32 === null || this._cachedI32.buffer !== this._memory.buffer) {
-      this._cachedI32 = new Int32Array(this._memory.buffer);
+    const cached = this._cachedI32;
+    if (cached !== null && cached.byteLength !== 0) {
+      return cached;
     }
-    return this._cachedI32;
+    const buffer = this._memory.buffer;
+    const remapped = new Int32Array(buffer);
+    this._cachedI32 = remapped;
+    return remapped;
   }
 
   private getU32(): Uint32Array {
-    if (this._cachedU32 === null || this._cachedU32.buffer !== this._memory.buffer) {
-      this._cachedU32 = new Uint32Array(this._memory.buffer);
+    const cached = this._cachedU32;
+    if (cached !== null && cached.byteLength !== 0) {
+      return cached;
     }
-    return this._cachedU32;
+    const buffer = this._memory.buffer;
+    const remapped = new Uint32Array(buffer);
+    this._cachedU32 = remapped;
+    return remapped;
   }
 
   private getI64(): BigInt64Array {
-    if (this._cachedI64 === null || this._cachedI64.buffer !== this._memory.buffer) {
-      this._cachedI64 = new BigInt64Array(this._memory.buffer);
+    const cached = this._cachedI64;
+    if (cached !== null && cached.byteLength !== 0) {
+      return cached;
     }
-    return this._cachedI64;
+    const buffer = this._memory.buffer;
+    const remapped = new BigInt64Array(buffer);
+    this._cachedI64 = remapped;
+    return remapped;
   }
 
   private getU64(): BigUint64Array {
-    if (this._cachedU64 === null || this._cachedU64.buffer !== this._memory.buffer) {
-      this._cachedU64 = new BigUint64Array(this._memory.buffer);
+    const cached = this._cachedU64;
+    if (cached !== null && cached.byteLength !== 0) {
+      return cached;
     }
-    return this._cachedU64;
+    const buffer = this._memory.buffer;
+    const remapped = new BigUint64Array(buffer);
+    this._cachedU64 = remapped;
+    return remapped;
   }
 
   private getF32(): Float32Array {
-    if (this._cachedF32 === null || this._cachedF32.buffer !== this._memory.buffer) {
-      this._cachedF32 = new Float32Array(this._memory.buffer);
+    const cached = this._cachedF32;
+    if (cached !== null && cached.byteLength !== 0) {
+      return cached;
     }
-    return this._cachedF32;
+    const buffer = this._memory.buffer;
+    const remapped = new Float32Array(buffer);
+    this._cachedF32 = remapped;
+    return remapped;
   }
 
   private getF64(): Float64Array {
-    if (this._cachedF64 === null || this._cachedF64.buffer !== this._memory.buffer) {
-      this._cachedF64 = new Float64Array(this._memory.buffer);
+    const cached = this._cachedF64;
+    if (cached !== null && cached.byteLength !== 0) {
+      return cached;
     }
-    return this._cachedF64;
+    const buffer = this._memory.buffer;
+    const remapped = new Float64Array(buffer);
+    this._cachedF64 = remapped;
+    return remapped;
   }
 
   allocString(value: string): StringAlloc {
@@ -893,10 +956,13 @@ export class BoltFFIModule {
   }
 
   private unpackPacked(packed: bigint): { pointer: number; length: number } {
-    return {
-      pointer: Number(packed & 0xffff_ffffn),
-      length: Number((packed >> 32n) & 0xffff_ffffn),
-    };
+    // Masking and shifting a BigInt allocates an intermediate per operation.
+    // Storing it once and reading the halves as u32 through an aliased view
+    // does no BigInt arithmetic at all — but the aliasing is host-endian, so
+    // which half is which is settled once, at load.
+    this._packedBits[0] = packed;
+    const halves = this._packedHalves;
+    return { pointer: halves[PACKED_LOW], length: halves[PACKED_HIGH] };
   }
 
   private freePacked(pointer: number, length: number): void {
@@ -1129,7 +1195,7 @@ export class BoltFFIModule {
   readPackedBuffer<T>(packed: bigint, read: (reader: WireReader) => T): T {
     const { pointer, length } = this.unpackPacked(packed);
     const empty = pointer === 0 || length === 0;
-    const buffer = empty ? EMPTY_BUFFER : this._memory.buffer;
+    const buffer = empty ? EMPTY_BUFFER : this.memoryBuffer();
     const start = empty ? 0 : pointer;
     const size = empty ? 0 : length;
 
@@ -1166,8 +1232,7 @@ export class BoltFFIModule {
   }
 
   takePackedI8Array(packed: bigint): Int8Array {
-    const pointer = Number(packed & 0xffff_ffffn);
-    const byteLen = Number((packed >> 32n) & 0xffff_ffffn);
+    const { pointer, length: byteLen } = this.unpackPacked(packed);
     if (pointer === 0 || byteLen === 0) return new Int8Array(0);
     const result = this.getI8().subarray(pointer, pointer + byteLen).slice();
     this.exports.boltffi_wasm_free_string_return(pointer, byteLen);
@@ -1175,8 +1240,7 @@ export class BoltFFIModule {
   }
 
   takePackedU8Array(packed: bigint): Uint8Array {
-    const pointer = Number(packed & 0xffff_ffffn);
-    const byteLen = Number((packed >> 32n) & 0xffff_ffffn);
+    const { pointer, length: byteLen } = this.unpackPacked(packed);
     if (pointer === 0 || byteLen === 0) return new Uint8Array(0);
     const result = this.getBytes().subarray(pointer, pointer + byteLen).slice();
     this.exports.boltffi_wasm_free_string_return(pointer, byteLen);
@@ -1320,8 +1384,7 @@ export class BoltFFIModule {
   }
 
   takePackedI16Array(packed: bigint): Int16Array {
-    const pointer = Number(packed & 0xffff_ffffn);
-    const byteLen = Number((packed >> 32n) & 0xffff_ffffn);
+    const { pointer, length: byteLen } = this.unpackPacked(packed);
     if (pointer === 0 || byteLen === 0) return new Int16Array(0);
     const elemCount = byteLen / 2;
     const result = new Int16Array(this._memory.buffer, pointer, elemCount).slice();
@@ -1330,8 +1393,7 @@ export class BoltFFIModule {
   }
 
   takePackedU16Array(packed: bigint): Uint16Array {
-    const pointer = Number(packed & 0xffff_ffffn);
-    const byteLen = Number((packed >> 32n) & 0xffff_ffffn);
+    const { pointer, length: byteLen } = this.unpackPacked(packed);
     if (pointer === 0 || byteLen === 0) return new Uint16Array(0);
     const elemCount = byteLen / 2;
     const result = new Uint16Array(this._memory.buffer, pointer, elemCount).slice();
@@ -1340,8 +1402,7 @@ export class BoltFFIModule {
   }
 
   takePackedI32Array(packed: bigint): Int32Array {
-    const pointer = Number(packed & 0xffff_ffffn);
-    const byteLen = Number((packed >> 32n) & 0xffff_ffffn);
+    const { pointer, length: byteLen } = this.unpackPacked(packed);
     if (pointer === 0 || byteLen === 0) return new Int32Array(0);
     const elemCount = byteLen / 4;
     const result = this.getI32().subarray(pointer / 4, pointer / 4 + elemCount).slice();
@@ -1350,8 +1411,7 @@ export class BoltFFIModule {
   }
 
   takePackedU32Array(packed: bigint): Uint32Array {
-    const pointer = Number(packed & 0xffff_ffffn);
-    const byteLen = Number((packed >> 32n) & 0xffff_ffffn);
+    const { pointer, length: byteLen } = this.unpackPacked(packed);
     if (pointer === 0 || byteLen === 0) return new Uint32Array(0);
     const elemCount = byteLen / 4;
     const result = this.getU32().subarray(pointer / 4, pointer / 4 + elemCount).slice();
@@ -1360,8 +1420,7 @@ export class BoltFFIModule {
   }
 
   takePackedI64Array(packed: bigint): BigInt64Array {
-    const pointer = Number(packed & 0xffff_ffffn);
-    const byteLen = Number((packed >> 32n) & 0xffff_ffffn);
+    const { pointer, length: byteLen } = this.unpackPacked(packed);
     if (pointer === 0 || byteLen === 0) return new BigInt64Array(0);
     const result = new BigInt64Array(this._memory.buffer, pointer, byteLen / 8).slice();
     this.exports.boltffi_wasm_free_string_return(pointer, byteLen);
@@ -1369,8 +1428,7 @@ export class BoltFFIModule {
   }
 
   takePackedU64Array(packed: bigint): BigUint64Array {
-    const pointer = Number(packed & 0xffff_ffffn);
-    const byteLen = Number((packed >> 32n) & 0xffff_ffffn);
+    const { pointer, length: byteLen } = this.unpackPacked(packed);
     if (pointer === 0 || byteLen === 0) return new BigUint64Array(0);
     const result = new BigUint64Array(this._memory.buffer, pointer, byteLen / 8).slice();
     this.exports.boltffi_wasm_free_string_return(pointer, byteLen);
@@ -1378,8 +1436,7 @@ export class BoltFFIModule {
   }
 
   takePackedF32Array(packed: bigint): Float32Array {
-    const pointer = Number(packed & 0xffff_ffffn);
-    const byteLen = Number((packed >> 32n) & 0xffff_ffffn);
+    const { pointer, length: byteLen } = this.unpackPacked(packed);
     if (pointer === 0 || byteLen === 0) return new Float32Array(0);
     const elemCount = byteLen / 4;
     const result = this.getF32().subarray(pointer / 4, pointer / 4 + elemCount).slice();
@@ -1388,8 +1445,7 @@ export class BoltFFIModule {
   }
 
   takePackedF64Array(packed: bigint): Float64Array {
-    const pointer = Number(packed & 0xffff_ffffn);
-    const byteLen = Number((packed >> 32n) & 0xffff_ffffn);
+    const { pointer, length: byteLen } = this.unpackPacked(packed);
     if (pointer === 0 || byteLen === 0) return new Float64Array(0);
     const elemCount = byteLen / 8;
     const result = this.getF64().subarray(pointer / 8, pointer / 8 + elemCount).slice();

--- a/runtime/typescript/src/wire.ts
+++ b/runtime/typescript/src/wire.ts
@@ -1,5 +1,4 @@
 const UTF8_DECODER = new TextDecoder("utf-8");
-const EMPTY_VIEW = new DataView(new ArrayBuffer(0));
 const UTF8_ENCODER = new TextEncoder();
 
 type TypedArrayConstructor<T extends ArrayBufferView> = {
@@ -26,17 +25,23 @@ export class WireReader {
    * read past the end throws instead of reaching into neighbouring memory.
    * Omitting `length` extends the view to the end of `buffer`.
    */
+  /**
+   * `limit` is the end of the payload. A bounded `DataView` would enforce it
+   * for free, but allocating one per call costs more than the checks do.
+   */
+  private limit: number;
+  private bufferRef: ArrayBuffer;
+
   constructor(
     buffer: ArrayBuffer,
     offset = 0,
     borrowed = false,
     length?: number
   ) {
-    this.view =
-      length === undefined
-        ? new DataView(buffer, offset)
-        : new DataView(buffer, offset, length);
-    this.offset = 0;
+    this.view = new DataView(buffer);
+    this.bufferRef = buffer;
+    this.offset = offset;
+    this.limit = length === undefined ? buffer.byteLength : offset + length;
     this.borrowed = borrowed;
   }
 
@@ -47,8 +52,13 @@ export class WireReader {
     length: number,
     borrowed: boolean
   ): this {
-    this.view = new DataView(buffer, offset, length);
-    this.offset = 0;
+    // Comparing `this.view.buffer` here would read two accessors per call.
+    if (this.bufferRef !== buffer) {
+      this.view = new DataView(buffer);
+      this.bufferRef = buffer;
+    }
+    this.offset = offset;
+    this.limit = offset + length;
     this.borrowed = borrowed;
     return this;
   }
@@ -59,8 +69,10 @@ export class WireReader {
    * nothing — the empty view is shared.
    */
   invalidate(): void {
-    this.view = EMPTY_VIEW;
+    // Every read goes through `take`, so an empty window is enough to make one
+    // throw. Keeping the view and buffer lets the next `reset` reuse them.
     this.offset = 0;
+    this.limit = 0;
   }
 
   /**
@@ -70,68 +82,60 @@ export class WireReader {
    */
   private take(byteLength: number): number {
     const start = this.offset;
-    if (byteLength < 0 || start + byteLength > this.view.byteLength) {
+    const end = start + byteLength;
+    if (byteLength < 0 || end > this.limit) {
       throw new RangeError("Wire read past the end of the payload");
     }
-    this.offset = start + byteLength;
-    return this.view.byteOffset + start;
+    this.offset = end;
+    return start;
   }
 
   readBool(): boolean {
-    const value = this.view.getUint8(this.offset);
-    this.offset += 1;
+    const value = this.view.getUint8(this.take(1));
     return value !== 0;
   }
 
   skip(n: number): void {
-    this.offset += n;
+    this.take(n);
   }
 
   readI8(): number {
-    const value = this.view.getInt8(this.offset);
-    this.offset += 1;
+    const value = this.view.getInt8(this.take(1));
     return value;
   }
 
   readU8(): number {
-    const value = this.view.getUint8(this.offset);
-    this.offset += 1;
+    const value = this.view.getUint8(this.take(1));
     return value;
   }
 
   readI16(): number {
-    const value = this.view.getInt16(this.offset, true);
-    this.offset += 2;
+    const value = this.view.getInt16(this.take(2), true);
     return value;
   }
 
   readU16(): number {
-    const value = this.view.getUint16(this.offset, true);
-    this.offset += 2;
+    const value = this.view.getUint16(this.take(2), true);
     return value;
   }
 
   readI32(): number {
-    const value = this.view.getInt32(this.offset, true);
-    this.offset += 4;
+    const value = this.view.getInt32(this.take(4), true);
     return value;
   }
 
   readU32(): number {
-    const value = this.view.getUint32(this.offset, true);
-    this.offset += 4;
+    const value = this.view.getUint32(this.take(4), true);
     return value;
   }
 
   readI64(): bigint {
-    const value = this.view.getBigInt64(this.offset, true);
-    this.offset += 8;
+    const value = this.view.getBigInt64(this.take(8), true);
     return value;
   }
 
   readU64(): bigint {
-    const value = this.view.getBigUint64(this.offset, true);
-    this.offset += 8;
+    const value = this.view.getBigUint64(this.take(8), true);
     return value;
   }
 
@@ -144,14 +148,12 @@ export class WireReader {
   }
 
   readF32(): number {
-    const value = this.view.getFloat32(this.offset, true);
-    this.offset += 4;
+    const value = this.view.getFloat32(this.take(4), true);
     return value;
   }
 
   readF64(): number {
-    const value = this.view.getFloat64(this.offset, true);
-    this.offset += 8;
+    const value = this.view.getFloat64(this.take(8), true);
     return value;
   }
 

--- a/runtime/typescript/test/reader-bounds.test.ts
+++ b/runtime/typescript/test/reader-bounds.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { WireReader, WireWriter } from "../src/wire.js";
+import { createFakeModule } from "./support/fake-module.js";
+
+/**
+ * A borrowed reader is a window into the whole of wasm memory, so both ends of
+ * the payload have to be enforced explicitly. Reads that build a typed array
+ * bypass the view's own check and go through the same gate.
+ */
+function payloadInsideLargerBuffer(payload: Uint8Array): ArrayBuffer {
+  const backing = new ArrayBuffer(payload.byteLength + 128);
+  const bytes = new Uint8Array(backing);
+  bytes.set(payload, 64);
+  bytes.fill(0xaa, 0, 64);
+  bytes.fill(0xaa, 64 + payload.byteLength); // neighbours that must stay unread
+  return backing;
+}
+
+describe("payload bounds", () => {
+  const reader = (payload: Uint8Array): WireReader =>
+    new WireReader(payloadInsideLargerBuffer(payload), 64, true, payload.byteLength);
+
+  it("throws instead of reading a scalar past the payload", () => {
+    const writer = new WireWriter();
+    writer.writeU32(1);
+    const r = reader(writer.getBytes());
+
+    expect(r.readU32()).toBe(1);
+    expect(() => r.readU32()).toThrow(RangeError);
+  });
+
+  it("throws instead of reading an array past the payload", () => {
+    const writer = new WireWriter();
+    writer.writeU32(32); // a length the payload cannot satisfy
+    expect(() => reader(writer.getBytes()).readU8Array()).toThrow(RangeError);
+  });
+
+  it("throws instead of decoding a string past the payload", () => {
+    const writer = new WireWriter();
+    writer.writeU32(32);
+    expect(() => reader(writer.getBytes()).readString()).toThrow(RangeError);
+  });
+
+  it("throws instead of reading a typed array past the payload", () => {
+    const writer = new WireWriter();
+    writer.writeU32(64);
+    expect(() => reader(writer.getBytes()).readF64Array()).toThrow(RangeError);
+  });
+
+  it("refuses to skip backwards out of the payload", () => {
+    const writer = new WireWriter();
+    writer.writeU32(7);
+    const r = reader(writer.getBytes());
+
+    expect(r.readU32()).toBe(7);
+    expect(() => r.skip(-8)).toThrow(RangeError);
+  });
+
+  it("refuses to skip past the payload", () => {
+    const writer = new WireWriter();
+    writer.writeU32(7);
+    expect(() => reader(writer.getBytes()).skip(8)).toThrow(RangeError);
+  });
+});
+
+describe("borrowed reads do not alias the payload", () => {
+  it("copies what would otherwise be a view over wasm memory", () => {
+    const fake = createFakeModule();
+    const writer = new WireWriter();
+    writer.writeU32(4);
+    writer.writeU8(1);
+    writer.writeU8(2);
+    writer.writeU8(3);
+    writer.writeU8(4);
+    const packed = fake.pack(writer.getBytes());
+    const pointer = Number(packed & 0xffff_ffffn);
+    const length = Number(packed >> 32n);
+
+    const value = fake.module.readPackedBuffer(packed, (r) => r.readU8Array());
+    fake.scribble(pointer, length);
+
+    expect(Array.from(value)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("still hands out a view when the reader owns its buffer", () => {
+    const writer = new WireWriter();
+    writer.writeU32(3);
+    writer.writeU8(1);
+    writer.writeU8(2);
+    writer.writeU8(3);
+    const bytes = writer.getBytes();
+
+    const value = new WireReader(bytes.buffer, bytes.byteOffset).readU8Array();
+    expect(value.buffer).toBe(bytes.buffer);
+  });
+});
+
+describe("memory growth", () => {
+  it("keeps reading the right bytes after wasm memory grows", () => {
+    const fake = createFakeModule();
+    const write = (n: number): bigint => {
+      const writer = new WireWriter();
+      writer.writeU32(n);
+      return fake.pack(writer.getBytes());
+    };
+
+    expect(fake.module.readPackedBuffer(write(11), (r) => r.readU32())).toBe(11);
+
+    const before = fake.memory.buffer;
+    fake.memory.grow(2);
+    expect(fake.memory.buffer).not.toBe(before);
+
+    expect(fake.module.readPackedBuffer(write(22), (r) => r.readU32())).toBe(22);
+  });
+
+  it("detaches a reader that outlives its payload", () => {
+    const fake = createFakeModule();
+    const writer = new WireWriter();
+    writer.writeU32(5);
+    let escaped: WireReader | undefined;
+
+    fake.module.readPackedBuffer(fake.pack(writer.getBytes()), (r) => {
+      escaped = r;
+      return r.readU32();
+    });
+
+    expect(() => escaped!.readU32()).toThrow(RangeError);
+  });
+});

--- a/runtime/typescript/test/support/fake-module.ts
+++ b/runtime/typescript/test/support/fake-module.ts
@@ -1,0 +1,64 @@
+import { AsyncFutureManager, BoltFFIModule } from "../../src/module.js";
+import { StreamPollManager } from "../../src/stream.js";
+
+/**
+ * A `BoltFFIModule` over a plain `WebAssembly.Memory` and a bump allocator, so
+ * the packed-return paths can be tested without building a wasm module.
+ *
+ * Frees are recorded rather than reclaimed: most of these tests are about a
+ * payload having been released, and nothing still pointing at it afterwards.
+ */
+export interface FakeModule {
+  module: BoltFFIModule;
+  memory: WebAssembly.Memory;
+  /** Every `(pointer, length)` released through the packed-return free. */
+  freed: Array<{ pointer: number; length: number }>;
+  /** Copies `bytes` into wasm memory and returns the packed pointer/length. */
+  pack(bytes: Uint8Array): bigint;
+  /** Builds a packed value by hand, to exercise malformed payloads. */
+  packRaw(pointer: number, length: number): bigint;
+  /** Overwrites a region, standing in for the allocator reusing it. */
+  scribble(pointer: number, length: number): void;
+}
+
+export function createFakeModule(pages = 1): FakeModule {
+  const memory = new WebAssembly.Memory({ initial: pages });
+  const freed: FakeModule["freed"] = [];
+  let bump = 64; // leave the return slot at 0 alone
+
+  const exports = {
+    memory,
+    boltffi_wasm_return_slot_addr: () => 0,
+    boltffi_wasm_alloc: (size: number) => {
+      const pointer = bump;
+      bump = (bump + size + 7) & ~7;
+      if (bump > memory.buffer.byteLength) {
+        memory.grow(Math.ceil((bump - memory.buffer.byteLength) / 65536) + 1);
+      }
+      return pointer;
+    },
+    boltffi_wasm_free: () => {},
+    boltffi_wasm_free_string_return: (pointer: number, length: number) => {
+      freed.push({ pointer, length });
+    },
+  };
+
+  const module = new BoltFFIModule(
+    { exports } as unknown as WebAssembly.Instance,
+    new AsyncFutureManager(),
+    new StreamPollManager()
+  );
+
+  const packRaw = (pointer: number, length: number): bigint =>
+    (BigInt(length) << 32n) | BigInt(pointer);
+  const pack = (bytes: Uint8Array): bigint => {
+    const pointer = exports.boltffi_wasm_alloc(bytes.length);
+    new Uint8Array(memory.buffer).set(bytes, pointer);
+    return packRaw(pointer, bytes.length);
+  };
+  const scribble = (pointer: number, length: number): void => {
+    new Uint8Array(memory.buffer).fill(0xff, pointer, pointer + length);
+  };
+
+  return { module, memory, freed, pack, packRaw, scribble };
+}


### PR DESCRIPTION
Three things the runtime did on every call across the boundary, none of which it needs to do. They are in one PR because their costs interlock: removing the accessor from `reset` buys nothing while the reader still allocates a `DataView` per call, so measured apart one number understates and the other overstates.

## 1. The memory caches revalidated through an accessor

`getBytes()`, `getView()`, `getI32()` and the rest checked `cached.buffer !== this._memory.buffer`. Both sides are accessors, not field loads.

| test | over floor |
| --- | ---: |
| `cached.buffer !== memory.buffer` | 15.91 ns |
| ↳ `memory.buffer` alone | 8.84 ns |
| ↳ `cached.buffer` alone | 6.48 ns |
| `cached.byteLength === 0` | **0.52 ns** |

This is paid by every runtime operation — `allocWireBytes` calls two of these getters, and the pair cost more than its two wasm calls put together (31 ns against 23 ns). A CPU profile shows `get buffer ()` as its own entry at 3.5% of the echo path, which is the evidence that does not depend on trusting a microbenchmark.

A detached typed array reports `byteLength === 0`, so the cache can test itself. Two things make this less obvious than it looks, both commented in the diff:

- **`DataView.prototype.byteLength` throws when detached** rather than reporting 0, so that cache cannot self-test and carries a `Uint8Array` probe alongside it.
- **Growing a *shared* `WebAssembly.Memory` does not detach the old buffer.** The old identity comparison caught that; this one would not. Nothing in the repo creates shared memory today, so it is dormant, but it is a trap for whoever adds threads and I would rather flag it than have it found later.

A module with zero initial pages reports `byteLength === 0` forever and remaps on every call — correct, just slow.

## 2. Unpacking the packed i64 allocated BigInts

`Number(packed & 0xffff_ffffn)` allocates an intermediate BigInt, and the shift allocates another. Every packed return path did this.

| approach | cost |
| --- | ---: |
| mask + shift | 39.3 ns |
| `BigInt.asUintN` | 36.1 ns |
| aliased `BigUint64Array`/`Uint32Array` | **12.1 ns** |

The ten other returns that split the value by hand now share `unpackPacked` instead of repeating it.

Note that aliasing the two views is **host-endian**, where the BigInt arithmetic it replaces was not. Which half is which is settled once at load, into `PACKED_LOW`/`PACKED_HIGH`. A reviewer who sees the aliasing and not the constants would be right to call it a bug.

## 3. The borrowed reader allocated a `DataView` per call

#735 bounded the reader with `new DataView(buffer, ptr, len)`. Correct, but an allocation per call, and it defeats the reuse `reset()` was there to provide.

| approach | cost |
| --- | ---: |
| `new DataView(buf, ptr, len)` per call | 49.4 ns |
| cached view + `limit` field | **3.6 ns** |

The guarantee is not automatically the same, and getting it wrong is the risk in this PR. A payload-relative bounded view bounds *both* ends; a `limit` only bounds the top. `skip()` now goes through `take()` as well, so a negative argument can no longer walk below the payload — it could before this change, and there is a test for it.

The trade-off, stated plainly: the bounded view got its per-read check free from the view, while `limit` pays an explicit compare on every read — **+0.306 ns per read**. Break-even is somewhere around a hundred-odd reads per call. Records with a handful of fields win clearly; a single call decoding a very large array pays a little.

## Numbers

Allocation, measured per path against `main`. These are counts rather than timings, and they reproduce:

| path | bytes/call | scavenges per 200k calls |
| --- | --- | --- |
| decode a record | 575.0 → **381.3** (−34%) | 55 → **37** |
| echo bytes | 480.1 → **337.4** (−30%) | 46 → **33** |
| encode a record | 480.7 → **337.4** (−30%) | 46 → **33** |

End-to-end CPU, as a multiple of a raw wasm call measured in the same process: a record decode went from **2.54x to 1.94x**, so the JS glue above the wasm call fell from 1.54 to 0.94 — roughly **−39% of the glue**.

### Please run these yourself

My machine was heavily loaded throughout (loadavg 12–33). The allocation table above is trustworthy — it counts objects. The CPU figure is the only end-to-end timing here that exceeded the noise floor; sibling PRs measured on the same machine showed ±8% swings on code paths they do not touch, which is why this PR claims one CPU number and not a table of them.

Measurement method, if it is useful: variants interleaved in a single process, each run carrying a raw wasm call as a control so results are multiples of that control rather than wall-clock, and minimum over many repetitions.

## Testing

- Runtime suite, 126 tests. New `reader-bounds.test.ts` covers both ends of the payload (scalar, array, string, typed array, and `skip` in both directions), that borrowed reads copy rather than alias, that a reader outliving its payload throws, and that reads stay correct after wasm memory grows.
- New `test/support/fake-module.ts` builds a `BoltFFIModule` over a plain `WebAssembly.Memory` and a bump allocator, so the packed-return paths can be tested without a wasm build. There was no fixture for this before.
- I checked the growth test fails without the fix: with the detach check disabled it fails exactly at the growth point.
- `examples/platforms/wasm` acceptance suite passes, which is what pins the decoded values end to end.
- No Rust changes in this PR, so the cargo suites are unaffected.

Touches `wire.ts` in the same region as #739 (short ascii strings); whichever lands second needs a trivial rebase.
