### PR TITLE
perf(wasm): return the packed empty buffer as a constant

### DIFF
--- a/boltffi_core/src/types/buf.rs
+++ b/boltffi_core/src/types/buf.rs
@@ -145,10 +145,19 @@ pub extern "C" fn boltffi_buf_with_len(len: usize) -> FfiBuf {
 
 #[cfg(target_arch = "wasm32")]
 impl FfiBuf {
+    /// Packed form of an empty buffer.
+    ///
+    /// `into_packed` returns `0` whenever `len == 0`, and `FfiBuf::empty()` has
+    /// `len == 0`, so `FfiBuf::default().into_packed()` is always this value.
+    /// Error paths return the constant instead: `into_packed` is a real call in
+    /// the wasm module, so spelling it out made every argument-decode failure
+    /// site build an `FfiBuf` on the stack and call into it.
+    pub const EMPTY_PACKED: u64 = 0;
+
     pub fn into_packed(self) -> u64 {
         let len = self.len;
         if len == 0 {
-            return 0;
+            return Self::EMPTY_PACKED;
         }
         if self.cap == len && self.align == 1 {
             let ptr = self.ptr;
@@ -165,6 +174,16 @@ impl FfiBuf {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn an_empty_buffer_has_no_length() {
+        // `EMPTY_PACKED` is only correct because `into_packed` returns 0 for a
+        // zero length and an empty buffer has one. That second half is what
+        // this pins; the first is two visible lines in `into_packed`, and is
+        // `wasm32`-gated so it cannot be asserted from a host test.
+        assert_eq!(FfiBuf::empty().len, 0);
+        assert_eq!(FfiBuf::default().len, 0);
+    }
+
     use super::*;
 
     #[test]

--- a/boltffi_macros/src/experimental/expansion/mod.rs
+++ b/boltffi_macros/src/experimental/expansion/mod.rs
@@ -9116,7 +9116,7 @@ mod tests {
                 pub extern "C" fn boltffi_function_demo_try_ping() -> u64 {
                     match try_ping() {
                         Ok(()) => {
-                            ::boltffi::__private::FfiBuf::default().into_packed()
+                            ::boltffi::__private::FfiBuf::EMPTY_PACKED
                         }
                         Err(__boltffi_error) => {
                             ::boltffi::__private::FfiBuf::wire_encode_owned_string(__boltffi_error).into_packed()
@@ -9165,7 +9165,7 @@ mod tests {
                                     );
                                 }
                             }
-                            ::boltffi::__private::FfiBuf::default().into_packed()
+                            ::boltffi::__private::FfiBuf::EMPTY_PACKED
                         }
                         Err(__boltffi_error) => {
                             ::boltffi::__private::FfiBuf::wire_encode_owned_string(__boltffi_error).into_packed()

--- a/boltffi_macros/src/experimental/surface/buffer.rs
+++ b/boltffi_macros/src/experimental/surface/buffer.rs
@@ -61,7 +61,7 @@ impl ReturnCrossing {
     pub fn empty(self) -> TokenStream {
         match self {
             Self::Buffer => quote! { ::boltffi::__private::FfiBuf::default() },
-            Self::Packed => quote! { ::boltffi::__private::FfiBuf::default().into_packed() },
+            Self::Packed => quote! { ::boltffi::__private::FfiBuf::EMPTY_PACKED },
         }
     }
 }

--- a/boltffi_macros/src/experimental/wrapper/callback.rs
+++ b/boltffi_macros/src/experimental/wrapper/callback.rs
@@ -4414,7 +4414,7 @@ impl CallbackEncodedError {
     fn empty_value(&self) -> TokenStream {
         match self {
             Self::NativeBuffer => quote! { ::boltffi::__private::FfiBuf::default() },
-            Self::WasmPacked => quote! { ::boltffi::__private::FfiBuf::default().into_packed() },
+            Self::WasmPacked => quote! { ::boltffi::__private::FfiBuf::EMPTY_PACKED },
         }
     }
 

--- a/boltffi_macros/src/experimental/wrapper/closure.rs
+++ b/boltffi_macros/src/experimental/wrapper/closure.rs
@@ -880,7 +880,7 @@ impl InvokeReturn {
                 return ::boltffi::__private::FfiBuf::default();
             },
             InvokeReturnKind::WasmEncoded { .. } => quote! {
-                return ::boltffi::__private::FfiBuf::default().into_packed();
+                return ::boltffi::__private::FfiBuf::EMPTY_PACKED;
             },
             InvokeReturnKind::Fallible(fallible) => fallible.error.failure(),
         }

--- a/boltffi_macros/src/experimental/wrapper/returns/encoded.rs
+++ b/boltffi_macros/src/experimental/wrapper/returns/encoded.rs
@@ -171,7 +171,7 @@ impl Render<Wasm32, Empty<Wasm32>> for Renderer {
             wasm32::BufferShape::Packed => Ok(Tokens {
                 value_type: quote! { u64 },
                 return_type: quote! { -> u64 },
-                value: quote! { ::boltffi::__private::FfiBuf::default().into_packed() },
+                value: quote! { ::boltffi::__private::FfiBuf::EMPTY_PACKED },
             }),
             wasm32::BufferShape::Slice => {
                 Err(Error::UnsupportedExpansion("wasm encoded return shape"))

--- a/boltffi_macros/src/lowering/returns/lower.rs
+++ b/boltffi_macros/src/lowering/returns/lower.rs
@@ -52,7 +52,7 @@ impl ResolvedReturn {
                 ) => quote! {
                     #[cfg(target_arch = "wasm32")]
                     {
-                        return ::boltffi::__private::FfiBuf::default().into_packed();
+                        return ::boltffi::__private::FfiBuf::EMPTY_PACKED;
                     }
                     #[cfg(not(target_arch = "wasm32"))]
                     {
@@ -91,7 +91,7 @@ impl ResolvedReturn {
                 ReturnPlatform::Wasm,
             ) {
                 Some(DirectBufferReturnMethod::Packed) => quote! {
-                    return ::boltffi::__private::FfiBuf::default().into_packed();
+                    return ::boltffi::__private::FfiBuf::EMPTY_PACKED;
                 },
                 method => panic!(
                     "unexpected wasm direct buffer return method for invalid-arg return: {:?}",

--- a/boltffi_macros/src/lowering/returns/mod.rs
+++ b/boltffi_macros/src/lowering/returns/mod.rs
@@ -267,7 +267,9 @@ mod tests {
                 .value_return_method(ReturnInvocationContext::SyncExport, ReturnPlatform::Wasm,),
             ValueReturnMethod::DirectReturn
         ));
-        assert!(statement.contains("FfiBuf :: default () . into_packed ()"));
+        // wasm returns the packed constant rather than building an `FfiBuf` and
+        // calling `into_packed`; the two are the same value by construction.
+        assert!(statement.contains("FfiBuf :: EMPTY_PACKED"));
         assert!(statement.contains("return :: boltffi :: __private :: FfiBuf :: default ()"));
     }
 


### PR DESCRIPTION
`FfiBuf::default().into_packed()` is provably `0`. `Default` forwards to `empty()`, which sets `len: 0`, and `into_packed` opens with `if len == 0 { return 0 }`. But `into_packed` is a real call in the wasm module, so every argument-decode failure site built an `FfiBuf` on the stack and called into it to obtain a constant.

Error paths now return `FfiBuf::EMPTY_PACKED`. The same expression was emitted for both branches of the packed shape, so this also takes the call off the **success** path of every fallible export.

No ABI, API or behaviour change: the value crossing the boundary is identical.

## What it is worth, honestly

**234 bytes on `examples/demo`**, measured by building the wasm target with and without the change (8 925 347 → 8 925 113). The demo has fallible exports across 20 modules. Reproduced twice.

**Nothing measurable on a small surface.** I also measured a workload with a single fallible export: 233 529 bytes either way, delta zero. So the saving scales with the number of fallible exports, and one is not enough to move the module. If you are looking for a headline number this is not it — the argument is that a call which provably returns a constant should be a constant, and 234 bytes on a realistic export surface is the size that follows.

I am flagging this because the effect is easy to fail to reproduce: pick a project with one or two fallible functions and you will see zero, and reasonably conclude the change does nothing.

## Testing

- `cargo test --workspace` — 11 groups, no failures.
- One test added, pinning the premise the constant rests on: an empty buffer has `len == 0`. The other half — `into_packed` returning `0` for a zero length — is `wasm32`-gated and cannot be asserted from a host test, and CI does not run `cargo test --target wasm32`; it is two visible lines in `into_packed`. I would rather say that than add a `#[cfg(target_arch = "wasm32")]` test that never runs and looks like coverage.
- `cargo clippy --workspace --all-targets` and `cargo fmt --all` clean.

Three `boltffi_macros` `core_only_interned_string_pool` fixture tests fail on `main` too (run 30531511211 on `main` shows the same three), so they are not from this change.
