### PR TITLE
Bug: `#[boltffi::default(Mode::Off)]` on a record field is rejected although docs list enum-variant defaults as supported

### DIFF
--- a/boltffi_backend/src/target/python/cpython/mod.rs
+++ b/boltffi_backend/src/target/python/cpython/mod.rs
@@ -1824,6 +1824,36 @@ Coordinates are plain `f64`.
     }
 
     #[test]
+    fn python_target_defines_enum_before_record_with_enum_variant_default() {
+        let output = target()
+            .render(&bindings(
+                r#"
+                #[repr(i32)]
+                #[data]
+                pub enum Mode {
+                    Off = 0,
+                    On = 1,
+                }
+
+                #[data]
+                pub struct Config {
+                    #[boltffi::default(Mode::Off)]
+                    pub mode: Mode,
+                }
+                "#,
+            ))
+            .expect("Python target should render enum record defaults");
+        let init = file(&output, "demo/__init__.py");
+        let stub = file(&output, "demo/__init__.pyi");
+        let enumeration = init.find("class Mode(IntEnum):").expect("Mode declaration");
+        let record = init.find("class Config:").expect("Config declaration");
+
+        assert!(enumeration < record);
+        assert!(init.contains("mode: Mode = Mode.OFF"));
+        assert!(stub.contains("mode: Mode = Mode.OFF"));
+    }
+
+    #[test]
     fn python_target_renders_empty_encoded_record_without_zero_length_array() {
         let output = target()
             .render(&bindings(

--- a/boltffi_backend/templates/target/python/package.py
+++ b/boltffi_backend/templates/target/python/package.py
@@ -482,6 +482,141 @@ def {{ encoder.name() }}({{ encoder.argument() }}) -> bytes:
 _native._register_wire_codec({{ encoder.key() }}, {{ encoder.name() }})
 
 {% endfor %}
+{% for enumeration in enums %}
+{%- if let Some(wire) = enumeration.wire %}
+class {{ enumeration.class_name }}:
+{{- enumeration.documentation.docstring("    ") }}
+    __slots__ = ()
+
+    @classmethod
+    def _boltffi_from_wire(cls, data: bytes) -> "{{ enumeration.class_name }}":
+        reader = _BoltFfiWireReader(data)
+        try:
+            value = cls._boltffi_from_reader(reader)
+        except struct.error as error:
+            raise ValueError("truncated BoltFFI wire bytes") from error
+        reader.finish()
+        return value
+
+    @classmethod
+    def _boltffi_from_reader(cls, reader: "_BoltFfiWireReader") -> "{{ enumeration.class_name }}":
+        tag = reader.u32()
+{%- for variant in wire.variants %}
+        if tag == {{ variant.tag }}:
+            return {{ variant.class_name }}._boltffi_from_reader_payload(reader)
+{%- endfor %}
+        raise ValueError("invalid {{ enumeration.class_name }} tag")
+{%- for constructor in enumeration.constructors %}
+
+    @classmethod
+    {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ enumeration.class_name }}":
+{{- constructor.documentation.docstring("        ") }}
+{%- for line in constructor.body %}
+        {{ line }}
+{%- endfor %}
+{%- endfor %}
+{%- for method in enumeration.static_methods %}
+
+    @staticmethod
+    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("        ") }}
+{%- for line in method.body %}
+        {{ line }}
+{%- endfor %}
+{%- endfor %}
+{%- for method in enumeration.instance_methods %}
+
+    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("        ") }}
+{%- for line in method.body %}
+        {{ line }}
+{%- endfor %}
+{%- endfor %}
+
+{% for variant in wire.variants %}
+@dataclass(frozen=True, slots=True)
+class {{ variant.class_name }}({{ enumeration.class_name }}):
+{{- variant.documentation.docstring("    ") }}
+{%- if variant.has_fields() %}
+{%- for field in variant.fields %}
+    {{ field.name }}: {{ field.annotation }}{% if let Some(default) = field.default %} = {{ default }}{% endif %}
+{{- field.documentation.docstring("    ") }}
+{%- endfor %}
+{%- else %}
+    pass
+{%- endif %}
+
+    def _boltffi_wire(self) -> bytes:
+{%- if variant.has_fields() %}
+        return _boltffi_wire_u32({{ variant.tag }}) + b"".join((
+{%- for field in variant.wire_fields %}
+            {{ field.encode }},
+{%- endfor %}
+        ))
+{%- else %}
+        return _boltffi_wire_u32({{ variant.tag }})
+{%- endif %}
+
+    @classmethod
+    def _boltffi_from_reader_payload(cls, reader: "_BoltFfiWireReader") -> "{{ variant.class_name }}":
+{%- if variant.has_fields() %}
+        return cls(
+{%- for field in variant.wire_fields %}
+            {{ field.name }}={{ field.decode }},
+{%- endfor %}
+        )
+{%- else %}
+        return cls()
+{%- endif %}
+
+{% endfor %}
+{%- else %}
+class {{ enumeration.class_name }}(IntEnum):
+{{- enumeration.documentation.docstring("    ") }}
+{%- for variant in enumeration.variants %}
+    {{ variant.name }} = {{ variant.value }}
+{%- endfor %}
+{%- for constructor in enumeration.constructors %}
+
+    @classmethod
+    {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ enumeration.class_name }}":
+{{- constructor.documentation.docstring("        ") }}
+{%- for line in constructor.body %}
+        {{ line }}
+{%- endfor %}
+{%- endfor %}
+{%- for method in enumeration.static_methods %}
+
+    @staticmethod
+    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("        ") }}
+{%- for line in method.body %}
+        {{ line }}
+{%- endfor %}
+{%- endfor %}
+{%- for method in enumeration.instance_methods %}
+
+    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("        ") }}
+{%- for line in method.body %}
+        {{ line }}
+{%- endfor %}
+{%- endfor %}
+
+{%- endif %}
+
+_native.{{ enumeration.register_method }}({{ enumeration.class_name }})
+{% if let Some(exception_name) = enumeration.exception_name %}
+
+class {{ exception_name }}(RuntimeError):
+    __slots__ = ("error",)
+
+    def __init__(self, error: {{ enumeration.class_name }}) -> None:
+        self.error = error
+        super().__init__(error)
+{% endif %}
+
+{% endfor %}
 {% for record in records %}
 {%- match record.wire %}
 {%- when RecordWire::Fixed(fixed) %}
