### PR TITLE
Support Windows ARM64 C# packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,3 +216,80 @@ jobs:
       - if: matrix.python-version != '3.13'
         run: ./examples/demo/verify-platform-demos.sh --platform python --python python
         shell: bash
+
+  csharp-windows-arm64:
+    name: C# Windows x64 + ARM64 package
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+          target: aarch64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-bin: false
+          prefix-key: v1-rust
+          key: csharp-windows-arm64
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+      - name: Build dual-architecture NuGet package
+        working-directory: examples/demo
+        shell: bash
+        run: >-
+          cargo run --quiet --manifest-path ../../Cargo.toml -p boltffi_cli --
+          --overlay boltffi.csharp-windows.toml
+          --cargo-arg=--features
+          --cargo-arg=csharp-demo
+          pack csharp
+      - name: Verify package assets and PE architectures
+        shell: pwsh
+        run: |
+          $dist = Join-Path $PWD 'examples/platforms/csharp/dist'
+          $package = Get-ChildItem -LiteralPath (Join-Path $dist 'packages') -Filter '*.nupkg' | Select-Object -First 1
+          if (-not $package) { throw 'NuGet package was not generated' }
+
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          $archive = [System.IO.Compression.ZipFile]::OpenRead($package.FullName)
+          try {
+            $entries = $archive.Entries.FullName -replace '\\', '/'
+            foreach ($expected in @(
+              'runtimes/win-x64/native/demo.dll',
+              'runtimes/win-arm64/native/demo.dll'
+            )) {
+              if ($entries -notcontains $expected) { throw "Missing NuGet asset: $expected" }
+            }
+          } finally {
+            $archive.Dispose()
+          }
+
+          function Get-PeMachine([string] $Path) {
+            $bytes = [System.IO.File]::ReadAllBytes($Path)
+            $peOffset = [BitConverter]::ToInt32($bytes, 0x3c)
+            [BitConverter]::ToUInt16($bytes, $peOffset + 4)
+          }
+
+          $x64Machine = Get-PeMachine (Join-Path $dist 'runtimes/win-x64/native/demo.dll')
+          $arm64Machine = Get-PeMachine (Join-Path $dist 'runtimes/win-arm64/native/demo.dll')
+          if ($x64Machine -ne 0x8664) { throw ('win-x64 asset has unexpected PE machine 0x{0:X4}' -f $x64Machine) }
+          if ($arm64Machine -ne 0xaa64) { throw ('win-arm64 asset has unexpected PE machine 0x{0:X4}' -f $arm64Machine) }
+      - name: Verify win-arm64 NuGet restore and publish
+        shell: pwsh
+        run: |
+          $packageDir = Join-Path $PWD 'examples/platforms/csharp/dist/packages'
+          $project = Join-Path $PWD 'examples/platforms/csharp/DemoTest/DemoTest.csproj'
+          $packagesCache = Join-Path $PWD 'examples/platforms/csharp/dist/.nuget/windows-arm64'
+          $publishDir = Join-Path $PWD 'examples/platforms/csharp/dist/publish/win-arm64'
+          dotnet publish $project `
+            --runtime win-arm64 `
+            --self-contained false `
+            --source $packageDir `
+            --property:RestorePackagesPath=$packagesCache `
+            --property:RestoreNoCache=true `
+            --output $publishDir `
+            --nologo
+          if (-not (Test-Path -LiteralPath (Join-Path $publishDir 'demo.dll'))) {
+            throw 'win-arm64 native asset was not selected for publish'
+          }

--- a/BOLTFFI_TOML_SPEC.md
+++ b/BOLTFFI_TOML_SPEC.md
@@ -434,12 +434,12 @@ Controls npm package generation in `boltffi pack wasm`.
 - `package_output` (path, optional): Directory where `boltffi pack csharp` writes `.nupkg` files.
   - Default: `{targets.csharp.output}/packages`
 - `runtime_identifiers` (array of strings, optional): Desired .NET native runtime asset outputs.
-  - Supported canonical values: `current`, `osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`, `win-x64`
-  - Supported aliases: `darwin-arm64`, `darwin-x86_64`, `linux-x86_64`, `linux-aarch64`, `windows-x86_64`
+  - Supported canonical values: `current`, `osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`, `win-x64`, `win-arm64`
+  - Supported aliases: `darwin-arm64`, `darwin-x86_64`, `linux-x86_64`, `linux-aarch64`, `windows-x86_64`, `windows-arm64`, `windows-aarch64`, `win-aarch64`
   - Default: `["current"]`
   - Behavior: `current` resolves to the active host RID, repeated values are deduped after resolution, and native libraries are packaged under NuGet `runtimes/{rid}/native/`.
   - `--no-build`: skips cross-host build toolchain validation and reuses existing artifacts from `target/{rust-target-triple}/{profile}/`.
-  - For `win-x64` with `--no-build`, `{rust-target-triple}` defaults to `x86_64-pc-windows-msvc`; configure Cargo `build.target` to use another compatible Windows Rust target.
+  - With `--no-build`, `win-x64` defaults to `x86_64-pc-windows-msvc` and `win-arm64` defaults to `aarch64-pc-windows-msvc`; configure Cargo `build.target` to use another architecture-compatible Windows Rust target.
 
 ### `[targets.csharp.nuget]` (optional)
 
@@ -464,7 +464,7 @@ Controls NuGet metadata rendered into the generated `BoltFFI.CSharp.csproj` duri
 
 `[package].description` continues to render as NuGet `Description` when set, and `targets.csharp.package_id` continues to render as NuGet `PackageId`.
 
-`boltffi pack csharp` rejects explicit Cargo `--target` passthrough args because the native asset matrix is controlled by `targets.csharp.runtime_identifiers`. Current-host packaging works on `osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`, and `win-x64`. When building native libraries, cross-host support follows the shared desktop toolchain support used by JVM packaging and unsupported host/target pairs fail during preflight.
+`boltffi pack csharp` rejects explicit Cargo `--target` passthrough args because the native asset matrix is controlled by `targets.csharp.runtime_identifiers`. Current-host packaging works on `osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`, `win-x64`, and `win-arm64`. Windows hosts can build both Windows architectures when the corresponding Rust target and Visual Studio C++ components are installed. Other unsupported host/target pairs fail during preflight.
 
 ## Apple SwiftPM layouts
 

--- a/boltffi_cli/src/config/mod.rs
+++ b/boltffi_cli/src/config/mod.rs
@@ -2522,7 +2522,7 @@ package_output = "artifacts/nuget"
 package_id = "Company.MyLib"
 namespace = "Company.MyLib.Bindings"
 target_framework = "net9.0"
-runtime_identifiers = ["current", "linux-x64"]
+runtime_identifiers = ["current", "linux-x64", "windows-aarch64"]
 "#,
         );
 
@@ -2538,10 +2538,37 @@ runtime_identifiers = ["current", "linux-x64"]
             config.csharp_requested_runtime_identifiers(),
             &[
                 crate::target::CSharpRuntimeIdentifier::Current,
-                crate::target::CSharpRuntimeIdentifier::LinuxX64
+                crate::target::CSharpRuntimeIdentifier::LinuxX64,
+                crate::target::CSharpRuntimeIdentifier::WinArm64,
             ]
         );
         assert!(config.should_process(Target::CSharp, false));
+    }
+
+    #[test]
+    fn csharp_configuration_parses_windows_arm64_aliases() {
+        for runtime_identifier in [
+            "win-arm64",
+            "windows-arm64",
+            "windows-aarch64",
+            "win-aarch64",
+        ] {
+            let config = parse_config(&format!(
+                r#"
+[package]
+name = "my-lib"
+
+[targets.csharp]
+enabled = true
+runtime_identifiers = ["{runtime_identifier}"]
+"#,
+            ));
+
+            assert_eq!(
+                config.csharp_requested_runtime_identifiers(),
+                &[crate::target::CSharpRuntimeIdentifier::WinArm64]
+            );
+        }
     }
 
     #[test]

--- a/boltffi_cli/src/pack/csharp/mod.rs
+++ b/boltffi_cli/src/pack/csharp/mod.rs
@@ -195,7 +195,7 @@ impl CSharpPackagingPlan {
                 })?;
         let current_host = NativeHostPlatform::current().ok_or_else(|| CliError::CommandFailed {
             command:
-                "C# packaging is only supported on osx-arm64, osx-x64, linux-x64, linux-arm64, and win-x64 hosts".to_string(),
+                "C# packaging is only supported on osx-arm64, osx-x64, linux-x64, linux-arm64, win-x64, and win-arm64 hosts".to_string(),
             status: None,
         })?;
         let build_profile = resolve_build_profile(release, &build_cargo_args);
@@ -725,9 +725,11 @@ fn dotnet_pack(plan: &CSharpPackagingPlan, step: &Step) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::{
-        CSharpPackageLayout, CSharpPackagingPlan, csharp_no_build_config_args, pack_csharp,
+        CSharpCargoContext, CSharpPackageLayout, CSharpPackagingPlan, CSharpPackagingTarget,
+        csharp_no_build_config_args, pack_csharp, remove_stale_csharp_runtime_assets,
         render_csharp_project,
     };
+    use crate::build::CargoBuildProfile;
     use crate::cargo::{Cargo, CargoCrateType};
     use crate::cli::CliError;
     use crate::commands::pack::{PackCSharpOptions, PackExecutionOptions};
@@ -881,9 +883,31 @@ mod tests {
         }
     }
 
+    fn packaging_target(runtime_identifier: CSharpRuntimeIdentifier) -> CSharpPackagingTarget {
+        let rust_target_triple = expected_no_build_rust_target_triple(runtime_identifier);
+        CSharpPackagingTarget {
+            runtime_identifier,
+            host_target: runtime_identifier.native_host_platform(),
+            cargo_context: CSharpCargoContext {
+                rust_target_triple: rust_target_triple.to_string(),
+                release: false,
+                build_profile: CargoBuildProfile::Debug,
+                artifact_name: "demo".to_string(),
+                cargo_manifest_path: PathBuf::from("/tmp/demo/Cargo.toml"),
+                package_selector: None,
+                target_directory: PathBuf::from("/tmp/demo/target"),
+                cargo_command_args: Vec::new(),
+                toolchain_selector: None,
+            },
+            toolchain: None,
+        }
+    }
+
     fn unsupported_csharp_runtime_identifier() -> CSharpRuntimeIdentifier {
         match NativeHostPlatform::current().expect("supported host for C# packaging tests") {
-            NativeHostPlatform::WindowsX86_64 => CSharpRuntimeIdentifier::OsxArm64,
+            NativeHostPlatform::WindowsX86_64 | NativeHostPlatform::WindowsAarch64 => {
+                CSharpRuntimeIdentifier::OsxArm64
+            }
             _ => CSharpRuntimeIdentifier::WinX64,
         }
     }
@@ -900,6 +924,7 @@ mod tests {
             CSharpRuntimeIdentifier::LinuxX64 => "x86_64-unknown-linux-gnu",
             CSharpRuntimeIdentifier::LinuxArm64 => "aarch64-unknown-linux-gnu",
             CSharpRuntimeIdentifier::WinX64 => "x86_64-pc-windows-msvc",
+            CSharpRuntimeIdentifier::WinArm64 => "aarch64-pc-windows-msvc",
         }
     }
 
@@ -955,16 +980,26 @@ mod tests {
                 .shared_library_filename("demo"),
             "demo.dll"
         );
+        assert_eq!(
+            CSharpRuntimeIdentifier::WinArm64
+                .native_host_platform()
+                .shared_library_filename("demo"),
+            "demo.dll"
+        );
     }
 
     #[test]
     fn csharp_project_includes_packable_native_assets() {
-        let plan = csharp_packaging_plan(PathBuf::from("/tmp/dist/csharp"));
+        let mut plan = csharp_packaging_plan(PathBuf::from("/tmp/dist/csharp"));
+        plan.packaging_targets = vec![
+            packaging_target(CSharpRuntimeIdentifier::WinX64),
+            packaging_target(CSharpRuntimeIdentifier::WinArm64),
+        ];
 
         let project = render_csharp_project(&config(), &plan).expect("C# project should render");
 
         assert!(project.contains("<TargetFramework>net10.0</TargetFramework>"));
-        assert!(project.contains("<RuntimeIdentifiers></RuntimeIdentifiers>"));
+        assert!(project.contains("<RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>"));
         assert!(project.contains("<PackageId>Demo.Runtime</PackageId>"));
         assert!(project.contains("<Version>1.2.3</Version>"));
         assert!(project.contains("<AllowUnsafeBlocks>true</AllowUnsafeBlocks>"));
@@ -1091,6 +1126,55 @@ mod tests {
         );
 
         std::fs::remove_dir_all(project).expect("cleanup temp cdylib project");
+    }
+
+    #[test]
+    fn csharp_no_build_plan_resolves_both_windows_architectures() {
+        let project = temp_cdylib_project();
+        let manifest_path = project.join("Cargo.toml");
+        let mut config = config();
+        config.targets.csharp.runtime_identifiers = Some(vec![
+            CSharpRuntimeIdentifier::WinX64,
+            CSharpRuntimeIdentifier::WinArm64,
+        ]);
+
+        let plan = CSharpPackagingPlan::from_config(
+            &config,
+            false,
+            &cargo_args_for_manifest(&manifest_path),
+            true,
+        )
+        .expect("both Windows C# runtime identifiers should resolve");
+
+        assert_eq!(plan.packaging_targets.len(), 2);
+        assert_eq!(
+            plan.packaging_targets
+                .iter()
+                .map(|target| target.cargo_context.rust_target_triple.as_str())
+                .collect::<Vec<_>>(),
+            ["x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc"]
+        );
+
+        std::fs::remove_dir_all(project).expect("cleanup temp cdylib project");
+    }
+
+    #[test]
+    fn removes_stale_windows_arm64_runtime_assets() {
+        let root = unique_temp_dir("boltffi-csharp-stale-runtime-test");
+        let x64 = root.join("runtimes/win-x64/native");
+        let arm64 = root.join("runtimes/win-arm64/native");
+        std::fs::create_dir_all(&x64).expect("create x64 runtime directory");
+        std::fs::create_dir_all(&arm64).expect("create ARM64 runtime directory");
+
+        let mut plan = csharp_packaging_plan(root.clone());
+        plan.packaging_targets = vec![packaging_target(CSharpRuntimeIdentifier::WinX64)];
+
+        remove_stale_csharp_runtime_assets(&plan).expect("remove stale runtime assets");
+
+        assert!(x64.exists());
+        assert!(!arm64.exists());
+
+        std::fs::remove_dir_all(root).expect("cleanup stale runtime test directory");
     }
 
     #[test]

--- a/boltffi_cli/src/pack/python/plan.rs
+++ b/boltffi_cli/src/pack/python/plan.rs
@@ -76,11 +76,13 @@ impl PythonPackagingPlan {
         cli_cargo_args: &[String],
         cli_python_interpreters: &[String],
     ) -> Result<Self> {
-        let host_platform = NativeHostPlatform::current().ok_or_else(|| CliError::CommandFailed {
-            command:
-                "python packaging is only supported on darwin-arm64, darwin-x86_64, linux-x86_64, linux-aarch64, and windows-x86_64 hosts".to_string(),
-            status: None,
-        })?;
+        let host_platform = NativeHostPlatform::current()
+            .filter(|platform| *platform != NativeHostPlatform::WindowsAarch64)
+            .ok_or_else(|| CliError::CommandFailed {
+                command:
+                    "python packaging is only supported on darwin-arm64, darwin-x86_64, linux-x86_64, linux-aarch64, and windows-x86_64 hosts".to_string(),
+                status: None,
+            })?;
         let module_name = config.python_module_name();
         let output_root = absolutize_configured_path(config.python_output())?;
         let wheel_directory = absolutize_configured_path(config.python_wheel_output())?;

--- a/boltffi_cli/src/target.rs
+++ b/boltffi_cli/src/target.rs
@@ -34,6 +34,7 @@ pub enum NativeHostPlatform {
     LinuxX86_64,
     LinuxAarch64,
     WindowsX86_64,
+    WindowsAarch64,
 }
 
 impl NativeHostPlatform {
@@ -44,6 +45,7 @@ impl NativeHostPlatform {
             Self::LinuxX86_64 => "linux-x86_64",
             Self::LinuxAarch64 => "linux-aarch64",
             Self::WindowsX86_64 => "windows-x86_64",
+            Self::WindowsAarch64 => "windows-aarch64",
         }
     }
 
@@ -54,6 +56,7 @@ impl NativeHostPlatform {
             ("linux", "x86_64") => Some(Self::LinuxX86_64),
             ("linux", "aarch64") => Some(Self::LinuxAarch64),
             ("windows", "x86_64") => Some(Self::WindowsX86_64),
+            ("windows", "aarch64") => Some(Self::WindowsAarch64),
             _ => None,
         }
     }
@@ -62,7 +65,7 @@ impl NativeHostPlatform {
         match self {
             Self::DarwinArm64 | Self::DarwinX86_64 => format!("lib{artifact_name}.dylib"),
             Self::LinuxX86_64 | Self::LinuxAarch64 => format!("lib{artifact_name}.so"),
-            Self::WindowsX86_64 => format!("{artifact_name}.dll"),
+            Self::WindowsX86_64 | Self::WindowsAarch64 => format!("{artifact_name}.dll"),
         }
     }
 
@@ -71,7 +74,7 @@ impl NativeHostPlatform {
             Self::DarwinArm64 | Self::DarwinX86_64 | Self::LinuxX86_64 | Self::LinuxAarch64 => {
                 format!("lib{artifact_name}.a")
             }
-            Self::WindowsX86_64 => {
+            Self::WindowsX86_64 | Self::WindowsAarch64 => {
                 if cfg!(all(target_os = "windows", target_env = "gnu")) {
                     format!("lib{artifact_name}.a")
                 } else {
@@ -91,7 +94,7 @@ impl NativeHostPlatform {
         match self {
             Self::DarwinArm64 | Self::DarwinX86_64 => "darwin",
             Self::LinuxX86_64 | Self::LinuxAarch64 => "linux",
-            Self::WindowsX86_64 => "win32",
+            Self::WindowsX86_64 | Self::WindowsAarch64 => "win32",
         }
     }
 
@@ -99,7 +102,7 @@ impl NativeHostPlatform {
         match self {
             Self::DarwinArm64 | Self::DarwinX86_64 => Some("-Wl,-rpath,@loader_path"),
             Self::LinuxX86_64 | Self::LinuxAarch64 => Some("-Wl,-rpath,$ORIGIN"),
-            Self::WindowsX86_64 => None,
+            Self::WindowsX86_64 | Self::WindowsAarch64 => None,
         }
     }
 }
@@ -107,14 +110,14 @@ impl NativeHostPlatform {
 trait NativeHostIdentifier: Copy + Eq {
     fn current_marker() -> Self;
 
-    fn from_platform(platform: NativeHostPlatform) -> Self;
+    fn from_platform(platform: NativeHostPlatform) -> Option<Self>;
 
     fn explicit_platform(self) -> Option<NativeHostPlatform>;
 
     fn unsupported_host_message() -> String;
 
     fn current() -> Option<Self> {
-        NativeHostPlatform::current().map(Self::from_platform)
+        NativeHostPlatform::current().and_then(Self::from_platform)
     }
 
     fn resolve_requested(targets: &[Self]) -> Result<Vec<Self>, String> {
@@ -199,14 +202,8 @@ impl JavaHostTarget {
         self.native_host_platform().rpath_flag()
     }
 
-    fn native_host_platform(self) -> NativeHostPlatform {
+    pub(crate) fn native_host_platform(self) -> NativeHostPlatform {
         <Self as NativeHostIdentifier>::resolved_platform(self)
-    }
-}
-
-impl From<NativeHostPlatform> for JavaHostTarget {
-    fn from(value: NativeHostPlatform) -> Self {
-        <Self as NativeHostIdentifier>::from_platform(value)
     }
 }
 
@@ -215,13 +212,14 @@ impl NativeHostIdentifier for JavaHostTarget {
         Self::Current
     }
 
-    fn from_platform(platform: NativeHostPlatform) -> Self {
+    fn from_platform(platform: NativeHostPlatform) -> Option<Self> {
         match platform {
-            NativeHostPlatform::DarwinArm64 => Self::DarwinArm64,
-            NativeHostPlatform::DarwinX86_64 => Self::DarwinX86_64,
-            NativeHostPlatform::LinuxX86_64 => Self::LinuxX86_64,
-            NativeHostPlatform::LinuxAarch64 => Self::LinuxAarch64,
-            NativeHostPlatform::WindowsX86_64 => Self::WindowsX86_64,
+            NativeHostPlatform::DarwinArm64 => Some(Self::DarwinArm64),
+            NativeHostPlatform::DarwinX86_64 => Some(Self::DarwinX86_64),
+            NativeHostPlatform::LinuxX86_64 => Some(Self::LinuxX86_64),
+            NativeHostPlatform::LinuxAarch64 => Some(Self::LinuxAarch64),
+            NativeHostPlatform::WindowsX86_64 => Some(Self::WindowsX86_64),
+            NativeHostPlatform::WindowsAarch64 => None,
         }
     }
 
@@ -255,6 +253,13 @@ pub enum CSharpRuntimeIdentifier {
     LinuxArm64,
     #[serde(rename = "win-x64", alias = "windows-x86_64", alias = "win-x86_64")]
     WinX64,
+    #[serde(
+        rename = "win-arm64",
+        alias = "windows-arm64",
+        alias = "windows-aarch64",
+        alias = "win-aarch64"
+    )]
+    WinArm64,
 }
 
 impl CSharpRuntimeIdentifier {
@@ -265,6 +270,7 @@ impl CSharpRuntimeIdentifier {
         Self::LinuxX64,
         Self::LinuxArm64,
         Self::WinX64,
+        Self::WinArm64,
     ];
 
     pub fn canonical_name(self) -> &'static str {
@@ -275,6 +281,7 @@ impl CSharpRuntimeIdentifier {
             Self::LinuxX64 => "linux-x64",
             Self::LinuxArm64 => "linux-arm64",
             Self::WinX64 => "win-x64",
+            Self::WinArm64 => "win-arm64",
         }
     }
 
@@ -290,6 +297,7 @@ impl CSharpRuntimeIdentifier {
 impl From<NativeHostPlatform> for CSharpRuntimeIdentifier {
     fn from(value: NativeHostPlatform) -> Self {
         <Self as NativeHostIdentifier>::from_platform(value)
+            .expect("native host platform should be supported by C# packaging")
     }
 }
 
@@ -298,14 +306,15 @@ impl NativeHostIdentifier for CSharpRuntimeIdentifier {
         Self::Current
     }
 
-    fn from_platform(platform: NativeHostPlatform) -> Self {
-        match platform {
+    fn from_platform(platform: NativeHostPlatform) -> Option<Self> {
+        Some(match platform {
             NativeHostPlatform::DarwinArm64 => Self::OsxArm64,
             NativeHostPlatform::DarwinX86_64 => Self::OsxX64,
             NativeHostPlatform::LinuxX86_64 => Self::LinuxX64,
             NativeHostPlatform::LinuxAarch64 => Self::LinuxArm64,
             NativeHostPlatform::WindowsX86_64 => Self::WinX64,
-        }
+            NativeHostPlatform::WindowsAarch64 => Self::WinArm64,
+        })
     }
 
     fn explicit_platform(self) -> Option<NativeHostPlatform> {
@@ -316,11 +325,12 @@ impl NativeHostIdentifier for CSharpRuntimeIdentifier {
             Self::LinuxX64 => Some(NativeHostPlatform::LinuxX86_64),
             Self::LinuxArm64 => Some(NativeHostPlatform::LinuxAarch64),
             Self::WinX64 => Some(NativeHostPlatform::WindowsX86_64),
+            Self::WinArm64 => Some(NativeHostPlatform::WindowsAarch64),
         }
     }
 
     fn unsupported_host_message() -> String {
-        "C# packaging is only supported on osx-arm64, osx-x64, linux-x64, linux-arm64, and win-x64 hosts".to_string()
+        "C# packaging is only supported on osx-arm64, osx-x64, linux-x64, linux-arm64, win-x64, and win-arm64 hosts".to_string()
     }
 }
 
@@ -615,7 +625,10 @@ mod tests {
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{Architecture, BuiltLibrary, JavaHostTarget, Platform, RustTarget};
+    use super::{
+        Architecture, BuiltLibrary, CSharpRuntimeIdentifier, JavaHostTarget, NativeHostIdentifier,
+        NativeHostPlatform, Platform, RustTarget,
+    };
 
     #[test]
     fn apple_targets_use_static_libraries() {
@@ -714,6 +727,20 @@ mod tests {
             .expect("expected current host resolution");
 
         assert_eq!(resolved, vec![current_host]);
+    }
+
+    #[test]
+    fn windows_arm64_is_exposed_to_csharp_but_not_java() {
+        assert_eq!(
+            CSharpRuntimeIdentifier::from(NativeHostPlatform::WindowsAarch64),
+            CSharpRuntimeIdentifier::WinArm64
+        );
+        assert_eq!(
+            <JavaHostTarget as NativeHostIdentifier>::from_platform(
+                NativeHostPlatform::WindowsAarch64
+            ),
+            None
+        );
     }
 
     #[test]

--- a/boltffi_cli/src/toolchain/native_host.rs
+++ b/boltffi_cli/src/toolchain/native_host.rs
@@ -148,7 +148,13 @@ impl NativeHostToolchain {
         current_host: JavaHostTarget,
     ) -> Result<Self> {
         let cargo_args = Self::cargo_discovery_args(cargo_args, cargo_manifest_path);
-        Self::discover_for_platform(toolchain_selector, &cargo_args, target, current_host, "JVM")
+        Self::discover_for_platform(
+            toolchain_selector,
+            &cargo_args,
+            target.native_host_platform(),
+            current_host.native_host_platform(),
+            "JVM",
+        )
     }
 
     pub fn discover_csharp(
@@ -157,13 +163,7 @@ impl NativeHostToolchain {
         target: NativeHostPlatform,
         current_host: NativeHostPlatform,
     ) -> Result<Self> {
-        Self::discover_for_platform(
-            toolchain_selector,
-            cargo_args,
-            target.into(),
-            current_host.into(),
-            "C#",
-        )
+        Self::discover_for_platform(toolchain_selector, cargo_args, target, current_host, "C#")
     }
 
     pub fn resolve_csharp_no_build_rust_target_triple(
@@ -183,8 +183,8 @@ impl NativeHostToolchain {
                     cargo_args,
                 )
             }
-            NativeHostPlatform::WindowsX86_64 => {
-                resolve_csharp_windows_no_build_rust_target_triple(cargo_args)
+            NativeHostPlatform::WindowsX86_64 | NativeHostPlatform::WindowsAarch64 => {
+                resolve_csharp_windows_no_build_rust_target_triple(cargo_args, target)
             }
         }
     }
@@ -192,8 +192,8 @@ impl NativeHostToolchain {
     fn discover_for_platform(
         toolchain_selector: Option<&str>,
         cargo_args: &[String],
-        target: JavaHostTarget,
-        current_host: JavaHostTarget,
+        target: NativeHostPlatform,
+        current_host: NativeHostPlatform,
         platform_name: &str,
     ) -> Result<Self> {
         ensure_supported_native_host_pair(current_host, target, platform_name)?;
@@ -210,12 +210,12 @@ impl NativeHostToolchain {
 
         match (current_host, target) {
             (
-                JavaHostTarget::DarwinArm64 | JavaHostTarget::DarwinX86_64,
-                JavaHostTarget::DarwinArm64,
+                NativeHostPlatform::DarwinArm64 | NativeHostPlatform::DarwinX86_64,
+                NativeHostPlatform::DarwinArm64,
             )
             | (
-                JavaHostTarget::DarwinArm64 | JavaHostTarget::DarwinX86_64,
-                JavaHostTarget::DarwinX86_64,
+                NativeHostPlatform::DarwinArm64 | NativeHostPlatform::DarwinX86_64,
+                NativeHostPlatform::DarwinX86_64,
             ) => {
                 let linker_program =
                     which::which("clang").map_err(|_| CliError::CommandFailed {
@@ -238,8 +238,8 @@ impl NativeHostToolchain {
                 })
             }
             (
-                JavaHostTarget::DarwinArm64 | JavaHostTarget::DarwinX86_64,
-                JavaHostTarget::LinuxX86_64,
+                NativeHostPlatform::DarwinArm64 | NativeHostPlatform::DarwinX86_64,
+                NativeHostPlatform::LinuxX86_64,
             ) => {
                 let (cargo_linker_program, jni_compiler_program, jni_compiler_args) =
                     resolve_linux_cross_toolchain(cargo_args, &rust_target_triple)?;
@@ -265,8 +265,8 @@ impl NativeHostToolchain {
                     jni_rustflag_linker_args: rustflag_linker_args,
                 })
             }
-            (JavaHostTarget::LinuxX86_64, JavaHostTarget::LinuxX86_64)
-            | (JavaHostTarget::LinuxAarch64, JavaHostTarget::LinuxAarch64) => {
+            (NativeHostPlatform::LinuxX86_64, NativeHostPlatform::LinuxX86_64)
+            | (NativeHostPlatform::LinuxAarch64, NativeHostPlatform::LinuxAarch64) => {
                 let (linker_program, linker_args) =
                     resolve_linux_host_linker(toolchain_selector, cargo_args, &rust_target_triple)?;
                 Ok(Self {
@@ -277,7 +277,10 @@ impl NativeHostToolchain {
                     jni_rustflag_linker_args: rustflag_linker_args,
                 })
             }
-            (JavaHostTarget::WindowsX86_64, JavaHostTarget::WindowsX86_64) => {
+            (
+                NativeHostPlatform::WindowsX86_64 | NativeHostPlatform::WindowsAarch64,
+                NativeHostPlatform::WindowsX86_64 | NativeHostPlatform::WindowsAarch64,
+            ) => {
                 let (linker_program, linker_args) = resolve_windows_host_linker(
                     toolchain_selector,
                     cargo_args,
@@ -338,24 +341,31 @@ impl NativeHostToolchain {
 }
 
 fn ensure_supported_native_host_pair(
-    current_host: JavaHostTarget,
-    target: JavaHostTarget,
+    current_host: NativeHostPlatform,
+    target: NativeHostPlatform,
     platform_name: &str,
 ) -> Result<()> {
     let supported = matches!(
         (current_host, target),
         (
-            JavaHostTarget::DarwinArm64 | JavaHostTarget::DarwinX86_64,
-            JavaHostTarget::DarwinArm64,
+            NativeHostPlatform::DarwinArm64 | NativeHostPlatform::DarwinX86_64,
+            NativeHostPlatform::DarwinArm64,
         ) | (
-            JavaHostTarget::DarwinArm64 | JavaHostTarget::DarwinX86_64,
-            JavaHostTarget::DarwinX86_64,
+            NativeHostPlatform::DarwinArm64 | NativeHostPlatform::DarwinX86_64,
+            NativeHostPlatform::DarwinX86_64,
         ) | (
-            JavaHostTarget::DarwinArm64 | JavaHostTarget::DarwinX86_64,
-            JavaHostTarget::LinuxX86_64,
-        ) | (JavaHostTarget::LinuxX86_64, JavaHostTarget::LinuxX86_64)
-            | (JavaHostTarget::LinuxAarch64, JavaHostTarget::LinuxAarch64)
-            | (JavaHostTarget::WindowsX86_64, JavaHostTarget::WindowsX86_64)
+            NativeHostPlatform::DarwinArm64 | NativeHostPlatform::DarwinX86_64,
+            NativeHostPlatform::LinuxX86_64,
+        ) | (
+            NativeHostPlatform::LinuxX86_64,
+            NativeHostPlatform::LinuxX86_64
+        ) | (
+            NativeHostPlatform::LinuxAarch64,
+            NativeHostPlatform::LinuxAarch64
+        ) | (
+            NativeHostPlatform::WindowsX86_64 | NativeHostPlatform::WindowsAarch64,
+            NativeHostPlatform::WindowsX86_64 | NativeHostPlatform::WindowsAarch64,
+        )
     );
 
     if supported {
@@ -373,19 +383,18 @@ fn ensure_supported_native_host_pair(
 }
 
 fn resolve_rust_target_triple(
-    target: JavaHostTarget,
-    current_host: JavaHostTarget,
+    target: NativeHostPlatform,
+    current_host: NativeHostPlatform,
     toolchain_selector: Option<&str>,
     cargo_args: &[String],
 ) -> Result<String> {
     match target {
-        JavaHostTarget::Current => unreachable!("resolved host target required"),
-        JavaHostTarget::DarwinArm64 => Ok("aarch64-apple-darwin".to_string()),
-        JavaHostTarget::DarwinX86_64 => Ok("x86_64-apple-darwin".to_string()),
-        JavaHostTarget::LinuxX86_64 | JavaHostTarget::LinuxAarch64 => {
+        NativeHostPlatform::DarwinArm64 => Ok("aarch64-apple-darwin".to_string()),
+        NativeHostPlatform::DarwinX86_64 => Ok("x86_64-apple-darwin".to_string()),
+        NativeHostPlatform::LinuxX86_64 | NativeHostPlatform::LinuxAarch64 => {
             resolve_linux_rust_target_triple(target, current_host, toolchain_selector, cargo_args)
         }
-        JavaHostTarget::WindowsX86_64 => {
+        NativeHostPlatform::WindowsX86_64 | NativeHostPlatform::WindowsAarch64 => {
             resolve_windows_rust_target_triple(target, current_host, toolchain_selector, cargo_args)
         }
     }
@@ -397,17 +406,12 @@ fn resolve_csharp_linux_no_build_rust_target_triple(
     toolchain_selector: Option<&str>,
     cargo_args: &[String],
 ) -> Result<String> {
-    resolve_linux_rust_target_triple(
-        target.into(),
-        current_host.into(),
-        toolchain_selector,
-        cargo_args,
-    )
+    resolve_linux_rust_target_triple(target, current_host, toolchain_selector, cargo_args)
 }
 
 fn resolve_linux_rust_target_triple(
-    target: JavaHostTarget,
-    current_host: JavaHostTarget,
+    target: NativeHostPlatform,
+    current_host: NativeHostPlatform,
     toolchain_selector: Option<&str>,
     cargo_args: &[String],
 ) -> Result<String> {
@@ -427,60 +431,88 @@ fn resolve_linux_rust_target_triple(
     validate_linux_rust_target_triple(&host_triple, target)
 }
 
-fn default_linux_rust_target_triple(target: JavaHostTarget) -> &'static str {
+fn default_linux_rust_target_triple(target: NativeHostPlatform) -> &'static str {
     match target {
-        JavaHostTarget::LinuxX86_64 => "x86_64-unknown-linux-gnu",
-        JavaHostTarget::LinuxAarch64 => "aarch64-unknown-linux-gnu",
+        NativeHostPlatform::LinuxX86_64 => "x86_64-unknown-linux-gnu",
+        NativeHostPlatform::LinuxAarch64 => "aarch64-unknown-linux-gnu",
         _ => unreachable!("linux target required"),
     }
 }
 
 fn resolve_windows_rust_target_triple(
-    target: JavaHostTarget,
-    current_host: JavaHostTarget,
+    target: NativeHostPlatform,
+    current_host: NativeHostPlatform,
     toolchain_selector: Option<&str>,
     cargo_args: &[String],
 ) -> Result<String> {
-    if current_host != target
-        && let Some(target_triple) = configured_windows_build_target(cargo_args)?
-    {
-        return Ok(target_triple);
+    if current_host != target {
+        if let Some(target_triple) = configured_windows_build_target(cargo_args, target)? {
+            return Ok(target_triple);
+        }
+
+        return Ok(default_windows_rust_target_triple(target).to_string());
     }
 
-    if let Some(target_triple) = current_host_windows_build_target(cargo_args) {
+    if let Some(target_triple) = current_host_windows_build_target(cargo_args, target) {
         return Ok(target_triple);
     }
 
     let host_triple = rustc_host_triple(toolchain_selector)?;
-    validate_windows_rust_target_triple(&host_triple)
+    validate_windows_rust_target_triple(&host_triple, target)
 }
 
-fn validate_windows_rust_target_triple(target_triple: &str) -> Result<String> {
-    match target_triple {
-        "x86_64-pc-windows-msvc" | "x86_64-pc-windows-gnu" | "x86_64-pc-windows-gnullvm" => {
-            Ok(target_triple.to_string())
-        }
-        _ => Err(CliError::CommandFailed {
-            command: format!(
-                "Windows JVM target '{}' is not a supported windows-x86_64 target",
-                target_triple
-            ),
-            status: None,
-        }),
+fn validate_windows_rust_target_triple(
+    target_triple: &str,
+    target: NativeHostPlatform,
+) -> Result<String> {
+    let is_supported = match target {
+        NativeHostPlatform::WindowsX86_64 => matches!(
+            target_triple,
+            "x86_64-pc-windows-msvc" | "x86_64-pc-windows-gnu" | "x86_64-pc-windows-gnullvm"
+        ),
+        NativeHostPlatform::WindowsAarch64 => matches!(
+            target_triple,
+            "aarch64-pc-windows-msvc" | "aarch64-pc-windows-gnullvm"
+        ),
+        _ => unreachable!("Windows target required"),
+    };
+
+    if is_supported {
+        return Ok(target_triple.to_string());
     }
+
+    Err(CliError::CommandFailed {
+        command: format!(
+            "Windows target '{}' is not a supported {} target",
+            target_triple,
+            target.canonical_name()
+        ),
+        status: None,
+    })
 }
 
-fn resolve_csharp_windows_no_build_rust_target_triple(cargo_args: &[String]) -> Result<String> {
-    if let Some(target_triple) = configured_windows_build_target(cargo_args)? {
+fn resolve_csharp_windows_no_build_rust_target_triple(
+    cargo_args: &[String],
+    target: NativeHostPlatform,
+) -> Result<String> {
+    if let Some(target_triple) = configured_windows_build_target(cargo_args, target)? {
         return Ok(target_triple);
     }
 
-    Ok("x86_64-pc-windows-msvc".to_string())
+    Ok(default_windows_rust_target_triple(target).to_string())
+}
+
+fn default_windows_rust_target_triple(target: NativeHostPlatform) -> &'static str {
+    match target {
+        NativeHostPlatform::WindowsX86_64 => "x86_64-pc-windows-msvc",
+        NativeHostPlatform::WindowsAarch64 => "aarch64-pc-windows-msvc",
+        _ => unreachable!("Windows target required"),
+    }
 }
 
 fn configured_linux_build_target(
     cargo_args: &[String],
-    target: JavaHostTarget,
+    target: NativeHostPlatform,
 ) -> Result<Option<String>> {
     let current_directory = std::env::current_dir().ok();
     let Some(target_triple) =
@@ -498,7 +530,7 @@ fn configured_linux_build_target(
 
 fn current_host_linux_build_target(
     cargo_args: &[String],
-    target: JavaHostTarget,
+    target: NativeHostPlatform,
 ) -> Option<String> {
     let current_directory = std::env::current_dir().ok();
     let target_triple = cargo_configured_build_target(cargo_args, current_directory.as_deref())?;
@@ -511,15 +543,15 @@ fn current_host_linux_build_target(
 
 fn validate_linux_rust_target_triple(
     target_triple: &str,
-    target: JavaHostTarget,
+    target: NativeHostPlatform,
 ) -> Result<String> {
     let is_supported = match target {
-        JavaHostTarget::LinuxX86_64 => {
+        NativeHostPlatform::LinuxX86_64 => {
             target_triple.starts_with("x86_64-")
                 && target_triple.contains("linux")
                 && !target_triple.contains("android")
         }
-        JavaHostTarget::LinuxAarch64 => {
+        NativeHostPlatform::LinuxAarch64 => {
             target_triple.starts_with("aarch64-")
                 && target_triple.contains("linux")
                 && !target_triple.contains("android")
@@ -533,7 +565,7 @@ fn validate_linux_rust_target_triple(
 
     Err(CliError::CommandFailed {
         command: format!(
-            "Linux JVM target '{}' is not a supported {} target",
+            "Linux target '{}' is not a supported {} target",
             target_triple,
             target.canonical_name()
         ),
@@ -541,7 +573,10 @@ fn validate_linux_rust_target_triple(
     })
 }
 
-fn configured_windows_build_target(cargo_args: &[String]) -> Result<Option<String>> {
+fn configured_windows_build_target(
+    cargo_args: &[String],
+    target: NativeHostPlatform,
+) -> Result<Option<String>> {
     let current_directory = std::env::current_dir().ok();
     let Some(target_triple) =
         cargo_configured_build_target(cargo_args, current_directory.as_deref())
@@ -553,17 +588,20 @@ fn configured_windows_build_target(cargo_args: &[String]) -> Result<Option<Strin
         return Ok(None);
     }
 
-    validate_windows_rust_target_triple(&target_triple).map(Some)
+    validate_windows_rust_target_triple(&target_triple, target).map(Some)
 }
 
-fn current_host_windows_build_target(cargo_args: &[String]) -> Option<String> {
+fn current_host_windows_build_target(
+    cargo_args: &[String],
+    target: NativeHostPlatform,
+) -> Option<String> {
     let current_directory = std::env::current_dir().ok();
     let target_triple = cargo_configured_build_target(cargo_args, current_directory.as_deref())?;
     if !target_triple.contains("windows") {
         return None;
     }
 
-    validate_windows_rust_target_triple(&target_triple).ok()
+    validate_windows_rust_target_triple(&target_triple, target).ok()
 }
 
 fn rustc_host_triple(toolchain_selector: Option<&str>) -> Result<String> {
@@ -602,8 +640,8 @@ fn parse_rustc_host_triple(output: &str) -> Option<String> {
 fn ensure_rust_target_installed(
     toolchain_selector: Option<&str>,
     target_triple: &str,
-    target: JavaHostTarget,
-    current_host: JavaHostTarget,
+    target: NativeHostPlatform,
+    current_host: NativeHostPlatform,
 ) -> Result<()> {
     let Some(rustup_path) = which::which("rustup").ok() else {
         return fallback_without_rustup(target, current_host);
@@ -629,7 +667,10 @@ fn ensure_rust_target_installed(
     validate_installed_rustup_target(&installed, target_triple)
 }
 
-fn fallback_without_rustup(target: JavaHostTarget, current_host: JavaHostTarget) -> Result<()> {
+fn fallback_without_rustup(
+    target: NativeHostPlatform,
+    current_host: NativeHostPlatform,
+) -> Result<()> {
     let _ = (target, current_host);
     // rustup is optional here. For the current host we should not block packaging,
     // and for cross-host targets Cargo will still fail with a clear missing-target
@@ -738,11 +779,11 @@ fn resolve_windows_host_linker_with_host_triple(
     let linker_program =
         discover_default_windows_jni_compiler(rust_target_triple).ok_or_else(|| {
             CliError::CommandFailed {
-                command:
-                    "no supported Windows C compiler driver found in PATH for JVM desktop linking"
-                        .to_string(),
-                status: None,
-            }
+            command:
+                "no supported Windows C compiler driver found in PATH for native desktop linking"
+                    .to_string(),
+            status: None,
+        }
         })?;
     let linker_args = windows_host_linker_args(&linker_program, rust_target_triple, &host_triple);
     Ok((linker_program, linker_args))
@@ -755,8 +796,10 @@ fn discover_default_windows_jni_compiler(rust_target_triple: &str) -> Option<Pat
 }
 
 fn default_windows_jni_compiler_candidates(rust_target_triple: &str) -> Vec<&'static str> {
-    if rust_target_triple == "x86_64-pc-windows-msvc" {
+    if rust_target_triple.ends_with("-pc-windows-msvc") {
         vec!["clang-cl", "cl", "clang"]
+    } else if rust_target_triple.starts_with("aarch64-") {
+        vec!["aarch64-w64-mingw32-clang", "clang"]
     } else {
         vec![
             "x86_64-w64-mingw32-gcc",
@@ -768,7 +811,7 @@ fn default_windows_jni_compiler_candidates(rust_target_triple: &str) -> Vec<&'st
 }
 
 fn discover_default_linux_x86_64_cross_compiler(rust_target_triple: &str) -> Option<PathBuf> {
-    if rust_target_triple != default_linux_rust_target_triple(JavaHostTarget::LinuxX86_64) {
+    if rust_target_triple != default_linux_rust_target_triple(NativeHostPlatform::LinuxX86_64) {
         return None;
     }
 
@@ -1077,7 +1120,7 @@ fn configured_linux_x86_64_cross_linker_values(
     configured_linux_x86_64_cross_linker_values_with_sources(
         cargo_args,
         rust_target_triple,
-        (rust_target_triple == default_linux_rust_target_triple(JavaHostTarget::LinuxX86_64))
+        (rust_target_triple == default_linux_rust_target_triple(NativeHostPlatform::LinuxX86_64))
             .then(|| std::env::var("BOLTFFI_JAVA_LINKER_X86_64_UNKNOWN_LINUX_GNU").ok())
             .flatten(),
         cargo_env_key.clone(),
@@ -1190,7 +1233,7 @@ fn missing_linux_x86_64_cross_linker_error(rust_target_triple: &str) -> CliError
         rust_target_triple, cargo_env_key, rust_target_triple
     );
 
-    if rust_target_triple == default_linux_rust_target_triple(JavaHostTarget::LinuxX86_64) {
+    if rust_target_triple == default_linux_rust_target_triple(NativeHostPlatform::LinuxX86_64) {
         command.push_str(
             ", set BOLTFFI_JAVA_LINKER_X86_64_UNKNOWN_LINUX_GNU, or install x86_64-linux-gnu-clang",
         );
@@ -1692,7 +1735,7 @@ mod tests {
         write_linux_cross_linker_wrapper,
     };
     use crate::cli::CliError;
-    use crate::target::{JavaHostTarget, NativeHostPlatform};
+    use crate::target::NativeHostPlatform;
     use std::ffi::OsStr;
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -2291,9 +2334,10 @@ unix
 
     #[test]
     fn ignores_non_windows_cargo_build_target_for_windows_jvm_packaging() {
-        let target = configured_windows_build_target(&[
-            "--config=build.target='x86_64-unknown-linux-gnu'".to_string(),
-        ])
+        let target = configured_windows_build_target(
+            &["--config=build.target='x86_64-unknown-linux-gnu'".to_string()],
+            NativeHostPlatform::WindowsX86_64,
+        )
         .expect("non-windows target should be ignored");
 
         assert_eq!(target, None);
@@ -2302,8 +2346,8 @@ unix
     #[test]
     fn honors_cross_host_linux_build_target_from_cargo_config() {
         let target = resolve_linux_rust_target_triple(
-            JavaHostTarget::LinuxX86_64,
-            JavaHostTarget::DarwinArm64,
+            NativeHostPlatform::LinuxX86_64,
+            NativeHostPlatform::DarwinArm64,
             None,
             &["--config=build.target='x86_64-unknown-linux-musl'".to_string()],
         )
@@ -2315,8 +2359,8 @@ unix
     #[test]
     fn honors_compatible_cargo_build_target_for_current_linux_jvm_host_resolution() {
         let target = resolve_linux_rust_target_triple(
-            JavaHostTarget::LinuxX86_64,
-            JavaHostTarget::LinuxX86_64,
+            NativeHostPlatform::LinuxX86_64,
+            NativeHostPlatform::LinuxX86_64,
             None,
             &["--config=build.target='x86_64-unknown-linux-musl'".to_string()],
         )
@@ -2328,10 +2372,10 @@ unix
     #[cfg(target_os = "linux")]
     #[test]
     fn ignores_cargo_build_target_for_current_linux_jvm_host_resolution() {
-        let current_host = JavaHostTarget::current().expect("supported test host");
+        let current_host = NativeHostPlatform::current().expect("supported test host");
         let configured_target = match current_host {
-            JavaHostTarget::LinuxX86_64 => "aarch64-unknown-linux-gnu",
-            JavaHostTarget::LinuxAarch64 => "x86_64-unknown-linux-gnu",
+            NativeHostPlatform::LinuxX86_64 => "aarch64-unknown-linux-gnu",
+            NativeHostPlatform::LinuxAarch64 => "x86_64-unknown-linux-gnu",
             other => panic!("unexpected current host for linux test: {other:?}"),
         };
         let target = resolve_linux_rust_target_triple(
@@ -2351,14 +2395,44 @@ unix
     #[test]
     fn honors_compatible_cargo_build_target_for_current_windows_jvm_host_resolution() {
         let target = super::resolve_windows_rust_target_triple(
-            JavaHostTarget::WindowsX86_64,
-            JavaHostTarget::WindowsX86_64,
+            NativeHostPlatform::WindowsX86_64,
+            NativeHostPlatform::WindowsX86_64,
             None,
             &["--config=build.target='x86_64-pc-windows-gnu'".to_string()],
         )
         .expect("current windows host should honor compatible cargo build target");
 
         assert_eq!(target, "x86_64-pc-windows-gnu");
+    }
+
+    #[test]
+    fn defaults_windows_x64_to_arm64_cross_build_to_msvc_target() {
+        let target = super::resolve_windows_rust_target_triple(
+            NativeHostPlatform::WindowsAarch64,
+            NativeHostPlatform::WindowsX86_64,
+            None,
+            &[],
+        )
+        .expect("Windows ARM64 cross target should resolve");
+
+        assert_eq!(target, "aarch64-pc-windows-msvc");
+    }
+
+    #[test]
+    fn accepts_cross_architecture_windows_host_pairs() {
+        for (current_host, target) in [
+            (
+                NativeHostPlatform::WindowsX86_64,
+                NativeHostPlatform::WindowsAarch64,
+            ),
+            (
+                NativeHostPlatform::WindowsAarch64,
+                NativeHostPlatform::WindowsX86_64,
+            ),
+        ] {
+            ensure_supported_native_host_pair(current_host, target, "C#")
+                .expect("Windows cross-architecture host pair should be supported");
+        }
     }
 
     #[test]
@@ -2388,6 +2462,36 @@ unix
     }
 
     #[test]
+    fn csharp_no_build_defaults_windows_arm64_rid_to_msvc_triple() {
+        let target = NativeHostToolchain::resolve_csharp_no_build_rust_target_triple(
+            None,
+            &[],
+            NativeHostPlatform::WindowsAarch64,
+            NativeHostPlatform::WindowsX86_64,
+        )
+        .expect("Windows ARM64 no-build C# target should resolve");
+
+        assert_eq!(target, "aarch64-pc-windows-msvc");
+    }
+
+    #[test]
+    fn csharp_no_build_rejects_mismatched_windows_arm64_build_target() {
+        let error = NativeHostToolchain::resolve_csharp_no_build_rust_target_triple(
+            None,
+            &["--config=build.target='x86_64-pc-windows-msvc'".to_string()],
+            NativeHostPlatform::WindowsAarch64,
+            NativeHostPlatform::WindowsX86_64,
+        )
+        .expect_err("x64 target should not be packaged as Windows ARM64");
+
+        assert!(matches!(
+            error,
+            CliError::CommandFailed { command, .. }
+                if command.contains("windows-aarch64")
+        ));
+    }
+
+    #[test]
     fn csharp_no_build_honors_configured_windows_build_target() {
         let target = NativeHostToolchain::resolve_csharp_no_build_rust_target_triple(
             None,
@@ -2403,7 +2507,7 @@ unix
     #[cfg(target_os = "windows")]
     #[test]
     fn ignores_cargo_build_target_for_current_windows_jvm_host_resolution() {
-        let current_host = JavaHostTarget::current().expect("supported test host");
+        let current_host = NativeHostPlatform::current().expect("supported test host");
         let target = super::resolve_windows_rust_target_triple(
             current_host,
             current_host,
@@ -2499,8 +2603,8 @@ unix
     #[test]
     fn rejects_unsupported_jvm_host_pairs_before_toolchain_probing() {
         let error = ensure_supported_native_host_pair(
-            JavaHostTarget::DarwinArm64,
-            JavaHostTarget::WindowsX86_64,
+            NativeHostPlatform::DarwinArm64,
+            NativeHostPlatform::WindowsX86_64,
             "JVM",
         )
         .expect_err("unsupported host pair should fail");
@@ -2519,7 +2623,7 @@ unix
     fn accepts_linux_musl_build_target_for_current_host_jvm_packaging() {
         let target = configured_linux_build_target(
             &["--config=build.target='x86_64-unknown-linux-musl'".to_string()],
-            JavaHostTarget::LinuxX86_64,
+            NativeHostPlatform::LinuxX86_64,
         )
         .expect("linux musl target should be accepted");
 
@@ -2530,7 +2634,7 @@ unix
     fn rejects_mismatched_linux_build_target_for_current_host_jvm_packaging() {
         let error = validate_linux_rust_target_triple(
             "aarch64-unknown-linux-musl",
-            JavaHostTarget::LinuxX86_64,
+            NativeHostPlatform::LinuxX86_64,
         )
         .expect_err("mismatched linux target should fail");
 
@@ -2548,7 +2652,7 @@ unix
     fn rejects_android_linux_build_target_for_desktop_jvm_packaging() {
         let error = configured_linux_build_target(
             &["--config=build.target='x86_64-linux-android'".to_string()],
-            JavaHostTarget::LinuxX86_64,
+            NativeHostPlatform::LinuxX86_64,
         )
         .expect_err("android target should be rejected");
 
@@ -2719,6 +2823,14 @@ unix
         assert_eq!(
             default_windows_jni_compiler_candidates("x86_64-pc-windows-msvc"),
             vec!["clang-cl", "cl", "clang"]
+        );
+        assert_eq!(
+            default_windows_jni_compiler_candidates("aarch64-pc-windows-msvc"),
+            vec!["clang-cl", "cl", "clang"]
+        );
+        assert_eq!(
+            default_windows_jni_compiler_candidates("aarch64-pc-windows-gnullvm"),
+            vec!["aarch64-w64-mingw32-clang", "clang"]
         );
         assert_eq!(
             default_windows_jni_compiler_candidates("x86_64-pc-windows-gnu"),
@@ -2973,19 +3085,20 @@ unix
 
     #[test]
     fn missing_rustup_does_not_block_current_host_packaging() {
-        let current_host = JavaHostTarget::current().expect("supported test host");
+        let current_host = NativeHostPlatform::current().expect("supported test host");
         fallback_without_rustup(current_host, current_host).expect("current host should pass");
     }
 
     #[test]
     fn missing_rustup_defers_cross_host_validation_to_cargo() {
-        let current_host = JavaHostTarget::current().expect("supported test host");
+        let current_host = NativeHostPlatform::current().expect("supported test host");
         let other_host = [
-            JavaHostTarget::DarwinArm64,
-            JavaHostTarget::DarwinX86_64,
-            JavaHostTarget::LinuxX86_64,
-            JavaHostTarget::LinuxAarch64,
-            JavaHostTarget::WindowsX86_64,
+            NativeHostPlatform::DarwinArm64,
+            NativeHostPlatform::DarwinX86_64,
+            NativeHostPlatform::LinuxX86_64,
+            NativeHostPlatform::LinuxAarch64,
+            NativeHostPlatform::WindowsX86_64,
+            NativeHostPlatform::WindowsAarch64,
         ]
         .into_iter()
         .find(|target| *target != current_host)
@@ -3015,17 +3128,36 @@ unix
 
     #[test]
     fn validates_configured_windows_gnu_target_triple() {
-        let target = validate_windows_rust_target_triple("x86_64-pc-windows-gnu")
-            .expect("windows gnu target");
+        let target = validate_windows_rust_target_triple(
+            "x86_64-pc-windows-gnu",
+            NativeHostPlatform::WindowsX86_64,
+        )
+        .expect("windows gnu target");
 
         assert_eq!(target, "x86_64-pc-windows-gnu");
     }
 
     #[test]
     fn validates_configured_windows_gnullvm_target_triple() {
-        let target = validate_windows_rust_target_triple("x86_64-pc-windows-gnullvm")
-            .expect("windows gnullvm target");
+        let target = validate_windows_rust_target_triple(
+            "x86_64-pc-windows-gnullvm",
+            NativeHostPlatform::WindowsX86_64,
+        )
+        .expect("windows gnullvm target");
 
         assert_eq!(target, "x86_64-pc-windows-gnullvm");
+    }
+
+    #[test]
+    fn validates_configured_windows_arm64_target_triples() {
+        for target_triple in ["aarch64-pc-windows-msvc", "aarch64-pc-windows-gnullvm"] {
+            let target = validate_windows_rust_target_triple(
+                target_triple,
+                NativeHostPlatform::WindowsAarch64,
+            )
+            .expect("Windows ARM64 target");
+
+            assert_eq!(target, target_triple);
+        }
     }
 }

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -584,10 +584,10 @@ Choose which .NET runtime identifiers `pack csharp` builds native assets for:
 ```toml
 [targets.csharp]
 enabled = true
