### PR TITLE
fix(typescript): invoke callback methods by their declared name

### DIFF
--- a/boltffi_backend/src/target/typescript/mod.rs
+++ b/boltffi_backend/src/target/typescript/mod.rs
@@ -632,6 +632,28 @@ mod tests {
         lower::<Wasm32>(&source).expect("source lowers")
     }
 
+    fn reserved_member_bindings() -> Bindings<Wasm32> {
+        let source = boltffi_scan::scan_file(
+            syn::parse_str(
+                r#"
+                #[export]
+                #[allow(async_fn_in_trait)]
+                pub trait Store {
+                    async fn delete(&self, key: String);
+                    fn r#new(&self, key: String);
+                }
+
+                #[export]
+                pub async fn evict(store: impl Store, key: String) { store.delete(key).await }
+                "#,
+            )
+            .expect("valid source"),
+            PackageInfo::new("demo", None),
+        )
+        .expect("source scans");
+        lower::<Wasm32>(&source).expect("source lowers")
+    }
+
     fn stream_bindings() -> Bindings<Wasm32> {
         let source = boltffi_scan::scan_file(
             syn::parse_str(
@@ -1403,6 +1425,7 @@ mod tests {
                 .contains("export function keepTimestamp(value: Timestamp): Timestamp")
         );
     }
+
     /// Only an owned `Vec<u8>` crosses unframed.
     ///
     /// A borrowed slice is written by `borrowed_buffer`, which always frames,
@@ -1436,6 +1459,39 @@ mod tests {
                 contents.contains(&format!("takePackedWireBytes((_exports.{framed}")),
                 "`{framed}` is written framed and must be read framed",
             );
+        }
+    }
+
+    /// A property may be spelled with a reserved word, so a callback method
+    /// named `delete` is declared as `delete` — and must then be *invoked* as
+    /// `delete`. Escaping only the invocation compiles and renders fine, then
+    /// calls `_delete` on an object the same file says has `delete`: the call
+    /// yields `undefined`, the `.then` throws, and the failure surfaces to Rust
+    /// as a panicked completion instead of anything naming the real cause.
+    #[test]
+    fn invokes_callback_methods_by_their_declared_reserved_names() {
+        let output = TypeScriptHost::new("demo")
+            .expect("host constructs")
+            .into_target()
+            .render(&reserved_member_bindings())
+            .expect("target renders");
+
+        for file in output.files() {
+            let contents = file.contents();
+            for name in ["delete", "new"] {
+                if contents.contains(&format!("{name}(key: string)")) {
+                    assert!(
+                        contents.contains(&format!("callback.{name}(")),
+                        "{} declares `{name}` but does not invoke it",
+                        file.path().as_path().display(),
+                    );
+                }
+                assert!(
+                    !contents.contains(&format!("callback._{name}(")),
+                    "{} invokes the escaped `_{name}`",
+                    file.path().as_path().display(),
+                );
+            }
         }
     }
 }