@@ -621,141 +756,6 @@ class {{ exception_name }}(RuntimeError):
     __slots__ = ("error",)
 
     def __init__(self, error: {{ record.class_name }}) -> None:
-        self.error = error
-        super().__init__(error)
-{% endif %}
-
-{% endfor %}
-{% for enumeration in enums %}
-{%- if let Some(wire) = enumeration.wire %}
-class {{ enumeration.class_name }}:
-{{- enumeration.documentation.docstring("    ") }}
-    __slots__ = ()
-
-    @classmethod
-    def _boltffi_from_wire(cls, data: bytes) -> "{{ enumeration.class_name }}":
-        reader = _BoltFfiWireReader(data)
-        try:
-            value = cls._boltffi_from_reader(reader)
-        except struct.error as error:
-            raise ValueError("truncated BoltFFI wire bytes") from error
-        reader.finish()
-        return value
-
-    @classmethod
-    def _boltffi_from_reader(cls, reader: "_BoltFfiWireReader") -> "{{ enumeration.class_name }}":
-        tag = reader.u32()
-{%- for variant in wire.variants %}
-        if tag == {{ variant.tag }}:
-            return {{ variant.class_name }}._boltffi_from_reader_payload(reader)
-{%- endfor %}
-        raise ValueError("invalid {{ enumeration.class_name }} tag")
-{%- for constructor in enumeration.constructors %}
-
-    @classmethod
-    {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ enumeration.class_name }}":
-{{- constructor.documentation.docstring("        ") }}
-{%- for line in constructor.body %}
-        {{ line }}
-{%- endfor %}
-{%- endfor %}
-{%- for method in enumeration.static_methods %}
-
-    @staticmethod
-    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:
-{{- method.documentation.docstring("        ") }}
-{%- for line in method.body %}
-        {{ line }}
-{%- endfor %}
-{%- endfor %}
-{%- for method in enumeration.instance_methods %}
-
-    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:
-{{- method.documentation.docstring("        ") }}
-{%- for line in method.body %}
-        {{ line }}
-{%- endfor %}
-{%- endfor %}
-
-{% for variant in wire.variants %}
-@dataclass(frozen=True, slots=True)
-class {{ variant.class_name }}({{ enumeration.class_name }}):
-{{- variant.documentation.docstring("    ") }}
-{%- if variant.has_fields() %}
-{%- for field in variant.fields %}
-    {{ field.name }}: {{ field.annotation }}{% if let Some(default) = field.default %} = {{ default }}{% endif %}
-{{- field.documentation.docstring("    ") }}
-{%- endfor %}
-{%- else %}
-    pass
-{%- endif %}
-
-    def _boltffi_wire(self) -> bytes:
-{%- if variant.has_fields() %}
-        return _boltffi_wire_u32({{ variant.tag }}) + b"".join((
-{%- for field in variant.wire_fields %}
-            {{ field.encode }},
-{%- endfor %}
-        ))
-{%- else %}
-        return _boltffi_wire_u32({{ variant.tag }})
-{%- endif %}
-
-    @classmethod
-    def _boltffi_from_reader_payload(cls, reader: "_BoltFfiWireReader") -> "{{ variant.class_name }}":
-{%- if variant.has_fields() %}
-        return cls(
-{%- for field in variant.wire_fields %}
-            {{ field.name }}={{ field.decode }},
-{%- endfor %}
-        )
-{%- else %}
-        return cls()
-{%- endif %}
-
-{% endfor %}
-{%- else %}
-class {{ enumeration.class_name }}(IntEnum):
-{{- enumeration.documentation.docstring("    ") }}
-{%- for variant in enumeration.variants %}
-    {{ variant.name }} = {{ variant.value }}
-{%- endfor %}
-{%- for constructor in enumeration.constructors %}
-
-    @classmethod
-    {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ enumeration.class_name }}":
-{{- constructor.documentation.docstring("        ") }}
-{%- for line in constructor.body %}
-        {{ line }}
-{%- endfor %}
-{%- endfor %}
-{%- for method in enumeration.static_methods %}
-
-    @staticmethod
-    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:
-{{- method.documentation.docstring("        ") }}
-{%- for line in method.body %}
-        {{ line }}
-{%- endfor %}
-{%- endfor %}
-{%- for method in enumeration.instance_methods %}
-
-    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:
-{{- method.documentation.docstring("        ") }}
-{%- for line in method.body %}
-        {{ line }}
-{%- endfor %}
-{%- endfor %}
-
-{%- endif %}
-
-_native.{{ enumeration.register_method }}({{ enumeration.class_name }})
-{% if let Some(exception_name) = enumeration.exception_name %}
-
-class {{ exception_name }}(RuntimeError):
-    __slots__ = ("error",)
-
-    def __init__(self, error: {{ enumeration.class_name }}) -> None:
         self.error = error
         super().__init__(error)
 {% endif %}

