### PR TITLE
perf(wasm): stop allocating a local buffer for region-bound writers

### DIFF
--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -210,6 +210,7 @@ export class BoltFFIModule {
   private _optionF64Bits = new BigUint64Array(this._optionF64Storage);
   private _optionF64Values = new Float64Array(this._optionF64Storage);
   private _returnSlotAddr: number = 0;
+  private _regionAllocator: WasmWireWriterAllocator | null = null;
 
   constructor(
     instance: WebAssembly.Instance,
@@ -793,7 +794,14 @@ export class BoltFFIModule {
   }
 
   writerFromMemory(ptr: number, size: number): WriterAlloc {
-    return WireWriter.withWasmRegion(ptr, size, () => this._memory.buffer);
+    // Callback trampolines call this once per element, so the allocator is
+    // built once and shared rather than rebuilt with four closures per call.
+    let allocator = this._regionAllocator;
+    if (allocator === null) {
+      allocator = WireWriter.fixedRegionAllocator(() => this._memory.buffer);
+      this._regionAllocator = allocator;
+    }
+    return WireWriter.withWasmRegion(ptr, size, allocator.buffer, allocator);
   }
 
   allocBufDescriptor(): number {

--- a/runtime/typescript/src/wire.ts
+++ b/runtime/typescript/src/wire.ts
@@ -401,8 +401,14 @@ export function matchWireResult<T, E, R>(
 }
 
 export class WireWriter {
-  private localBuffer: ArrayBuffer;
-  private localView: DataView;
+  /**
+   * Only used when the writer is not bound to a wasm region. A region-bound
+   * writer never reads either, so both are left unallocated for it — they are
+   * two allocations per call on the callback trampoline, which builds one
+   * writer per element.
+   */
+  private localBuffer: ArrayBuffer | null;
+  private localView: DataView | null;
   private wasmAllocator: WasmWireWriterAllocator | null;
   private wasmPtr: number;
   private allocationSize: number;
@@ -410,10 +416,11 @@ export class WireWriter {
   private cachedWasmView: DataView | null;
   private cachedWasmBuffer: ArrayBuffer | null;
 
-  constructor(initialSize = 256) {
+  constructor(initialSize = 256, allocateLocal = true) {
     const normalizedSize = Math.max(initialSize, 1);
-    this.localBuffer = new ArrayBuffer(normalizedSize);
-    this.localView = new DataView(this.localBuffer);
+    this.localBuffer = allocateLocal ? new ArrayBuffer(normalizedSize) : null;
+    this.localView =
+      this.localBuffer === null ? null : new DataView(this.localBuffer);
     this.wasmAllocator = null;
     this.wasmPtr = 0;
     this.allocationSize = normalizedSize;
@@ -438,16 +445,30 @@ export class WireWriter {
     return writer;
   }
 
-  static withWasmRegion(pointer: number, size: number, buffer: () => ArrayBuffer): WireWriter {
-    const writer = new WireWriter(1);
-    writer.wasmAllocator = {
-      alloc: () => pointer,
+  /** Allocator for a caller-owned region: it can only report the buffer. */
+  static fixedRegionAllocator(buffer: () => ArrayBuffer): WasmWireWriterAllocator {
+    return {
+      alloc: () => {
+        throw new Error("Fixed WASM region cannot allocate");
+      },
       realloc: () => {
         throw new Error("Fixed WASM region exceeded its capacity");
       },
       free: () => {},
       buffer,
     };
+  }
+
+  static withWasmRegion(
+    pointer: number,
+    size: number,
+    buffer: () => ArrayBuffer,
+    allocator?: WasmWireWriterAllocator
+  ): WireWriter {
+    const writer = new WireWriter(1, false);
+    // `allocator` lets the caller hand in one shared object instead of building
+    // a fresh one with four closures per call.
+    writer.wasmAllocator = allocator ?? WireWriter.fixedRegionAllocator(buffer);
     writer.wasmPtr = pointer;
     writer.allocationSize = size;
     return writer;
@@ -473,17 +494,30 @@ export class WireWriter {
     return this.allocationSize;
   }
 
+  private ensureLocalBuffer(): ArrayBuffer {
+    let buffer = this.localBuffer;
+    if (buffer === null) {
+      buffer = new ArrayBuffer(Math.max(this.allocationSize, 1));
+      this.localBuffer = buffer;
+      this.localView = new DataView(buffer);
+    }
+    return buffer;
+  }
+
   private inWasmMemory(): boolean {
     return this.wasmAllocator !== null;
   }
 
   private currentBuffer(): ArrayBuffer {
-    return this.inWasmMemory() ? this.wasmAllocator!.buffer() : this.localBuffer;
+    return this.inWasmMemory()
+      ? this.wasmAllocator!.buffer()
+      : this.ensureLocalBuffer();
   }
 
   private currentView(): DataView {
     if (!this.inWasmMemory()) {
-      return this.localView;
+      this.ensureLocalBuffer();
+      return this.localView as DataView;
     }
     const buffer = this.wasmAllocator!.buffer();
     if (this.cachedWasmBuffer !== buffer) {
@@ -519,9 +553,9 @@ export class WireWriter {
       return;
     }
     const newBuffer = new ArrayBuffer(newSize);
-    new Uint8Array(newBuffer).set(new Uint8Array(this.localBuffer));
+    new Uint8Array(newBuffer).set(new Uint8Array(this.ensureLocalBuffer()));
     this.localBuffer = newBuffer;
-    this.localView = new DataView(this.localBuffer);
+    this.localView = new DataView(newBuffer);
     this.allocationSize = newSize;
   }
 

--- a/runtime/typescript/test/region-writer.test.ts
+++ b/runtime/typescript/test/region-writer.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { WireReader, WireWriter } from "../src/wire.js";
+
+/**
+ * A writer bound to a caller-owned region writes straight into that memory and
+ * never reads its local buffer, so it no longer allocates one. These pin the
+ * behaviour that change must not alter.
+ */
+describe("region-bound writer", () => {
+  const memory = () => new WebAssembly.Memory({ initial: 1 });
+
+  it("writes into the region it was given", () => {
+    const wasm = memory();
+    const offset = 128;
+    const writer = WireWriter.withWasmRegion(offset, 24, () => wasm.buffer);
+
+    writer.writeF64(1.5);
+    writer.writeF64(-2.25);
+    writer.writeU64(7n);
+
+    const reader = new WireReader(wasm.buffer, offset, false, 24);
+    expect(reader.readF64()).toBe(1.5);
+    expect(reader.readF64()).toBe(-2.25);
+    expect(reader.readU64()).toBe(7n);
+  });
+
+  it("refuses to grow past the region", () => {
+    const wasm = memory();
+    const writer = WireWriter.withWasmRegion(0, 8, () => wasm.buffer);
+
+    writer.writeF64(1);
+    expect(() => writer.writeF64(2)).toThrow();
+  });
+
+  it("can be reset and written again", () => {
+    const wasm = memory();
+    const writer = WireWriter.withWasmRegion(64, 8, () => wasm.buffer);
+
+    writer.writeF64(3.5);
+    writer.reset();
+    writer.writeF64(9.25);
+
+    expect(new WireReader(wasm.buffer, 64, false, 8).readF64()).toBe(9.25);
+  });
+
+  it("shares one allocator across writers without crossing their regions", () => {
+    const wasm = memory();
+    const allocator = WireWriter.fixedRegionAllocator(() => wasm.buffer);
+    const first = WireWriter.withWasmRegion(0, 8, allocator.buffer, allocator);
+    const second = WireWriter.withWasmRegion(64, 8, allocator.buffer, allocator);
+
+    first.writeF64(1.5);
+    second.writeF64(2.5);
+
+    expect(new WireReader(wasm.buffer, 0, false, 8).readF64()).toBe(1.5);
+    expect(new WireReader(wasm.buffer, 64, false, 8).readF64()).toBe(2.5);
+  });
+});
+
+describe("local writer still grows", () => {
+  it("keeps earlier bytes when it reallocates", () => {
+    // The grow path reads the local buffer through the lazy accessor now.
+    const writer = new WireWriter(8);
+    for (let index = 0; index < 64; index++) {
+      writer.writeU32(index);
+    }
+
+    const bytes = writer.getBytes();
+    const reader = new WireReader(bytes.buffer as ArrayBuffer, bytes.byteOffset);
+    for (let index = 0; index < 64; index++) {
+      expect(reader.readU32()).toBe(index);
+    }
+  });
+});


### PR DESCRIPTION
A `WireWriter` bound to a caller-owned wasm region writes straight into that region and never reads its local buffer — but the constructor allocated one anyway, plus a `DataView` over it. Callback trampolines build one such writer per element, so every item crossing the boundary allocated and collected an `ArrayBuffer` and a `DataView` that were never touched.

## What the callback path was doing

The generated trampoline runs once per element:

```js
_callbackImports["…data_provider_get_item"] = (handle, resultPointer, index) => {
    const callback = _dataProviderRegistry.get(handle);
    const result = callback.getItem(index);
    const resultWriter = _module.writerFromMemory(resultPointer, 24);   // per element
    DataPointCodec.encode(resultWriter, result);
};
```

`writerFromMemory` reached `WireWriter.withWasmRegion`, which allocated the writer, its unused local `ArrayBuffer` and `DataView`, and an allocator object holding four closures — about six allocations to write 24 bytes to a pointer Rust had already supplied.

## The change

- The local buffer and its view are allocated on first use. A region-bound writer never asks for them.
- `writerFromMemory` builds its allocator once and reuses it, rather than a fresh object per call.

Both are safe by construction — no shared mutable state, no lifetime to track. Pooling the writer itself would be worth more (see below) but `writerFromMemory` has no release point: the generated glue acquires a writer and never hands it back, so an in-use flag would latch. Not attempted.

`fixedRegionAllocator`'s `alloc` now throws rather than returning a pointer it cannot honour. It is unreachable on this path — only `free` and `realloc` are ever called on an already-pointed writer — and a silent wrong value would hide a mistake.

## Numbers

Per element on the fixed-region path, min of 9, measured against the built runtime on each side:

| | ns/element |
| --- | ---: |
| `main` | 722.5 |
| local buffer allocated on demand | 79.8 |
| + allocator built once | **61.9** |
| pooled writer, not implemented | 32.5 |

**Most of it is the `ArrayBuffer`, not the closures.** Sharing the allocator is worth about 18 ns of the 660; the rest is not allocating a backing store per element. That was not my first guess.

End to end, `benchmarks/harnesses/wasm-bench`, three runs:

| case | before | after | wasm-bindgen |
| --- | ---: | ---: | ---: |
| `callback_100` | 71.7 / 83.8 us | **9.7 / 9.7 / 12.1 us** | 22.2 / 23.6 / 39.5 us |
| `callback_1k` | 690 / 944 us | **100 / 104 / 223 us** | 210 / 216 / 301 us |

That moves both cases from roughly 3.5–4x slower than wasm-bindgen to about 2x faster. Retained heap on the same path measures 1.7 bytes per element afterwards.

This harness is noisy — the third run above is slower on both sides — so treat the ratios as the signal and the absolutes as indicative. The direction held in every run, and the per-element figure above was measured separately against each build.

## Testing

- Runtime suite 150 tests, `tsc --noEmit` clean. New `test/region-writer.test.ts` covers writing into the given region, refusing to grow past it, resetting and rewriting, and two writers sharing one allocator without crossing regions. It also pins that a local writer still preserves earlier bytes when it grows, since the grow path now reads the buffer through the lazy accessor.
- `examples/platforms/wasm` acceptance suite passes.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --all` clean.

The lazy accessor is the part worth reviewing: every read of `localBuffer`/`localView` now goes through it, and a path that reached either field directly would see `null`.
