### PR TITLE
fix: emit BufFromBytes for the C# wire runtime

### DIFF
--- a/boltffi_backend/src/target/csharp/mod.rs
+++ b/boltffi_backend/src/target/csharp/mod.rs
@@ -231,7 +231,7 @@ impl host::HostBackend for CSharpHost {
     fn assemble<'decl>(
         &self,
         bindings: &Bindings<Self::Surface>,
-        _bridge: &Self::Bridge,
+        bridge: &Self::Bridge,
         _context: &RenderContext<Self::Surface>,
         declarations: Vec<RenderedDeclaration<'decl, Self::Surface>>,
     ) -> Result<GeneratedOutput> {
@@ -240,6 +240,7 @@ impl host::HostBackend for CSharpHost {
             &namespace,
             Name::new(bindings.package().name()).pascal()?,
             Literal::string(&self.library_for(bindings)),
+            Literal::string(bridge.support().buffer_from_bytes()?.name()),
         )
         .render(declarations)
     }
@@ -885,6 +886,7 @@ mod tests {
         assert!(source.contains("EnumeratorCancellation"));
         assert!(source.contains("NativeEngineValuesPopBatch"));
         assert!(source.contains("NativeMethods.FreeBuf(buffer);"));
+        assert!(source.contains("internal static extern FfiBuf BufFromBytes"));
         assert!(source.contains(
             "await foreach (var item in ReadAll(subscription, cancellation.Token)) callback(item);"
         ));
@@ -1320,6 +1322,33 @@ mod tests {
         assert!(module.contains("profile.Encode(profileWriter);"));
         assert!(module.contains("return global::Demo.Profile.Decode(resultReader);"));
         assert!(output.diagnostics().is_empty());
+    }
+
+    #[test]
+    fn csharp_target_emits_copy_support_for_standalone_wire_types() {
+        for source in [
+            r#"
+            #[data]
+            pub struct Profile {
+                pub name: String,
+            }
+            "#,
+            r#"
+            #[data]
+            pub enum Shape {
+                Empty,
+                Label(String),
+            }
+            "#,
+        ] {
+            let output = target(CSharpHost::new())
+                .render(&bindings(source))
+                .expect("standalone wire types should render");
+
+            let module = file(&output, "Demo.cs");
+            assert!(module.contains("internal static extern FfiBuf BufFromBytes"));
+            assert!(output.diagnostics().is_empty());
+        }
     }
 
     #[test]

--- a/boltffi_backend/src/target/csharp/mod.rs
+++ b/boltffi_backend/src/target/csharp/mod.rs
@@ -633,6 +633,7 @@ mod tests {
         assert!(source.contains("internal sealed class WireReader"));
         assert!(source.contains("internal sealed class WireWriter"));
         assert!(source.contains("internal static extern void FreeBuf(FfiBuf buffer);"));
+        assert!(source.contains("internal static extern FfiBuf BufFromBytes"));
         assert!(source.contains("[In] byte[] nameBytes, nuint nameLength"));
         assert!(output.diagnostics().is_empty());
     }

--- a/boltffi_backend/src/target/csharp/render/mod.rs
+++ b/boltffi_backend/src/target/csharp/render/mod.rs
@@ -1352,7 +1352,9 @@ impl Function {
             })
             .transpose()?;
         let is_asynchronous = asynchronous.is_some();
-        let copy_buffer_entry = requires_copy_buffer
+        // The wire runtime's FfiBuf helpers use BufFromBytes as well as closure
+        // callbacks that explicitly require copy-buffer support.
+        let copy_buffer_entry = (requires_wire_runtime || requires_copy_buffer)
             .then(|| {
                 bridge
                     .support()

--- a/boltffi_backend/src/target/csharp/render/mod.rs
+++ b/boltffi_backend/src/target/csharp/render/mod.rs
@@ -1352,9 +1352,7 @@ impl Function {
             })
             .transpose()?;
         let is_asynchronous = asynchronous.is_some();
-        // The wire runtime's FfiBuf helpers use BufFromBytes as well as closure
-        // callbacks that explicitly require copy-buffer support.
-        let copy_buffer_entry = (requires_wire_runtime || requires_copy_buffer)
+        let copy_buffer_entry = requires_copy_buffer
             .then(|| {
                 bridge
                     .support()
@@ -2064,6 +2062,7 @@ pub(super) struct Module<'module> {
     namespace: &'module Namespace,
     class_name: Identifier,
     library: Literal,
+    copy_buffer_entry: Literal,
 }
 
 impl<'module> Module<'module> {
@@ -2071,11 +2070,13 @@ impl<'module> Module<'module> {
         namespace: &'module Namespace,
         class_name: Identifier,
         library: Literal,
+        copy_buffer_entry: Literal,
     ) -> Self {
         Self {
             namespace,
             class_name,
             library,
+            copy_buffer_entry,
         }
     }
 
@@ -2137,6 +2138,18 @@ impl<'module> Module<'module> {
                     }
                 }
             }
+        }
+
+        let wire_runtime = WireTemplate.render()?;
+        if support.contains_key(&wire_runtime) {
+            native_functions
+                .entry(HelperId::new(CanonicalName::single("csharp_copy_buffer")))
+                .or_insert(Statement::new(
+                    CopyBufferTemplate {
+                        entry_point: &self.copy_buffer_entry,
+                    }
+                    .render()?,
+                ));
         }
 
         let native_functions = native_functions.into_values().collect::<Vec<_>>();