--- a/boltffi_binding/src/lower/callable/params.rs
+++ b/boltffi_binding/src/lower/callable/params.rs
@@ -64,7 +64,11 @@ where
     let type_expr = substitute_self_type(owner, &parameter.type_expr)?;
     let receive = receive_for_passing(parameter.passing);
     let canonical_name = CanonicalName::from(&parameter.name);
-    let meta = metadata::element_meta(parameter.doc.as_ref(), None, parameter.default.as_ref())?;
+    let meta = metadata::element_meta(
+        parameter.doc.as_ref(),
+        None,
+        metadata::default_value(parameter.default.as_ref())?,
+    );
     if let Some(closure) = ClosureSource::from_type_expr(&type_expr) {
         if !matches!(receive, Receive::ByValue) {
             return Err(LowerError::unsupported_type(

--- a/boltffi_binding/src/lower/constants.rs
+++ b/boltffi_binding/src/lower/constants.rs
@@ -203,9 +203,21 @@ fn enum_variant_from_path(
     if !enum_qualifier_matches(enumeration, qualifier) && !associated_self {
         return None;
     }
+    unit_variant_default(enumeration, variant_segment.name.as_str())
+}
+
+pub fn enum_variant_default(enumeration: &SourceEnum, path: &SourcePath) -> Option<DefaultValue> {
+    let (variant_segment, qualifier) = path.segments.split_last()?;
+    if !enum_qualifier_matches(enumeration, qualifier) {
+        return None;
+    }
+    unit_variant_default(enumeration, variant_segment.name.as_str())
+}
+
+fn unit_variant_default(enumeration: &SourceEnum, variant_segment: &str) -> Option<DefaultValue> {
     let variant = enumeration.variants.iter().find(|variant| {
         matches!(variant.payload, VariantPayload::Unit)
-            && canonical_name_matches_segment(&variant.name, variant_segment.name.as_str())
+            && canonical_name_matches_segment(&variant.name, variant_segment)
     })?;
     Some(DefaultValue::EnumVariant {
         enum_name: CanonicalName::from(&enumeration.name),

--- a/boltffi_binding/src/lower/enums.rs
+++ b/boltffi_binding/src/lower/enums.rs
@@ -86,7 +86,7 @@ fn lower_c_style<S: SurfaceLower>(
                 Ok(CStyleVariantDecl::new(
                     CanonicalName::from(&variant.name),
                     IntegerValue::new(discriminant),
-                    metadata::element_meta(variant.doc.as_ref(), None, None)?,
+                    metadata::element_meta(variant.doc.as_ref(), None, None),
                 ))
             })
             .collect::<Result<Vec<_>, LowerError>>()?,
@@ -136,7 +136,7 @@ fn lower_variant(
         CanonicalName::from(&variant.name),
         VariantTag::from_index(variant_index).ok_or_else(LowerError::variant_tag_overflow)?,
         lower_payload(index, ids, &variant.payload)?,
-        metadata::element_meta(variant.doc.as_ref(), None, None)?,
+        metadata::element_meta(variant.doc.as_ref(), None, None),
     ))
 }
 
@@ -171,7 +171,11 @@ fn lower_payload(
                     key,
                     ty,
                     codec,
-                    metadata::element_meta(field.doc.as_ref(), None, field.default.as_ref())?,
+                    metadata::element_meta(
+                        field.doc.as_ref(),
+                        None,
+                        metadata::default_value(field.default.as_ref())?,
+                    ),
                 ))
             })
             .collect::<Result<Vec<_>, LowerError>>()

--- a/boltffi_binding/src/lower/metadata.rs
+++ b/boltffi_binding/src/lower/metadata.rs
@@ -1,13 +1,13 @@
 use boltffi_ast::{
     DefaultValue as SourceDefaultValue, DeprecationInfo as SourceDeprecationInfo,
-    DocComment as SourceDocComment, FloatLiteral as SourceFloatLiteral,
+    DocComment as SourceDocComment, FloatLiteral as SourceFloatLiteral, TypeExpr,
 };
 
 use crate::{
     DeclMeta, DefaultValue, DeprecationInfo, DocComment, ElementMeta, FloatValue, IntegerValue,
 };
 
-use super::{LowerError, error::UnsupportedType};
+use super::{LowerError, constants, error::UnsupportedType, index::Index};
 
 pub fn decl_meta(
     doc: Option<&SourceDocComment>,
@@ -19,13 +19,38 @@ pub fn decl_meta(
 pub fn element_meta(
     doc: Option<&SourceDocComment>,
     deprecated: Option<&SourceDeprecationInfo>,
-    default: Option<&SourceDefaultValue>,
-) -> Result<ElementMeta, LowerError> {
-    Ok(ElementMeta::new(
+    default: Option<DefaultValue>,
+) -> ElementMeta {
+    ElementMeta::new(
         doc.map(DocComment::from),
         deprecated.map(Into::into),
-        default.map(DefaultValue::try_from).transpose()?,
-    ))
+        default,
+    )
+}
+
+pub fn default_value(
+    default: Option<&SourceDefaultValue>,
+) -> Result<Option<DefaultValue>, LowerError> {
+    default.map(DefaultValue::try_from).transpose()
+}
+
+pub fn default_value_for_type(
+    index: &Index,
+    type_expr: &TypeExpr,
+    default: Option<&SourceDefaultValue>,
+) -> Result<Option<DefaultValue>, LowerError> {
+    default
+        .map(|default| match (type_expr, default) {
+            (TypeExpr::Enum { id, .. }, SourceDefaultValue::Path(path)) => index
+                .enumeration(id)
+                .and_then(|enumeration| constants::enum_variant_default(enumeration, path))
+                .ok_or_else(|| LowerError::unsupported_type(UnsupportedType::DefaultValue)),
+            (_, SourceDefaultValue::Path(_)) => {
+                Err(LowerError::unsupported_type(UnsupportedType::DefaultValue))
+            }
+            (_, default) => DefaultValue::try_from(default),
+        })
+        .transpose()
 }
 
 impl From<&SourceDocComment> for DocComment {

--- a/boltffi_binding/src/lower/records.rs
+++ b/boltffi_binding/src/lower/records.rs
@@ -82,7 +82,11 @@ fn lower_direct<S: SurfaceLower>(
                 FieldKey::from(field),
                 primitive::direct_field_type(&field.type_expr)
                     .ok_or_else(|| LowerError::unsupported_type(UnsupportedType::RecordField))?,
-                metadata::element_meta(field.doc.as_ref(), None, field.default.as_ref())?,
+                metadata::element_meta(
+                    field.doc.as_ref(),
+                    None,
+                    metadata::default_value(field.default.as_ref())?,
+                ),
             ))
         })
         .collect::<Result<Vec<_>, LowerError>>()?;
@@ -117,7 +121,15 @@ fn lower_encoded<S: SurfaceLower>(
                 key,
                 ty,
                 codec,
-                metadata::element_meta(field.doc.as_ref(), None, field.default.as_ref())?,
+                metadata::element_meta(
+                    field.doc.as_ref(),
+                    None,
+                    metadata::default_value_for_type(
+                        index,
+                        &field.type_expr,
+                        field.default.as_ref(),
+                    )?,
+                ),
             ))
         })
         .collect::<Result<Vec<_>, LowerError>>()?;
