### PR TITLE
feat(cli): add --deny-skipped to generate

### DIFF
--- a/boltffi_cli/src/cli.rs
+++ b/boltffi_cli/src/cli.rs
@@ -117,6 +117,12 @@ pub enum Commands {
 
         #[arg(long, help = "Render through the IR-AST metadata pipeline")]
         ir: bool,
+
+        #[arg(
+            long,
+            help = "Fail instead of emitting a binding with declarations left out"
+        )]
+        deny_skipped: bool,
     },
 
     #[command(
@@ -479,6 +485,7 @@ pub(crate) fn execute_command(
             output,
             experimental,
             ir,
+            deny_skipped,
         } => {
             let config = load_config(config_paths)?;
             let options = GenerateOptions {
@@ -499,6 +506,7 @@ pub(crate) fn execute_command(
                 experimental,
                 ir,
                 cargo_args: cargo_args.clone(),
+                deny_skipped,
             };
             run_generate_with_output(&config, options)
         }
@@ -867,6 +875,7 @@ fn run_release(
             experimental: false,
             ir: false,
             cargo_args: cargo_args.clone(),
+            deny_skipped: false,
         },
     )?;
     println!();

--- a/boltffi_cli/src/commands/generate/ir.rs
+++ b/boltffi_cli/src/commands/generate/ir.rs
@@ -125,12 +125,13 @@ fn generate_typescript(config: &Config, options: &GenerateOptions) -> Result<()>
         .typescript_module(config.wasm_typescript_module_name())
         .typescript_runtime_package(config.wasm_runtime_package())
         .render(Target::TypeScript)
-        .and_then(|output| {
-            print_coverage("typescript", &output);
-            Generation::write_output(output, &output_directory)
-        })
-        .map(drop)
         .map_err(|error| generation_error("typescript", error))
