### PR TITLE
Bug: every C-native record type raises `DeprecationWarning: builtin type X has no __module__ attribute` on import

### DIFF
--- a/boltffi_backend/src/target/python/cpython/mod.rs
+++ b/boltffi_backend/src/target/python/cpython/mod.rs
@@ -647,6 +647,8 @@ mod tests {
         assert!(extension.contains("} boltffi_python_point_object;"));
         assert!(extension.contains("static PyObject *boltffi_python_point_new(PyTypeObject *cls"));
         assert!(extension.contains("static int boltffi_python_setup_point_type(PyObject *module)"));
+        assert!(extension.contains("\"_native.Point\","));
+        assert!(!extension.contains("\n    \"Point\","));
         assert!(extension.contains(
             "boltffi_python_point_type = PyType_FromSpec(&boltffi_python_point_type_spec);"
         ));
@@ -666,6 +668,7 @@ mod tests {
         assert!(!extension.contains("_register_point"));
         assert!(extension.contains("Py_CLEAR(boltffi_python_point_type);"));
         assert!(init.contains("Point = _native.Point"));
+        assert!(init.contains("Point.__module__ = __name__"));
         assert!(init.contains("Point.__match_args__ = (\"x\",\"y\",)"));
         assert!(init.contains("Point.__annotations__ = {\"x\": float, \"y\": float}"));
         assert!(!init.contains("_native._register_point(Point)"));

--- a/boltffi_backend/src/target/python/cpython/render/record.rs
+++ b/boltffi_backend/src/target/python/cpython/render/record.rs
@@ -24,6 +24,7 @@ use crate::{
 #[derive(AskamaTemplate)]
 #[template(path = "target/python/record.c", escape = "none")]
 struct DirectTemplate {
+    module_name: String,
     class_name: PythonIdentifier,
     c_type: TypeFragment,
     type_object: Identifier,
@@ -73,12 +74,17 @@ impl Record {
     pub fn render(self) -> Result<Emitted> {
         let symbols = self.symbols;
         let source = match self.shape {
-            Shape::Direct { fields, .. } => {
+            Shape::Direct {
+                fields,
+                module_name,
+                ..
+            } => {
                 let c_type = symbols.c_type()?.clone();
                 let object_struct = symbols.object_struct()?;
                 let prefix = symbols.prefix()?;
                 let type_setup = symbols.type_setup()?;
                 DirectTemplate {
+                    module_name,
                     class_name: symbols.class_name,
                     c_type,
                     type_object: symbols.type_object,
@@ -235,7 +241,11 @@ impl Record {
         let callables = Self::direct_callables(record, &symbols, bridge, context)?;
         Ok(Self {
             symbols,
-            shape: Shape::Direct { primitives, fields },
+            shape: Shape::Direct {
+                primitives,
+                fields,
+                module_name: bridge.module().as_str().to_owned(),
+            },
             method: None,
             callables,
         })
@@ -485,6 +495,7 @@ enum Shape {
     Direct {
         fields: Vec<Field>,
         primitives: Vec<primitive::Runtime>,
+        module_name: String,
     },
     Encoded {
         codec: EncodedCodec,

--- a/boltffi_backend/templates/target/python/record.c
+++ b/boltffi_backend/templates/target/python/record.c
@@ -181,7 +181,7 @@ static PyType_Slot {{ prefix }}_type_slots[] = {
 };
 
 static PyType_Spec {{ prefix }}_type_spec = {
-    "{{ class_name }}",
+    "{{ module_name }}.{{ class_name }}",
     sizeof({{ object_struct }}),
     0,
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,


### PR DESCRIPTION
Fixes the un-dotted `PyType_Spec` name in the direct-record C template, which caused `PyType_FromSpec` to raise a `DeprecationWarning` per C-native record class on every import of the generated Python package.