@@ -148,8 +160,8 @@ mod tests {
         DeprecationInfo as SourceDeprecationInfo, DocComment as SourceDocComment, EnumDef,
         ExecutionKind, FieldDef, FnSig, FnTrait, FnTraitKind, IntegerLiteral, MapKind, MethodDef,
         MethodId as SourceMethodId, PackageInfo as SourcePackage, ParameterDef, ParameterPassing,
-        Path as SourcePath, Primitive, Receiver, RecordDef, ReprAttr, ReprItem, ReturnDef, Source,
-        SourceContract, TypeExpr, VariantDef, VariantPayload,
+        Path as SourcePath, PathRoot, PathSegment, Primitive, Receiver, RecordDef, ReprAttr,
+        ReprItem, ReturnDef, Source, SourceContract, TypeExpr, VariantDef, VariantPayload,
     };
 
     use crate::lower::lower;
@@ -2267,6 +2279,32 @@ mod tests {
         assert!(matches!(
             error.kind(),
             LowerErrorKind::UnsupportedType(UnsupportedType::DefaultValue)
+        ));
+    }
+
+    #[test]
+    fn enum_variant_record_field_default_lowers_against_its_declared_type() {
+        let mut mode = EnumDef::new("demo::Mode".into(), name("Mode"));
+        mode.variants = vec![VariantDef::unit(name("Off")), VariantDef::unit(name("On"))];
+        let mut mode_field = field("mode", enum_type("demo::Mode", "Mode"));
+        mode_field.default = Some(SourceDefaultValue::Path(SourcePath::new(
+            PathRoot::Relative,
+            vec![PathSegment::new("Mode"), PathSegment::new("Off")],
+        )));
+
+        let bindings = lower_contract::<Native>(
+            vec![record("demo::Config", "Config", vec![mode_field])],
+            vec![mode],
+        );
+        let default = encoded_record(&bindings).fields()[0].meta().default();
+
+        assert!(matches!(
+            default,
+            Some(DefaultValue::EnumVariant {
+                enum_name,
+                variant_name,
+            }) if enum_name == &CanonicalName::single("Mode")
+                && variant_name == &CanonicalName::single("Off")
         ));
     }
 


### PR DESCRIPTION
Fixes lowering of enum-variant defaults on record fields, and emits Python enums before records so the generated defaults resolve.