### PR TITLE
fix(wasm): drop the reader's byte cache when its buffer changes

### DIFF
--- a/runtime/typescript/src/wire.ts
+++ b/runtime/typescript/src/wire.ts
@@ -24,19 +24,13 @@ export class WireReader {
    */
   private borrowed: boolean;
   private bytes: Uint8Array | null = null;
+  /** The reader's buffer, held directly to keep `view.buffer` off hot paths. */
   private bufferRef: ArrayBuffer;
-
-  /**
-   * The view spans exactly the payload, so `offset` is relative to it and any
-   * read past the end throws instead of reaching into neighbouring memory.
-   * Omitting `length` extends the view to the end of `buffer`.
-   */
   /**
    * `limit` is the end of the payload. A bounded `DataView` would enforce it
    * for free, but allocating one per call costs more than the checks do.
    */
   private limit: number;
-  private bufferRef: ArrayBuffer;
 
   constructor(
     buffer: ArrayBuffer,
@@ -49,7 +43,6 @@ export class WireReader {
     this.offset = offset;
     this.limit = length === undefined ? buffer.byteLength : offset + length;
     this.borrowed = borrowed;
-    this.bufferRef = buffer;
   }
 
   /** Points an existing reader at another payload, reusing the instance. */
@@ -63,14 +56,13 @@ export class WireReader {
     if (this.bufferRef !== buffer) {
       this.view = new DataView(buffer);
       this.bufferRef = buffer;
+      // `asBytes` only notices detachment, not a swap between two live
+      // buffers, so the cache has to be dropped here.
+      this.bytes = null;
     }
     this.offset = offset;
     this.limit = offset + length;
     this.borrowed = borrowed;
-    if (this.bufferRef !== buffer) {
-      this.bufferRef = buffer;
-      this.bytes = null;
-    }
     return this;
   }
 


### PR DESCRIPTION
`main` does not build. `tsc` rejects `runtime/typescript/src/wire.ts`:

```
src/wire.ts(39,11): error TS2300: Duplicate identifier 'bufferRef'.
```

and `runtime/typescript/test/ascii-string.test.ts > readString > re-reads after being pointed at another buffer` fails.

## How it got in

Nothing was wrong with any of the pull requests involved. #739 and #740 each needed the reader to hold its buffer directly rather than reach for `view.buffer`, and each added a `private bufferRef` field and its own branch in `reset`. The two edits landed in different hunks, so merging the second produced no conflict — and both CI runs were green on their own branches, 23/23 checks each.

The breakage is visible on the merge commit for #739 (run 30414074207), where `Demo Platforms` fails on all three runners with the error above. Nothing about it is reachable from either branch in isolation.

## What it broke

Two declarations of the same field is the part `tsc` catches. The part it does not:

```ts
if (this.bufferRef !== buffer) {
  this.view = new DataView(buffer);
  this.bufferRef = buffer;      // bufferRef is now === buffer
}
this.offset = offset;
this.limit = offset + length;
this.borrowed = borrowed;
if (this.bufferRef !== buffer) { // always false from here on
  this.bufferRef = buffer;
  this.bytes = null;             // never runs
}
```

The second branch is #739's, and the assignment it guards is the one that drops the byte cache. `asBytes` revalidates on `byteLength === 0`, which catches detachment but not a swap between two buffers that are both live, so that cache is what `reset` has to invalidate. #739 shipped a test for exactly this, and that is the test failing on `main`.

## The fix

One field, one branch, with the invalidation inside it. No behaviour is added or removed relative to what #739 and #740 each intended; the merge is what dropped it.

## Testing

- `runtime/typescript`: 145 tests pass, `tsc --noEmit` clean. On `main` the same suite is `1 failed | 144 passed`, plus the compile error.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets` clean.

## Worth considering separately

The existing test caught this; it just never ran against the merged tree. Four pull requests touched `wire.ts` inside the same window, and required-checks-on-the-branch cannot see a semantic conflict of this shape. A merge queue, or requiring branches to be up to date with `main` before merging, would have caught it — either seems worth more than another test here.
