### PR TITLE
fix(wasm): treat a binary payload as a callback success

### DIFF
--- a/runtime/typescript/src/wire.ts
+++ b/runtime/typescript/src/wire.ts
@@ -399,12 +399,17 @@ export function matchWireResult<T, E, R>(
   if (value instanceof Error) {
     return err(value as E);
   }
-  // A binary payload is never a `WireResult`: it carries no `tag`, and a
-  // caller cannot have meant it as one. Without this a callback returning
+  // A typed array is never a `WireResult`: it carries no `tag`, and a caller
+  // cannot have meant it as one. Without this a callback returning
   // `Result<Vec<u8>, E>` hits the ambiguity below, the throw is reported as
   // completion code -2, and the Rust side decodes that message as the error
   // enum — a decode failure that aborts the process rather than surfacing.
-  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+  //
+  // Only views with a numeric `length`, which is what the bytes codec sizes
+  // and writes through. A bare `ArrayBuffer` or a `DataView` has none, so
+  // exempting them would size the payload as `NaN` and throw inside the
+  // encoder instead — the same abort, one step later.
+  if (ArrayBuffer.isView(value) && typeof (value as { length?: unknown }).length === "number") {
     return ok(value as T);
   }
   if (typeof value === "object" && value !== null) {

--- a/runtime/typescript/src/wire.ts
+++ b/runtime/typescript/src/wire.ts
@@ -399,6 +399,14 @@ export function matchWireResult<T, E, R>(
   if (value instanceof Error) {
     return err(value as E);
   }
+  // A binary payload is never a `WireResult`: it carries no `tag`, and a
+  // caller cannot have meant it as one. Without this a callback returning
+  // `Result<Vec<u8>, E>` hits the ambiguity below, the throw is reported as
+  // completion code -2, and the Rust side decodes that message as the error
+  // enum — a decode failure that aborts the process rather than surfacing.
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+    return ok(value as T);
+  }
   if (typeof value === "object" && value !== null) {
     throw new Error(
       "Ambiguous Result object. Pass wireOk(value) or wireErr(error) for object payloads."

--- a/runtime/typescript/test/wire-result.test.ts
+++ b/runtime/typescript/test/wire-result.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { matchWireResult, wireErr, wireOk } from "../src/wire.js";
+
+const take = (value: unknown) =>
+  matchWireResult(
+    value as never,
+    (ok) => ({ ok }),
+    (err) => ({ err })
+  );
+
+describe("matchWireResult", () => {
+  it("treats a binary payload as success", () => {
+    // A callback returning `Result<Vec<u8>, E>` hands back a `Uint8Array`. It
+    // carries no `tag`, so it used to reach the ambiguity throw; that throw was
+    // reported as completion code -2 and decoded on the Rust side as the error
+    // enum, which aborted the process instead of surfacing anything.
+    const bytes = new Uint8Array([1, 2, 3]);
+
+    expect(take(bytes)).toEqual({ ok: bytes });
+    expect(take(new Float64Array([1.5]))).toEqual({ ok: new Float64Array([1.5]) });
+    expect(take(new ArrayBuffer(4))).toEqual({ ok: new ArrayBuffer(4) });
+  });
+
+  it("still refuses a plain object", () => {
+    // A record genuinely is ambiguous: it could be either side of the result,
+    // so the caller has to say which.
+    expect(() => take({ id: 1 })).toThrow(/Ambiguous/);
+  });
+
+  it("keeps the explicit wrappers working", () => {
+    const bytes = new Uint8Array([9]);
+
+    expect(take(wireOk(bytes))).toEqual({ ok: bytes });
+    expect(take(wireErr("boom"))).toEqual({ err: "boom" });
+  });
+
+  it("keeps scalars and errors on their existing sides", () => {
+    expect(take("text")).toEqual({ ok: "text" });
+    expect(take(42)).toEqual({ ok: 42 });
+    const failure = new Error("nope");
+    expect(take(failure)).toEqual({ err: failure });
+  });
+});

--- a/runtime/typescript/test/wire-result.test.ts
+++ b/runtime/typescript/test/wire-result.test.ts
@@ -18,7 +18,15 @@ describe("matchWireResult", () => {
 
     expect(take(bytes)).toEqual({ ok: bytes });
     expect(take(new Float64Array([1.5]))).toEqual({ ok: new Float64Array([1.5]) });
-    expect(take(new ArrayBuffer(4))).toEqual({ ok: new ArrayBuffer(4) });
+  });
+
+  it("leaves buffers without a length ambiguous", () => {
+    // The bytes codec sizes and writes through `.length`. A bare `ArrayBuffer`
+    // and a `DataView` have none, so treating them as success would size the
+    // payload as `NaN` and throw inside the encoder — the same failure one
+    // step later. They keep asking the caller to disambiguate.
+    expect(() => take(new ArrayBuffer(4))).toThrow(/Ambiguous/);
+    expect(() => take(new DataView(new ArrayBuffer(4)))).toThrow(/Ambiguous/);
   });
 
   it("still refuses a plain object", () => {


### PR DESCRIPTION
A JS callback implementing `Result<Vec<u8>, E>` generates cleanly, with no skip reported, and then aborts the process:

```
RuntimeError: unreachable
  at gap_b.wasm.__rust_abort
  ...
  at rust_future_poll_sync::<Result<Vec<u8>, ProbeError>>
```

Nothing catches it. The trap is raised outside the promise chain, so a `try`/`catch` around the `await` never sees it and Node exits 1. `Result<String, E>` and a plain `Vec<u8>` both work in the same build, so it is the payload type.

## What is actually happening

The message does not reach stderr — `panic = "abort"` on wasm32 discards it. I recovered it by installing a panic hook that copies the message into a static, then reading it back after catching the trap through `uncaughtException`:

```
async callback error conversion failed: InvalidValue(EnumTag)
```

The **error** conversion, on a call that succeeded. The chain:

1. The callback returns a bare `Uint8Array`.
2. `matchWireResult` sees an object with no `tag`, falls through to the ambiguity guard, and throws *"Ambiguous Result object. Pass wireOk(value) or wireErr(error) for object payloads."*
3. The surrounding `.catch()` reports completion code **-2** with that message as text.
4. The Rust side takes the failure branch and decodes the message bytes as the error enum. `InvalidValue(EnumTag)`, panic, abort.

So the encoder and decoder never disagreed about bytes. A guard meant to ask the caller for a disambiguation became an uncatchable process kill carrying an unrelated diagnostic.

## The change

A binary payload is never a `WireResult`: it carries no `tag`, and a caller cannot have meant it as one. It is now a success. A plain object stays ambiguous, because a record genuinely could be either side and the caller does have to say which.

This is narrower than the symptom suggests. `Result<String, E>` always worked — a string is not an object. `wireOk(bytes)` always worked. Only the bare binary return was affected, and it is the natural thing to write.

## Verified

The original reproduction, unchanged, in one build:

| shape | before | after |
| --- | --- | --- |
| `async fn f(..) -> Vec<u8>` | ok | ok |
| `async fn f(..) -> Result<String, E>` | ok | ok |
| `async fn f(..) -> Result<Vec<u8>, E>` | **`RuntimeError: unreachable`**, process dies | ok, `[4,5,6]` |

Runtime suite 160 tests, four of them new. They have teeth: removing the guard fails `treats a binary payload as success`, checked by making the change. `examples/platforms/wasm` acceptance suite passes, `cargo test --workspace` has no failures, clippy and fmt clean.

## Worth a maintainer's judgement, not fixed here

Two things this exposes that are wider than the one-line guard:

**Failure codes are conflated.** `AsyncCallbackCompletionCode::from(i32)` maps everything that is not `0` or `-1` to `Panicked`, and the generated async body does `if code.is_success() { Ok(..) } else { Err(decode_error(..)) }`. So the user-error code `1` and the internal code `-2` decode the same way, and `-2` carries UTF-8 text rather than an encoded error enum. That is why this failure presented as an enum-tag decode error. `UnexpectedFfiCallbackError` exists for exactly this and the async fallible path does not use it.

**A panic on that path is unobservable.** It aborts with no message, outside anything a caller can catch. Whatever the policy on the above, a decode failure crossing the callback boundary should arrive as a rejection.
