### PR TITLE
fix: classify blittable records through one shared portable-layout rule

### DIFF
--- a/boltffi_bindgen/src/ir/definitions.rs
+++ b/boltffi_bindgen/src/ir/definitions.rs
@@ -1,5 +1,5 @@
 use boltffi_ffi_rules::callable::{CallableForm, ExecutionKind};
-use boltffi_ffi_rules::classification::{self, FieldPrimitive, PassableCategory};
+use boltffi_ffi_rules::classification::{self, PassableCategory};
 
 use crate::ir::abi::CallId;
 use crate::ir::ids::{
@@ -56,22 +56,14 @@ impl RecordDef {
     }
 
     pub fn is_blittable(&self) -> bool {
-        let field_primitives: Vec<FieldPrimitive> = self
-            .fields
-            .iter()
-            .filter_map(|f| match &f.type_expr {
-                TypeExpr::Primitive(p) => Some(p.to_field_primitive()),
-                _ => None,
-            })
-            .collect();
-        let all_primitive = field_primitives.len() == self.fields.len();
-        let classify_fields = if all_primitive {
-            &field_primitives[..]
-        } else {
-            &[]
-        };
         matches!(
-            classification::classify_struct(self.is_repr_c, classify_fields),
+            classification::classify_struct_fields(
+                self.is_repr_c,
+                self.fields.iter().map(|f| match &f.type_expr {
+                    TypeExpr::Primitive(p) => Some(*p),
+                    _ => None,
+                }),
+            ),
             PassableCategory::Blittable,
         )
     }

--- a/boltffi_bindgen/src/ir/lower/codec.rs
+++ b/boltffi_bindgen/src/ir/lower/codec.rs
@@ -65,22 +65,17 @@ impl<'c> Lowerer<'c> {
     }
 
     pub(super) fn is_blittable_record(&self, definition: &RecordDef) -> bool {
-        let field_primitives: Vec<_> = definition
-            .fields
-            .iter()
-            .filter_map(|field| match &field.type_expr {
-                TypeExpr::Primitive(primitive) => Some(primitive.to_field_primitive()),
-                _ => None,
-            })
-            .collect();
-        let all_primitive = field_primitives.len() == definition.fields.len();
-        let classify_fields = if all_primitive {
-            &field_primitives[..]
-        } else {
-            &[]
-        };
         matches!(
-            classification::classify_struct(definition.is_repr_c, classify_fields),
+            classification::classify_struct_fields(
+                definition.is_repr_c,
+                definition
+                    .fields
+                    .iter()
+                    .map(|field| match &field.type_expr {
+                        TypeExpr::Primitive(primitive) => Some(*primitive),
+                        _ => None,
+                    }),
+            ),
             PassableCategory::Blittable,
         )
     }

--- a/boltffi_bindgen/src/ir/lower/mod.rs
+++ b/boltffi_bindgen/src/ir/lower/mod.rs
@@ -845,6 +845,40 @@ mod tests {
     }
 
     #[test]
+    fn mixed_alignment_record_layout_is_encoded() {
+        let mut contract = test_contract();
+        let record_id = RecordId::new("Trade");
+        contract.catalog.insert_record(RecordDef {
+            is_repr_c: true,
+            is_error: false,
+            id: record_id.clone(),
+            fields: vec![
+                FieldDef {
+                    name: FieldName::new("symbol_id"),
+                    type_expr: TypeExpr::Primitive(PrimitiveType::I32),
+                    doc: None,
+                    default: None,
+                },
+                FieldDef {
+                    name: FieldName::new("price"),
+                    type_expr: TypeExpr::Primitive(PrimitiveType::F64),
+                    doc: None,
+                    default: None,
+                },
+            ],
+            constructors: vec![],
+            methods: vec![],
+            doc: None,
+            deprecated: None,
+        });
+
+        let lowerer = lowerer_for_contract(&contract);
+        let layout = lowerer.record_layout(&record_id);
+
+        assert!(matches!(layout, RecordLayout::Encoded { .. }));
+    }
+
+    #[test]
     fn encoded_record_layout() {
         let mut contract = test_contract();
         let record_id = RecordId::new("Person");

--- a/boltffi_binding/Cargo.toml
+++ b/boltffi_binding/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["development-tools::ffi"]
 
 [dependencies]
 boltffi_ast.workspace = true
+boltffi_ffi_rules.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/boltffi_binding/src/lower/layout.rs
+++ b/boltffi_binding/src/lower/layout.rs
@@ -1,103 +1,40 @@
-use boltffi_ast::RecordDef as SourceRecord;
+use boltffi_ast::{RecordDef as SourceRecord, TypeExpr};
+use boltffi_ffi_rules::classification;
 
-use crate::{
-    ByteAlignment, ByteOffset, ByteSize, DirectFieldType, FieldKey, FieldLayout, Primitive,
-    RecordLayout,
-};
+use crate::{ByteAlignment, ByteOffset, ByteSize, FieldKey, FieldLayout, RecordLayout};
 
 use super::{LowerError, error::UnsupportedType, primitive};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum WideScalarAlignment {
-    EightBytes,
-    FourBytes,
-}
-
-impl WideScalarAlignment {
-    const fn bytes(self) -> u64 {
-        match self {
-            Self::EightBytes => 8,
-            Self::FourBytes => 4,
-        }
-    }
-}
-
 /// Computes the byte-level layout of a direct record.
 ///
-/// Walks the fields in source order, advancing the running offset to
-/// the alignment each primitive demands and tracking the largest
-/// alignment seen as the record's own. The trailing size is rounded up
-/// to that alignment so an array of these records lays out without
-/// internal padding.
+/// Delegates the offset walk to [`classification::layout_profile`] under the
+/// natural alignment profile, so the layout emitted here cannot drift from
+/// the one the shared classifier called blittable.
 pub fn compute(record: &SourceRecord) -> Result<RecordLayout, LowerError> {
-    compute_with_wide_scalar_alignment(record, WideScalarAlignment::EightBytes)
-}
-
-/// Reports whether every supported native ABI gives a record the same bytes.
-///
-/// Most native targets align `i64`, `u64`, and `f64` to eight bytes. The
-/// 32-bit x86 ABI aligns those scalars to four bytes instead. Direct records
-/// are safe only when both profiles agree on the total byte count and every
-/// field offset. Their container alignment may differ: the IR retains the
-/// larger alignment so generated allocators always over-align rather than
-/// under-align storage.
-pub fn has_portable_byte_layout(record: &SourceRecord) -> bool {
-    let eight_byte_layout =
-        compute_with_wide_scalar_alignment(record, WideScalarAlignment::EightBytes);
-    let four_byte_layout =
-        compute_with_wide_scalar_alignment(record, WideScalarAlignment::FourBytes);
-
-    matches!(
-        (eight_byte_layout, four_byte_layout),
-        (Ok(eight_byte), Ok(four_byte))
-            if eight_byte.size() == four_byte.size()
-                && eight_byte.fields() == four_byte.fields()
-    )
-}
-
-fn compute_with_wide_scalar_alignment(
-    record: &SourceRecord,
-    wide_scalar_alignment: WideScalarAlignment,
-) -> Result<RecordLayout, LowerError> {
-    let (offset, alignment, fields) = record.fields.iter().try_fold(
-        (0_u64, 1_u64, Vec::new()),
-        |(offset, alignment, mut fields), field| {
-            let field_type = primitive::direct_field_type(&field.type_expr)
-                .ok_or_else(|| LowerError::unsupported_type(UnsupportedType::RecordField))?;
-            let field_alignment = field_alignment(field_type, wide_scalar_alignment).get();
-            let field_offset = align_up(offset, field_alignment);
-            fields.push(FieldLayout::new(
-                FieldKey::from(field),
-                ByteOffset::new(field_offset),
-            ));
-            Ok::<_, LowerError>((
-                field_offset + field_type.byte_size().get(),
-                alignment.max(field_alignment),
-                fields,
-            ))
-        },
-    )?;
-    let alignment = ByteAlignment::new(alignment)
+    let field_primitives = record
+        .fields
+        .iter()
+        .map(|field| match &field.type_expr {
+            TypeExpr::Primitive(field_primitive) => {
+                Ok(primitive::classification_primitive(*field_primitive))
+            }
+            _ => Err(LowerError::unsupported_type(UnsupportedType::RecordField)),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let profile = classification::layout_profile(&field_primitives, u64::MAX)
+        .ok_or_else(|| LowerError::unsupported_type(UnsupportedType::RecordField))?;
+    let alignment = ByteAlignment::new(profile.alignment)
         .map_err(|error| LowerError::invalid_alignment(error.bytes()))?;
+    let fields = record
+        .fields
+        .iter()
+        .zip(&profile.offsets)
+        .map(|(field, offset)| FieldLayout::new(FieldKey::from(field), ByteOffset::new(*offset)))
+        .collect();
 
     Ok(RecordLayout::new(
-        ByteSize::new(align_up(offset, alignment.get())),
+        ByteSize::new(profile.size),
         alignment,
         fields,
     ))
-}
-
-fn field_alignment(
-    field_type: DirectFieldType,
-    wide_scalar_alignment: WideScalarAlignment,
-) -> ByteAlignment {
-    let bytes = match field_type.primitive() {
-        Primitive::I64 | Primitive::U64 | Primitive::F64 => wide_scalar_alignment.bytes(),
-        _ => field_type.byte_alignment().get(),
-    };
-    ByteAlignment::new(bytes).expect("direct field alignments are powers of two")
-}
-
-fn align_up(offset: u64, alignment: u64) -> u64 {
-    (offset + alignment - 1) & !(alignment - 1)
 }

--- a/boltffi_binding/src/lower/primitive.rs
+++ b/boltffi_binding/src/lower/primitive.rs
@@ -2,6 +2,27 @@ use boltffi_ast::{Primitive as SourcePrimitive, ReprAttr, ReprItem, TypeExpr};
 
 use crate::{DirectFieldType, IntegerRepr, Primitive};
 
+pub fn classification_primitive(
+    primitive: SourcePrimitive,
+) -> boltffi_ffi_rules::primitive::Primitive {
+    use boltffi_ffi_rules::primitive::Primitive as RulesPrimitive;
+    match primitive {
+        SourcePrimitive::Bool => RulesPrimitive::Bool,
+        SourcePrimitive::I8 => RulesPrimitive::I8,
+        SourcePrimitive::U8 => RulesPrimitive::U8,
+        SourcePrimitive::I16 => RulesPrimitive::I16,
+        SourcePrimitive::U16 => RulesPrimitive::U16,
+        SourcePrimitive::I32 => RulesPrimitive::I32,
+        SourcePrimitive::U32 => RulesPrimitive::U32,
+        SourcePrimitive::I64 => RulesPrimitive::I64,
+        SourcePrimitive::U64 => RulesPrimitive::U64,
+        SourcePrimitive::ISize => RulesPrimitive::ISize,
+        SourcePrimitive::USize => RulesPrimitive::USize,
+        SourcePrimitive::F32 => RulesPrimitive::F32,
+        SourcePrimitive::F64 => RulesPrimitive::F64,
+    }
+}
+
 pub fn direct_field_type(type_expr: &TypeExpr) -> Option<DirectFieldType> {
     match type_expr {
         TypeExpr::Primitive(primitive) => DirectFieldType::new((*primitive).into()),

--- a/boltffi_binding/src/lower/records.rs
+++ b/boltffi_binding/src/lower/records.rs
@@ -1,4 +1,5 @@
 use boltffi_ast::{RecordDef as SourceRecord, TypeExpr};
+use boltffi_ffi_rules::classification;
 
 use crate::{
     CanonicalName, DirectFieldDecl, DirectRecordDecl, EncodedFieldDecl, EncodedRecordDecl,
@@ -43,14 +44,22 @@ pub fn lower<S: SurfaceLower>(
 /// A record that declares a different `repr` keeps the layout intent it
 /// wrote and crosses encoded. Records whose size or field offsets change
 /// between supported native ABI alignment profiles also cross encoded.
+///
+/// Delegates to [`classification::classify_struct_fields`] so the macro,
+/// the generator, and this lowering share one classifier.
 pub fn is_direct(record: &SourceRecord) -> bool {
-    primitive::has_effective_repr_c(&record.repr)
-        && !record.fields.is_empty()
-        && record
-            .fields
-            .iter()
-            .all(|field| primitive::direct_field_type(&field.type_expr).is_some())
-        && layout::has_portable_byte_layout(record)
+    matches!(
+        classification::classify_struct_fields(
+            primitive::has_effective_repr_c(&record.repr),
+            record.fields.iter().map(|field| match &field.type_expr {
+                TypeExpr::Primitive(field_primitive) => {
+                    Some(primitive::classification_primitive(*field_primitive))
+                }
+                _ => None,
+            }),
+        ),
+        classification::PassableCategory::Blittable
+    )
 }
 
 fn lower_one<S: SurfaceLower>(

--- a/boltffi_ffi_rules/src/lib.rs
+++ b/boltffi_ffi_rules/src/lib.rs
@@ -1499,6 +1499,8 @@ pub mod transport {
 }
 
 pub mod classification {
+    use super::primitive::Primitive;
+
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub enum PassableCategory {
         Scalar,
@@ -1506,11 +1508,23 @@ pub mod classification {
         WireEncoded,
     }
 
-    pub fn classify_struct(is_repr_c: bool, field_types: &[FieldPrimitive]) -> PassableCategory {
-        if is_repr_c && !field_types.is_empty() && field_types.iter().all(|f| f.is_fixed_width) {
+    pub fn classify_struct(is_repr_c: bool, field_types: &[Primitive]) -> PassableCategory {
+        if is_repr_c && !field_types.is_empty() && has_portable_layout(field_types) {
             PassableCategory::Blittable
         } else {
             PassableCategory::WireEncoded
+        }
+    }
+
+    /// Classifies a struct from per-field primitives where `None` marks a
+    /// field that is not an admissible primitive; any `None` is wire-encoded.
+    pub fn classify_struct_fields<I>(is_repr_c: bool, field_types: I) -> PassableCategory
+    where
+        I: IntoIterator<Item = Option<Primitive>>,
+    {
+        match field_types.into_iter().collect::<Option<Vec<_>>>() {
+            Some(fields) => classify_struct(is_repr_c, &fields),
+            None => PassableCategory::WireEncoded,
         }
     }
 
@@ -1522,32 +1536,58 @@ pub mod classification {
         }
     }
 
-    #[derive(Debug, Clone, Copy)]
-    pub struct FieldPrimitive {
-        pub is_fixed_width: bool,
+    /// Reports whether every supported native ABI gives the fields the same
+    /// bytes.
+    ///
+    /// Most native targets use each scalar's natural alignment; 32-bit x86
+    /// caps alignment at four bytes. Blittable structs must agree on total
+    /// size and every field offset under both profiles. Container alignment
+    /// may differ: allocators over-align rather than under-align storage.
+    fn has_portable_layout(field_types: &[Primitive]) -> bool {
+        match (
+            layout_profile(field_types, u64::MAX),
+            layout_profile(field_types, 4),
+        ) {
+            (Some(natural), Some(four_byte)) => {
+                natural.size == four_byte.size && natural.offsets == four_byte.offsets
+            }
+            _ => false,
+        }
     }
 
-    impl FieldPrimitive {
-        pub fn fixed() -> Self {
-            Self {
-                is_fixed_width: true,
-            }
-        }
+    /// Size, container alignment, and field offsets of a field sequence
+    /// under one alignment profile.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct LayoutProfile {
+        pub size: u64,
+        pub alignment: u64,
+        pub offsets: Vec<u64>,
+    }
 
-        pub fn platform_sized() -> Self {
-            Self {
-                is_fixed_width: false,
-            }
+    /// Walks the fields in source order under C layout rules with every field
+    /// alignment capped at `alignment_cap` (`u64::MAX` for the natural
+    /// profile); `None` when a field has no fixed ABI width.
+    pub fn layout_profile(field_types: &[Primitive], alignment_cap: u64) -> Option<LayoutProfile> {
+        let mut offset = 0_u64;
+        let mut struct_alignment = 1_u64;
+        let mut offsets = Vec::with_capacity(field_types.len());
+        for field in field_types {
+            let size = field.size_bytes()? as u64;
+            let alignment = (field.alignment()? as u64).min(alignment_cap);
+            offset = align_up(offset, alignment);
+            offsets.push(offset);
+            offset += size;
+            struct_alignment = struct_alignment.max(alignment);
         }
+        Some(LayoutProfile {
+            size: align_up(offset, struct_alignment),
+            alignment: struct_alignment,
+            offsets,
+        })
+    }
 
-        pub fn from_type_name(name: &str) -> Option<Self> {
-            match name {
-                "i8" | "u8" | "i16" | "u16" | "i32" | "u32" | "i64" | "u64" | "f32" | "f64"
-                | "bool" => Some(Self::fixed()),
-                "isize" | "usize" => Some(Self::platform_sized()),
-                _ => None,
-            }
-        }
+    fn align_up(offset: u64, alignment: u64) -> u64 {
+        (offset + alignment - 1) & !(alignment - 1)
     }
 
     #[cfg(test)]
@@ -1571,13 +1611,61 @@ pub mod classification {
 
         #[test]
         fn all_fixed_width_struct_is_blittable() {
-            let fields = vec![FieldPrimitive::fixed(), FieldPrimitive::fixed()];
+            let fields = vec![Primitive::U32, Primitive::F32];
             assert_eq!(classify_struct(true, &fields), PassableCategory::Blittable);
         }
 
         #[test]
+        fn wide_scalar_struct_is_blittable() {
+            let fields = vec![Primitive::F64, Primitive::I64];
+            assert_eq!(classify_struct(true, &fields), PassableCategory::Blittable);
+        }
+
+        #[test]
+        fn explicitly_padded_mixed_alignment_struct_is_blittable() {
+            let fields = vec![Primitive::U32, Primitive::U32, Primitive::F64];
+            assert_eq!(classify_struct(true, &fields), PassableCategory::Blittable);
+        }
+
+        #[test]
+        fn non_primitive_field_is_wire_encoded() {
+            let fields = vec![Some(Primitive::U32), None];
+            assert_eq!(
+                classify_struct_fields(true, fields),
+                PassableCategory::WireEncoded
+            );
+        }
+
+        #[test]
+        fn all_primitive_fields_classify_through_shared_rule() {
+            let fields = vec![Some(Primitive::U32), Some(Primitive::F32)];
+            assert_eq!(
+                classify_struct_fields(true, fields),
+                PassableCategory::Blittable
+            );
+        }
+
+        #[test]
+        fn mixed_alignment_struct_is_wire_encoded() {
+            let fields = vec![Primitive::U32, Primitive::F64];
+            assert_eq!(
+                classify_struct(true, &fields),
+                PassableCategory::WireEncoded
+            );
+        }
+
+        #[test]
+        fn trailing_padding_struct_is_wire_encoded() {
+            let fields = vec![Primitive::F64, Primitive::U32];
+            assert_eq!(
+                classify_struct(true, &fields),
+                PassableCategory::WireEncoded
+            );
+        }
+
+        #[test]
         fn struct_with_platform_sized_is_wire_encoded() {
-            let fields = vec![FieldPrimitive::fixed(), FieldPrimitive::platform_sized()];
+            let fields = vec![Primitive::U32, Primitive::USize];
             assert_eq!(
                 classify_struct(true, &fields),
                 PassableCategory::WireEncoded
@@ -1586,7 +1674,7 @@ pub mod classification {
 
         #[test]
         fn struct_without_repr_c_is_wire_encoded() {
-            let fields = vec![FieldPrimitive::fixed()];
+            let fields = vec![Primitive::U32];
             assert_eq!(
                 classify_struct(false, &fields),
                 PassableCategory::WireEncoded

--- a/boltffi_ffi_rules/src/primitive.rs
+++ b/boltffi_ffi_rules/src/primitive.rs
@@ -1,7 +1,5 @@
 use std::str::FromStr;
 
-use super::classification::FieldPrimitive;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Primitive {
@@ -174,14 +172,6 @@ impl Primitive {
                 | Self::U32
                 | Self::F32
         )
-    }
-
-    pub fn to_field_primitive(self) -> FieldPrimitive {
-        if self.is_platform_sized() {
-            FieldPrimitive::platform_sized()
-        } else {
-            FieldPrimitive::fixed()
-        }
     }
 }
 

--- a/boltffi_macros/src/data/analysis.rs
+++ b/boltffi_macros/src/data/analysis.rs
@@ -1,5 +1,8 @@
-use boltffi_ffi_rules::classification::{self, FieldPrimitive, PassableCategory};
-use syn::{Attribute, Fields, ItemEnum, ItemStruct, Type};
+use std::str::FromStr;
+
+use boltffi_ffi_rules::classification::{self, PassableCategory};
+use boltffi_ffi_rules::primitive::Primitive;
+use syn::{Attribute, ItemEnum, ItemStruct, Type};
 
 pub(crate) struct StructDataShape<'a> {
     item_struct: &'a ItemStruct,
@@ -7,11 +10,6 @@ pub(crate) struct StructDataShape<'a> {
 
 pub(crate) struct EnumDataShape<'a> {
     item_enum: &'a ItemEnum,
-}
-
-struct StructFieldFacts {
-    primitives: Vec<FieldPrimitive>,
-    total_fields: usize,
 }
 
 struct DataItemAttributes<'a> {
@@ -28,9 +26,12 @@ impl<'a> StructDataShape<'a> {
     }
 
     pub(crate) fn passable_category(&self) -> PassableCategory {
-        classification::classify_struct(
+        classification::classify_struct_fields(
             self.has_effective_repr_c(),
-            &self.classification_primitives(),
+            self.item_struct
+                .fields
+                .iter()
+                .map(|field| primitive_for(&field.ty)),
         )
     }
 
@@ -42,14 +43,15 @@ impl<'a> StructDataShape<'a> {
         let data_attributes = DataItemAttributes::new(&self.item_struct.attrs);
         data_attributes.has_repr_c() || !data_attributes.has_any_repr()
     }
+}
 
-    fn classification_primitives(&self) -> Vec<FieldPrimitive> {
-        let field_facts = StructFieldFacts::from_fields(&self.item_struct.fields);
-        if field_facts.primitives.len() == field_facts.total_fields {
-            field_facts.primitives
-        } else {
-            Vec::new()
-        }
+fn primitive_for(rust_type: &Type) -> Option<Primitive> {
+    match rust_type {
+        Type::Path(type_path) => type_path
+            .path
+            .get_ident()
+            .and_then(|ident| Primitive::from_str(&ident.to_string()).ok()),
+        _ => None,
     }
 }
 
@@ -88,38 +90,6 @@ impl<'a> EnumDataShape<'a> {
     fn has_effective_integer_repr(&self) -> bool {
         let data_attributes = DataItemAttributes::new(&self.item_enum.attrs);
         self.has_integer_repr() || (self.is_c_style() && !data_attributes.has_any_repr())
-    }
-}
-
-impl StructFieldFacts {
-    fn from_fields(fields: &Fields) -> Self {
-        match fields {
-            Fields::Named(named_fields) => Self::from_field_iter(named_fields.named.iter()),
-            Fields::Unnamed(unnamed_fields) => Self::from_field_iter(unnamed_fields.unnamed.iter()),
-            Fields::Unit => Self {
-                primitives: Vec::new(),
-                total_fields: 0,
-            },
-        }
-    }
-
-    fn from_field_iter<'a>(fields: impl Iterator<Item = &'a syn::Field>) -> Self {
-        let field_types = fields.map(|field| &field.ty).collect::<Vec<_>>();
-        let primitives = field_types.iter().filter_map(Self::primitive_for).collect();
-        Self {
-            primitives,
-            total_fields: field_types.len(),
-        }
-    }
-
-    fn primitive_for(rust_type: &&Type) -> Option<FieldPrimitive> {
-        match rust_type {
-            Type::Path(type_path) => type_path
-                .path
-                .get_ident()
-                .and_then(|ident| FieldPrimitive::from_type_name(&ident.to_string())),
-            _ => None,
-        }
     }
 }
 
@@ -192,5 +162,40 @@ impl<'a> DataItemAttributes<'a> {
         self.attrs
             .iter()
             .any(|attribute| attribute.path().is_ident("repr"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::parse_quote;
+
+    use super::*;
+
+    #[test]
+    fn mixed_alignment_data_struct_is_wire_encoded() {
+        let item: syn::ItemStruct = parse_quote! {
+            pub struct Sample {
+                pub id: u32,
+                pub value: f64,
+            }
+        };
+        assert_eq!(
+            StructDataShape::new(&item).passable_category(),
+            PassableCategory::WireEncoded
+        );
+    }
+
+    #[test]
+    fn uniform_alignment_data_struct_is_blittable() {
+        let item: syn::ItemStruct = parse_quote! {
+            pub struct Sample {
+                pub id: u32,
+                pub value: f32,
+            }
+        };
+        assert_eq!(
+            StructDataShape::new(&item).passable_category(),
+            PassableCategory::Blittable
+        );
     }
 }

--- a/boltffi_macros/tests/fixtures/core_only_interned_string_pool/Cargo.lock
+++ b/boltffi_macros/tests/fixtures/core_only_interned_string_pool/Cargo.lock
@@ -14,6 +14,7 @@ name = "boltffi_binding"
 version = "0.29.0"
 dependencies = [
  "boltffi_ast",
+ "boltffi_ffi_rules",
  "serde",
  "serde_json",
 ]

--- a/boltffi_macros/tests/fixtures/renamed_core_only_interned_string_pool/Cargo.lock
+++ b/boltffi_macros/tests/fixtures/renamed_core_only_interned_string_pool/Cargo.lock
@@ -14,6 +14,7 @@ name = "boltffi_binding"
 version = "0.29.0"
 dependencies = [
  "boltffi_ast",
+ "boltffi_ffi_rules",
  "serde",
  "serde_json",
 ]

--- a/boltffi_macros/tests/fixtures/renamed_interned_string_pool/Cargo.lock
+++ b/boltffi_macros/tests/fixtures/renamed_interned_string_pool/Cargo.lock
@@ -22,6 +22,7 @@ name = "boltffi_binding"
 version = "0.29.0"
 dependencies = [
  "boltffi_ast",
+ "boltffi_ffi_rules",
  "serde",
  "serde_json",
 ]


### PR DESCRIPTION
The workspace has two blittable classifiers that disagree on mixed-alignment records. `boltffi_binding`'s `is_direct` rejects records whose layout differs between native ABI alignment profiles (32-bit x86 aligns `i64`/`u64`/`f64` to four bytes), but `boltffi_ffi_rules::classification::classify_struct` — the classifier behind the macro expansion and the bindgen IR lane — had no such check.

The demo already contains a witness:

```rust
#[data]
pub struct Trade {
    pub id: i64,
    pub symbol_id: i32,
    pub price: f64,
    // ...
}
```

`price` sits at offset 16 under the eight-byte profile and offset 12 under the 32-bit x86 profile, so every shipping backend (which renders from the binding-lowered metadata) declares `Trade` wire-encoded — while the macro expansion classifies the same struct blittable and crosses it as raw struct bytes.

This PR makes the portable-layout check part of the shared rule:

- `classify_struct` now takes `&[Primitive]` (which already knows size and   alignment) and requires layout agreement between the natural and  four-byte-capped alignment profiles; the width-blind `FieldPrimitive`  type is gone. A `classify_struct_fields` helper covers the  not-every-field-is-a-primitive case, so all call sites share the same short-circuit instead of hand-rolling it.
- `boltffi_binding::lower::records::is_direct` delegates to the shared classifier, and `lower/layout.rs::compute` builds its offsets from the same shared walk (`classification::layout_profile`), so the emitted layout cannot drift from what the classifier approved.
- The macro lane and the bindgen IR lane pick up the check through their existing classification calls.

Behavior change: `#[data]` structs whose field offsets or total size differ between alignment profiles (such as `Trade` above) now use wire-encoded transport on the Rust side too, matching what the backends already generate. Bindings and dylib regenerate together, so a rebuild keeps both sides consistent; the flip deserves a release-note line.

A mixed-alignment struct can keep the blittable path by making the padding explicit, so both profiles agree on every offset:

```rust
#[data]
pub struct Trade {
    pub id: i64,
    pub symbol_id: i32,
    _pad: i32,
    pub price: f64,
}
```

## Release-note line

Mixed-alignment `#[data]` structs (field offsets or total size differing between native ABI alignment profiles, e.g. an `i32` followed by an `f64`) now cross wire-encoded on every lane. Previously the Rust wrapper passed them as raw struct bytes while generated backends encoded them. Making the padding explicit with filler fields restores the blittable path.

## Follow-up

The explicit-padding recipe leaks a `_pad` field into every generated foreign API. I'm happy to follow up with a padding-field annotation — skipped in the generated surfaces, zeroed on construction — so mixed-alignment structs stay blittable without the wart. Should I go ahead?

🤖 Generated with [Claude Code](https://claude.com/claude-code) and a human