+        .and_then(|output| {
+            print_coverage("typescript", &output, options.deny_skipped)?;
+            Generation::write_output(output, &output_directory)
+                .map(drop)
+                .map_err(|error| generation_error("typescript", error))
+        })
 }
 
 fn generate_java(config: &Config, options: &GenerateOptions) -> Result<()> {
@@ -143,7 +144,13 @@ fn generate_java(config: &Config, options: &GenerateOptions) -> Result<()> {
     ensure_java_cargo_target_unset(&cargo_args, plan.platform())?;
     let expansion = BindingExpansion::resolve(config, &cargo_args)?;
     let generations = resolve_java_generations(config, &plan, &expansion)?;
-    write_java(config, &plan, expansion.artifact_name(), generations)
+    write_java(
+        config,
+        &plan,
+        expansion.artifact_name(),
+        generations,
+        options.deny_skipped,
+    )
 }
 
 fn ensure_java_cargo_target_unset(cargo_args: &[String], platform: JavaPlatform) -> Result<()> {
@@ -225,7 +232,7 @@ pub fn run_java_generations(
     generations: impl IntoIterator<Item = TargetGeneration>,
 ) -> Result<()> {
     let plan = JavaPlan::resolve(config, output)?;
-    write_java(config, &plan, artifact_name, generations)
+    write_java(config, &plan, artifact_name, generations, false)
 }
 
 fn write_java(
@@ -233,6 +240,7 @@ fn write_java(
     plan: &JavaPlan,
     artifact_name: &str,
     generations: impl IntoIterator<Item = TargetGeneration>,
+    deny_skipped: bool,
 ) -> Result<()> {
     let bindgen_target = Target::Java;
     let target_name = bindgen_target.name();
@@ -277,7 +285,7 @@ fn write_java(
             status: None,
         });
     }
-    print_coverage(target_name, &generated.output);
+    print_coverage(target_name, &generated.output, deny_skipped)?;
     JavaOutput::new(plan.output(), &config.java_package())?.write(generated.output)
 }
 
@@ -309,12 +317,13 @@ fn generate_swift(config: &Config, options: &GenerateOptions) -> Result<()> {
         .swift_file(config.swift_bindings_file_stem())
         .swift_custom_mappings(config.apple_swift_custom_mappings())
         .render(target)
-        .and_then(|output| {
-            print_coverage(target_name, &output);
-            Generation::write_output(output, &output_directory)
-        })
-        .map(drop)
         .map_err(|error| generation_error(target_name, error))
+        .and_then(|output| {
+            print_coverage(target_name, &output, options.deny_skipped)?;
+            Generation::write_output(output, &output_directory)
+                .map(drop)
+                .map_err(|error| generation_error(target_name, error))
+        })
 }
 
 fn swift_output_directory(config: &Config, options: &GenerateOptions) -> PathBuf {
@@ -351,12 +360,13 @@ fn generate_csharp(config: &Config, options: &GenerateOptions) -> Result<()> {
         .csharp_namespace(config.csharp_namespace().map(str::to_owned))
         .csharp_native_library(expansion.artifact_name())
         .render(Target::CSharp)
-        .and_then(|output| {
-            print_coverage(Target::CSharp.name(), &output);
-            Generation::write_output(output, &output_directory)
-        })
-        .map(drop)
         .map_err(|error| generation_error(Target::CSharp.name(), error))
+        .and_then(|output| {
+            print_coverage(Target::CSharp.name(), &output, false)?;
+            Generation::write_output(output, &output_directory)
+                .map(drop)
+                .map_err(|error| generation_error(Target::CSharp.name(), error))
+        })
 }
 
 fn generate_python(config: &Config, options: &GenerateOptions) -> Result<()> {
@@ -428,12 +438,13 @@ fn generate_kotlin(config: &Config, options: &GenerateOptions) -> Result<()> {
         ))
         .kotlin_c_header(PathBuf::from("jni").join(format!("{}.h", config.library_name())))
         .render(target)
-        .and_then(|output| {
-            print_coverage(target_name, &output);
-            Generation::write_output(output, &output_directory)
-        })
-        .map(drop)
         .map_err(|error| generation_error(target_name, error))
+        .and_then(|output| {
+            print_coverage(target_name, &output, options.deny_skipped)?;
+            Generation::write_output(output, &output_directory)
+                .map(drop)
+                .map_err(|error| generation_error(target_name, error))
+        })
 }
 
 fn generate_kmp(config: &Config, options: &GenerateOptions) -> Result<()> {
@@ -554,12 +565,13 @@ pub fn run_csharp_generation(
         .csharp_namespace(config.csharp_namespace().map(str::to_owned))
         .csharp_native_library(artifact_name)
         .render(Target::CSharp)
-        .and_then(|output| {
-            print_coverage(Target::CSharp.name(), &output);
-            Generation::write_output(output, &output_directory)
-        })
-        .map(drop)
         .map_err(|error| generation_error(Target::CSharp.name(), error))
+        .and_then(|output| {
+            print_coverage(Target::CSharp.name(), &output, false)?;
+            Generation::write_output(output, &output_directory)
+                .map(drop)
+                .map_err(|error| generation_error(Target::CSharp.name(), error))
+        })
 }
 
 pub fn run_kmp_generation(
@@ -622,12 +634,13 @@ fn write_python(
         .python_package_version(config.package_version())
         .python_native_library(artifact_name)
         .render(Target::Python)
-        .and_then(|output| {
-            print_coverage("python", &output);
-            Generation::write_output(output, &output_directory)
-        })
-        .map(drop)
         .map_err(|error| generation_error("python", error))
+        .and_then(|output| {
+            print_coverage("python", &output, false)?;
+            Generation::write_output(output, &output_directory)
+                .map(drop)
+                .map_err(|error| generation_error("python", error))
+        })
 }
 
 fn write_kmp(
@@ -717,10 +730,15 @@ fn remove_stale_generated_path(path: PathBuf) -> Result<()> {
     }
 }
 
-fn print_coverage(target: &str, output: &GeneratedOutput) {
+/// Reports declarations the target could not render.
+///
+/// The table alone is easy to miss: generation still succeeds and the binding
+/// ships without them, so a build that checks only the exit status cannot tell
+/// a complete binding from a truncated one. `--deny-skipped` makes it fail.
+fn print_coverage(target: &str, output: &GeneratedOutput, deny: bool) -> Result<()> {
     let unsupported = output.coverage().unsupported();
     if unsupported.is_empty() {
-        return;
+        return Ok(());
     }
 
     eprintln!("{target} generation skipped unsupported declarations");
@@ -733,6 +751,17 @@ fn print_coverage(target: &str, output: &GeneratedOutput) {
             item.reason()
         );
     });
+
+    if !deny {
+        return Ok(());
+    }
+    Err(CliError::CommandFailed {
+        command: format!(
+            "generate {target}: {} declaration(s) skipped",
+            unsupported.len()
+        ),
+        status: None,
+    })
 }
 
 fn generation_error(target: &str, error: GenerationError) -> CliError {
@@ -885,6 +914,7 @@ enabled = false
                 experimental: false,
                 ir: true,
                 cargo_args: Vec::new(),
+                deny_skipped: false,
             },
         )
         .expect_err("disabled KMP IR generation should fail before cargo probing");
@@ -913,6 +943,7 @@ version = "0.1.0"
                 experimental: false,
                 ir: true,
                 cargo_args: Vec::new(),
+                deny_skipped: false,
             },
         )
         .expect_err("disabled Java IR generation should fail before cargo probing");