--- a/boltffi_backend/tests/csharp.rs
+++ b/boltffi_backend/tests/csharp.rs
@@ -49,6 +49,42 @@ fn csharp_target_compiles_a_regular_vec_u8_wire_api() {
 }
 
 #[test]
+fn csharp_target_compiles_standalone_wire_types() {
+    let bindings = bindings(
+        r#"
+        #[data]
+        pub struct Profile {
+            pub name: String,
+        }
+
+        #[data]
+        pub enum Shape {
+            Empty,
+            Label(String),
+        }
+        "#,
+    );
+    let output = target(
+        CSharpHost::new()
+            .namespace("Company.Bindings")
+            .expect("valid namespace")
+            .native_library("demo_native"),
+    )
+    .render(&bindings)
+    .expect("standalone wire types should render");
+
+    let module = output
+        .files()
+        .iter()
+        .find(|file| file.path().as_path() == Path::new("Demo.cs"))
+        .map(|file| file.contents())
+        .expect("generated Demo.cs");
+    assert!(module.contains("internal static extern FfiBuf BufFromBytes"));
+
+    compile_csharp_with_dotnet_when_available(&output, "csharp-standalone-wire-types");
+}
+
+#[test]
 fn csharp_target_qualifies_a_class_method_named_after_its_return_record() {
     let bindings = bindings(
         r#"

--- a/boltffi_backend/tests/csharp.rs
+++ b/boltffi_backend/tests/csharp.rs
@@ -21,6 +21,34 @@ fn target(host: CSharpHost) -> Target<CSharpHost, CBridge> {
 }
 
 #[test]
+fn csharp_target_compiles_a_regular_vec_u8_wire_api() {
+    let bindings = bindings(
+        r#"
+        #[export]
+        pub fn echo_bytes(value: Vec<u8>) -> Vec<u8> { value }
+        "#,
+    );
+    let output = target(
+        CSharpHost::new()
+            .namespace("Company.Bindings")
+            .expect("valid namespace")
+            .native_library("demo_native"),
+    )
+    .render(&bindings)
+    .expect("a regular Vec<u8> API should render");
+
+    let module = output
+        .files()
+        .iter()
+        .find(|file| file.path().as_path() == Path::new("Demo.cs"))
+        .map(|file| file.contents())
+        .expect("generated Demo.cs");
+    assert!(module.contains("internal static extern FfiBuf BufFromBytes"));
+
+    compile_csharp_with_dotnet_when_available(&output, "csharp-vec-u8-wire-runtime");
+}
+
+#[test]
 fn csharp_target_qualifies_a_class_method_named_after_its_return_record() {
     let bindings = bindings(
         r#"
@@ -182,6 +210,7 @@ fn compile_csharp_with_dotnet_when_available(output: &GeneratedOutput, prefix: &
         .arg("build")
         .arg(directory.join("Smoke.csproj"))
         .arg("--nologo")
+        .env("APPDATA", directory.join("appdata"))
         .output()
         .expect("dotnet build should execute");
     assert!(


### PR DESCRIPTION
## Summary

I found a C# generation bug for regular `Vec<u8>` APIs. The generated wire runtime uses `FfiBuf.FromBytes`, but the `NativeMethods.BufFromBytes` P/Invoke was only emitted when closure parameters required copy-buffer support. That leaves generated C# failing with CS0117.

Emit the P/Invoke whenever the wire runtime is generated, and add renderer coverage plus a .NET compile smoke test for a plain exported `Vec<u8>` API.

The C# smoke helper also isolates `APPDATA` so the compile test does not depend on the host's NuGet configuration.

Closes #783.
