### PR TITLE
fix(ci): make Windows ARM64 NuGet restore deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,14 +278,14 @@ jobs:
       - name: Verify win-arm64 NuGet restore and publish
         shell: pwsh
         run: |
-          $packageDir = Join-Path $PWD 'examples/platforms/csharp/dist/packages'
           $project = Join-Path $PWD 'examples/platforms/csharp/DemoTest/DemoTest.csproj'
+          $nugetConfig = Join-Path $PWD 'examples/platforms/csharp/DemoTest/NuGet.windows-arm64.config'
           $packagesCache = Join-Path $PWD 'examples/platforms/csharp/dist/.nuget/windows-arm64'
           $publishDir = Join-Path $PWD 'examples/platforms/csharp/dist/publish/win-arm64'
           dotnet publish $project `
             --runtime win-arm64 `
             --self-contained false `
-            --source $packageDir `
+            --property:RestoreConfigFile=$nugetConfig `
             --property:RestorePackagesPath=$packagesCache `
             --property:RestoreNoCache=true `
             --output $publishDir `

--- a/examples/platforms/csharp/DemoTest/NuGet.windows-arm64.config
+++ b/examples/platforms/csharp/DemoTest/NuGet.windows-arm64.config
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="boltffi-local" value="../dist/packages" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="boltffi-local">
+      <package pattern="demo" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
Closes #776.

The Windows ARM64 check only pointed `dotnet restore` at the generated local package feed. That worked when the runner already had the ARM64 host pack and failed on a clean runner.

Add NuGet.org as a second source so the Microsoft host pack can be restored while the demo package still comes from the local feed.