### PR TITLE
perf(wasm): size decoded collections up front instead of growing them

### DIFF
--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -4,6 +4,20 @@ import { StreamPollManager } from "./stream.js";
 
 const EMPTY_BUFFER = new ArrayBuffer(0);
 
+/**
+ * Widens bytes to booleans.
+ *
+ * `Array.from` with a mapper walks the TypedArray through the iterator
+ * protocol, which costs an order of magnitude more than indexing it.
+ */
+function toBoolArray(bytes: Uint8Array): boolean[] {
+  const result = new Array<boolean>(bytes.length);
+  for (let index = 0; index < bytes.length; index++) {
+    result[index] = bytes[index] !== 0;
+  }
+  return result;
+}
+
 const LITTLE_ENDIAN = new Uint8Array(new Uint32Array([1]).buffer)[0] === 1;
 const PACKED_LOW = LITTLE_ENDIAN ? 0 : 1;
 const PACKED_HIGH = LITTLE_ENDIAN ? 1 : 0;
@@ -530,7 +544,7 @@ export class BoltFFIModule {
   }
 
   borrowBoolArray(ptr: number, len: number): boolean[] {
-    return Array.from(this.getBytes().subarray(ptr, ptr + len), (value) => value !== 0);
+    return toBoolArray(this.getBytes().subarray(ptr, ptr + len));
   }
 
   borrowI8Array(ptr: number, len: number): Int8Array {
@@ -921,8 +935,7 @@ export class BoltFFIModule {
   takeBufBoolArray(bufPtr: number): boolean[] {
     const { ptr, len } = this.readBufDescriptor(bufPtr);
     if (ptr === 0) return [];
-    const bytes = this.getBytes().subarray(ptr, ptr + len);
-    return Array.from(bytes, (value) => value !== 0);
+    return toBoolArray(this.getBytes().subarray(ptr, ptr + len));
   }
 
   takeBufStructArray<T>(bufPtr: number, stride: number, decode: (view: DataView, offset: number) => T): T[] {
@@ -931,7 +944,11 @@ export class BoltFFIModule {
     const copy = new Uint8Array(this._memory.buffer, ptr, byteLen).slice();
     const view = new DataView(copy.buffer, copy.byteOffset, copy.byteLength);
     const count = (byteLen / stride) | 0;
-    return Array.from({ length: count }, (_, index) => decode(view, index * stride));
+    const result = new Array<T>(count);
+    for (let index = 0; index < count; index++) {
+      result[index] = decode(view, index * stride);
+    }
+    return result;
   }
 
   writeToMemory(ptr: number, data: Uint8Array): void {
@@ -1357,8 +1374,7 @@ export class BoltFFIModule {
   takeSlotBoolArray(): boolean[] {
     const { ptr, len, cap, align } = this.readSlot();
     if (ptr === 0) return [];
-    const bytes = this.getBytes().subarray(ptr, ptr + len);
-    const result = Array.from(bytes, (b) => b !== 0);
+    const result = toBoolArray(this.getBytes().subarray(ptr, ptr + len));
     this.freeSlotBuf(ptr, cap, align);
     return result;
   }

--- a/runtime/typescript/src/wire.ts
+++ b/runtime/typescript/src/wire.ts
@@ -215,7 +215,13 @@ export class WireReader {
   readBoolArray(): boolean[] {
     const len = this.readU32();
     const values = new Uint8Array(this.view.buffer, this.take(len), len);
-    return Array.from(values, (value) => value !== 0);
+    // `Array.from` with a mapper walks a TypedArray through the iterator
+    // protocol, which costs an order of magnitude more than indexing it.
+    const result = new Array<boolean>(len);
+    for (let index = 0; index < len; index++) {
+      result[index] = values[index] !== 0;
+    }
+    return result;
   }
 
   private readTypedArray<T extends ArrayBufferView>(
@@ -289,9 +295,10 @@ export class WireReader {
 
   readArray<T>(readElement: () => T): T[] {
     const len = this.readU32();
-    const result: T[] = [];
-    for (let i = 0; i < len; i++) {
-      result.push(readElement());
+    // The length is known, so the array is sized once rather than grown.
+    const result = new Array<T>(len);
+    for (let index = 0; index < len; index++) {
+      result[index] = readElement();
     }
     return result;
   }

--- a/runtime/typescript/test/collections.test.ts
+++ b/runtime/typescript/test/collections.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { WireReader, WireWriter } from "../src/wire.js";
+
+function readerOver(writer: WireWriter): WireReader {
+  const bytes = writer.getBytes();
+  return new WireReader(bytes.buffer as ArrayBuffer, bytes.byteOffset);
+}
+
+/**
+ * Both decoders size the result array up front instead of growing it. That is
+ * only equivalent if every index is written: an array built with
+ * `new Array(len)` and left partly unassigned has holes, which `Object.keys`,
+ * `in` and `forEach` all skip, so a value could go missing without the length
+ * or a `toEqual` comparison noticing.
+ */
+function expectNoHoles(values: readonly unknown[]): void {
+  expect(Object.keys(values)).toHaveLength(values.length);
+  for (let index = 0; index < values.length; index++) {
+    expect(index in values).toBe(true);
+  }
+}
+
+describe("readArray", () => {
+  it("decodes an empty array", () => {
+    const writer = new WireWriter();
+    writer.writeArray<number>([], (value) => writer.writeU32(value));
+
+    const values = readerOver(writer).readArray(() => 0);
+    expect(values).toEqual([]);
+    expectNoHoles(values);
+  });
+
+  it("preserves order and leaves no holes", () => {
+    const source = Array.from({ length: 300 }, (_, index) => index * 3);
+    const writer = new WireWriter();
+    writer.writeArray(source, (value) => writer.writeU32(value));
+
+    const reader = readerOver(writer);
+    const values = reader.readArray(() => reader.readU32());
+
+    expect(values).toEqual(source);
+    expectNoHoles(values);
+  });
+
+  it("keeps nested arrays independent", () => {
+    const writer = new WireWriter();
+    writer.writeArray(
+      [
+        [1, 2],
+        [3],
+        [],
+      ],
+      (inner) => writer.writeArray(inner, (value) => writer.writeI32(value))
+    );
+
+    const reader = readerOver(writer);
+    const values = reader.readArray(() => reader.readArray(() => reader.readI32()));
+
+    expect(values).toEqual([[1, 2], [3], []]);
+    values.forEach(expectNoHoles);
+    expectNoHoles(values);
+  });
+});
+
+describe("readBoolArray", () => {
+  it("decodes an empty array", () => {
+    const writer = new WireWriter();
+    writer.writeArray<boolean>([], (value) => writer.writeBool(value));
+
+    const values = readerOver(writer).readBoolArray();
+    expect(values).toEqual([]);
+    expectNoHoles(values);
+  });
+
+  it("widens every byte and leaves no holes", () => {
+    const source = Array.from({ length: 257 }, (_, index) => index % 3 === 0);
+    const writer = new WireWriter();
+    writer.writeArray(source, (value) => writer.writeBool(value));
+
+    const values = readerOver(writer).readBoolArray();
+
+    expect(values).toEqual(source);
+    expectNoHoles(values);
+  });
+
+  it("treats any non-zero byte as true", () => {
+    // The wire only ever carries 0 or 1, but the decoder should not assume it.
+    const writer = new WireWriter();
+    writer.writeU32(3);
+    writer.writeU8(0);
+    writer.writeU8(1);
+    writer.writeU8(0xff);
+
+    expect(readerOver(writer).readBoolArray()).toEqual([false, true, true]);
+  });
+});


### PR DESCRIPTION
Both array decoders read the element count before building the result, so the array can be sized once instead of grown. `readArray` started from `[]` and pushed; the four boolean paths went through `Array.from` with a mapping function.

`takeSlotStructArray` already built its result the other way, so this makes the remaining paths consistent with it rather than introducing a pattern.

## `Array.from` with a mapper is the expensive one

Over a `TypedArray` it walks the iterator protocol. Against an indexed loop, interleaved in one process, min of 9:

| length | `Array.from` + mapper | indexed | |
| ---: | ---: | ---: | ---: |
| 8 | 290 ns | 8 ns | 36x |
| 64 | 1096 ns | 55 ns | 20x |
| 1000 | 13578 ns | 592 ns | 23x |
| 10000 | 136658 ns | 9669 ns | 14x |

Four sites did this: `WireReader.readBoolArray`, `borrowBoolArray`, `takeBufBoolArray`, `takeSlotBoolArray`.

## Sizing the array is the smaller one

| length | `push` onto `[]` | `new Array(len)` + index | |
| ---: | ---: | ---: | ---: |
| 8 | 26 ns | 13 ns | 1.93x |
| 64 | 235 ns | 195 ns | 1.20x |
| 1000 | 4249 ns | 3398 ns | 1.25x |
| 10000 | 50522 ns | 38017 ns | 1.33x |

`new Array(len)` gives V8 a holey elements kind, so the obvious objection is that the caller pays back what the decoder saves. Measured with a consumer pass included, it does not: 1.39x at 64, 2.10x at 1000, 2.17x at 10000, and filling with `.fill()` first to force packed is worse than leaving it alone.

## End to end

`examples/demo` through `benchmarks/harnesses/wasm-bench`. `echo_vec_vec_bool` decodes through both changed paths — `readArray` of `readBoolArray`. `find_name` touches neither and is carried as a control.

| | before | after |
| --- | ---: | ---: |
| `echo_vec_vec_bool` 64x64 | 121.1 / 117.1 / 109.5 us | **45.8 / 46.3 / 45.9 / 47.6 us** |
| `find_name` (control) | 92 / 87 / 87 ns | 95 / 86 / 87 / 96 ns |

**~2.5x.** The control is flat across the two builds, so this is the decode getting faster rather than the machine moving. Ranges do not overlap.

### What this does not show

`generate_particles_10k` returns `Vec<record>` and so uses `readArray` but not the boolean path. Expected gain there is the sizing alone — about 1.25 ns per element against roughly 43 ns of per-element record decoding, so a few percent. Three runs per side did not resolve it, and the paired ratios sit within the control's own drift. I am not claiming it.

`borrowBoolArray`, `takeBufBoolArray` and `takeSlotBoolArray` are on paths this harness does not exercise. They are the same conversion as `readBoolArray` and are changed the same way, but the number above is not evidence for them.

### Measured and rejected

`writeArray` iterates with `for...of` over an `ArrayLike & Iterable`, which looked like the same class of problem. Replacing it with an indexed loop is **slower** from 64 elements up — 0.77x at 64, 0.84x at 1000, 0.88x at 10000 — and only wins at 8 elements. V8 handles `for...of` over a packed array better than the naive alternative, so it is left alone. `readMap` has no equivalent: a JS `Map` does not preallocate.

## Testing

- Runtime suite 151 tests, `tsc --noEmit` clean. New `test/collections.test.ts` covers empty arrays, order and value preservation at 300 and 257 elements, nested arrays, and non-zero bytes widening to `true`.
- The tests assert the results have **no holes** (`Object.keys(values).length === values.length`, and every index `in` the array). That is the property `new Array(len)` puts at risk: an array left partly unassigned has holes that `Object.keys`, `in` and `forEach` skip, so a missing value would not show up in a `toEqual` comparison or in the length.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --all` clean.
