### PR TITLE
capture: async functions join the per-invocation wrapper ABI

### DIFF
--- a/boltffi_macros/src/capture.rs
+++ b/boltffi_macros/src/capture.rs
@@ -264,9 +264,6 @@ fn wrapper_tokens(
     if !item.sig.generics.params.is_empty() {
         return Err("generic functions have no per-invocation wrapper");
     }
-    if item.sig.asyncness.is_some() {
-        return Err("async functions have no per-invocation wrapper yet");
-    }
     if item.sig.variadic.is_some() || item.sig.abi.is_some() {
         return Err("extern or variadic functions have no per-invocation wrapper");
     }
@@ -311,9 +308,20 @@ fn wrapper_tokens(
     let ident = &item.sig.ident;
     let symbol = invocation_symbol(&ident.to_string());
     def.native_symbol = Some(symbol.clone());
-    let symbol_ident = quote::format_ident!("{symbol}");
     let facade = facade();
 
+    if item.sig.asyncness.is_some() {
+        return Ok(async_wrapper_tokens(
+            ident,
+            &symbol,
+            &names,
+            &types,
+            &return_type,
+            &facade,
+        ));
+    }
+
+    let symbol_ident = quote::format_ident!("{symbol}");
     Ok(quote! {
         #[doc(hidden)]
         #[unsafe(no_mangle)]
@@ -350,6 +358,121 @@ fn wrapper_tokens(
             }
         }
     })
+}
+
+/// The async family behind one record-carried start symbol: poll, complete, cancel,
+/// free, and panic-message companions are fixed suffixes of it — an ABI convention
+/// like the trailing status parameter, not a name derived from user items.
+fn async_wrapper_tokens(
+    ident: &syn::Ident,
+    symbol: &str,
+    names: &[syn::Ident],
+    types: &[syn::Type],
+    return_type: &syn::Type,
+    facade: &TokenStream,
+) -> TokenStream {
+    let start_ident = quote::format_ident!("{symbol}");
+    let poll_ident = quote::format_ident!("{symbol}_poll");
+    let complete_ident = quote::format_ident!("{symbol}_complete");
+    let cancel_ident = quote::format_ident!("{symbol}_cancel");
+    let free_ident = quote::format_ident!("{symbol}_free");
+    let panic_message_ident = quote::format_ident!("{symbol}_panic_message");
+
+    quote! {
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        #[allow(clippy::missing_safety_doc)]
+        pub unsafe extern "C" fn #start_ident(
+            #(#names: <#types as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::Ffi,)*
+        ) -> #facade::__private::RustFutureHandle {
+            #(
+                let #names = match <#types as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::lift(#names) {
+                    ::core::result::Result::Ok(value) => value,
+                    ::core::result::Result::Err(error) => {
+                        unsafe {
+                            #facade::__private::capture::note_invalid_arg(::core::ptr::null_mut(), error)
+                        };
+                        return #facade::__private::rustfuture::rust_future_invalid_arg::<#return_type>();
+                    }
+                };
+            )*
+            #facade::__private::rustfuture::rust_future_new(async move {
+                #ident(#(#names),*).await
+            })
+        }
+
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        #[allow(clippy::missing_safety_doc)]
+        pub unsafe extern "C" fn #poll_ident(
+            handle: #facade::__private::RustFutureHandle,
+            callback_data: u64,
+            callback: #facade::__private::RustFutureContinuationCallback,
+        ) {
+            unsafe {
+                #facade::__private::rustfuture::rust_future_poll::<#return_type>(
+                    handle,
+                    callback,
+                    callback_data,
+                )
+            }
+        }
+
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        #[allow(clippy::missing_safety_doc)]
+        pub unsafe extern "C" fn #complete_ident(
+            handle: #facade::__private::RustFutureHandle,
+            __boltffi_status: *mut #facade::__private::FfiStatus,
+        ) -> <#return_type as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::Ffi {
+            match unsafe {
+                #facade::__private::rustfuture::rust_future_complete::<#return_type>(handle)
+            } {
+                ::core::result::Result::Ok(value) => {
+                    if !__boltffi_status.is_null() {
+                        unsafe { *__boltffi_status = #facade::__private::FfiStatus::OK };
+                    }
+                    <#return_type as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::lower(value)
+                }
+                ::core::result::Result::Err(status) => {
+                    if !__boltffi_status.is_null() {
+                        unsafe { *__boltffi_status = status };
+                    }
+                    <#return_type as #facade::__private::capture::FfiCross<crate::__BoltffiTag>>::poisoned()
+                }
+            }
+        }
+
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        #[allow(clippy::missing_safety_doc)]
+        pub unsafe extern "C" fn #cancel_ident(handle: #facade::__private::RustFutureHandle) {
+            unsafe { #facade::__private::rustfuture::rust_future_cancel::<#return_type>(handle) }
+        }
+
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        #[allow(clippy::missing_safety_doc)]
+        pub unsafe extern "C" fn #free_ident(handle: #facade::__private::RustFutureHandle) {
+            unsafe { #facade::__private::rustfuture::rust_future_free::<#return_type>(handle) }
+        }
+
+        #[doc(hidden)]
+        #[unsafe(no_mangle)]
+        #[allow(clippy::missing_safety_doc)]
+        pub unsafe extern "C" fn #panic_message_ident(
+            handle: #facade::__private::RustFutureHandle,
+        ) -> #facade::__private::FfiBuf {
+            match unsafe {
+                #facade::__private::rustfuture::rust_future_panic_message::<#return_type>(handle)
+            } {
+                ::core::option::Option::Some(message) => {
+                    #facade::__private::FfiBuf::wire_encode(&message)
+                }
+                ::core::option::Option::None => #facade::__private::FfiBuf::empty(),
+            }
+        }
+    }
 }
 
 fn crossing_unsupported(ty: &syn::Type) -> bool {

--- a/boltffi_tests/tests/capture_wrappers.rs
+++ b/boltffi_tests/tests/capture_wrappers.rs
@@ -7,12 +7,13 @@
 use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use boltffi_bindgen::metadata::BindingMetadataBuild;
-use boltffi_core::FfiStatus;
 use boltffi_core::safety::PANIC_STATUS;
 use boltffi_core::types::FfiBuf;
+use boltffi_core::{FfiStatus, RustFutureContinuationCallback, RustFutureHandle, RustFuturePoll};
 
 const FIXTURE_SOURCE: &str = r#"
 use boltffi::*;
@@ -56,6 +57,58 @@ pub fn boom(trigger: bool) -> f64 {
     }
     1.0
 }
