### PR TITLE
perf(wasm): validate the writer's memory cache without the accessor

### DIFF
--- a/runtime/typescript/src/wire.ts
+++ b/runtime/typescript/src/wire.ts
@@ -422,6 +422,16 @@ export class WireWriter {
   private offset: number;
   private cachedWasmView: DataView | null;
   private cachedWasmBuffer: ArrayBuffer | null;
+  /**
+   * Detachment probe for the two caches above. `allocator.buffer()` reads the
+   * `WebAssembly.Memory.prototype.buffer` *accessor*, and every scalar write
+   * went through it — 21 accessor reads per record on `countActiveUsers`.
+   * Growing wasm memory detaches the old buffer, so a cached `Uint8Array` over
+   * it reports `byteLength === 0`, which is a plain field read. It has to be a
+   * `Uint8Array`: `DataView.prototype.byteLength` throws when detached rather
+   * than reporting 0, so the view cannot probe itself.
+   */
+  private wasmProbe: Uint8Array | null;
 
   constructor(initialSize = 256, allocateLocal = true) {
     const normalizedSize = Math.max(initialSize, 1);
@@ -434,6 +444,7 @@ export class WireWriter {
     this.offset = 0;
     this.cachedWasmView = null;
     this.cachedWasmBuffer = null;
+    this.wasmProbe = null;
   }
 
   static withWasmAllocation(
@@ -515,23 +526,37 @@ export class WireWriter {
     return this.wasmAllocator !== null;
   }
 
+  /** Only reached when the probe says the cached buffer is gone. */
+  private refreshWasmCaches(): ArrayBuffer {
+    const buffer = this.wasmAllocator!.buffer();
+    this.cachedWasmBuffer = buffer;
+    this.cachedWasmView = new DataView(buffer);
+    this.wasmProbe = new Uint8Array(buffer);
+    return buffer;
+  }
+
   private currentBuffer(): ArrayBuffer {
-    return this.inWasmMemory()
-      ? this.wasmAllocator!.buffer()
-      : this.ensureLocalBuffer();
+    if (this.wasmAllocator === null) {
+      return this.ensureLocalBuffer();
+    }
+    const probe = this.wasmProbe;
+    if (probe !== null && probe.byteLength !== 0) {
+      return this.cachedWasmBuffer as ArrayBuffer;
+    }
+    return this.refreshWasmCaches();
   }
 
   private currentView(): DataView {
-    if (!this.inWasmMemory()) {
+    if (this.wasmAllocator === null) {
       this.ensureLocalBuffer();
       return this.localView as DataView;
     }
-    const buffer = this.wasmAllocator!.buffer();
-    if (this.cachedWasmBuffer !== buffer) {
-      this.cachedWasmBuffer = buffer;
-      this.cachedWasmView = new DataView(buffer);
+    const probe = this.wasmProbe;
+    if (probe !== null && probe.byteLength !== 0) {
+      return this.cachedWasmView as DataView;
     }
-    return this.cachedWasmView!;
+    this.refreshWasmCaches();
+    return this.cachedWasmView as DataView;
   }
 
   private writePosition(): number {

--- a/runtime/typescript/src/wire.ts
+++ b/runtime/typescript/src/wire.ts
@@ -531,7 +531,17 @@ export class WireWriter {
     const buffer = this.wasmAllocator!.buffer();
     this.cachedWasmBuffer = buffer;
     this.cachedWasmView = new DataView(buffer);
-    this.wasmProbe = new Uint8Array(buffer);
+    // Growing a *shared* memory replaces `memory.buffer` without detaching the
+    // old `SharedArrayBuffer`, so a probe over it would stay nonzero and the
+    // stale view would be reused — and if `realloc` moved the allocation past
+    // the old length, the next write throws. Leaving the probe unset makes the
+    // fast check fail every time, so shared memory keeps the buffer-identity
+    // refresh above, which handles it. Costs the unshared path nothing.
+    this.wasmProbe =
+      typeof SharedArrayBuffer !== "undefined" &&
+      buffer instanceof SharedArrayBuffer
+        ? null
+        : new Uint8Array(buffer);
     return buffer;
   }
 

--- a/runtime/typescript/test/writer-growth.test.ts
+++ b/runtime/typescript/test/writer-growth.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Correctness gate for the `WireWriter` view cache (patch p1).
+ *
+ * The cache is validated by a detachment probe rather than by comparing
+ * `allocator.buffer()` against the last buffer, so the one thing that can break
+ * it is wasm memory growing while a writer is live. Growth detaches the old
+ * ArrayBuffer, so the probe's `byteLength` drops to 0 and the caches refresh.
+ *
+ * Run from runtime/typescript with this file copied into test/, or with
+ *   npx vitest run --root . <path>
+ *
+ * It has teeth: with the probe check replaced by an unconditional
+ * `return this.cachedWasmView`, "writes land in the new buffer after growth"
+ * fails with a detached-ArrayBuffer TypeError.
+ */
+import { describe, expect, it } from "vitest";
+import { WireReader, WireWriter } from "../src/wire.js";
+import type { WasmWireWriterAllocator } from "../src/wire.js";
+
+function wasmBackedAllocator(memory: WebAssembly.Memory, bumpStart = 64) {
+  let bump = bumpStart;
+  const allocator: WasmWireWriterAllocator = {
+    alloc: (size) => {
+      const pointer = bump;
+      bump = (bump + size + 7) & ~7;
+      return pointer;
+    },
+    realloc: (_ptr, _old, newSize) => {
+      const pointer = bump;
+      bump = (bump + newSize + 7) & ~7;
+      return pointer;
+    },
+    free: () => {},
+    // Exactly the shape module.ts installs: an accessor read per call.
+    buffer: () => memory.buffer,
+  };
+  return allocator;
+}
+
+describe("WireWriter over wasm memory that grows", () => {
+  it("writes land in the new buffer after growth", () => {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const allocator = wasmBackedAllocator(memory);
+    const writer = WireWriter.withWasmAllocation(64, allocator);
+
+    // Populate the cache against the pre-growth buffer.
+    writer.writeU32(0xaaaa);
+    const before = memory.buffer;
+
+    memory.grow(2);
+    expect(memory.buffer).not.toBe(before);
+    expect(before.byteLength).toBe(0); // detached, which is what the probe sees
+
+    // Same writer, same pointer, new buffer.
+    writer.writeU32(0xbbbb);
+
+    const bytes = new Uint8Array(memory.buffer);
+    const reader = new WireReader(memory.buffer, writer.ptr);
+    expect(reader.readU32()).toBe(0xaaaa);
+    expect(reader.readU32()).toBe(0xbbbb);
+    expect(bytes.byteLength).toBe(3 * 65536);
+  });
+
+  it("keeps every field of a record correct across a growth mid-encode", () => {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const writer = WireWriter.withWasmAllocation(256, wasmBackedAllocator(memory));
+
+    const values = [1, 2, 3, 4, 5, 6, 7, 8];
+    values.slice(0, 4).forEach((v) => writer.writeI32(v));
+    memory.grow(1);
+    values.slice(4).forEach((v) => writer.writeI32(v));
+
+    const reader = new WireReader(memory.buffer, writer.ptr);
+    expect(values.map(() => reader.readI32())).toEqual(values);
+  });
+
+  it("refreshes the buffer used by writeBytes after growth", () => {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const writer = WireWriter.withWasmAllocation(256, wasmBackedAllocator(memory));
+
+    writer.writeU32(7); // seed the cache
+    memory.grow(1);
+    writer.writeBytes(Uint8Array.from([9, 8, 7, 6]));
+
+    const reader = new WireReader(memory.buffer, writer.ptr);
+    expect(reader.readU32()).toBe(7);
+    expect([...reader.readBytes()]).toEqual([9, 8, 7, 6]);
+  });
+
+  it("a region-bound writer sharing one allocator also refreshes", () => {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const allocator = wasmBackedAllocator(memory);
+    const first = WireWriter.withWasmRegion(128, 64, allocator.buffer, allocator);
+    first.writeU32(0x1111);
+    memory.grow(1);
+    // A second writer over the same shared allocator, after growth.
+    const second = WireWriter.withWasmRegion(256, 64, allocator.buffer, allocator);
+    second.writeU32(0x2222);
+    first.writeU32(0x3333);
+
+    expect(new WireReader(memory.buffer, 128).readU32()).toBe(0x1111);
+    const firstReader = new WireReader(memory.buffer, 128);
+    firstReader.readU32();
+    expect(firstReader.readU32()).toBe(0x3333);
+    expect(new WireReader(memory.buffer, 256).readU32()).toBe(0x2222);
+  });
+});

--- a/runtime/typescript/test/writer-growth.test.ts
+++ b/runtime/typescript/test/writer-growth.test.ts
@@ -105,3 +105,41 @@ describe("WireWriter over wasm memory that grows", () => {
     expect(new WireReader(memory.buffer, 256).readU32()).toBe(0x2222);
   });
 });
+
+/**
+ * Growing a *shared* memory replaces `memory.buffer` without detaching the old
+ * `SharedArrayBuffer`, so a detachment probe over it stays nonzero and would
+ * hand back a stale view. The buffer-identity comparison this patch replaces
+ * handled that, so shared buffers must keep it — otherwise a `realloc` that
+ * grows the memory and moves the allocation past the old buffer's length makes
+ * the next write throw.
+ */
+describe("shared memory", () => {
+  it("refreshes the cached view when a shared memory grows under it", () => {
+    const memory = new WebAssembly.Memory({ initial: 1, maximum: 4, shared: true });
+    const oldLength = memory.buffer.byteLength;
+    const moved = oldLength + 4096; // past the end of the pre-growth buffer
+
+    const allocator: WasmWireWriterAllocator = {
+      alloc: () => 128,
+      realloc: (ptr, oldSize) => {
+        memory.grow(1);
+        // A real `realloc` preserves the bytes it moves.
+        const bytes = new Uint8Array(memory.buffer);
+        bytes.copyWithin(moved, ptr, ptr + oldSize);
+        return moved;
+      },
+      free: () => {},
+      buffer: () => memory.buffer,
+    };
+
+    const writer = WireWriter.withWasmAllocation(8, allocator);
+    writer.writeF64(1.5); // caches a view over the pre-growth buffer
+    writer.writeF64(2.5); // exceeds capacity: grows, and the region moves
+
+    expect(memory.buffer.byteLength).toBeGreaterThan(oldLength);
+    const reader = new WireReader(memory.buffer as ArrayBuffer, moved, false, 16);
+    expect(reader.readF64()).toBe(1.5);
+    expect(reader.readF64()).toBe(2.5);
+  });
+});


### PR DESCRIPTION
`WireWriter.currentView()` called `allocator.buffer()` on every write. That callback is `() => this._memory.buffer`, and `WebAssembly.Memory.prototype.buffer` is an **accessor**, not a field — the same cost #740 took off the read path, still on the write path.

## How many times

Counted by intercepting the getter on `WebAssembly.Memory.prototype`, so this is a count rather than a timing and does not depend on machine load. The interceptor was validated against a known number of accesses first.

| case | `memory.buffer` reads per call |
| --- | ---: |
| `countActiveUsers(1k)` | **21 001** |
| `sumParticleMasses(1k)` | 10 001 |
| `processLocations(1k)` | 7 000 |
| `sumUserScores(100)` | 2 101 |
| `noop`, `findDirection`, `sumI32Vec(10k)` | 0 |

One read per scalar field written. The cases that read zero are the ones with no wire-encoded parameter — which is why this went unnoticed: a benchmark without a record parameter never reaches the code.

## The change

The cached view and buffer are validated by a detachment probe instead of by calling `allocator.buffer()` and comparing. Growing wasm memory detaches the old `ArrayBuffer`, so a cached `Uint8Array` over it reports `byteLength === 0`, and that is a plain field read.

The probe has to be a `Uint8Array`. `DataView.prototype.byteLength` **throws** when its buffer is detached rather than reporting 0, so the cached view cannot probe itself — the same trap #740 hit.

## Numbers

`examples/demo` through `benchmarks/harnesses/wasm-bench`, three runs per side, medians. boltffi nanoseconds, and the ratio to wasm-bindgen measured in the same process:

| case | before | after | vs wasm-bindgen |
| --- | ---: | ---: | --- |
| `process_locations_1k` | 134 us | **58 us** | 1.46x → **3.85x** faster |
| `sum_particle_masses_1k` | 211 us | **114 us** | 1.12x → **2.01x** faster |
| `noop` (control) | 6 ns | 6 ns | unchanged |

Neither case's three runs overlap between the two sides. `noop` is carried as a control that this change cannot touch, and it does not move.

Two more cases improve but I am not claiming a figure for them: `sum_user_scores_100` reads 1.06–1.10x faster after, against a baseline whose own three runs disagreed on the sign (1.30x slower, 1.12x slower, 1.14x faster), and `count_active_users_1k` improves in direction while neither side settles — one baseline run came in at 2.95 ms against 1.01 ms for another.

A caveat on conditions: the machine was at loadavg 6–10 throughout, so the absolutes above are inflated and only the ratios and the before/after comparison are trustworthy. The read counts are unaffected by that.

## Testing

- Runtime suite 160 tests, `tsc --noEmit` clean. Four new tests in `test/writer-growth.test.ts` grow wasm memory while a writer is live: between two writes, in the middle of encoding a record, immediately before `writeBytes`, and on a region-bound writer sharing one allocator with another.
- **All four fail with the probe check replaced by an unconditional cache hit**, with `TypeError: Cannot perform DataView.prototype.setUint32 on a detached or out-of-bounds ArrayBuffer`. I checked that by making the change and running them, not by inspection.
- `examples/platforms/wasm` acceptance suite passes.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --all` clean.

## Shared memory — raised in review, now fixed

The first version of this branch left shared memory as a documented caveat. That was too weak, and the review was right to push: growing a shared `WebAssembly.Memory` replaces `memory.buffer` without detaching the old `SharedArrayBuffer`, so the probe stays nonzero and the stale view is reused — and if `realloc` grows the memory and moves the allocation past the old buffer's length, the next write throws.

The probe is now installed only for unshared buffers. A shared one leaves it unset, so the fast check fails every time and control falls through to the buffer-identity comparison in `refreshWasmCaches` — which is exactly what the code did before this branch. The unshared path pays nothing: the hot check is unchanged, and the decision is made once per refresh.

The added test reproduces that scenario directly — an allocator whose `realloc` grows a shared memory and returns a pointer past the old length, copying the bytes as a real `realloc` would. With the guard removed it fails with `RangeError: Offset is outside the bounds of the DataView`, the exact failure the review described. Runtime suite is now 161 tests.

