### PR TITLE
Python - support doc comments

### DIFF
--- a/boltffi_backend/src/target/python/cpython/mod.rs
+++ b/boltffi_backend/src/target/python/cpython/mod.rs
@@ -1622,6 +1622,175 @@ mod tests {
     }
 
     #[test]
+    fn python_target_renders_doc_comments_as_docstrings() {
+        let output = target()
+            .render(&bindings(
+                r#"
+                /// A geometric point.
+                ///
+                /// Coordinates are plain `f64`.
+                #[repr(C)]
+                #[data]
+                pub struct Point {
+                    /// Horizontal coordinate.
+                    pub x: f64,
+                    pub y: f64,
+                }
+
+                #[data(impl)]
+                impl Point {
+                    /// Builds the origin.
+                    pub fn origin() -> Self {
+                        Self { x: 0.0, y: 0.0 }
+                    }
+
+                    /// Returns the distance from the origin.
+                    pub fn magnitude(&self) -> f64 {
+                        0.0
+                    }
+                }
+
+                /// A named label.
+                #[data]
+                pub struct Label {
+                    /// The visible text.
+                    pub text: String,
+                }
+
+                pub struct Counter {
+                    value: u32,
+                }
+
+                /// A counter that lives in Rust.
+                #[export(single_threaded)]
+                impl Counter {
+                    /// Creates a counter starting at `value`.
+                    pub fn new(value: u32) -> Self {
+                        Self { value }
+                    }
+
+                    /// Bumps the counter.
+                    pub fn bump(&mut self) {
+                        self.value += 1;
+                    }
+                }
+
+                /// The answer to everything.
+                #[export]
+                pub const ANSWER: u32 = 42;
+
+                /// Greets someone by name.
+                #[export]
+                pub fn greet(name: String) -> String {
+                    name
+                }
+
+                #[export]
+                pub fn undocumented(value: i32) -> i32 {
+                    value
+                }
+                "#,
+            ))
+            .expect("Python target should render doc comments");
+        let init = file(&output, "demo/__init__.py");
+        let stub = file(&output, "demo/__init__.pyi");
+
+        assert!(init.contains(
+            r#"Point.__doc__ = """A geometric point.
+
+Coordinates are plain `f64`.
+"""
+"#
+        ));
+        assert!(stub.contains(
+            r#"class Point:
+    """A geometric point.
+
+    Coordinates are plain `f64`.
+    """
+"#
+        ));
+        assert!(stub.contains(
+            r#"    x: float
+    """Horizontal coordinate."""
+    y: float
+"#
+        ));
+        assert!(init.contains(
+            r#"def _boltffi_attach_Point_magnitude(self) -> float:
+    """Returns the distance from the origin."""
+"#
+        ));
+        assert!(stub.contains(
+            r#"    def origin(cls) -> "Point":
+        """Builds the origin."""
+"#
+        ));
+        assert!(stub.contains(
+            r#"    def magnitude(self) -> float:
+        """Returns the distance from the origin."""
+"#
+        ));
+
+        let label = r#"class Label:
+    """A named label."""
+    text: str
+    """The visible text."""
+"#;
+        assert!(init.contains(label));
+        assert!(stub.contains(label));
+
+        let counter = "class Counter:\n    \"\"\"A counter that lives in Rust.\"\"\"\n";
+        assert!(init.contains(counter));
+        assert!(stub.contains(counter));
+        assert!(init.contains(
+            r#"    def __init__(self, value: int) -> None:
+        """Creates a counter starting at `value`."""
+"#
+        ));
+        assert!(stub.contains(
+            r#"    def bump(self) -> None:
+        """Bumps the counter."""
+"#
+        ));
+
+        assert!(init.contains("answer: int = 42\n\"\"\"The answer to everything.\"\"\"\n"));
+        assert!(stub.contains("answer: int\n\"\"\"The answer to everything.\"\"\"\n"));
+
+        let greet = "def greet(name: str) -> str:\n    \"\"\"Greets someone by name.\"\"\"\n";
+        assert!(init.contains(greet));
+        assert!(stub.contains(greet));
+
+        assert!(stub.contains("def undocumented(value: int) -> int: ...\n"));
+        assert!(init.contains(
+            "def undocumented(value: int) -> int:\n    return _native.undocumented(value)\n"
+        ));
+    }
+
+    #[test]
+    fn python_target_escapes_docstring_delimiters_and_backslashes() {
+        let output = target()
+            .render(&bindings(
+                r##"
+                /// Spelled """like this""", with a raw regex \d+ and a trailing \
+                #[data]
+                pub struct Awkward {
+                    pub text: String,
+                }
+                "##,
+            ))
+            .expect("Python target should render awkward doc comments");
+        let init = file(&output, "demo/__init__.py");
+        let stub = file(&output, "demo/__init__.pyi");
+
+        let docstring = r#"    """Spelled \"\""like this\"\"", with a raw regex \\d+ and a trailing \\"""
+"#;
+        assert!(init.contains(docstring));
+        assert!(stub.contains(docstring));
+        assert!(!init.contains(r#"Spelled """like"#));
+    }
+
+    #[test]
     fn python_target_renders_record_field_defaults() {
         let output = target()
             .render(&bindings(

--- a/boltffi_backend/src/target/python/render/callable/function.rs
+++ b/boltffi_backend/src/target/python/render/callable/function.rs
@@ -8,11 +8,12 @@ use crate::{
     },
 };
 
-use super::super::Package;
+use super::super::{Documentation, Package};
 use super::{body::CallableBody, parameter::ParameterStub, return_value::ReturnStub};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FunctionStub {
+    pub documentation: Documentation,
     pub python_name: Identifier,
     pub parameters: Vec<ParameterStub>,
     pub return_annotation: TypeAnnotation,
@@ -48,6 +49,7 @@ impl FunctionStub {
         let uses_wire_helpers =
             parameters.iter().any(ParameterStub::uses_wire_helpers) || returned.uses_wire_helpers();
         Ok(Self {
+            documentation: Documentation::new(function.meta().doc()),
             python_name: Name::new(function.name()).function()?,
             parameters,
             return_annotation: returned.into_annotation(),

--- a/boltffi_backend/src/target/python/render/callable/member.rs
+++ b/boltffi_backend/src/target/python/render/callable/member.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 use super::{
-    super::Package,
+    super::{Documentation, Package},
     body::CallableBody,
     parameter::ParameterStub,
     return_value::{ReturnStub, ReturnedValue},
@@ -20,6 +20,7 @@ use super::{
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssociatedCallable {
+    pub documentation: Documentation,
     pub receiver: bool,
     pub python_name: Identifier,
     pub native_name: Identifier,
@@ -38,6 +39,7 @@ impl AssociatedCallable {
         symbols: &class_render::Symbols,
         package: &Package,
     ) -> Result<Self> {
+        let documentation = Documentation::new(initializer.meta().doc());
         let parameters = initializer
             .callable()
             .params()
@@ -56,6 +58,7 @@ impl AssociatedCallable {
         )?;
         let uses_wire_helpers = parameters.iter().any(ParameterStub::uses_wire_helpers);
         Ok(Self {
+            documentation,
             receiver: false,
             python_name: Name::new(initializer.name()).function()?,
             asynchronous: body.is_async(),
@@ -74,6 +77,7 @@ impl AssociatedCallable {
         symbols: &class_render::Symbols,
         package: &Package,
     ) -> Result<Self> {
+        let documentation = Documentation::new(method.meta().doc());
         let receiver = method.callable().receiver().is_some();
         let parameters = method
             .callable()
@@ -95,6 +99,7 @@ impl AssociatedCallable {
         let uses_wire_helpers =
             parameters.iter().any(ParameterStub::uses_wire_helpers) || returned.uses_wire_helpers();
         Ok(Self {
+            documentation,
             receiver,
             python_name: Name::new(method.name()).function()?,
             asynchronous: body.is_async(),
@@ -113,6 +118,7 @@ impl AssociatedCallable {
         native_name: Identifier,
         package: &Package,
     ) -> Result<Self> {
+        let documentation = Documentation::new(initializer.meta().doc());
         let parameters = Self::parameters(initializer.callable().params(), package)?;
         let returned = ReturnStub::from_callable(initializer.callable(), package)?;
         let arguments = Self::arguments(None, &parameters);
@@ -126,6 +132,7 @@ impl AssociatedCallable {
         let uses_wire_helpers =
             parameters.iter().any(ParameterStub::uses_wire_helpers) || returned.uses_wire_helpers();
         Ok(Self {
+            documentation,
             receiver: false,
             python_name: Name::new(initializer.name()).function()?,
             asynchronous: body.is_async(),
@@ -146,6 +153,7 @@ impl AssociatedCallable {
         mutated_receiver_type: Option<TypeAnnotation>,
         package: &Package,
     ) -> Result<Self> {
+        let documentation = Documentation::new(method.meta().doc());
         let parameters = Self::parameters(method.callable().params(), package)?;
         let returned = match mutated_receiver_type {
             Some(annotation) => ReturnStub::native(annotation),
@@ -162,6 +170,7 @@ impl AssociatedCallable {
         let uses_wire_helpers =
             parameters.iter().any(ParameterStub::uses_wire_helpers) || returned.uses_wire_helpers();
         Ok(Self {
+            documentation,
             receiver: receiver.is_some(),
             python_name: Name::new(method.name()).function()?,
             asynchronous: body.is_async(),

--- a/boltffi_backend/src/target/python/render/class.rs
+++ b/boltffi_backend/src/target/python/render/class.rs
@@ -8,10 +8,11 @@ use crate::{
     },
 };
 
-use super::{AssociatedCallable, ClassStream, ConstantStub, NameScope, Package};
+use super::{AssociatedCallable, ClassStream, ConstantStub, Documentation, NameScope, Package};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Class {
+    pub documentation: Documentation,
     pub class_name: Identifier,
     pub release_method: Identifier,
     pub constants: Vec<ConstantStub>,
@@ -63,6 +64,7 @@ impl Class {
             .map(|stream| ClassStream::from_declaration(stream, &class_name, package))
             .collect::<Result<Vec<_>>>()?;
         Ok(Self {
+            documentation: Documentation::new(declaration.meta().doc()),
             class_name,
             release_method: symbols.release()?,
             constants: package.constants_for_owner(ConstantOwner::Class(declaration.id()))?,

--- a/boltffi_backend/src/target/python/render/constant.rs
+++ b/boltffi_backend/src/target/python/render/constant.rs
@@ -8,10 +8,11 @@ use crate::{
     },
 };
 
-use super::{Package, callable::ReturnStub, type_hint::TypeHint};
+use super::{Documentation, Package, callable::ReturnStub, type_hint::TypeHint};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConstantStub {
+    pub documentation: Documentation,
     pub owner: Option<Identifier>,
     pub python_name: Identifier,
     pub annotation: TypeAnnotation,
@@ -32,9 +33,10 @@ impl ConstantStub {
             || Name::new(constant.name()).function(),
             |_| Name::new(constant.name()).constant(),
         )?;
+        let documentation = Documentation::new(constant.meta().doc());
         match constant.value() {
             ConstantValueDecl::Inline { ty, value, .. } => {
-                Self::from_inline(owner, python_name, ty, value, package)
+                Self::from_inline(documentation, owner, python_name, ty, value, package)
             }
             ConstantValueDecl::Accessor { callable, .. } => {
                 let returned = ReturnStub::from_plan(callable.returns().plan(), package)?;
@@ -49,6 +51,7 @@ impl ConstantStub {
                 let expression = returned.expression(native_call)?;
                 let uses_wire_helpers = returned.uses_wire_helpers();
                 Ok(Self {
+                    documentation,
                     owner,
                     python_name,
                     annotation: returned.into_annotation(),
@@ -82,6 +85,7 @@ impl ConstantStub {
     }
 
     fn from_inline(
+        documentation: Documentation,
         owner: Option<Identifier>,
         python_name: Identifier,
         ty: &TypeRef,
@@ -89,6 +93,7 @@ impl ConstantStub {
         package: &Package,
     ) -> Result<Self> {
         Ok(Self {
+            documentation,
             owner,
             python_name,
             annotation: TypeHint::from_type_ref(ty, package)?.into_annotation(),

--- a/boltffi_backend/src/target/python/render/documentation.rs
+++ b/boltffi_backend/src/target/python/render/documentation.rs
@@ -1,0 +1,140 @@
+use boltffi_binding::DocComment;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Documentation(Option<String>);
+
+impl Documentation {
+    pub fn new(documentation: Option<&DocComment>) -> Self {
+        Self(
+            documentation
+                .map(DocComment::as_str)
+                .map(str::trim_end)
+                .filter(|text| !text.trim().is_empty())
+                .map(Self::escape),
+        )
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_none()
+    }
+
+    pub fn docstring(&self, indentation: &str) -> String {
+        match self.render(indentation) {
+            Some(block) => format!("\n{indentation}{block}"),
+            None => String::new(),
+        }
+    }
+
+    pub fn literal(&self) -> String {
+        self.render("").unwrap_or_default()
+    }
+
+    fn render(&self, indentation: &str) -> Option<String> {
+        let text = self.0.as_deref()?;
+        let mut lines = text.lines();
+        let first = lines.next()?;
+        let Some(second) = lines.next() else {
+            return Some(format!("\"\"\"{first}\"\"\""));
+        };
+        let mut block = format!("\"\"\"{first}");
+        std::iter::once(second).chain(lines).for_each(|line| {
+            block.push('\n');
+            if !line.is_empty() {
+                block.push_str(indentation);
+                block.push_str(line);
+            }
+        });
+        block.push('\n');
+        block.push_str(indentation);
+        block.push_str("\"\"\"");
+        Some(block)
+    }
+
+    fn escape(text: &str) -> String {
+        text.char_indices().fold(
+            String::with_capacity(text.len()),
+            |mut escaped, (index, character)| {
+                match character {
+                    '\\' => escaped.push_str("\\\\"),
+                    '"' => {
+                        if text
+                            .as_bytes()
+                            .get(index + 1)
+                            .is_none_or(|following| *following == b'"')
+                        {
+                            escaped.push('\\');
+                        }
+                        escaped.push('"');
+                    }
+                    character => escaped.push(character),
+                }
+                escaped
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use boltffi_binding::DocComment;
+
+    use super::Documentation;
+
+    #[test]
+    fn absent_documentation_renders_nothing() {
+        let documentation = Documentation::new(None);
+
+        assert!(documentation.is_empty());
+        assert_eq!(documentation.docstring("    "), "");
+    }
+
+    #[test]
+    fn single_line_documentation_renders_on_one_line() {
+        let doc_comment = DocComment::new("Returns the stored value.");
+
+        assert_eq!(
+            Documentation::new(Some(&doc_comment)).docstring("    "),
+            "\n    \"\"\"Returns the stored value.\"\"\""
+        );
+    }
+
+    #[test]
+    fn multi_line_documentation_keeps_blank_lines_unindented() {
+        let doc_comment = DocComment::new("A point.\n\nCarries two coordinates.");
+
+        assert_eq!(
+            Documentation::new(Some(&doc_comment)).docstring("    "),
+            "\n    \"\"\"A point.\n\n    Carries two coordinates.\n    \"\"\""
+        );
+    }
+
+    #[test]
+    fn literal_documents_native_classes_through_an_assignment() {
+        let doc_comment = DocComment::new("A point.\n\nCarries two coordinates.");
+
+        assert_eq!(
+            Documentation::new(Some(&doc_comment)).literal(),
+            "\"\"\"A point.\n\nCarries two coordinates.\n\"\"\""
+        );
+    }
+
+    #[test]
+    fn embedded_triple_quotes_cannot_close_the_docstring() {
+        let doc_comment = DocComment::new("Use \"\"\"text\"\"\" for docstrings.");
+
+        assert_eq!(
+            Documentation::new(Some(&doc_comment)).docstring(""),
+            "\n\"\"\"Use \\\"\\\"\"text\\\"\\\"\" for docstrings.\"\"\""
+        );
+    }
+
+    #[test]
+    fn trailing_backslash_cannot_escape_the_closing_delimiter() {
+        let doc_comment = DocComment::new("Matches \\d+\\");
+
+        assert_eq!(
+            Documentation::new(Some(&doc_comment)).docstring(""),
+            "\n\"\"\"Matches \\\\d+\\\\\"\"\""
+        );
+    }
+}

--- a/boltffi_backend/src/target/python/render/enumeration.rs
+++ b/boltffi_backend/src/target/python/render/enumeration.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 
 use super::{
-    AssociatedCallable, ConstantStub, NameScope, Package, record::EncodedRecordField,
-    record::RecordField,
+    AssociatedCallable, ConstantStub, Documentation, NameScope, Package,
+    record::EncodedRecordField, record::RecordField,
 };
 
 pub enum VariantStyle {
@@ -47,6 +47,7 @@ impl VariantStyle {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EnumClass {
+    pub documentation: Documentation,
     pub class_name: Identifier,
     pub exception_name: Option<Identifier>,
     pub register_method: Identifier,
@@ -69,6 +70,7 @@ impl EnumClass {
         )?;
         let symbols = enumeration_render::Symbols::from_c_style(enumeration, c_enum)?;
         Ok(Self {
+            documentation: Documentation::new(enumeration.meta().doc()),
             class_name: class.class_name().clone(),
             exception_name: enumeration
                 .is_error_payload()
@@ -92,6 +94,7 @@ impl EnumClass {
         let symbols = enumeration_render::Symbols::from_data(enumeration)?;
         let class_name = symbols.class_name().clone();
         Ok(Self {
+            documentation: Documentation::new(enumeration.meta().doc()),
             class_name: class_name.clone(),
             exception_name: enumeration
                 .is_error_payload()
@@ -293,6 +296,7 @@ pub struct DataEnumWire {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DataEnumVariant {
+    pub documentation: Documentation,
     pub class_name: Identifier,
     pub tag: u32,
     pub fields: Vec<RecordField>,
@@ -311,6 +315,7 @@ impl DataEnumVariant {
     ) -> Result<Self> {
         let fields = Self::payload_fields(variant.payload())?;
         Ok(Self {
+            documentation: Documentation::new(variant.meta().doc()),
             class_name: Identifier::parse(format!(
                 "{}{}",
                 enum_class_name,

--- a/boltffi_backend/src/target/python/render/mod.rs
+++ b/boltffi_backend/src/target/python/render/mod.rs
@@ -26,6 +26,7 @@ use crate::{
 mod callable;
 mod class;
 mod constant;
+mod documentation;
 mod enumeration;
 mod name_scope;
 mod record;
@@ -36,6 +37,7 @@ use self::{
     callable::{AssociatedCallable, FunctionStub},
     class::Class,
     constant::ConstantStub,
+    documentation::Documentation,
     enumeration::EnumClass,
     name_scope::NameScope,
     record::{RecordClass, RecordWire},

--- a/boltffi_backend/src/target/python/render/record.rs
+++ b/boltffi_backend/src/target/python/render/record.rs
@@ -15,11 +15,13 @@ use crate::{
 };
 
 use super::{
-    AssociatedCallable, ConstantStub, NameScope, constant::DefaultExpression, type_hint::TypeHint,
+    AssociatedCallable, ConstantStub, Documentation, NameScope, constant::DefaultExpression,
+    type_hint::TypeHint,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RecordClass {
+    pub documentation: Documentation,
     pub class_name: Identifier,
     pub exception_name: Option<Identifier>,
     pub register_method: Identifier,
@@ -43,6 +45,7 @@ impl RecordClass {
                 })?;
         let symbols = record_render::Symbols::from_direct(record, c_record)?;
         Ok(Self {
+            documentation: Documentation::new(record.meta().doc()),
             class_name: symbols.class_name().clone(),
             exception_name: record
                 .is_error_payload()
@@ -79,6 +82,7 @@ impl RecordClass {
             .map(|field| EncodedRecordField::from_field(field, package))
             .collect::<Result<Vec<_>>>()?;
         Ok(Self {
+            documentation: Documentation::new(record.meta().doc()),
             class_name: symbols.class_name().clone(),
             exception_name: record
                 .is_error_payload()
@@ -217,6 +221,7 @@ impl RecordClass {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RecordField {
+    pub documentation: Documentation,
     pub name: Identifier,
     pub annotation: TypeAnnotation,
     pub default: Option<Expression>,
@@ -225,6 +230,7 @@ pub struct RecordField {
 impl RecordField {
     pub fn from_encoded(field: &EncodedFieldDecl, package: &Package) -> Result<Self> {
         Ok(Self {
+            documentation: Documentation::new(field.meta().doc()),
             name: Self::name(field.key())?,
             annotation: TypeHint::from_type_ref(field.ty(), package)?.into_annotation(),
             default: field
@@ -271,6 +277,7 @@ impl RecordField {
 
     fn from_direct(field: &DirectFieldDecl, package: &Package) -> Result<Self> {
         Ok(Self {
+            documentation: Documentation::new(field.meta().doc()),
             name: Self::name(field.key())?,
             annotation: TypeHint::from_primitive(field.ty().primitive())?.into_annotation(),
             default: field

--- a/boltffi_backend/src/target/python/render/stream.rs
+++ b/boltffi_backend/src/target/python/render/stream.rs
@@ -14,10 +14,11 @@ use crate::{
     },
 };
 
-use super::type_hint::TypeHint;
+use super::{Documentation, type_hint::TypeHint};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ClassStream {
+    pub documentation: Documentation,
     pub python_name: Identifier,
     pub subscribe_method: Identifier,
     pub subscription_class: Identifier,
@@ -40,6 +41,7 @@ impl ClassStream {
         let pop_batch_body = item.pop_batch_body(symbols.pop_batch()?)?;
         let uses_wire_helpers = item.uses_wire_helpers;
         Ok(Self {
+            documentation: Documentation::new(declaration.meta().doc()),
             python_name: Name::new(declaration.name()).function()?,
             subscribe_method: symbols.subscribe()?,
             subscription_class: Identifier::parse(format!(

--- a/boltffi_backend/templates/target/python/package.py
+++ b/boltffi_backend/templates/target/python/package.py
@@ -487,6 +487,9 @@ _native._register_wire_codec({{ encoder.key() }}, {{ encoder.name() }})
 {%- when RecordWire::Fixed(fixed) %}
 {{ record.class_name }} = _native.{{ record.class_name }}
 {{ record.class_name }}.__module__ = __name__
+{%- if !record.documentation.is_empty() %}
+{{ record.class_name }}.__doc__ = {{ record.documentation.literal() }}
+{%- endif %}
 {{ record.class_name }}.__match_args__ = ({% for field in record.fields %}"{{ field.name }}",{% endfor %})
 {{ record.class_name }}.__annotations__ = {{ "{" }}{% for field in record.fields %}"{{ field.name }}": {{ field.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}{{ "}" }}
 {{ fixed.struct_global() }} = struct.Struct("{{ fixed.format() }}")
@@ -517,6 +520,7 @@ def _boltffi_attach_{{ record.class_name }}_from_reader(cls, reader: "_BoltFfiWi
 
 
 {% if constructor.asynchronous %}async {% endif %}def _boltffi_attach_{{ record.class_name }}_{{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ record.class_name }}":
+{{- constructor.documentation.docstring("    ") }}
 {%- for line in constructor.body %}
     {{ line }}
 {%- endfor %}
@@ -528,6 +532,7 @@ def _boltffi_attach_{{ record.class_name }}_from_reader(cls, reader: "_BoltFfiWi
 
 
 {% if method.asynchronous %}async {% endif %}def _boltffi_attach_{{ record.class_name }}_{{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("    ") }}
 {%- for line in method.body %}
     {{ line }}
 {%- endfor %}
@@ -539,6 +544,7 @@ def _boltffi_attach_{{ record.class_name }}_from_reader(cls, reader: "_BoltFfiWi
 
 
 {% if method.asynchronous %}async {% endif %}def _boltffi_attach_{{ record.class_name }}_{{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("    ") }}
 {%- for line in method.body %}
     {{ line }}
 {%- endfor %}
@@ -549,8 +555,10 @@ def _boltffi_attach_{{ record.class_name }}_from_reader(cls, reader: "_BoltFfiWi
 {%- when RecordWire::Fields(wire_fields) %}
 @dataclass(frozen=True, slots=True)
 class {{ record.class_name }}:
+{{- record.documentation.docstring("    ") }}
 {%- for field in record.fields %}
     {{ field.name }}: {{ field.annotation }}{% if let Some(default) = field.default %} = {{ default }}{% endif %}
+{{- field.documentation.docstring("    ") }}
 {%- endfor %}
 
     def _boltffi_wire(self) -> bytes:
@@ -581,6 +589,7 @@ class {{ record.class_name }}:
 
     @classmethod
     {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ record.class_name }}":
+{{- constructor.documentation.docstring("        ") }}
 {%- for line in constructor.body %}
         {{ line }}
 {%- endfor %}
@@ -589,6 +598,7 @@ class {{ record.class_name }}:
 
     @staticmethod
     {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("        ") }}
 {%- for line in method.body %}
         {{ line }}
 {%- endfor %}
@@ -596,6 +606,7 @@ class {{ record.class_name }}:
 {%- for method in record.instance_methods %}
 
     {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("        ") }}
 {%- for line in method.body %}
         {{ line }}
 {%- endfor %}
@@ -618,6 +629,7 @@ class {{ exception_name }}(RuntimeError):
 {% for enumeration in enums %}
 {%- if let Some(wire) = enumeration.wire %}
 class {{ enumeration.class_name }}:
+{{- enumeration.documentation.docstring("    ") }}
     __slots__ = ()
 
     @classmethod
@@ -642,6 +654,7 @@ class {{ enumeration.class_name }}:
 
     @classmethod
     {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ enumeration.class_name }}":
+{{- constructor.documentation.docstring("        ") }}
 {%- for line in constructor.body %}
         {{ line }}
 {%- endfor %}
@@ -650,6 +663,7 @@ class {{ enumeration.class_name }}:
 
     @staticmethod
     {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("        ") }}
 {%- for line in method.body %}
         {{ line }}
 {%- endfor %}
@@ -657,6 +671,7 @@ class {{ enumeration.class_name }}:
 {%- for method in enumeration.instance_methods %}
 
     {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("        ") }}
 {%- for line in method.body %}
         {{ line }}
 {%- endfor %}
@@ -665,9 +680,11 @@ class {{ enumeration.class_name }}:
 {% for variant in wire.variants %}
 @dataclass(frozen=True, slots=True)
 class {{ variant.class_name }}({{ enumeration.class_name }}):
+{{- variant.documentation.docstring("    ") }}
 {%- if variant.has_fields() %}
 {%- for field in variant.fields %}
     {{ field.name }}: {{ field.annotation }}{% if let Some(default) = field.default %} = {{ default }}{% endif %}
+{{- field.documentation.docstring("    ") }}
 {%- endfor %}
 {%- else %}
     pass
@@ -699,6 +716,7 @@ class {{ variant.class_name }}({{ enumeration.class_name }}):
 {% endfor %}
 {%- else %}
 class {{ enumeration.class_name }}(IntEnum):
+{{- enumeration.documentation.docstring("    ") }}
 {%- for variant in enumeration.variants %}
     {{ variant.name }} = {{ variant.value }}
 {%- endfor %}
@@ -706,6 +724,7 @@ class {{ enumeration.class_name }}(IntEnum):
 
     @classmethod
     {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ enumeration.class_name }}":
+{{- constructor.documentation.docstring("        ") }}
 {%- for line in constructor.body %}
         {{ line }}
 {%- endfor %}
@@ -714,6 +733,7 @@ class {{ enumeration.class_name }}(IntEnum):
 
     @staticmethod
     {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("        ") }}
 {%- for line in method.body %}
         {{ line }}
 {%- endfor %}
@@ -721,6 +741,7 @@ class {{ enumeration.class_name }}(IntEnum):
 {%- for method in enumeration.instance_methods %}
 
     {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("        ") }}
 {%- for line in method.body %}
         {{ line }}
 {%- endfor %}
@@ -742,11 +763,13 @@ class {{ exception_name }}(RuntimeError):
 {% endfor %}
 {% for class in classes %}
 class {{ class.class_name }}:
+{{- class.documentation.docstring("    ") }}
     __slots__ = ("_handle",)
 
 {% if !class.init.is_empty() %}
 {% for init in class.init %}
     def __init__(self{% for parameter in init.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> None:
+{{- init.documentation.docstring("        ") }}
         self._handle = _native.{{ init.native_name }}({{ init.arguments }})
 {% endfor %}
 {% else %}
@@ -769,6 +792,7 @@ class {{ class.class_name }}:
 
     @classmethod
     {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ class.class_name }}":
+{{- constructor.documentation.docstring("        ") }}
 {%- for line in constructor.body %}
         {{ line }}
 {%- endfor %}
@@ -777,6 +801,7 @@ class {{ class.class_name }}:
 
     @staticmethod
     {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("        ") }}
 {%- for line in method.body %}
         {{ line }}
 {%- endfor %}
@@ -784,6 +809,7 @@ class {{ class.class_name }}:
 {%- for method in class.instance_methods %}
 
     {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:
+{{- method.documentation.docstring("        ") }}
 {%- for line in method.body %}
         {{ line }}
 {%- endfor %}
@@ -791,6 +817,7 @@ class {{ class.class_name }}:
 {%- for stream in class.streams %}
 
     def {{ stream.python_name }}(self) -> "{{ stream.subscription_class }}":
+{{- stream.documentation.docstring("        ") }}
         return {{ stream.subscription_class }}._from_handle(_native.{{ stream.subscribe_method }}(self._handle))
 {%- endfor %}
 
@@ -842,9 +869,11 @@ class {{ stream.subscription_class }}:
 {% endfor %}
 {% for constant in constants %}
 {{ constant.python_name }}: {{ constant.annotation }} = {{ constant.expression }}
+{{- constant.documentation.docstring("") }}
 {% endfor %}
 {% for function in functions %}
 {% if function.asynchronous %}async {% endif %}def {{ function.python_name }}({% for parameter in function.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ function.return_annotation }}:
+{{- function.documentation.docstring("    ") }}
 {%- for line in function.body %}
     {{ line }}
 {%- endfor %}

--- a/boltffi_backend/templates/target/python/package.pyi
+++ b/boltffi_backend/templates/target/python/package.pyi
@@ -24,22 +24,25 @@ PACKAGE_VERSION: str | None
 {% for record in records %}
 @dataclass(frozen=True, slots=True)
 class {{ record.class_name }}:
+{{- record.documentation.docstring("    ") }}
 {%- for constant in record.constants %}
     {{ constant.python_name }}: ClassVar[{{ constant.annotation }}]
+{{- constant.documentation.docstring("    ") }}
 {%- endfor %}
 {%- for field in record.fields %}
     {{ field.name }}: {{ field.annotation }}{% if let Some(default) = field.default %} = {{ default }}{% endif %}
+{{- field.documentation.docstring("    ") }}
 {%- endfor %}
 {%- for constructor in record.constructors %}
     @classmethod
-    {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ record.class_name }}": ...
+    {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ record.class_name }}":{% if constructor.documentation.is_empty() %} ...{% else %}{{ constructor.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 {%- for method in record.static_methods %}
     @staticmethod
-    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}: ...
+    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:{% if method.documentation.is_empty() %} ...{% else %}{{ method.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 {%- for method in record.instance_methods %}
-    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}: ...
+    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:{% if method.documentation.is_empty() %} ...{% else %}{{ method.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 
 {% if let Some(exception_name) = record.exception_name %}
@@ -52,30 +55,34 @@ class {{ exception_name }}(RuntimeError):
 {% for enumeration in enums %}
 {%- if let Some(wire) = enumeration.wire %}
 class {{ enumeration.class_name }}:
+{{- enumeration.documentation.docstring("    ") }}
 {%- if enumeration.constructors.is_empty() && enumeration.static_methods.is_empty() && enumeration.instance_methods.is_empty() && enumeration.constants.is_empty() %}
     pass
 {%- endif %}
 {%- for constant in enumeration.constants %}
     {{ constant.python_name }}: ClassVar[{{ constant.annotation }}]
+{{- constant.documentation.docstring("    ") }}
 {%- endfor %}
 {%- for constructor in enumeration.constructors %}
     @classmethod
-    {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ enumeration.class_name }}": ...
+    {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ enumeration.class_name }}":{% if constructor.documentation.is_empty() %} ...{% else %}{{ constructor.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 {%- for method in enumeration.static_methods %}
     @staticmethod
-    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}: ...
+    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:{% if method.documentation.is_empty() %} ...{% else %}{{ method.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 {%- for method in enumeration.instance_methods %}
-    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}: ...
+    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:{% if method.documentation.is_empty() %} ...{% else %}{{ method.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 
 {% for variant in wire.variants %}
 @dataclass(frozen=True, slots=True)
 class {{ variant.class_name }}({{ enumeration.class_name }}):
+{{- variant.documentation.docstring("    ") }}
 {%- if variant.has_fields() %}
 {%- for field in variant.fields %}
     {{ field.name }}: {{ field.annotation }}{% if let Some(default) = field.default %} = {{ default }}{% endif %}
+{{- field.documentation.docstring("    ") }}
 {%- endfor %}
 {%- else %}
     pass
@@ -84,22 +91,24 @@ class {{ variant.class_name }}({{ enumeration.class_name }}):
 {% endfor %}
 {%- else %}
 class {{ enumeration.class_name }}(IntEnum):
+{{- enumeration.documentation.docstring("    ") }}
 {%- for variant in enumeration.variants %}
     {{ variant.name }} = {{ variant.value }}
 {%- endfor %}
 {%- for constant in enumeration.constants %}
     {{ constant.python_name }}: ClassVar[{{ constant.annotation }}]
+{{- constant.documentation.docstring("    ") }}
 {%- endfor %}
 {%- for constructor in enumeration.constructors %}
     @classmethod
-    {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ enumeration.class_name }}": ...
+    {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ enumeration.class_name }}":{% if constructor.documentation.is_empty() %} ...{% else %}{{ constructor.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 {%- for method in enumeration.static_methods %}
     @staticmethod
-    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}: ...
+    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:{% if method.documentation.is_empty() %} ...{% else %}{{ method.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 {%- for method in enumeration.instance_methods %}
-    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}: ...
+    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:{% if method.documentation.is_empty() %} ...{% else %}{{ method.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 
 {%- endif %}
@@ -112,13 +121,15 @@ class {{ exception_name }}(RuntimeError):
 {% endfor %}
 {% for class in classes %}
 class {{ class.class_name }}:
+{{- class.documentation.docstring("    ") }}
     _handle: int
 {%- for constant in class.constants %}
     {{ constant.python_name }}: ClassVar[{{ constant.annotation }}]
+{{- constant.documentation.docstring("    ") }}
 {%- endfor %}
 {% if !class.init.is_empty() %}
 {% for init in class.init %}
-    def __init__(self{% for parameter in init.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> None: ...
+    def __init__(self{% for parameter in init.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> None:{% if init.documentation.is_empty() %} ...{% else %}{{ init.documentation.docstring("        ") }}{% endif %}
 {% endfor %}
 {% else %}
     def __init__(self) -> None: ...
@@ -128,17 +139,17 @@ class {{ class.class_name }}:
     def __del__(self) -> None: ...
 {%- for constructor in class.constructors %}
     @classmethod
-    {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ class.class_name }}": ...
+    {% if constructor.asynchronous %}async {% endif %}def {{ constructor.python_name }}(cls{% for parameter in constructor.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> "{{ class.class_name }}":{% if constructor.documentation.is_empty() %} ...{% else %}{{ constructor.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 {%- for method in class.static_methods %}
     @staticmethod
-    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}: ...
+    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}({% for parameter in method.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ method.return_annotation }}:{% if method.documentation.is_empty() %} ...{% else %}{{ method.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 {%- for method in class.instance_methods %}
-    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}: ...
+    {% if method.asynchronous %}async {% endif %}def {{ method.python_name }}(self{% for parameter in method.parameters %}, {{ parameter.name }}: {{ parameter.annotation }}{% endfor %}) -> {{ method.return_annotation }}:{% if method.documentation.is_empty() %} ...{% else %}{{ method.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 {%- for stream in class.streams %}
-    def {{ stream.python_name }}(self) -> "{{ stream.subscription_class }}": ...
+    def {{ stream.python_name }}(self) -> "{{ stream.subscription_class }}":{% if stream.documentation.is_empty() %} ...{% else %}{{ stream.documentation.docstring("        ") }}{% endif %}
 {%- endfor %}
 
 {% for stream in class.streams %}
@@ -156,7 +167,8 @@ class {{ stream.subscription_class }}:
 {% endfor %}
 {% for constant in constants %}
 {{ constant.python_name }}: {{ constant.annotation }}
+{{- constant.documentation.docstring("") }}
 {% endfor %}
 {% for function in functions %}
-{% if function.asynchronous %}async {% endif %}def {{ function.python_name }}({% for parameter in function.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ function.return_annotation }}: ...
+{% if function.asynchronous %}async {% endif %}def {{ function.python_name }}({% for parameter in function.parameters %}{{ parameter.name }}: {{ parameter.annotation }}{% if !loop.last %}, {% endif %}{% endfor %}) -> {{ function.return_annotation }}:{% if function.documentation.is_empty() %} ...{% else %}{{ function.documentation.docstring("    ") }}{% endif %}
 {%- endfor %}


### PR DESCRIPTION
Pipes Rust doc comments into the generated Python bindings as docstrings in `package.py` and `package.pyi`; the C extension still sets no `ml_doc`/`tp_doc`, which is a possible follow-up.