### PR TITLE
fix: classify #[data] records through the binding IR rule

### DIFF
--- a/adrs/0001-adr-binding-ir-architecture.md
+++ b/adrs/0001-adr-binding-ir-architecture.md
@@ -1346,3 +1346,18 @@ The items below are deliberately not pinned by this ADR. Each one is downstream 
 - **Per-language template revisions.** How a `DirectRecord` is spelled in Swift versus Kotlin versus Java is the backend's job and is the reason backends exist. Templates change with idiom, taste, and language version. The architectural seam (Section 3.3, "What stays drifty") is exactly between "decided once" (covered by this ADR) and "spelled per language" (template work).
 
 These are tracked in implementation notes and PRs. They are downstream of accepting this architecture and do not change its shape.
+
+---
+
+## Addendum (2026-08): The fifth answer — macro expansion
+
+Section 1.5 counts four answers to "is this record blittable?", all on the generator side, and the architecture above makes those four structurally one: after the resolver's single branch, a backend cannot disagree because there is nothing to disagree with.
+
+There was a fifth answer the ADR did not cover. The pre-promotion `#[data]` expansion in `boltffi_macros` classified the record again — at proc-macro time, inside the user's crate, where it fixes the compiled library's ABI. That answer came from `ffi_rules::classification`, which was width-blind: it accepted any repr(C) struct of fixed-width primitives, without checking that the field offsets agree across native alignment profiles. The result was the drift of Section 1.5 reproduced across the FFI boundary itself: a mixed-alignment record (`{ i64, i32, f64 }`) compiled into the dylib as raw struct bytes while every IR-backed backend generated wire-encoded access.
+
+Promoting Binding IR generation removed that classifier structurally: the expansion now consumes lowered binding declarations and never re-decides an FFI fact. What remains is making the one rule that survives — `records::is_direct` in `boltffi_binding::lower` — actually sound at the boundary:
+
+- The rule is stated once as `direct_record_fields` and applied by `is_direct`. It requires effective `repr(C)`, at least one field, every field an admissible fixed-width primitive, and byte layout agreement across the supported native ABI alignment profiles.
+- Effective `repr(C)` is strict: `repr(C, packed)` and `repr(C, align(N))` change the compiled layout the direct crossing assumes, so such records cross encoded rather than direct with wrong offsets. `repr(packed)` on a `#[data]` record is rejected outright at expansion with a targeted error, because the wire encoder takes field references, which is an error (E0793) on packed structs.
+
+The same "decided once, then structural" property the IR gives backends is the end state for the macro side as well: the per-invocation wrapper work (RFC #665) can make the expansion's crossing representation a *type-level* consequence of this classification, at which point disagreement between the compiled ABI and the generated bindings becomes inexpressible rather than tested-for.

--- a/boltffi_binding/src/lib.rs
+++ b/boltffi_binding/src/lib.rs
@@ -31,11 +31,12 @@
 //! an enum is C-style or data-bearing, a callable gets concrete lower
 //! and lift plans, a native symbol is picked and validated. The
 //! lowering pass runs once; nothing downstream re-runs it on the same
-//! source.
+//! source. Any lane that must classify outside the pass applies the
+//! same exported rule rather than keeping a copy.
 //!
 //! # Public surfaces
 //!
-//! Two public entry points sit alongside [`ir`]:
+//! Three public entry points sit alongside [`ir`]:
 //!
 //! - [`lower`] is the macro-facing API. Given a
 //!   [`boltffi_ast::SourceContract`] and a target [`SurfaceLower`]
@@ -46,6 +47,13 @@
 //!   imports. `boltffi_bindgen` reconstructs a [`Bindings<S>`] from
 //!   the serialized metadata embedded in the user's compiled
 //!   artifact and reads it through the [`ir`] types.
+//! - [`direct_record_fields`] is the record classification rule on its
+//!   own: effective `repr(C)`, at least one field, every field an
+//!   admissible fixed-width primitive, and byte layout agreement across
+//!   the supported native ABI alignment profiles. It is the single
+//!   statement of the rule `is_direct` applies during lowering, exported
+//!   so a lane that cannot run the full pass still classifies a record
+//!   identically to the compiled library.
 //!
 //! # What this crate does not do
 //!

--- a/boltffi_binding/src/lib.rs
+++ b/boltffi_binding/src/lib.rs
@@ -64,5 +64,5 @@ pub use ir::*;
 pub use ir::{ErrorChannel, ErrorPlacement};
 pub use lower::{
     DeclarationFamily, DeclarationMap, LowerError, LowerErrorKind, LoweredBindings, SurfaceLower,
-    UnsupportedType, lower, lower_with_declarations,
+    UnsupportedType, direct_record_fields, lower, lower_with_declarations,
 };

--- a/boltffi_binding/src/lower/layout.rs
+++ b/boltffi_binding/src/lower/layout.rs
@@ -30,7 +30,22 @@ impl WideScalarAlignment {
 /// to that alignment so an array of these records lays out without
 /// internal padding.
 pub fn compute(record: &SourceRecord) -> Result<RecordLayout, LowerError> {
-    compute_with_wide_scalar_alignment(record, WideScalarAlignment::EightBytes)
+    let field_types = direct_field_types(record)?;
+    let profile = profile(&field_types, WideScalarAlignment::EightBytes);
+    let alignment = ByteAlignment::new(profile.alignment)
+        .map_err(|error| LowerError::invalid_alignment(error.bytes()))?;
+    let fields = record
+        .fields
+        .iter()
+        .zip(&profile.offsets)
+        .map(|(field, offset)| FieldLayout::new(FieldKey::from(field), ByteOffset::new(*offset)))
+        .collect();
+
+    Ok(RecordLayout::new(
+        ByteSize::new(profile.size),
+        alignment,
+        fields,
+    ))
 }
 
 /// Reports whether every supported native ABI gives a record the same bytes.
@@ -42,49 +57,57 @@ pub fn compute(record: &SourceRecord) -> Result<RecordLayout, LowerError> {
 /// larger alignment so generated allocators always over-align rather than
 /// under-align storage.
 pub fn has_portable_byte_layout(record: &SourceRecord) -> bool {
-    let eight_byte_layout =
-        compute_with_wide_scalar_alignment(record, WideScalarAlignment::EightBytes);
-    let four_byte_layout =
-        compute_with_wide_scalar_alignment(record, WideScalarAlignment::FourBytes);
-
-    matches!(
-        (eight_byte_layout, four_byte_layout),
-        (Ok(eight_byte), Ok(four_byte))
-            if eight_byte.size() == four_byte.size()
-                && eight_byte.fields() == four_byte.fields()
-    )
+    direct_field_types(record).is_ok_and(|field_types| portable_direct_fields(&field_types))
 }
 
-fn compute_with_wide_scalar_alignment(
-    record: &SourceRecord,
-    wide_scalar_alignment: WideScalarAlignment,
-) -> Result<RecordLayout, LowerError> {
-    let (offset, alignment, fields) = record.fields.iter().try_fold(
-        (0_u64, 1_u64, Vec::new()),
-        |(offset, alignment, mut fields), field| {
-            let field_type = primitive::direct_field_type(&field.type_expr)
-                .ok_or_else(|| LowerError::unsupported_type(UnsupportedType::RecordField))?;
-            let field_alignment = field_alignment(field_type, wide_scalar_alignment).get();
-            let field_offset = align_up(offset, field_alignment);
-            fields.push(FieldLayout::new(
-                FieldKey::from(field),
-                ByteOffset::new(field_offset),
-            ));
-            Ok::<_, LowerError>((
-                field_offset + field_type.byte_size().get(),
-                alignment.max(field_alignment),
-                fields,
-            ))
-        },
-    )?;
-    let alignment = ByteAlignment::new(alignment)
-        .map_err(|error| LowerError::invalid_alignment(error.bytes()))?;
+/// Reports whether fields of these types get the same bytes on every
+/// supported native ABI.
+///
+/// The profile-agreement half of the record classification rule; see
+/// [`has_portable_byte_layout`] for the profiles compared.
+pub(crate) fn portable_direct_fields(field_types: &[DirectFieldType]) -> bool {
+    let natural = profile(field_types, WideScalarAlignment::EightBytes);
+    let four_byte = profile(field_types, WideScalarAlignment::FourBytes);
+    natural.size == four_byte.size && natural.offsets == four_byte.offsets
+}
 
-    Ok(RecordLayout::new(
-        ByteSize::new(align_up(offset, alignment.get())),
+struct LayoutProfile {
+    size: u64,
+    alignment: u64,
+    offsets: Vec<u64>,
+}
+
+fn direct_field_types(record: &SourceRecord) -> Result<Vec<DirectFieldType>, LowerError> {
+    record
+        .fields
+        .iter()
+        .map(|field| {
+            primitive::direct_field_type(&field.type_expr)
+                .ok_or_else(|| LowerError::unsupported_type(UnsupportedType::RecordField))
+        })
+        .collect()
+}
+
+fn profile(
+    field_types: &[DirectFieldType],
+    wide_scalar_alignment: WideScalarAlignment,
+) -> LayoutProfile {
+    let mut offset = 0_u64;
+    let mut alignment = 1_u64;
+    let mut offsets = Vec::with_capacity(field_types.len());
+    for field_type in field_types {
+        let field_alignment = field_alignment(*field_type, wide_scalar_alignment).get();
+        offset = align_up(offset, field_alignment);
+        offsets.push(offset);
+        offset += field_type.byte_size().get();
+        alignment = alignment.max(field_alignment);
+    }
+
+    LayoutProfile {
+        size: align_up(offset, alignment),
         alignment,
-        fields,
-    ))
+        offsets,
+    }
 }
 
 fn field_alignment(

--- a/boltffi_binding/src/lower/layout.rs
+++ b/boltffi_binding/src/lower/layout.rs
@@ -48,7 +48,9 @@ pub fn compute(record: &SourceRecord) -> Result<RecordLayout, LowerError> {
     ))
 }
 
-/// Reports whether every supported native ABI gives a record the same bytes.
+/// Reports whether fields of these types get the same bytes on every
+/// supported native ABI: the profile-agreement half of the record
+/// classification rule.
 ///
 /// Most native targets align `i64`, `u64`, and `f64` to eight bytes. The
 /// 32-bit x86 ABI aligns those scalars to four bytes instead. Direct records
@@ -56,15 +58,6 @@ pub fn compute(record: &SourceRecord) -> Result<RecordLayout, LowerError> {
 /// field offset. Their container alignment may differ: the IR retains the
 /// larger alignment so generated allocators always over-align rather than
 /// under-align storage.
-pub fn has_portable_byte_layout(record: &SourceRecord) -> bool {
-    direct_field_types(record).is_ok_and(|field_types| portable_direct_fields(&field_types))
-}
-
-/// Reports whether fields of these types get the same bytes on every
-/// supported native ABI.
-///
-/// The profile-agreement half of the record classification rule; see
-/// [`has_portable_byte_layout`] for the profiles compared.
 pub(crate) fn portable_direct_fields(field_types: &[DirectFieldType]) -> bool {
     let natural = profile(field_types, WideScalarAlignment::EightBytes);
     let four_byte = profile(field_types, WideScalarAlignment::FourBytes);

--- a/boltffi_binding/src/lower/mod.rs
+++ b/boltffi_binding/src/lower/mod.rs
@@ -66,6 +66,7 @@ use boltffi_ast::SourceContract;
 use crate::{BindingError, Bindings, CanonicalName, Decl, PackageInfo};
 
 pub use self::error::{DeclarationFamily, LowerError, LowerErrorKind, UnsupportedType};
+pub use self::records::direct_record_fields;
 pub use self::surface::SurfaceLower;
 
 use self::{ids::DeclarationIds, index::Index, symbol::SymbolAllocator};

--- a/boltffi_binding/src/lower/primitive.rs
+++ b/boltffi_binding/src/lower/primitive.rs
@@ -25,12 +25,12 @@ pub fn integer_repr(repr: &ReprAttr) -> Option<IntegerRepr> {
     })
 }
 
-pub fn has_repr_c(repr: &ReprAttr) -> bool {
-    repr.items.iter().any(|item| matches!(item, ReprItem::C))
-}
-
+/// Reports whether a record's repr pins the plain C layout the direct
+/// crossing assumes: no repr at all (`#[data]` materializes `#[repr(C)]`)
+/// or `repr(C)` with no layout modifier. `packed`, `align(N)`, and any
+/// other item change the compiled layout, so such records cross encoded.
 pub fn has_effective_repr_c(repr: &ReprAttr) -> bool {
-    repr.items.is_empty() || has_repr_c(repr)
+    repr.items.iter().all(|item| matches!(item, ReprItem::C))
 }
 
 impl From<SourcePrimitive> for Primitive {

--- a/boltffi_binding/src/lower/records.rs
+++ b/boltffi_binding/src/lower/records.rs
@@ -41,7 +41,8 @@ pub fn lower<S: SurfaceLower>(
 /// A record with no `repr` items qualifies because `#[data]` materializes
 /// `#[repr(C)]` on the emitted struct; expansion verifies the resulting
 /// layout against the lowered record layout with compile-time assertions.
-/// A record that declares a different `repr` keeps the layout intent it
+/// A record that declares any repr other than plain `repr(C)` — including
+/// `repr(C, packed)` or `repr(C, align(N))` — keeps the layout intent it
 /// wrote and crosses encoded. Records whose size or field offsets change
 /// between supported native ABI alignment profiles also cross encoded.
 pub fn is_direct(record: &SourceRecord) -> bool {
@@ -66,6 +67,9 @@ pub fn direct_record_fields<I>(effective_repr_c: bool, field_primitives: I) -> b
 where
     I: IntoIterator<Item = Option<SourcePrimitive>>,
 {
+    if !effective_repr_c {
+        return false;
+    }
     let Some(field_types) = field_primitives
         .into_iter()
         .map(|field_primitive| {
@@ -75,7 +79,7 @@ where
     else {
         return false;
     };
-    effective_repr_c && !field_types.is_empty() && layout::portable_direct_fields(&field_types)
+    !field_types.is_empty() && layout::portable_direct_fields(&field_types)
 }
 
 fn lower_one<S: SurfaceLower>(
@@ -373,6 +377,40 @@ mod tests {
             vec![field("raw", TypeExpr::Primitive(Primitive::U64))],
         );
         record.repr = ReprAttr::new(vec![ReprItem::Transparent]);
+
+        let bindings = lower_record::<Native>(record);
+
+        encoded_record(&bindings);
+    }
+
+    #[test]
+    fn classifies_packed_record_as_encoded() {
+        let mut record = record(
+            "demo::Packet",
+            "packet",
+            vec![
+                field("tag", TypeExpr::Primitive(Primitive::U8)),
+                field("count", TypeExpr::Primitive(Primitive::U32)),
+            ],
+        );
+        record.repr = ReprAttr::new(vec![ReprItem::C, ReprItem::Packed(None)]);
+
+        let bindings = lower_record::<Native>(record);
+
+        encoded_record(&bindings);
+    }
+
+    #[test]
+    fn classifies_over_aligned_record_as_encoded() {
+        let mut record = record(
+            "demo::Cell",
+            "cell",
+            vec![
+                field("a", TypeExpr::Primitive(Primitive::U32)),
+                field("b", TypeExpr::Primitive(Primitive::U32)),
+            ],
+        );
+        record.repr = ReprAttr::new(vec![ReprItem::C, ReprItem::Align(8)]);
 
         let bindings = lower_record::<Native>(record);
 

--- a/boltffi_binding/src/lower/records.rs
+++ b/boltffi_binding/src/lower/records.rs
@@ -1,8 +1,9 @@
-use boltffi_ast::{RecordDef as SourceRecord, TypeExpr};
+use boltffi_ast::{Primitive as SourcePrimitive, RecordDef as SourceRecord, TypeExpr};
 
 use crate::{
-    CanonicalName, DirectFieldDecl, DirectRecordDecl, EncodedFieldDecl, EncodedRecordDecl,
-    ExportedMethodDecl, FieldKey, InitializerDecl, NativeSymbol, RecordDecl, ValueRef,
+    CanonicalName, DirectFieldDecl, DirectFieldType, DirectRecordDecl, EncodedFieldDecl,
+    EncodedRecordDecl, ExportedMethodDecl, FieldKey, InitializerDecl, NativeSymbol, RecordDecl,
+    ValueRef,
 };
 
 use super::{
@@ -44,13 +45,37 @@ pub fn lower<S: SurfaceLower>(
 /// wrote and crosses encoded. Records whose size or field offsets change
 /// between supported native ABI alignment profiles also cross encoded.
 pub fn is_direct(record: &SourceRecord) -> bool {
-    primitive::has_effective_repr_c(&record.repr)
-        && !record.fields.is_empty()
-        && record
-            .fields
-            .iter()
-            .all(|field| primitive::direct_field_type(&field.type_expr).is_some())
-        && layout::has_portable_byte_layout(record)
+    direct_record_fields(
+        primitive::has_effective_repr_c(&record.repr),
+        record.fields.iter().map(|field| match &field.type_expr {
+            TypeExpr::Primitive(field_primitive) => Some(*field_primitive),
+            _ => None,
+        }),
+    )
+}
+
+/// Classifies record fields for direct-vs-encoded crossing from per-field
+/// primitives, `None` marking a field whose type is not a primitive.
+///
+/// The record classification rule itself, split out from [`is_direct`] so the
+/// `#[data]` expansion classifies the struct it compiles through the same rule
+/// this lowering applies to the aggregated contract: effective `repr(C)`, at
+/// least one field, every field an admissible fixed-width primitive, and byte
+/// layout agreement across the supported native ABI alignment profiles.
+pub fn direct_record_fields<I>(effective_repr_c: bool, field_primitives: I) -> bool
+where
+    I: IntoIterator<Item = Option<SourcePrimitive>>,
+{
+    let Some(field_types) = field_primitives
+        .into_iter()
+        .map(|field_primitive| {
+            field_primitive.and_then(|field_primitive| DirectFieldType::new(field_primitive.into()))
+        })
+        .collect::<Option<Vec<_>>>()
+    else {
+        return false;
+    };
+    effective_repr_c && !field_types.is_empty() && layout::portable_direct_fields(&field_types)
 }
 
 fn lower_one<S: SurfaceLower>(

--- a/boltffi_binding/src/lower/records.rs
+++ b/boltffi_binding/src/lower/records.rs
@@ -58,11 +58,11 @@ pub fn is_direct(record: &SourceRecord) -> bool {
 /// Classifies record fields for direct-vs-encoded crossing from per-field
 /// primitives, `None` marking a field whose type is not a primitive.
 ///
-/// The record classification rule itself, split out from [`is_direct`] so the
-/// `#[data]` expansion classifies the struct it compiles through the same rule
-/// this lowering applies to the aggregated contract: effective `repr(C)`, at
-/// least one field, every field an admissible fixed-width primitive, and byte
-/// layout agreement across the supported native ABI alignment profiles.
+/// The record classification rule itself, split out of `is_direct` and
+/// exported so a lane that cannot run the full lowering pass classifies a
+/// record through the same rule: effective `repr(C)`, at least one field,
+/// every field an admissible fixed-width primitive, and byte layout
+/// agreement across the supported native ABI alignment profiles.
 pub fn direct_record_fields<I>(effective_repr_c: bool, field_primitives: I) -> bool
 where
     I: IntoIterator<Item = Option<SourcePrimitive>>,

--- a/boltffi_macros/src/data/repr.rs
+++ b/boltffi_macros/src/data/repr.rs
@@ -1,27 +1,54 @@
+use boltffi_ast::ReprItem;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Attribute, Item, ItemEnum, ItemStruct};
 
-pub(crate) fn materialize(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    materialize_tokens(item.into()).into()
+pub(crate) fn materialize(
+    item: proc_macro::TokenStream,
+) -> Result<proc_macro::TokenStream, proc_macro::TokenStream> {
+    materialize_tokens(item.into())
+        .map(Into::into)
+        .map_err(|error| error.to_compile_error().into())
 }
 
-fn materialize_tokens(item: TokenStream) -> TokenStream {
+fn materialize_tokens(item: TokenStream) -> syn::Result<TokenStream> {
     let Ok(item) = syn::parse2::<Item>(item.clone()) else {
-        return item;
+        return Ok(item);
     };
     match item {
         Item::Struct(item) => struct_repr(item),
-        Item::Enum(item) => enum_repr(item),
-        item => quote!(#item),
+        Item::Enum(item) => Ok(enum_repr(item)),
+        item => Ok(quote!(#item)),
     }
 }
 
-fn struct_repr(mut item: ItemStruct) -> TokenStream {
+fn struct_repr(mut item: ItemStruct) -> syn::Result<TokenStream> {
+    reject_packed_repr(&item.attrs)?;
     if lacks_repr(&item.attrs) {
         item.attrs.insert(0, syn::parse_quote!(#[repr(C)]));
     }
-    quote!(#item)
+    Ok(quote!(#item))
+}
+
+/// Packed records cross wire-encoded, but the wire encoder takes
+/// references to fields, which is an error (E0793) on packed structs.
+fn reject_packed_repr(attrs: &[Attribute]) -> syn::Result<()> {
+    for attribute in attrs {
+        if !attribute.path().is_ident("repr") {
+            continue;
+        }
+        if boltffi_scan::scan_repr(std::slice::from_ref(attribute))
+            .items
+            .iter()
+            .any(|item| matches!(item, ReprItem::Packed(_)))
+        {
+            return Err(syn::Error::new_spanned(
+                attribute,
+                "#[data] does not support repr(packed); remove the packed modifier",
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn enum_repr(mut item: ItemEnum) -> TokenStream {
@@ -49,7 +76,9 @@ mod tests {
     use super::materialize_tokens;
 
     fn materialized(item: proc_macro2::TokenStream) -> String {
-        materialize_tokens(item).to_string()
+        materialize_tokens(item)
+            .expect("item must materialize")
+            .to_string()
     }
 
     #[test]
@@ -99,6 +128,36 @@ mod tests {
         });
 
         assert!(!tokens.contains("repr"));
+    }
+
+    #[test]
+    fn packed_repr_struct_is_rejected() {
+        let error = materialize_tokens(quote! {
+            #[repr(C, packed)]
+            pub struct Packet { pub tag: u8, pub count: u32 }
+        })
+        .expect_err("packed must be rejected");
+
+        assert!(error.to_string().contains("repr(packed)"));
+    }
+
+    #[test]
+    fn packed_with_alignment_repr_struct_is_rejected() {
+        materialize_tokens(quote! {
+            #[repr(C)]
+            #[repr(packed(2))]
+            pub struct Packet { pub tag: u8, pub count: u32 }
+        })
+        .expect_err("packed(N) must be rejected");
+    }
+
+    #[test]
+    fn plain_repr_c_struct_is_accepted() {
+        materialize_tokens(quote! {
+            #[repr(C)]
+            pub struct Point { pub x: f64, pub y: f64 }
+        })
+        .expect("plain repr(C) must expand");
     }
 
     #[test]

--- a/boltffi_macros/src/lib.rs
+++ b/boltffi_macros/src/lib.rs
@@ -50,13 +50,19 @@ pub fn data(attribute: TokenStream, item: TokenStream) -> TokenStream {
     if attribute.to_string().trim() == "impl" {
         expand(item)
     } else {
-        expand_data(data::repr::materialize(item))
+        match data::repr::materialize(item) {
+            Ok(item) => expand_data(item),
+            Err(error) => error,
+        }
     }
 }
 
 #[proc_macro_attribute]
 pub fn error(_attribute: TokenStream, item: TokenStream) -> TokenStream {
-    expand_data(data::repr::materialize(item))
+    match data::repr::materialize(item) {
+        Ok(item) => expand_data(item),
+        Err(error) => error,
+    }
 }
 
 #[proc_macro_attribute]

--- a/boltffi_scan/src/lib.rs
+++ b/boltffi_scan/src/lib.rs
@@ -22,7 +22,9 @@ mod visibility;
 pub use cfg::ActiveCfg;
 pub use error::ScanError;
 pub use input::ScanInput;
+pub use repr::scan as scan_repr;
 pub use scan::{PackageScan, scan, scan_file, scan_package, scan_source};
+pub use type_expr::primitive_path;
 pub use unsupported::{UnsupportedFeature, UnsupportedInfo};
 
 use path::{ModulePath, ModuleScope};

--- a/boltffi_scan/src/repr.rs
+++ b/boltffi_scan/src/repr.rs
@@ -2,7 +2,7 @@ use syn::{Token, punctuated::Punctuated};
 
 use boltffi_ast::{Primitive, ReprAttr, ReprItem};
 
-pub(super) fn scan(attrs: &[syn::Attribute]) -> ReprAttr {
+pub fn scan(attrs: &[syn::Attribute]) -> ReprAttr {
     ReprAttr::new(
         attrs
             .iter()

--- a/boltffi_scan/src/type_expr.rs
+++ b/boltffi_scan/src/type_expr.rs
@@ -205,7 +205,7 @@ impl<'a> Scanner<'a> {
         if name == "str" {
             return Ok(TypeExpr::Str);
         }
-        if let Some(primitive) = Primitive::from_rust_name(&name) {
+        if let Some(primitive) = primitive_path(&type_path.path) {
             return Ok(TypeExpr::Primitive(primitive));
         }
         let path = ast_path(&type_path.path, self)?;
@@ -508,6 +508,28 @@ impl<'a> Scanner<'a> {
     }
 }
 
+/// Resolves a type path to a primitive: a bare spelling like `i64`, or the
+/// canonical qualified forms `std::primitive::i64` / `core::primitive::i64`.
+/// Any other qualified path may name a user type that shares the leaf
+/// spelling, so it does not resolve.
+pub fn primitive_path(path: &syn::Path) -> Option<Primitive> {
+    if path
+        .segments
+        .iter()
+        .any(|segment| !matches!(segment.arguments, syn::PathArguments::None))
+    {
+        return None;
+    }
+    let primitive = Primitive::from_rust_name(&path.segments.last()?.ident.to_string())?;
+    match path.segments.len() {
+        1 => Some(primitive),
+        3 => ((path.segments[0].ident == "std" || path.segments[0].ident == "core")
+            && path.segments[1].ident == "primitive")
+            .then_some(primitive),
+        _ => None,
+    }
+}
+
 pub fn unwrapped(ty: &syn::Type) -> &syn::Type {
     match ty {
         syn::Type::Paren(paren) => unwrapped(&paren.elem),
@@ -787,6 +809,22 @@ mod tests {
             BaseTrait::Function(Box::new(function_trait)),
             bounds,
         ))
+    }
+
+    #[test]
+    fn resolves_primitives_from_bare_and_canonical_spellings_only() {
+        assert_eq!(
+            scan("std::primitive::i64"),
+            Ok(TypeExpr::Primitive(Primitive::I64))
+        );
+        assert_eq!(
+            scan("core::primitive::f32"),
+            Ok(TypeExpr::Primitive(Primitive::F32))
+        );
+        assert!(
+            scan("mymod::i64").is_err(),
+            "a user type sharing a primitive leaf spelling must not resolve as that primitive"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Rebased over the Binding IR promotion, which changed what this PR is. The promotion deleted the two extra classifiers the original series unified — the `#[data]` expansion's `ffi_rules` lane and the legacy generator lane — so the routing, parity-test, memoization, and deprecation commits are dropped: the expansion now consumes lowered declarations and cannot reclassify, and the original mixed-alignment witness (`Trade` crossing as raw struct bytes in the dylib while every backend encoded it) is already fixed on main. What rides on is the rule itself:

- `boltffi_binding` states the record rule once as `direct_record_fields`; `records::is_direct` applies it, and the layout walk that produces the classification also produces the emitted offsets.
- Effective `repr(C)` is now strict. A `repr(C, align(N))` record classified direct with the natural-alignment layout the compiled struct doesn't have; the expansion's const layout assertions turned that into an inscrutable compile error. It now crosses wire-encoded:

```rust
#[data]
#[repr(C, align(16))]
pub struct Slot { pub id: i64, pub price: f64 }
// main: `const _: [(); 16] = [(); size_of::<Slot>()]` fails in the expansion
// this PR: crosses wire-encoded, like the backends already expect
```

- `repr(packed)` `#[data]` records are rejected with a targeted error — the wire encoder takes references to fields, which is E0793 on packed structs. Proper packed support via unaligned reads is a follow-up if anyone needs it.
- Primitive resolution in `boltffi_scan` is deliberately narrow: a bare spelling or `std::primitive::i64` / `core::primitive::i64` resolves, while any other qualified path (`mymod::i64` naming a user type) no longer classifies as the primitive its leaf spells.
- The ADR-0001 addendum records the fifth answer as history and what the promotion made structural. The ask stands: flipping the ADR to Accepted is yours to make; the addendum rides either way.

## Release-note line

`#[data]` records declaring `repr(C, align(N))` now cross wire-encoded instead of failing the expansion's layout assertions. `repr(packed)` `#[data]` records are rejected at compile time with a targeted error. A record reclassified by this change alters wire representation: regenerate bindings together with the recompiled dylib.