@@ -943,6 +974,7 @@ enabled = false
                 experimental: false,
                 ir: true,
                 cargo_args: Vec::new(),
+                deny_skipped: false,
             },
         )
         .expect_err("disabled TypeScript IR generation should fail before cargo probing");
@@ -977,6 +1009,7 @@ host_targets = ["current"]
                     "--target".to_string(),
                     "x86_64-unknown-linux-gnu".to_string(),
                 ],
+                deny_skipped: false,
             },
         )
         .expect_err("explicit Cargo target must not bypass the configured Java matrix");
@@ -1010,6 +1043,7 @@ enabled = true
                     "--target=aarch64-linux-android".to_string(),
                     "--offline".to_string(),
                 ],
+                deny_skipped: false,
             },
         )
         .expect_err("explicit Cargo target must not narrow the configured Android matrix");
@@ -1093,6 +1127,7 @@ enabled = true
                 experimental: false,
                 ir: true,
                 cargo_args: Vec::new(),
+                deny_skipped: false,
             },
         )
         .expect_err("KMP IR generation should require experimental opt-in");

--- a/boltffi_cli/src/commands/generate/ir.rs
+++ b/boltffi_cli/src/commands/generate/ir.rs
@@ -362,7 +362,7 @@ fn generate_csharp(config: &Config, options: &GenerateOptions) -> Result<()> {
         .render(Target::CSharp)
         .map_err(|error| generation_error(Target::CSharp.name(), error))
         .and_then(|output| {
-            print_coverage(Target::CSharp.name(), &output, false)?;
+            print_coverage(Target::CSharp.name(), &output, options.deny_skipped)?;
             Generation::write_output(output, &output_directory)
                 .map(drop)
                 .map_err(|error| generation_error(Target::CSharp.name(), error))
@@ -394,6 +394,7 @@ fn generate_python(config: &Config, options: &GenerateOptions) -> Result<()> {
         expansion.artifact_name().to_string(),
         expansion.cargo_args().clone().into_vec(),
         expansion.toolchain_selector().map(str::to_owned),
+        options.deny_skipped,
     )
 }
 
@@ -491,6 +492,7 @@ fn generate_kmp(config: &Config, options: &GenerateOptions) -> Result<()> {
         library_target.name.clone(),
         cargo.probe_command_arguments(),
         cargo.toolchain_selector().map(str::to_owned),
+        options.deny_skipped,
     )
 }
 
@@ -523,6 +525,7 @@ pub fn run_python_generation(
     artifact_name: String,
     cargo_args: Vec<String>,
     toolchain_selector: Option<String>,
+    deny_skipped: bool,
 ) -> Result<()> {
     if !config.is_python_enabled() {
         return Err(CliError::CommandFailed {
@@ -540,6 +543,7 @@ pub fn run_python_generation(
         artifact_name,
         cargo_args,
         toolchain_selector,
+        deny_skipped,
     )
 }
 
@@ -550,6 +554,7 @@ pub fn run_csharp_generation(
     artifact_name: String,
     cargo_args: Vec<String>,
     toolchain_selector: Option<String>,
+    deny_skipped: bool,
 ) -> Result<()> {
     if !config.is_csharp_enabled() {
         return Err(CliError::CommandFailed {
@@ -567,7 +572,7 @@ pub fn run_csharp_generation(
         .render(Target::CSharp)
         .map_err(|error| generation_error(Target::CSharp.name(), error))
         .and_then(|output| {
-            print_coverage(Target::CSharp.name(), &output, false)?;
+            print_coverage(Target::CSharp.name(), &output, deny_skipped)?;
             Generation::write_output(output, &output_directory)
                 .map(drop)
                 .map_err(|error| generation_error(Target::CSharp.name(), error))
@@ -598,6 +603,8 @@ pub fn run_kmp_generation(
         artifact_name,
         cargo_args,
         toolchain_selector,
+        // Entry point used by pack; the flag belongs to `generate`.
+        false,
     )
 }
 
@@ -624,6 +631,7 @@ fn write_python(
     artifact_name: String,
     cargo_args: Vec<String>,
     toolchain_selector: Option<String>,
+    deny_skipped: bool,
 ) -> Result<()> {
     Generation::new(manifest_path)
         .cargo_args(cargo_args)
@@ -636,7 +644,7 @@ fn write_python(
         .render(Target::Python)
         .map_err(|error| generation_error("python", error))
         .and_then(|output| {
-            print_coverage("python", &output, false)?;
+            print_coverage("python", &output, deny_skipped)?;
             Generation::write_output(output, &output_directory)
                 .map(drop)
                 .map_err(|error| generation_error("python", error))
@@ -650,6 +658,7 @@ fn write_kmp(
     artifact_name: String,
     cargo_args: Vec<String>,
     toolchain_selector: Option<String>,
+    deny_skipped: bool,
 ) -> Result<()> {
     let support_mode = if config.kotlin_multiplatform_preview_prune_unsupported() {
         eprintln!(
@@ -688,6 +697,10 @@ fn write_kmp(
         .kmp_support_mode(support_mode)
         .render(Target::KotlinMultiplatform)
         .map_err(|error| generation_error("kmp", error))?;
+
+    // Preview pruning omits unsupported APIs on purpose, so it is exactly the
+    // mode where a denied run has to stop before writing.
+    print_coverage("kmp", &output, deny_skipped)?;
 
     write_kmp_output(output, &output_directory)
 }
@@ -1161,6 +1174,7 @@ package = "com.boltffi.demo"
             "demo".to_string(),
             Vec::new(),
             None,
+            false,
         )
         .expect_err("production IR KMP must fail closed for unsupported declarations");
 

--- a/boltffi_cli/src/commands/generate/mod.rs
+++ b/boltffi_cli/src/commands/generate/mod.rs
@@ -216,6 +216,7 @@ pub fn run_generate_python_with_manifest(
     artifact_name: String,
     cargo_args: Vec<String>,
     toolchain_selector: Option<String>,
+    deny_skipped: bool,
 ) -> Result<()> {
     ir::run_python_generation(
         config,
@@ -224,6 +225,7 @@ pub fn run_generate_python_with_manifest(
         artifact_name,
         cargo_args,
         toolchain_selector,
+        deny_skipped,
     )
 }
 
@@ -268,6 +270,7 @@ pub fn run_generate_csharp_with_output_from_source_dir(
     crate_name: &str,
     cargo_args: Vec<String>,
     toolchain_selector: Option<String>,
+    deny_skipped: bool,
 ) -> Result<()> {
     ir::run_csharp_generation(
         config,
@@ -276,6 +279,7 @@ pub fn run_generate_csharp_with_output_from_source_dir(
         crate_name.to_owned(),
         cargo_args,
         toolchain_selector,
+        deny_skipped,
     )
 }
 

--- a/boltffi_cli/src/commands/generate/mod.rs
+++ b/boltffi_cli/src/commands/generate/mod.rs
@@ -38,6 +38,8 @@ pub struct GenerateOptions {
     pub experimental: bool,
     pub ir: bool,
     pub cargo_args: Vec<String>,
+    /// Turn skipped declarations into a failure instead of a printed table.
+    pub deny_skipped: bool,
 }
 
 pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Result<()> {
@@ -73,6 +75,7 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
                         experimental: options.experimental,
                         ir: true,
                         cargo_args: options.cargo_args.clone(),
+                        deny_skipped: options.deny_skipped,
                     },
                 )?;
             }
@@ -86,6 +89,7 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
                         experimental: options.experimental,
                         ir: true,
                         cargo_args: options.cargo_args.clone(),
+                        deny_skipped: options.deny_skipped,
                     },
                 )?;
             }
@@ -99,6 +103,7 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
                         experimental: options.experimental,
                         ir: true,
                         cargo_args: options.cargo_args.clone(),
+                        deny_skipped: options.deny_skipped,
                     },
                 )?;
             }
@@ -112,6 +117,7 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
                         experimental: options.experimental,
                         ir: true,
                         cargo_args: options.cargo_args.clone(),
+                        deny_skipped: options.deny_skipped,
                     },
                 )?;
             }
@@ -125,6 +131,7 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
                         experimental: options.experimental,
                         ir: true,
                         cargo_args: options.cargo_args.clone(),
+                        deny_skipped: options.deny_skipped,
                     },
                 )?;
             }
@@ -142,6 +149,7 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
                         experimental: options.experimental,
                         ir: true,
                         cargo_args: options.cargo_args.clone(),
+                        deny_skipped: options.deny_skipped,
                     },
                 )?;
             }
@@ -155,6 +163,7 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
                         experimental: options.experimental,
                         ir: true,
                         cargo_args: options.cargo_args.clone(),
+                        deny_skipped: options.deny_skipped,
                     },
                 )?;
             }
