### PR TITLE
Request: publish aarch64 Linux CLI binaries (PR attached)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,14 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             artifact: boltffi-linux-x86_64-musl
+            musl_linker: CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            artifact: boltffi-linux-aarch64
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            artifact: boltffi-linux-aarch64-musl
+            musl_linker: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact: boltffi-darwin-x86_64
@@ -141,12 +149,12 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Install musl-tools
-        if: matrix.target == 'x86_64-unknown-linux-musl'
+        if: matrix.musl_linker
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Configure musl linker
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> "$GITHUB_ENV"
+        if: matrix.musl_linker
+        run: echo "${{ matrix.musl_linker }}=musl-gcc" >> "$GITHUB_ENV"
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -28,6 +28,8 @@ Each [GitHub release](https://github.com/boltffi/boltffi/releases) includes a CL
 | --- | --- | --- |
 | Linux x86_64 | `boltffi-linux-x86_64.tar.gz` | `boltffi-linux-x86_64.tar.gz.sha256` |
 | Linux x86_64 (musl) | `boltffi-linux-x86_64-musl.tar.gz` | `boltffi-linux-x86_64-musl.tar.gz.sha256` |
+| Linux ARM64 | `boltffi-linux-aarch64.tar.gz` | `boltffi-linux-aarch64.tar.gz.sha256` |
+| Linux ARM64 (musl) | `boltffi-linux-aarch64-musl.tar.gz` | `boltffi-linux-aarch64-musl.tar.gz.sha256` |
 | macOS x86_64 | `boltffi-darwin-x86_64.tar.gz` | `boltffi-darwin-x86_64.tar.gz.sha256` |
 | macOS ARM64 | `boltffi-darwin-aarch64.tar.gz` | `boltffi-darwin-aarch64.tar.gz.sha256` |
 | Windows x86_64 | `boltffi-windows-x86_64.zip` | `boltffi-windows-x86_64.zip.sha256` |


### PR DESCRIPTION
Adds aarch64 Linux (gnu + musl) CLI binaries to the release workflow.