### PR TITLE
perf(wasm): borrow byte slice parameters instead of decoding them

### DIFF
--- a/boltffi_core/src/wire/decode.rs
+++ b/boltffi_core/src/wire/decode.rs
@@ -71,6 +71,20 @@ pub trait WireDecode: Sized {
     fn decode_from(buf: &[u8]) -> DecodeResult<Self>;
 }
 
+/// Borrow the payload of an encoded byte buffer instead of copying it out.
+///
+/// Decoding into `Vec<u8>` allocates and copies the whole payload. A `&[u8]`
+/// parameter needs neither: the bytes are already contiguous behind their
+/// length prefix, so the caller can borrow them for as long as the encoded
+/// buffer lives. Trailing bytes are ignored, as they are by [`decode`].
+///
+/// [`decode`]: crate::wire::decode
+pub fn decode_bytes(buf: &[u8]) -> Result<&[u8], DecodeError> {
+    let mut reader = WireReader::new(buf);
+    let count = reader.read_value::<u32>()? as usize;
+    reader.read_exact(count)
+}
+
 struct WireReader<'buffer> {
     buffer: &'buffer [u8],
     offset: usize,
@@ -97,7 +111,11 @@ impl<'buffer> WireReader<'buffer> {
     #[inline]
     fn read_exact(&mut self, byte_count: usize) -> Result<&'buffer [u8], DecodeError> {
         let start = self.offset;
-        let end = start + byte_count;
+        // `usize` is 32 bits on wasm32, so a hostile length read off the wire
+        // can overflow this and trap where it should report a decode error.
+        let end = start
+            .checked_add(byte_count)
+            .ok_or(DecodeError::BufferTooSmall)?;
         let bytes = self
             .buffer
             .get(start..end)
@@ -469,6 +487,65 @@ impl_wire_tuple_decode!(A, B, C, D, E, F, G, H, I, J, K, L);
 
 #[cfg(test)]
 mod tests {
+    use super::decode_bytes;
+    use crate::wire::encode;
+
+    #[test]
+    fn decode_bytes_borrows_the_payload_without_copying() {
+        let encoded = encode(&vec![1u8, 2, 3, 4]);
+        let borrowed = decode_bytes(&encoded).expect("borrowed payload");
+
+        assert_eq!(borrowed, &[1, 2, 3, 4]);
+        // The whole point: the slice points into `encoded`, it is not a copy.
+        assert!(core::ptr::eq(borrowed.as_ptr(), encoded[4..].as_ptr()));
+    }
+
+    #[test]
+    fn decode_bytes_matches_the_owned_decoder() {
+        for payload in [vec![], vec![0u8], vec![7u8; 300]] {
+            let encoded = encode(&payload);
+            let owned: Vec<u8> = crate::wire::decode(&encoded).expect("owned decode");
+            assert_eq!(decode_bytes(&encoded).expect("borrowed decode"), &owned[..]);
+        }
+    }
+
+    #[test]
+    fn decode_bytes_ignores_trailing_bytes_like_decode() {
+        let mut encoded = encode(&vec![9u8, 8]);
+        encoded.extend_from_slice(&[0xff; 16]);
+
+        assert_eq!(decode_bytes(&encoded).expect("borrowed payload"), &[9, 8]);
+    }
+
+    #[test]
+    fn decode_bytes_rejects_a_length_the_buffer_cannot_satisfy() {
+        // A truncated or malformed payload must not hand out neighbouring bytes.
+        let mut encoded = encode(&vec![1u8, 2, 3, 4]);
+        encoded[0] = 0xff;
+
+        assert!(decode_bytes(&encoded).is_err());
+    }
+
+    #[test]
+    fn decode_bytes_rejects_the_largest_length_without_overflowing() {
+        // `usize` is 32 bits on wasm32, where `offset + u32::MAX` wraps and an
+        // overflow-checked build traps instead of reporting a decode error.
+        // On a 64-bit host the addition cannot overflow, so what this asserts
+        // here is only that the largest representable length is rejected — the
+        // guard itself is exercised on wasm32.
+        let mut encoded = encode(&vec![1u8, 2, 3, 4]);
+        encoded[..4].copy_from_slice(&u32::MAX.to_le_bytes());
+
+        assert!(decode_bytes(&encoded).is_err());
+    }
+
+    #[test]
+    fn decode_bytes_rejects_a_buffer_too_short_for_the_prefix() {
+        for truncated in [&[][..], &[0][..], &[0, 0, 0][..]] {
+            assert!(decode_bytes(truncated).is_err());
+        }
+    }
+
     use super::*;
     use crate::wire::encode::WireEncode;
 

--- a/boltffi_core/src/wire/mod.rs
+++ b/boltffi_core/src/wire/mod.rs
@@ -9,5 +9,5 @@ mod temporal;
 pub use blittable::Blittable;
 pub use buffer::{WireBuffer, decode, encode};
 pub use constants::*;
-pub use decode::{DecodeError, DecodeResult, InvalidWireValue, WireDecode};
+pub use decode::{DecodeError, DecodeResult, InvalidWireValue, WireDecode, decode_bytes};
 pub use encode::{WireEncode, WireEncodingKind};

--- a/boltffi_macros/src/experimental/expansion/mod.rs
+++ b/boltffi_macros/src/experimental/expansion/mod.rs
@@ -1763,6 +1763,53 @@ mod tests {
         source
     }
 
+    fn borrowed_bytes_param_contract() -> SourceContract {
+        let mut function = FunctionDef::new(
+            FunctionId::new("demo::bytes_sum"),
+            CanonicalName::single("bytes_sum"),
+        );
+        let mut parameter = parameter("bytes", byte_slice());
+        parameter.passing = ParameterPassing::Ref;
+        function.parameters = vec![parameter];
+        function.returns = ReturnDef::value(TypeExpr::Primitive(Primitive::U32));
+
+        let mut source = SourceContract::new(PackageInfo::new("demo", None));
+        source.functions.push(function);
+        source
+    }
+
+    fn borrowed_byte_vec_param_contract() -> SourceContract {
+        let mut function = FunctionDef::new(
+            FunctionId::new("demo::vec_sum"),
+            CanonicalName::single("vec_sum"),
+        );
+        let mut parameter = parameter("bytes", byte_vec());
+        parameter.passing = ParameterPassing::Ref;
+        function.parameters = vec![parameter];
+        function.returns = ReturnDef::value(TypeExpr::Primitive(Primitive::U32));
+
+        let mut source = SourceContract::new(PackageInfo::new("demo", None));
+        source.functions.push(function);
+        source
+    }
+
+    fn two_borrowed_bytes_params_contract() -> SourceContract {
+        let mut function = FunctionDef::new(
+            FunctionId::new("demo::both_sum"),
+            CanonicalName::single("both_sum"),
+        );
+        let mut left = parameter("left", byte_slice());
+        left.passing = ParameterPassing::Ref;
+        let mut right = parameter("right", byte_slice());
+        right.passing = ParameterPassing::Ref;
+        function.parameters = vec![left, right];
+        function.returns = ReturnDef::value(TypeExpr::Primitive(Primitive::U32));
+
+        let mut source = SourceContract::new(PackageInfo::new("demo", None));
+        source.functions.push(function);
+        source
+    }
+
     fn mutable_bytes_param_contract() -> SourceContract {
         let mut function =
             FunctionDef::new(FunctionId::new("demo::fill"), CanonicalName::single("fill"));
@@ -5254,6 +5301,110 @@ mod tests {
             }
             .to_string()
         );
+    }
+
+    #[test]
+    fn wasm_borrowed_bytes_param_expansion_borrows_the_payload() {
+        // `&[u8]` borrows the wire payload rather than decoding it into a
+        // `Vec` that exists only to be borrowed from. Compare against
+        // `wasm_bytes_param_expansion_decodes_owned_bytes`, where the owned
+        // `Vec<u8>` parameter still decodes.
+        let source = borrowed_bytes_param_contract();
+        let lowered = lower_with_declarations::<Wasm32>(&source).expect("lowered bindings");
+        let expansion = Expansion::new(&lowered);
+        let syntax = syn::parse_quote! {
+            pub fn bytes_sum(bytes: &[u8]) -> u32 {
+                bytes.iter().map(|byte| u32::from(*byte)).sum()
+            }
+        };
+
+        let tokens =
+            expand_function(&expansion, &source.functions[0], syntax).expect("expanded function");
+
+        assert_eq!(
+            tokens.to_string(),
+            quote! {
+                pub fn bytes_sum(bytes: &[u8]) -> u32 {
+                    bytes.iter().map(|byte| u32::from(*byte)).sum()
+                }
+                #[cfg(target_arch = "wasm32")]
+                #[unsafe(no_mangle)]
+                pub unsafe extern "C" fn boltffi_function_demo_bytes_sum(
+                    __boltffi_bytes_ptr: *const u8,
+                    __boltffi_bytes_len: usize
+                ) -> u32 {
+                    let bytes: &[u8] = {
+                        if __boltffi_bytes_ptr.is_null() && __boltffi_bytes_len > 0 {
+                            ::boltffi::__private::set_last_error_len(stringify!(bytes), "null pointer with non-zero length", __boltffi_bytes_len as usize);
+                            return <u32 as ::core::default::Default>::default();
+                        }
+                        let __boltffi_bytes: &[u8] = if __boltffi_bytes_len == 0 {
+                            &[]
+                        } else {
+                            unsafe {
+                                ::core::slice::from_raw_parts(
+                                    __boltffi_bytes_ptr,
+                                    __boltffi_bytes_len
+                                )
+                            }
+                        };
+                        match ::boltffi::__private::wire::decode_bytes(__boltffi_bytes) {
+                            Ok(value) => value,
+                            Err(error) => {
+                                ::boltffi::__private::set_last_error_display(stringify!(bytes), "wire decode failed", &error, __boltffi_bytes_len as usize);
+                                return <u32 as ::core::default::Default>::default();
+                            }
+                        }
+                    };
+                    bytes_sum(bytes)
+                }
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn wasm_borrowed_byte_vec_param_keeps_decoding_into_owned_storage() {
+        // `&Vec<u8>` borrows the vector, not a slice of it, so it still needs
+        // the owned storage to point at. The guard is on the borrow shape, not
+        // on the codec alone.
+        let source = borrowed_byte_vec_param_contract();
+        let lowered = lower_with_declarations::<Wasm32>(&source).expect("lowered bindings");
+        let expansion = Expansion::new(&lowered);
+        let syntax = syn::parse_quote! {
+            pub fn vec_sum(bytes: &Vec<u8>) -> u32 {
+                bytes.len() as u32
+            }
+        };
+
+        let tokens = expand_function(&expansion, &source.functions[0], syntax)
+            .expect("expanded function")
+            .to_string();
+
+        assert!(tokens.contains("wire :: decode ::"), "{tokens}");
+        assert!(!tokens.contains("decode_bytes"), "{tokens}");
+    }
+
+    #[test]
+    fn wasm_two_borrowed_bytes_params_each_borrow_their_own_payload() {
+        let source = two_borrowed_bytes_params_contract();
+        let lowered = lower_with_declarations::<Wasm32>(&source).expect("lowered bindings");
+        let expansion = Expansion::new(&lowered);
+        let syntax = syn::parse_quote! {
+            pub fn both_sum(left: &[u8], right: &[u8]) -> u32 {
+                (left.len() + right.len()) as u32
+            }
+        };
+
+        let tokens = expand_function(&expansion, &source.functions[0], syntax)
+            .expect("expanded function")
+            .to_string();
+
+        assert_eq!(tokens.matches("decode_bytes").count(), 2, "{tokens}");
+        // Each parameter reads its own pointer and length, so the two borrows
+        // cannot alias unless the caller passes overlapping buffers.
+        assert!(tokens.contains("__boltffi_left_ptr"), "{tokens}");
+        assert!(tokens.contains("__boltffi_right_ptr"), "{tokens}");
     }
 
     #[test]

--- a/boltffi_macros/src/experimental/wrapper/encoded/incoming.rs
+++ b/boltffi_macros/src/experimental/wrapper/encoded/incoming.rs
@@ -200,6 +200,9 @@ impl Input {
         borrow: rust_api::DecodeBorrow,
         expansion: &Expansion<'lowered, S>,
     ) -> Result<TokenStream, Error> {
+        if let Some(borrowed) = self.borrowed_bytes(codec, borrow, expansion)? {
+            return Ok(borrowed);
+        }
         let storage = names::Parameter::new(&self.binding).storage();
         let owned = self.owned(
             codec,
@@ -214,6 +217,65 @@ impl Input {
             #owned
             let #binding = #borrow;
         })
+    }
+
+    /// `&[u8]` borrows the encoded payload instead of decoding it into owned
+    /// storage first. The bytes are already contiguous behind their length
+    /// prefix, so the `Vec` the general path builds is allocated and copied
+    /// only to be borrowed from and dropped.
+    ///
+    /// The borrow lives only for the synchronous call, which is when the host
+    /// still owns the buffer. It assumes what the ABI already requires of every
+    /// pointer pair: that a caller passing several buffers passes disjoint
+    /// ones. Generated bindings allocate each parameter separately, so this
+    /// only binds hand-written callers of the raw exports.
+    ///
+    /// Narrow on purpose. `&mut [u8]` mutates and has its own direct path; a
+    /// custom codec produces a different value than the bytes on the wire;
+    /// wider element types would be misaligned at the payload offset and are
+    /// little-endian encoded rather than native. Returns `None` whenever this
+    /// does not apply, leaving the general path to handle it.
+    fn borrowed_bytes<'lowered, S: RenderSurface>(
+        &self,
+        codec: &CodecNode,
+        borrow: rust_api::DecodeBorrow,
+        expansion: &Expansion<'lowered, S>,
+    ) -> Result<Option<TokenStream>, Error> {
+        if !matches!(borrow, rust_api::DecodeBorrow::Slice { mutable: false })
+            || !matches!(codec, CodecNode::Bytes)
+        {
+            return Ok(None);
+        }
+        let converted =
+            super::custom::Incoming::new(codec, expansion).convert(quote! { __boltffi_decoded })?;
+        if converted.changed() {
+            return Ok(None);
+        }
+
+        let binding = &self.binding;
+        let pointer = &self.pointer;
+        let length = &self.length;
+        let failure = &self.failure;
+        Ok(Some(quote! {
+            let #binding: &[u8] = {
+                if #pointer.is_null() && #length > 0 {
+                    ::boltffi::__private::set_last_error_len(stringify!(#binding), "null pointer with non-zero length", #length as usize);
+                    #failure
+                }
+                let __boltffi_bytes: &[u8] = if #length == 0 {
+                    &[]
+                } else {
+                    unsafe { ::core::slice::from_raw_parts(#pointer, #length) }
+                };
+                match ::boltffi::__private::wire::decode_bytes(__boltffi_bytes) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        ::boltffi::__private::set_last_error_display(stringify!(#binding), "wire decode failed", &error, #length as usize);
+                        #failure
+                    }
+                }
+            };
+        }))
     }
 
     fn owned<'lowered, S: RenderSurface>(


### PR DESCRIPTION
A `&[u8]` parameter decodes into an owned `Vec<u8>` that exists only to be borrowed from and dropped. Borrowing the payload in place instead removes one allocation and one full copy of every byte argument, inside wasm.

## What was happening

`experimental/rust_api/ty.rs` models a borrowed slice as owned storage plus a later borrow, so the encoded-parameter lowering emits:

```rust
let __bytes_storage: Vec<u8> = wire::decode::<Vec<u8>>(__boltffi_bytes)?;
let bytes = __bytes_storage.as_slice();
```

`Vec<u8>` decoding allocates a vector and `copy_nonoverlapping`s the payload into it. The `Vec` is then borrowed from and dropped. The bytes were already contiguous behind their four-byte length prefix, so none of that was needed.

## The change

```rust
let bytes: &[u8] = wire::decode_bytes(__boltffi_bytes)?;
```

`decode_bytes` reads the length prefix and returns the payload as a sub-slice of the buffer the shim already built from `(ptr, len)`, with the same bounds checking. No allocation, no copy.

**The ABI does not change.** Hosts still pass wire-encoded bytes and still allocate them the same way, so no binding generator and no runtime moves. I considered the direct-buffer ABI that `&mut [u8]` uses (`wrapper/param/encoded.rs`), which would also drop the four-byte prefix — but that changes the wire contract, and the `ByMutRef` derivation is duplicated across six language backends plus the runtime. The prefix costs a `setUint32` and a prefix read; the copy is what costs.

### Where it does not apply

`&mut [u8]` mutates and has its own direct path. A custom codec produces a different value than the bytes on the wire. Wider element types would be misaligned at the payload offset and are little-endian encoded rather than native. `&Vec<u8>` borrows the vector, not a slice of it, so it still needs the storage. Async reference parameters are rejected before this renderer. Each of those keeps decoding, and there are tests pinning the ones that could plausibly regress.

The lowering is generic over the render surface, so native is affected too. The measurements are from wasm.

### Unrelated fix, included because this reaches it

`WireReader::read_exact` computed `start + byte_count`. `usize` is 32 bits on wasm32, so a hostile length off the wire could overflow it and trap in an overflow-checked build instead of returning `DecodeError`. It now uses `checked_add`.

## Numbers

Two Rust→wasm builds of one shared workload, boltffi and wasm-bindgen, both exports called directly with no generated glue so only wasm-side work is timed. Three runs per side, each side rebuilt; medians below.

| payload | boltffi before | boltffi after | wasm-bindgen before | wasm-bindgen after |
| ---: | ---: | ---: | ---: | ---: |
| 16 KiB | 930 ns | **574 ns** | 414 ns | 417 ns |
| 64 KiB | 4171 ns | **3156 ns** | 2344 ns | 2434 ns |
| 256 KiB | 16.9 us | **12.6 us** | 9137 ns | 8982 ns |
| 1 MiB | 106.5 us | **59.6 us** | 41.9 us | 44.2 us |

wasm-bindgen is carried as a control: its numbers are flat across the two builds, so this is boltffi getting faster rather than the baseline drifting. As a ratio to it, the in-wasm gap goes 2.24x → 1.34x at 16 KiB, 1.78x → 1.30x at 64 KiB, 1.84x → 1.40x at 256 KiB, 2.61x → 1.40x at 1 MiB. No overlap between the three-run sets at any size.

Module size: 228,780 → 228,105 bytes.

### What this does *not* do

End-to-end, the same 64 KiB echo moves from 1.17x to 1.13x of wasm-bindgen — about three points. At these sizes the call is dominated by the host-side allocation that copies the result out of wasm memory, which both bindings pay and neither avoids. The change removes a real payload-proportional cost, and most of it is currently hidden behind a larger one. I would rather state that than quote the in-wasm figure alone.

### On the measurements

Numbers are medians of paired measurements: each repetition times both bindings back to back with the order flipped between repetitions, and the ratio is formed inside the repetition. An earlier harness that divided two independently chosen minima produced ratios that did not reproduce, which is why the absolute timings and the control are both here rather than a ratio alone.

## Testing

- `cargo test --workspace` — no new failures. Two `boltffi_bindgen` metadata tests and three `boltffi_macros` fixture tests fail identically on `main` in this environment; they shell out to `cargo build`.
- New: five unit tests for `decode_bytes` (borrows rather than copies, agrees with the owned decoder, ignores trailing bytes, rejects a length the buffer cannot satisfy, rejects `u32::MAX` without overflowing) and three expansion tests (`&[u8]` borrows, `&Vec<u8>` still decodes, two `&[u8]` parameters each borrow their own payload). The first expansion test fails on `main`, which I checked by reverting the change under it.
- `boltffi_tests`' existing `borrowed_byte_sum` crossing test covers the payload offset end to end.
- `cargo clippy --workspace --all-targets` clean, `cargo fmt --all` applied.

The borrow is the part worth reviewing. It lives only for the synchronous call, which is while the host still owns the buffer, and it assumes what the ABI already requires of any caller passing several pointer pairs: that the buffers are disjoint. Generated bindings allocate each parameter separately, so that only binds hand-written callers of the raw exports — but it is now an invariant rather than an accident, and I have noted it in the code.