@@ -330,6 +339,7 @@ enabled = true
                     "--manifest-path".to_string(),
                     "/definitely/missing/boltffi/Cargo.toml".to_string(),
                 ],
+                deny_skipped: false,
             },
         )
         .expect_err("production KMP generation should use IR cargo selection");
@@ -360,6 +370,7 @@ enabled = false
                 experimental: false,
                 ir: false,
                 cargo_args: Vec::new(),
+                deny_skipped: false,
             },
         )
         .expect_err("production TypeScript generation should use the IR route");
@@ -393,6 +404,7 @@ enabled = true
                     "--manifest-path".to_string(),
                     "/definitely/missing/boltffi/Cargo.toml".to_string(),
                 ],
+                deny_skipped: false,
             },
         )
         .expect_err("production C# generation should use IR cargo selection");
@@ -483,6 +495,7 @@ Email = { type = "java.net.URI", conversion = "url_string" }
                     "--manifest-path".to_string(),
                     demo_manifest_path().display().to_string(),
                 ],
+                deny_skipped: false,
             },
         )
         .expect("kotlin multiplatform generate should succeed");
@@ -571,6 +584,7 @@ package = "com.boltffi.demo"
                     "--manifest-path".to_string(),
                     demo_manifest_path().display().to_string(),
                 ],