-runtime_identifiers = ["osx-arm64", "linux-x64", "win-x64"]
+runtime_identifiers = ["osx-arm64", "linux-x64", "win-x64", "win-arm64"]
 ```
 
-`current` resolves to the active host RID. Supported canonical values are `osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`, and `win-x64`. See [BOLTFFI_TOML_SPEC.md](https://github.com/boltffi/boltffi/blob/main/BOLTFFI_TOML_SPEC.md) for the full list of options including `package_id`, `target_framework`, and `package_output`.
+`current` resolves to the active host RID. Supported canonical values are `osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`, `win-x64`, and `win-arm64`. A Windows host can build both Windows architectures when the corresponding Rust target and Visual Studio C++ components are installed. See [BOLTFFI_TOML_SPEC.md](https://github.com/boltffi/boltffi/blob/main/BOLTFFI_TOML_SPEC.md) for the full list of options including `package_id`, `target_framework`, and `package_output`.
 
 ## WASM Configuration
 

--- a/docs/src/content/docs/packaging.mdx
+++ b/docs/src/content/docs/packaging.mdx
@@ -124,7 +124,8 @@ dist/
 │   ├── runtimes/
 │   │   ├── osx-arm64/native/libmylib.dylib
 │   │   ├── linux-x64/native/libmylib.so
-│   │   └── win-x64/native/mylib.dll
+│   │   ├── win-x64/native/mylib.dll
+│   │   └── win-arm64/native/mylib.dll
 │   └── packages/
 │       └── MyLib.0.1.0.nupkg
 ├── wasm/
@@ -548,12 +549,13 @@ enabled = true
 output = "dist/csharp"
 package_id = "MyOrg.MyLib"
 target_framework = "net10.0"
-runtime_identifiers = ["osx-arm64", "linux-x64", "win-x64"]
+runtime_identifiers = ["osx-arm64", "linux-x64", "win-x64", "win-arm64"]
 ```
 
 `runtime_identifiers` controls which native assets are built and bundled into the NuGet package.
 `current` resolves to the active host RID; canonical values are `osx-arm64`, `osx-x64`,
