### PR TITLE
Fix fixture lock files broken by v0.29.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,14 @@ jobs:
       - name: Bump versions
         run: cargo set-version --workspace ${{ inputs.version }}
 
+      - name: Regenerate test fixture lock files
+        run: |
+          find . -path ./target -prune -o -name Cargo.lock -print \
+            | grep -v '^\./Cargo.lock$' \
+            | while read -r lock; do
+                (cd "$(dirname "$lock")" && cargo update --workspace --offline)
+              done
+
       - name: Bump npm runtime version
         if: ${{ !inputs.skip_npm }}
         run: |

--- a/boltffi_macros/tests/fixtures/core_only_interned_string_pool/Cargo.lock
+++ b/boltffi_macros/tests/fixtures/core_only_interned_string_pool/Cargo.lock
@@ -4,14 +4,14 @@ version = 4
 
 [[package]]
 name = "boltffi_ast"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "boltffi_binding"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_ast",
  "serde",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "boltffi_core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_macros",
  "url",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "boltffi_ffi_rules"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "boltffi_macros"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_ast",
  "boltffi_binding",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "boltffi_scan"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_ast",
  "proc-macro2",

--- a/boltffi_macros/tests/fixtures/renamed_core_only_interned_string_pool/Cargo.lock
+++ b/boltffi_macros/tests/fixtures/renamed_core_only_interned_string_pool/Cargo.lock
@@ -4,14 +4,14 @@ version = 4
 
 [[package]]
 name = "boltffi_ast"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "boltffi_binding"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_ast",
  "serde",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "boltffi_core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_macros",
  "url",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "boltffi_ffi_rules"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "boltffi_macros"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_ast",
  "boltffi_binding",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "boltffi_scan"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_ast",
  "proc-macro2",

--- a/boltffi_macros/tests/fixtures/renamed_interned_string_pool/Cargo.lock
+++ b/boltffi_macros/tests/fixtures/renamed_interned_string_pool/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "boltffi"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_core",
  "boltffi_macros",
@@ -12,14 +12,14 @@ dependencies = [
 
 [[package]]
 name = "boltffi_ast"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "boltffi_binding"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_ast",
  "serde",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "boltffi_core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_macros",
  "url",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "boltffi_ffi_rules"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "boltffi_macros"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_ast",
  "boltffi_binding",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "boltffi_scan"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "boltffi_ast",
  "proc-macro2",


### PR DESCRIPTION
The v0.29.0 bump left the macro fixture lock files at 0.28.0, breaking their `cargo check --locked` tests on main. Regenerates the locks and makes the release workflow do it automatically after `cargo set-version`.