+                deny_skipped: false,
             },
         )
         .expect_err("strict KMP generation should reject unsupported demo APIs");

--- a/boltffi_cli/src/pack/android/mod.rs
+++ b/boltffi_cli/src/pack/android/mod.rs
@@ -90,6 +90,7 @@ pub(crate) fn pack_android(
                 experimental: false,
                 ir: false,
                 cargo_args: build_cargo_args.clone(),
+                deny_skipped: false,
             },
         )?;
         step.finish_success();
@@ -103,6 +104,7 @@ pub(crate) fn pack_android(
                 experimental: false,
                 ir: false,
                 cargo_args: build_cargo_args.clone(),
+                deny_skipped: false,
             },
         )?;
         step.finish_success();

--- a/boltffi_cli/src/pack/csharp/mod.rs
+++ b/boltffi_cli/src/pack/csharp/mod.rs
@@ -60,6 +60,9 @@ pub(crate) fn pack_csharp(
             &plan.artifact_name,
             plan.generation_cargo_args.clone(),
             plan.generation_toolchain_selector.clone(),
+            // Pack pipelines keep the previous behaviour: the flag belongs to
+            // `generate`, where a caller can ask for it.
+            false,
         )?;
         step.finish_success();
     }

--- a/boltffi_cli/src/pack/dart/mod.rs
+++ b/boltffi_cli/src/pack/dart/mod.rs
@@ -83,6 +83,7 @@ pub(crate) fn pack_dart(
                 experimental: options.experimental,
                 ir: false,
                 cargo_args: build_cargo_args.clone(),
+                deny_skipped: false,
             },
         )?;
 