-`linux-x64`, `linux-arm64`, and `win-x64`.
+`linux-x64`, `linux-arm64`, `win-x64`, and `win-arm64`. Windows hosts can build both
+Windows architectures when the corresponding Rust target and Visual Studio C++ components are installed.
 
 ### Output Structure
 
@@ -568,7 +570,8 @@ dist/csharp/
 ├── runtimes/
 │   ├── osx-arm64/native/libmylib.dylib
 │   ├── linux-x64/native/libmylib.so
-│   └── win-x64/native/mylib.dll
+│   ├── win-x64/native/mylib.dll
+│   └── win-arm64/native/mylib.dll
 └── packages/
     └── MyLib.0.1.0.nupkg
 ```

--- a/examples/demo/boltffi.csharp-windows.toml
+++ b/examples/demo/boltffi.csharp-windows.toml
@@ -1,0 +1,2 @@
+[targets.csharp]
+runtime_identifiers = ["win-x64", "win-arm64"]


### PR DESCRIPTION
This closes #655.

It adds `win-arm64` as a supported C# runtime identifier, including configuration aliases, target resolution, NuGet runtime asset placement, and no-build packaging. The shared native desktop toolchain now selects and validates Windows ARM64 targets, including `aarch64-pc-windows-msvc` and `aarch64-pc-windows-gnullvm`.

Java's public target matrix remains unchanged. C# maps its runtime identifiers directly onto the shared native host platform, while Java continues to expose only its existing Java-specific targets. Python also keeps its existing supported platform set.

I updated the TOML specification and packaging documentation, and added a demo configuration that builds both `win-x64` and `win-arm64` assets.

The Windows GitHub Actions job builds a dual-architecture NuGet package, checks that both runtime assets are present, validates their PE machine types, and verifies that `dotnet publish -r win-arm64` selects the ARM64 native library.