### PR TITLE
perf(wasm): poll a future before registering it

### DIFF
--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -109,20 +109,27 @@ export class AsyncFutureManager {
       entry.resolve(handle);
     } else if (status < 0) {
       this.pendingFutures.delete(handle);
-      entry.reject(this.extractAsyncError(handle, status, entry));
+      entry.reject(
+        this.extractAsyncError(handle, status, entry.panicMessage, entry.free)
+      );
     }
   }
 
-  private extractAsyncError(handle: number, status: number, entry: PendingFuture): Error {
+  private extractAsyncError(
+    handle: number,
+    status: number,
+    panicMessage: (handle: number) => number,
+    free: (handle: number) => void
+  ): Error {
     if (status === WasmPollStatus.Panicked && this._module) {
-      const bufPtr = entry.panicMessage(handle);
+      const bufPtr = panicMessage(handle);
       const reader = this._module.readerFromBuf(bufPtr);
       const message = reader.readString();
       this._module.freeBuf(bufPtr);
-      entry.free(handle);
+      free(handle);
       return new BoltFFIPanicError(message);
     }
-    entry.free(handle);
+    free(handle);
     if (status === WasmPollStatus.Cancelled) {
       return new BoltFFICancelledError();
     }
@@ -135,17 +142,23 @@ export class AsyncFutureManager {
     panicMessage: (handle: number) => number,
     free: (handle: number) => void
   ): Promise<number> {
+    // Poll before registering. An async fn that never yields — the common
+    // case, and the whole of `async_add` — was paying a Map insert, a Map
+    // delete, a five-field entry object and a `new Promise` executor to
+    // discover on the very next line that it was already done. `wake()` only
+    // adds to a set and queues a microtask, so a wake raised from inside
+    // `pollSync` cannot observe the window where the entry is absent.
+    const status = pollSync(handle);
+    if (status === WasmPollStatus.Ready) {
+      return Promise.resolve(handle);
+    }
+    if (status < 0) {
+      return Promise.reject(
+        this.extractAsyncError(handle, status, panicMessage, free)
+      );
+    }
     return new Promise((resolve, reject) => {
       this.pendingFutures.set(handle, { resolve, reject, pollSync, panicMessage, free });
-
-      const status = pollSync(handle);
-      if (status === WasmPollStatus.Ready) {
-        this.pendingFutures.delete(handle);
-        resolve(handle);
-      } else if (status < 0) {
-        this.pendingFutures.delete(handle);
-        reject(this.extractAsyncError(handle, status, { resolve, reject, pollSync, panicMessage, free }));
-      }
     });
   }
 }


### PR DESCRIPTION
`pollAsync` registered a future before finding out whether there was anything to wait for. For an `async fn` that never yields — the common case, and the whole of `async_add` — it built a `new Promise` and its executor, a five-field entry object, did a `Map.set`, polled, got `Ready`, and did a `Map.delete`, all to learn on the very next line that the value was already there.

## The change

Poll first. Only build the promise and register the entry if the future is actually pending:

```ts
const status = pollSync(handle);
if (status === WasmPollStatus.Ready) return Promise.resolve(handle);
if (status < 0) return Promise.reject(this.extractAsyncError(handle, status, panicMessage, free));
// still pending — now it is worth a promise and a map entry
```

`extractAsyncError` took a whole `PendingFuture` only to read two of its fields, so it now takes those two callbacks directly and works before an entry exists.

## Why it is safe under a synchronous wake

The thing that could break is a wake raised from inside `pollSync`, while the entry is not yet in the map. It cannot bite, and all three links are in the code rather than assumed:

- `wake()` does `wokenHandles.add(handle)` and queues a microtask. It never touches `pendingFutures`.
- `drainWakes` therefore runs after `pollAsync` has returned, by which time the entry exists if the future was pending.
- `repollHandle` opens with `const entry = this.pendingFutures.get(handle); if (!entry) return;`. So a wake for a future that completed synchronously and was never registered is a no-op — which was already true before this change, since a wake could always arrive after an entry was deleted.

## Numbers

**The harness's own `async_add` reading is not usable.** Across three runs it reported wasm-bindgen at 6201 ns, then 370 ns, then 267 ns — the first is a warm-up artefact, and awaiting a promise puts microtask scheduling inside the sample in a way benchmark.js does not handle well.

So this is measured directly: both backends' real glue, timed back to back inside each repetition with the order flipped between repetitions, median of 11, three independent runs per side. A synchronous `echo_i32` is carried as a control the change cannot touch.

| | main | this branch |
| --- | ---: | ---: |
| `async_add` vs wasm-bindgen | 1.17x / 1.13x / 1.28x **slower** | **0.75x / 0.69x / 0.64x faster** |
| `echo_i32` control | 1.05x / 1.08x / 1.10x | 1.05x / 1.16x / 1.04x |

The two three-run sets do not overlap (1.13–1.28 against 0.64–0.75), and the control does not move.

Isolated component costs, for what the saving is made of: the `Map` set + delete + entry object measures 41 ns, and `new Promise(r => r(x))` against `Promise.resolve(x)` 13 ns. For reference, `await Promise.resolve()` alone is 68.6 ns on this machine, so a good part of what remains is the language, not the binding.

A caveat on conditions: loadavg was 11–13 throughout, so absolute figures are inflated and only the ratios and the before/after comparison should be read. Both backends were measured in the same process, which is what makes the ratio survive that.

## Testing

- Runtime suite 156 tests, `tsc --noEmit` clean. `runtime.test.ts > throws invalid argument from completion status` covers the error path this touches, and it still passes — worth noting because that test pins the wasm-side free as observable behaviour.
- `examples/platforms/wasm` acceptance suite passes.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --all` clean.

## Related, measured and not included

Reusing the async status cell instead of allocating and freeing one per completion looked like the obvious companion change. It is worth nothing — 0.98x / 0.98x / 0.95x on `async_add`, parity elsewhere, two wasm calls at roughly 11 ns each lost in the noise — and it breaks the completion-status test above, which pins that free as observable. Not pursued.