--- a/boltffi_backend/src/target/typescript/mod.rs
+++ b/boltffi_backend/src/target/typescript/mod.rs
@@ -1468,6 +1468,10 @@ mod tests {
     /// calls `_delete` on an object the same file says has `delete`: the call
     /// yields `undefined`, the `.then` throws, and the failure surfaces to Rust
     /// as a panicked completion instead of anything naming the real cause.
+    ///
+    /// `new` is the one name that cannot be declared bare: `new(key: string)`
+    /// in an interface is a construct signature, so the member would not exist
+    /// no matter how it is invoked. It is quoted, and reached by index.
     #[test]
     fn invokes_callback_methods_by_their_declared_reserved_names() {
         let output = TypeScriptHost::new("demo")
@@ -1476,16 +1480,22 @@ mod tests {
             .render(&reserved_member_bindings())
             .expect("target renders");
 
+        let declarations = [
+            ("delete", "  delete(key: string)", "callback.delete("),
+            ("new", "  \"new\"(key: string)", "callback[\"new\"]("),
+        ];
+
         for file in output.files() {
             let contents = file.contents();
-            for name in ["delete", "new"] {
-                if contents.contains(&format!("{name}(key: string)")) {
-                    assert!(
-                        contents.contains(&format!("callback.{name}(")),
-                        "{} declares `{name}` but does not invoke it",
-                        file.path().as_path().display(),
-                    );
+            for (name, declaration, invocation) in declarations {
+                if !contents.contains(declaration) {
+                    continue;
                 }
+                assert!(
+                    contents.contains(invocation),
+                    "{} declares `{name}` as `{declaration}` but does not invoke it as `{invocation}`",
+                    file.path().as_path().display(),
+                );
                 assert!(
                     !contents.contains(&format!("callback._{name}(")),
                     "{} invokes the escaped `_{name}`",
@@ -1493,5 +1503,11 @@ mod tests {
                 );
             }
         }
+
+        let declared = output
+            .files()
+            .iter()
+            .any(|file| file.contents().contains("  \"new\"(key: string)"));
+        assert!(declared, "no file declared the quoted `new` member");
     }
 }

--- a/boltffi_backend/src/target/typescript/render/callback.rs
+++ b/boltffi_backend/src/target/typescript/render/callback.rs
@@ -11,7 +11,7 @@ use super::super::{
     name_style::Name,
     primitive::Scalar,
     syntax::{
-        ArgumentList, Expression, Identifier, MemberName, MethodDeclaration, Statement,
+        ArgumentList, Expression, Identifier, InterfaceMemberName, MethodDeclaration, Statement,
         StringLiteral, TypeName,
     },
 };
@@ -35,7 +35,7 @@ pub struct Callback {
 }
 
 struct Method {
-    name: MemberName,
+    name: InterfaceMemberName,
     import: StringLiteral,
     parameters: Vec<Parameter>,
     public_return: TypeName,
@@ -66,7 +66,7 @@ struct VectorReturn {
 }
 
 struct AsyncMethod {
-    name: MemberName,
+    name: InterfaceMemberName,
     import: StringLiteral,
     complete: Identifier,
     parameters: Vec<Parameter>,
@@ -218,7 +218,7 @@ impl Method {
             _ => invocation,
         };
         Ok(Self {
-            name: Name::new(method.name()).member()?,
+            name: InterfaceMemberName::new(Name::new(method.name()).member()?),
             import: StringLiteral::new(method.target().name().as_str()),
             parameters,
             public_return: return_shape.public_type,
@@ -548,7 +548,7 @@ impl AsyncMethod {
             _ => return Err(Method::unsupported("callback async error")),
         };
         Ok(Self {
-            name: Name::new(method.name()).member()?,
+            name: InterfaceMemberName::new(Name::new(method.name()).member()?),
             import: StringLiteral::new(method.target().name().as_str()),
             complete: Identifier::parse(complete.name().as_str())?,
             parameters,

--- a/boltffi_backend/src/target/typescript/render/callback.rs
+++ b/boltffi_backend/src/target/typescript/render/callback.rs
@@ -203,9 +203,9 @@ impl Method {
             Some((public_type, _)) => ReturnShape::fallible(public_type.clone()),
             None => Self::return_shape(method.callable().returns().plan(), context)?,
         };
-        let invocation = Expression::call(
+        let invocation = Expression::call_member(
             Expression::identifier(Identifier::known("callback")),
-            Name::new(method.name()).identifier()?,
+            &Name::new(method.name()).member()?,
             parameters
                 .iter()
                 .map(|parameter| parameter.argument.clone())
@@ -466,9 +466,9 @@ impl AsyncMethod {
             .iter()
             .map(|parameter| Parameter::from_declaration(parameter, context))
             .collect::<Result<Vec<_>>>()?;
-        let invocation = Expression::call(
+        let invocation = Expression::call_member(
             Expression::identifier(Identifier::known("callback")),
-            Name::new(method.name()).identifier()?,
+            &Name::new(method.name()).member()?,
             parameters
                 .iter()
                 .map(|parameter| parameter.argument.clone())

--- a/boltffi_backend/src/target/typescript/syntax/expression.rs
+++ b/boltffi_backend/src/target/typescript/syntax/expression.rs
@@ -70,8 +70,14 @@ impl Expression {
     /// valid — so this takes the unescaped `MemberName` an interface declares.
     /// Escaping here instead would invoke `_delete` on an object that, per the
     /// emitted interface, has `delete`.
+    ///
+    /// A name the declaration had to quote is reached through the index form,
+    /// since `receiver."new"(…)` is not an expression.
     pub fn call_member(receiver: Self, method: &MemberName, arguments: ArgumentList) -> Self {
-        Self(format!("{receiver}.{method}({arguments})"))
+        match method.needs_quoting() {
+            true => Self(format!("{receiver}[\"{method}\"]({arguments})")),
+            false => Self(format!("{receiver}.{method}({arguments})")),
+        }
     }
 
     pub fn invoke(function: Identifier, arguments: ArgumentList) -> Self {

--- a/boltffi_backend/src/target/typescript/syntax/expression.rs
+++ b/boltffi_backend/src/target/typescript/syntax/expression.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::core::syntax::sealed;
 
-use super::{Identifier, IntegerLiteral, PropertyKey, StringLiteral};
+use super::{Identifier, IntegerLiteral, MemberName, PropertyKey, StringLiteral};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Expression(String);
@@ -61,6 +61,16 @@ impl Expression {
     }
 
     pub fn call(receiver: Self, method: Identifier, arguments: ArgumentList) -> Self {
+        Self(format!("{receiver}.{method}({arguments})"))
+    }
+
+    /// Calls a method by the name a declaration gave it.
+    ///
+    /// A property may be spelled with a reserved word — `map.delete(k)` is
+    /// valid — so this takes the unescaped `MemberName` an interface declares.
+    /// Escaping here instead would invoke `_delete` on an object that, per the
+    /// emitted interface, has `delete`.
+    pub fn call_member(receiver: Self, method: &MemberName, arguments: ArgumentList) -> Self {
         Self(format!("{receiver}.{method}({arguments})"))
     }
 

--- a/boltffi_backend/src/target/typescript/syntax/identifier.rs
+++ b/boltffi_backend/src/target/typescript/syntax/identifier.rs
@@ -57,9 +57,42 @@ impl MemberName {
     }
 }
 
+impl MemberName {
+    /// Whether this name has to be spelled as a string to declare a member.
+    ///
+    /// `new(key: string): void` inside an interface is a construct signature,
+    /// not a method named `new`, so the member silently does not exist. Every
+    /// other reserved word — `delete`, `class`, even `constructor` — reads as
+    /// an ordinary member here and needs no quoting.
+    pub(super) fn needs_quoting(&self) -> bool {
+        self.0 == "new"
+    }
+}
+
 impl fmt::Display for MemberName {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(&self.0)
+    }
+}
+
+/// A member name in the position where an interface declares it.
+///
+/// Only this position is ambiguous. A class body may declare `new(…) {}` as an
+/// ordinary method, and `Counter.new(1)` reads it back; an interface may not.
+pub struct InterfaceMemberName(MemberName);
+
+impl InterfaceMemberName {
+    pub fn new(name: MemberName) -> Self {
+        Self(name)
+    }
+}
+
+impl fmt::Display for InterfaceMemberName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0.needs_quoting() {
+            true => write!(formatter, "\"{}\"", self.0),
+            false => formatter.write_str(&self.0.0),
+        }
     }
 }
 

--- a/boltffi_backend/src/target/typescript/syntax/mod.rs
+++ b/boltffi_backend/src/target/typescript/syntax/mod.rs
@@ -9,7 +9,7 @@ use crate::core::{LanguageSyntax, syntax::sealed};
 
 pub use declaration::MethodDeclaration;
 pub use expression::{ArgumentList, Expression, Statement};
-pub use identifier::{Identifier, MemberName};
+pub use identifier::{Identifier, InterfaceMemberName, MemberName};
 pub use literal::{IntegerLiteral, StringLiteral};
 pub use property::PropertyKey;
 pub use type_name::TypeName;


### PR DESCRIPTION
## Problem

A callback method whose name is a JavaScript reserved word is **declared** unescaped and **invoked** escaped. The two disagree inside the same generated file.

For `async fn delete(&self, store: String, key: String) -> Result<(), E>`:

```ts
// interface
delete(store: string, key: string): Promise<void | WireResult<void, ProbeError> | Error>;

// glue
.then(() => callback._delete(store, key))
```

A user implementing the interface exactly as declared has no `_delete`. The call yields `undefined`, `.then` throws, the failure arrives in Rust as completion code `-2`, and the panic message names `InvalidValue(EnumTag)` — the decoder's complaint about the payload, not the missing method. Nothing in the message points at the name.

The declaration is the correct side: a property may be spelled with a reserved word. `map.delete(k)` is valid JavaScript.

## Cause

`render/callback.rs` built the invocation with `Name::identifier()`, which routes through `Identifier::escape` and prepends `_` for keywords. The interface uses `Name::member()`, which does not escape — `MemberName` is a property position, where no escaping is needed.

Both call sites (sync and async) used `identifier()`.

## Fix

Added `Expression::call_member`, which takes the unescaped `MemberName` a declaration produces, and used it at both sites.

The only other user-derived name passed as a method is `codec_identifier()` in `imported.rs`, which appends `Codec` to an upper-camel name and can never be a keyword. Every remaining `Expression::call` names a fixed runtime method.

## Verification

A repro crate with `delete`, `set(…, Vec<u8>)` and a sync `delete_sync`, all `Result<(), E>`:

```
  async delete(store, key)           OK
  async set(store, key, Vec<u8>)     OK
  sync  delete(store, key)           OK
```

Before the fix, the two `delete` shapes aborted the process; `set` passed, which is what makes this look like a payload problem rather than a naming one.

Regression test in `target/typescript/tests`: renders a trait with `delete` and `new`, and asserts that a name the interface declares is the name the glue invokes. Reverting the fix fails it with `demo.ts declares `delete` but does not invoke it`.


## `new`, from review

`new` needed more than a matching invocation. `new(key: string): void` inside an interface is a **construct signature**, so the member does not exist however it is called. It is declared as `"new"(…)` and reached as `callback["new"](…)`.

Checked against real `tsc`: of `new`, `get`, `set`, `readonly`, `delete`, `in`, `typeof`, `function`, `class`, `constructor`, `static`, `async`, `declare`, `void`, `return`, only `new` fails. Scoped to the interface position — a class body declares `new(…) {}` as an ordinary method, and quoting there broke the existing `static new(initial: number): Counter`.

The generated module now type-checks under `--strict` alongside a consumer implementing the interface exactly as declared; reverting the quoting fails it with TS2353 and TS2339.