--- a/boltffi_cli/src/pack/python/mod.rs
+++ b/boltffi_cli/src/pack/python/mod.rs
@@ -47,6 +47,9 @@ pub(crate) fn pack_python(
             plan.cargo_context.artifact_name.clone(),
             plan.cargo_context.cargo_command_args.clone(),
             plan.cargo_context.toolchain_selector.clone(),
+            // Pack pipelines keep the previous behaviour: the flag belongs to
+            // `generate`, where a caller can ask for it.
+            false,
         )?;
         step.finish_success();
     }

--- a/boltffi_cli/src/pack/wasm/mod.rs
+++ b/boltffi_cli/src/pack/wasm/mod.rs
@@ -114,6 +114,7 @@ pub(crate) fn pack_wasm(
                 experimental: false,
                 ir: true,
                 cargo_args: build_cargo_args.clone(),
+                deny_skipped: false,
             },
         )?;
         step.finish_success();


### PR DESCRIPTION
`generate` prints a table of declarations the target could not render, and then exits 0:

```
typescript generation skipped unsupported declarations
kind         name                    reason
callback     sync::void::result      callback fallible success
callback     async::void::result     callback async fallible success
```

The binding ships without them. A build that checks only the exit status cannot tell a complete binding from one with a trait silently missing — the failure is visible only to whoever reads the log, which in CI is nobody. That is how a gap reaches production.

## The change

`--deny-skipped` turns the table into a failure:

```
error: command failed: generate typescript: 2 declaration(s) skipped
```

The check runs **before** anything is written, so a denied run leaves no partial output on disk.

**Default behaviour is unchanged.** Failing by default would break every project that currently tolerates a skip, and that is a call for the maintainers to make deliberately rather than inherit as a side effect of this change. The flag applies to `generate`; the pack pipelines pass `false` and behave exactly as before.

## Verified

Against a crate with two callbacks the TypeScript target cannot render today:

| invocation | exit | output written |
| --- | ---: | --- |
| `boltffi generate typescript` | 0 | yes, with both traits missing |
| `boltffi generate typescript --deny-skipped` | 1 | nothing |

`cargo test --workspace` has no failures. `cargo clippy --workspace --all-targets` and `cargo fmt --all` are clean.

## What I did not add

An automated test. `print_coverage` needs a `GeneratedOutput` carrying unsupported declarations to exercise either branch, and `Coverage` is not exported from `boltffi_backend`, so constructing one from a test means either widening that crate's public surface or building a fixture crate the CLI can render — both larger than this change. The verification above is a real run of the shipped binary against a real crate, and I would rather say that plainly than add a test that asserts something narrower than the behaviour and looks like more coverage than it is.

If you would prefer the export widened so this can be unit-tested, say so and I will do that instead.