+
+#[export]
+pub async fn shout_later(value: String, suffix: String) -> String {
+    Delay::new(std::time::Duration::from_millis(10)).await;
+    format!("{}{suffix}", value.to_uppercase())
+}
+
+#[export]
+pub async fn double(value: f64) -> f64 {
+    value * 2.0
+}
+
+struct Delay {
+    woken: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    started: bool,
+    delay: std::time::Duration,
+}
+
+impl Delay {
+    fn new(delay: std::time::Duration) -> Self {
+        Self {
+            woken: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            started: false,
+            delay,
+        }
+    }
+}
+
+impl std::future::Future for Delay {
+    type Output = ();
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<()> {
+        if self.woken.load(std::sync::atomic::Ordering::Acquire) {
+            return std::task::Poll::Ready(());
+        }
+        if !self.started {
+            self.started = true;
+            let woken = self.woken.clone();
+            let waker = cx.waker().clone();
+            let delay = self.delay;
+            std::thread::spawn(move || {
+                std::thread::sleep(delay);
+                woken.store(true, std::sync::atomic::Ordering::Release);
+                waker.wake();
+            });
+        }
+        std::task::Poll::Pending
+    }
+}
 "#;
 
 struct FixtureCrate {
@@ -98,6 +151,11 @@ impl Drop for FixtureCrate {
     fn drop(&mut self) {
         let _ = fs::remove_dir_all(&self.root);
     }
+}
+
+extern "C" fn send_poll_signal(callback_data: u64, poll: RustFuturePoll) {
+    let sender = unsafe { &*(callback_data as *const mpsc::Sender<RustFuturePoll>) };
+    sender.send(poll).expect("the poll signal delivers");
 }
 
 fn wire_string(value: &str) -> FfiBuf {
@@ -226,4 +284,121 @@ fn wrappers_are_called_through_their_record_carried_symbols() {
         "the wrapper resets the status on entry"
     );
     assert_eq!(calm, 1.0);
+
+    let drive =
+        |poll: unsafe extern "C" fn(RustFutureHandle, u64, RustFutureContinuationCallback),
+         handle: RustFutureHandle| {
+            let (sender, receiver) = mpsc::channel::<RustFuturePoll>();
+            let sender = Box::new(sender);
+            loop {
+                let callback_data = &*sender as *const mpsc::Sender<RustFuturePoll> as u64;
+                unsafe { poll(handle, callback_data, send_poll_signal) };
+                match receiver
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("the continuation callback fires")
+                {
+                    RustFuturePoll::Ready => break,
+                    RustFuturePoll::MaybeReady => continue,
+                }
+            }
+        };
+
+    let shout_later = symbol("shout_later");
+    let start: libloading::Symbol<'_, unsafe extern "C" fn(FfiBuf, FfiBuf) -> RustFutureHandle> =
+        unsafe { library.get(shout_later.as_bytes()) }.expect("shout_later symbol resolves");
+    let poll: libloading::Symbol<
+        '_,
+        unsafe extern "C" fn(RustFutureHandle, u64, RustFutureContinuationCallback),
+    > = unsafe { library.get(format!("{shout_later}_poll").as_bytes()) }
+        .expect("shout_later poll companion resolves");
+    let complete: libloading::Symbol<
+        '_,
+        unsafe extern "C" fn(RustFutureHandle, *mut FfiStatus) -> FfiBuf,
+    > = unsafe { library.get(format!("{shout_later}_complete").as_bytes()) }
+        .expect("shout_later complete companion resolves");
+    let cancel: libloading::Symbol<'_, unsafe extern "C" fn(RustFutureHandle)> =
+        unsafe { library.get(format!("{shout_later}_cancel").as_bytes()) }
+            .expect("shout_later cancel companion resolves");
+    let free: libloading::Symbol<'_, unsafe extern "C" fn(RustFutureHandle)> =
+        unsafe { library.get(format!("{shout_later}_free").as_bytes()) }
+            .expect("shout_later free companion resolves");
+    unsafe {
+        library.get::<unsafe extern "C" fn(RustFutureHandle) -> FfiBuf>(
+            format!("{shout_later}_panic_message").as_bytes(),
+        )
+    }
+    .expect("shout_later panic message companion resolves");
+
+    let handle = unsafe { start(wire_string("later"), wire_string("!")) };
+    drive(*poll, handle);
+    let mut status = FfiStatus::OK;
+    let shouted = unsafe { complete(handle, &mut status) };
+    assert_eq!(status, FfiStatus::OK);
+    assert_eq!(
+        unwire_string(shouted),
+        "LATER!",
+        "async values cross at the completion call"
+    );
+    unsafe { free(handle) };
+
+    let handle = unsafe {
+        start(
+            wire_string("later"),
+            FfiBuf::from_vec(vec![0xFF, 0xFF, 0xFF]),
+        )
+    };
+    drive(*poll, handle);
+    let mut status = FfiStatus::OK;
+    let refused = unsafe { complete(handle, &mut status) };
+    assert_eq!(
+        status,
+        FfiStatus::INVALID_ARG,
+        "malformed argument bytes surface at the completion call"
+    );
+    assert!(
+        unsafe { refused.as_byte_slice() }.is_empty(),
+        "the refused completion is the empty buffer"
+    );
+    unsafe { free(handle) };
+
+    let handle = unsafe { start(wire_string("dropped"), wire_string("?")) };
+    unsafe { cancel(handle) };
+    drive(*poll, handle);
+    let mut status = FfiStatus::OK;
+    let cancelled = unsafe { complete(handle, &mut status) };
+    assert_eq!(
+        status,
+        FfiStatus::CANCELLED,
+        "a cancelled future reports through the completion status"
+    );
+    assert!(
+        unsafe { cancelled.as_byte_slice() }.is_empty(),
+        "the cancelled completion is the empty buffer"
+    );
+    unsafe { free(handle) };
+
+    let double = symbol("double");
+    let start_double: libloading::Symbol<'_, unsafe extern "C" fn(f64) -> RustFutureHandle> =
+        unsafe { library.get(double.as_bytes()) }.expect("double symbol resolves");
+    let poll_double: libloading::Symbol<
+        '_,
+        unsafe extern "C" fn(RustFutureHandle, u64, RustFutureContinuationCallback),
+    > = unsafe { library.get(format!("{double}_poll").as_bytes()) }
+        .expect("double poll companion resolves");
+    let complete_double: libloading::Symbol<
+        '_,
+        unsafe extern "C" fn(RustFutureHandle, *mut FfiStatus) -> f64,
+    > = unsafe { library.get(format!("{double}_complete").as_bytes()) }
+        .expect("double complete companion resolves");
+    let free_double: libloading::Symbol<'_, unsafe extern "C" fn(RustFutureHandle)> =
+        unsafe { library.get(format!("{double}_free").as_bytes()) }
+            .expect("double free companion resolves");
+
+    let handle = unsafe { start_double(21.0) };
+    drive(*poll_double, handle);
+    let mut status = FfiStatus::OK;
+    let doubled = unsafe { complete_double(handle, &mut status) };
+    assert_eq!(status, FfiStatus::OK);
+    assert_eq!(doubled, 42.0, "direct async values cross by value");
+    unsafe { free_double(handle) };
 }


### PR DESCRIPTION
Async functions graduate into the per-invocation wrapper ABI: with `BOLTFFI_CAPTURE_WRAPPERS` set, an `#[export] async fn` expands to the same future family the legacy path exports, behind an invocation-minted symbol.

```rust
#[export]
pub async fn shout_later(value: String) -> String { ... }

// expands (gated) to:
pub unsafe extern "C" fn boltffi_inv_mycrate_shout_later_1a2b3c4d(
    value: FfiBuf,                                    // FfiCross-lifted eagerly
) -> RustFutureHandle
// plus boltffi_inv_..._{poll, complete, cancel, free, panic_message}
```

- The record keeps carrying only the start symbol; the poll/complete/cancel/free/panic-message companions are fixed suffixes of it — an ABI convention like the trailing status parameter, not a name derived from user items.
- Arguments lift eagerly at the start call. A malformed buffer sets the last error and returns an already-failed future, so the failure surfaces as `INVALID_ARG` at the completion call — the same channel the legacy async path uses (which records no message at all). Since last-error storage is thread-local, the message is only readable on the start thread; the flip PR's call-sites should read it there.
- `complete(handle, *mut FfiStatus)` lowers the whole value through `FfiCross`, `Result` included: no `PlainComplete`/`FallibleComplete` split, per the #734 contract decision. A non-OK future (invalid arg, cancelled) writes its status and returns the poisoned value.
- Poll/cancel/free/panic-message delegate to the same generic `rustfuture` runtime the legacy exports use; no core or ast changes.

Known parity note: a panic inside the polled future aborts on native today on both the legacy and wrapper paths (only wasm's `poll_sync` catches). Hardening that belongs to the runtime, not this ABI.
