### PR TITLE
feat(cli): accept --deny-skipped on pack

### DIFF
--- a/boltffi_cli/src/cli.rs
+++ b/boltffi_cli/src/cli.rs
@@ -142,6 +142,13 @@ pub enum Commands {
         long_about = "Package platform artifacts.\n\nExamples:\n  boltffi pack apple\n  boltffi pack apple --layout bundled\n  boltffi pack android --release\n  boltffi pack kmp --experimental\n  boltffi pack wasm --release\n  boltffi pack python\n  boltffi pack csharp\n"
     )]
     Pack {
+        #[arg(
+            long,
+            global = true,
+            help = "Fail instead of emitting a binding with declarations left out"
+        )]
+        deny_skipped: bool,
+
         #[command(subcommand)]
         target: PackTargetArg,
     },
@@ -529,7 +536,10 @@ pub(crate) fn execute_command(
             run_build(&config, options).map(|_| ())
         }
 
-        Commands::Pack { target } => {
+        Commands::Pack {
+            deny_skipped,
+            target,
+        } => {
             let config = load_config(config_paths)?;
             let command = match target {
                 PackTargetArg::All {
@@ -543,6 +553,7 @@ pub(crate) fn execute_command(
                         release,
                         regenerate,
                         no_build,
+                        deny_skipped,
                         cargo_args.clone(),
                     ),
                     experimental,
@@ -561,6 +572,7 @@ pub(crate) fn execute_command(
                         release,
                         regenerate,
                         no_build,
+                        deny_skipped,
                         cargo_args.clone(),
                     ),
                     version,
@@ -582,6 +594,7 @@ pub(crate) fn execute_command(
                         release,
                         regenerate,
                         no_build,
+                        deny_skipped,
                         cargo_args.clone(),
                     ),
                 }),
@@ -595,6 +608,7 @@ pub(crate) fn execute_command(
                         release,
                         regenerate,
                         no_build,
+                        deny_skipped,
                         cargo_args.clone(),
                     ),
                     experimental,
@@ -608,6 +622,7 @@ pub(crate) fn execute_command(
                         release,
                         regenerate,
                         no_build,
+                        deny_skipped,
                         cargo_args.clone(),
                     ),
                 }),
@@ -620,6 +635,7 @@ pub(crate) fn execute_command(
                         release,
                         regenerate,
                         no_build,
+                        deny_skipped,
                         cargo_args.clone(),
                     ),
                     experimental: false,
@@ -635,6 +651,7 @@ pub(crate) fn execute_command(
                         release,
                         regenerate,
                         no_build,
+                        deny_skipped,
                         cargo_args.clone(),
                     ),
                     python_interpreters,
@@ -645,7 +662,13 @@ pub(crate) fn execute_command(
                     no_build,
                     experimental,
                 } => PackCommand::Dart(PackDartOptions {
-                    execution: pack_execution_options(release, regenerate, no_build, cargo_args),
+                    execution: pack_execution_options(
+                        release,
+                        regenerate,
+                        no_build,
+                        deny_skipped,
+                        cargo_args,
+                    ),
                     experimental,
                 }),
                 PackTargetArg::Csharp {
@@ -653,7 +676,13 @@ pub(crate) fn execute_command(
                     regenerate,
                     no_build,
                 } => PackCommand::CSharp(PackCSharpOptions {
-                    execution: pack_execution_options(release, regenerate, no_build, cargo_args),
+                    execution: pack_execution_options(
+                        release,
+                        regenerate,
+                        no_build,
+                        deny_skipped,
+                        cargo_args,
+                    ),
                 }),
             };
             run_pack(&config, command, reporter)
@@ -679,12 +708,14 @@ fn pack_execution_options(
     release: bool,
     regenerate: bool,
     no_build: bool,
+    deny_skipped: bool,
     cargo_args: Vec<String>,
 ) -> PackExecutionOptions {
     PackExecutionOptions {
         release,
         regenerate,
         no_build,
+        deny_skipped,
         cargo_args,
     }
 }
@@ -903,7 +934,13 @@ fn release_pack_commands(
         Some(BuildPlatformArg::Apple) => {
             if config.is_apple_enabled() {
                 commands.push(PackCommand::Apple(PackAppleOptions {
-                    execution: pack_execution_options(true, false, true, cargo_args.to_vec()),
+                    execution: pack_execution_options(
+                        true,
+                        false,
+                        true,
+                        false,
+                        cargo_args.to_vec(),
+                    ),
                     version: None,
                     spm_only: false,
                     xcframework_only: false,
@@ -914,21 +951,39 @@ fn release_pack_commands(
         Some(BuildPlatformArg::Android) => {
             if config.is_android_enabled() {
                 commands.push(PackCommand::Android(PackAndroidOptions {
-                    execution: pack_execution_options(true, false, true, cargo_args.to_vec()),
+                    execution: pack_execution_options(
+                        true,
+                        false,
+                        true,
+                        false,
+                        cargo_args.to_vec(),
+                    ),
                 }));
             }
         }
         Some(BuildPlatformArg::Wasm) => {
             if config.is_wasm_enabled() {
                 commands.push(PackCommand::Wasm(PackWasmOptions {
-                    execution: pack_execution_options(true, false, true, cargo_args.to_vec()),
+                    execution: pack_execution_options(
+                        true,
+                        false,
+                        true,
+                        false,
+                        cargo_args.to_vec(),
+                    ),
                 }));
             }
         }
         Some(BuildPlatformArg::Dart) => {
             if config.is_dart_enabled() {
                 commands.push(PackCommand::Dart(PackDartOptions {
-                    execution: pack_execution_options(true, false, true, cargo_args.to_vec()),
+                    execution: pack_execution_options(
+                        true,
+                        false,
+                        true,
+                        false,
+                        cargo_args.to_vec(),
+                    ),
                     experimental: true,
                 }));
             }
@@ -936,7 +991,13 @@ fn release_pack_commands(
         Some(BuildPlatformArg::All) | None => {
             if config.is_apple_enabled() {
                 commands.push(PackCommand::Apple(PackAppleOptions {
-                    execution: pack_execution_options(true, false, true, cargo_args.to_vec()),
+                    execution: pack_execution_options(
+                        true,
+                        false,
+                        true,
+                        false,
+                        cargo_args.to_vec(),
+                    ),
                     version: None,
                     spm_only: false,
                     xcframework_only: false,
@@ -945,43 +1006,85 @@ fn release_pack_commands(
             }
             if config.is_android_enabled() {
                 commands.push(PackCommand::Android(PackAndroidOptions {
-                    execution: pack_execution_options(true, false, true, cargo_args.to_vec()),
+                    execution: pack_execution_options(
+                        true,
+                        false,
+                        true,
+                        false,
+                        cargo_args.to_vec(),
+                    ),
                 }));
             }
             if config.should_process(Target::KotlinMultiplatform, false) {
                 commands.push(PackCommand::Kmp(PackKmpOptions {
-                    execution: pack_execution_options(true, true, false, cargo_args.to_vec()),
+                    execution: pack_execution_options(
+                        true,
+                        true,
+                        false,
+                        false,
+                        cargo_args.to_vec(),
+                    ),
                     experimental: false,
                 }));
             }
             if config.is_wasm_enabled() {
                 commands.push(PackCommand::Wasm(PackWasmOptions {
-                    execution: pack_execution_options(true, false, true, cargo_args.to_vec()),
+                    execution: pack_execution_options(
+                        true,
+                        false,
+                        true,
+                        false,
+                        cargo_args.to_vec(),
+                    ),
                 }));
             }
             if config.should_process(Target::Python, false) {
                 commands.push(PackCommand::Python(PackPythonOptions {
-                    execution: pack_execution_options(true, false, false, cargo_args.to_vec()),
+                    execution: pack_execution_options(
+                        true,
+                        false,
+                        false,
+                        false,
+                        cargo_args.to_vec(),
+                    ),
                     python_interpreters: Vec::new(),
                 }));
             }
             if config.should_process(Target::Java, false) {
                 commands.push(PackCommand::Java(PackJavaOptions {
-                    execution: pack_execution_options(true, true, false, cargo_args.to_vec()),
+                    execution: pack_execution_options(
+                        true,
+                        true,
+                        false,
+                        false,
+                        cargo_args.to_vec(),
+                    ),
                     experimental: false,
                 }));
             }
 
             if config.should_process(Target::Dart, false) {
                 commands.push(PackCommand::Dart(PackDartOptions {
-                    execution: pack_execution_options(true, false, false, cargo_args.to_vec()),
+                    execution: pack_execution_options(
+                        true,
+                        false,
+                        false,
+                        false,
+                        cargo_args.to_vec(),
+                    ),
                     experimental: false,
                 }));
             }
 
             if config.is_csharp_enabled() {
                 commands.push(PackCommand::CSharp(PackCSharpOptions {
-                    execution: pack_execution_options(true, true, false, cargo_args.to_vec()),
+                    execution: pack_execution_options(
+                        true,
+                        true,
+                        false,
+                        false,
+                        cargo_args.to_vec(),
+                    ),
                 }));
             }
         }
@@ -1387,6 +1490,47 @@ enabled = true
         ));
     }
 
+    /// `pack` is what builds the artifact, so a coverage gate that only `generate`
+    /// accepts does not guard the thing that ships. Every target takes the flag,
+    /// on either side of the subcommand, and defaults to off.
+    #[test]
+    fn cli_parses_deny_skipped_on_every_pack_target() {
+        for target in [
+            "all", "apple", "android", "kmp", "wasm", "python", "csharp", "java", "dart",
+        ] {
+            let default = Cli::try_parse_from(["boltffi", "pack", target])
+                .unwrap_or_else(|error| panic!("pack {target} should parse: {error}"));
+            assert!(
+                matches!(
+                    default.command,
+                    Commands::Pack {
+                        deny_skipped: false,
+                        ..
+                    }
+                ),
+                "pack {target} should default to emitting a truncated binding",
+            );
+
+            for argv in [
+                vec!["boltffi", "pack", target, "--deny-skipped"],
+                vec!["boltffi", "pack", "--deny-skipped", target],
+            ] {
+                let cli = Cli::try_parse_from(&argv)
+                    .unwrap_or_else(|error| panic!("{argv:?} should parse: {error}"));
+                assert!(
+                    matches!(
+                        cli.command,
+                        Commands::Pack {
+                            deny_skipped: true,
+                            ..
+                        }
+                    ),
+                    "{argv:?} should deny skipped declarations",
+                );
+            }
+        }
+    }
+
     #[test]
     fn cli_parses_pack_python_target() {
         let cli =
@@ -1395,6 +1539,7 @@ enabled = true
         assert!(matches!(
             cli.command,
             Commands::Pack {
+                deny_skipped: _,
                 target: PackTargetArg::Python { .. }
             }
         ));
@@ -1408,6 +1553,7 @@ enabled = true
         assert!(matches!(
             cli.command,
             Commands::Pack {
+                deny_skipped: _,
                 target: PackTargetArg::Csharp { .. }
             }
         ));
@@ -1425,6 +1571,7 @@ enabled = true
         assert!(matches!(
             default.command,
             Commands::Pack {
+                deny_skipped: _,
                 target: PackTargetArg::Java {
                     regenerate: true,
                     ..
@@ -1434,6 +1581,7 @@ enabled = true
         assert!(matches!(
             enabled.command,
             Commands::Pack {
+                deny_skipped: _,
                 target: PackTargetArg::Java {
                     regenerate: true,
                     ..
@@ -1443,6 +1591,7 @@ enabled = true
         assert!(matches!(
             disabled.command,
             Commands::Pack {
+                deny_skipped: _,
                 target: PackTargetArg::Java {
                     regenerate: false,
                     ..
@@ -1464,6 +1613,7 @@ enabled = true
         assert!(matches!(
             cli.command,
             Commands::Pack {
+                deny_skipped: _,
                 target: PackTargetArg::Android {
                     experimental: true,
                     ..
@@ -1480,6 +1630,7 @@ enabled = true
         assert!(matches!(
             cli.command,
             Commands::Pack {
+                deny_skipped: _,
                 target: PackTargetArg::Kmp {
                     experimental: true,
                     ..
@@ -1496,6 +1647,7 @@ enabled = true
         assert!(matches!(
             cli.command,
             Commands::Pack {
+                deny_skipped: _,
                 target: PackTargetArg::Python {
                     experimental: true,
                     ..
@@ -1520,6 +1672,7 @@ enabled = true
         assert!(matches!(
             cli.command,
             Commands::Pack {
+                deny_skipped: _,
                 target: PackTargetArg::Python {
                     python_interpreters,
                     ..

--- a/boltffi_cli/src/commands/generate/ir.rs
+++ b/boltffi_cli/src/commands/generate/ir.rs
@@ -230,9 +230,10 @@ pub fn run_java_generations(
     output: Option<PathBuf>,
     artifact_name: &str,
     generations: impl IntoIterator<Item = TargetGeneration>,
+    deny_skipped: bool,
 ) -> Result<()> {
     let plan = JavaPlan::resolve(config, output)?;
-    write_java(config, &plan, artifact_name, generations, false)
+    write_java(config, &plan, artifact_name, generations, deny_skipped)
 }
 
 fn write_java(
@@ -586,6 +587,7 @@ pub fn run_kmp_generation(
     artifact_name: String,
     cargo_args: Vec<String>,
     toolchain_selector: Option<String>,
+    deny_skipped: bool,
 ) -> Result<()> {
     if !config.is_kotlin_multiplatform_enabled() {
         return Err(CliError::CommandFailed {
@@ -603,8 +605,7 @@ pub fn run_kmp_generation(
         artifact_name,
         cargo_args,
         toolchain_selector,
-        // Entry point used by pack; the flag belongs to `generate`.
-        false,
+        deny_skipped,
     )
 }
 
@@ -748,7 +749,7 @@ fn remove_stale_generated_path(path: PathBuf) -> Result<()> {
 /// The table alone is easy to miss: generation still succeeds and the binding
 /// ships without them, so a build that checks only the exit status cannot tell
 /// a complete binding from a truncated one. `--deny-skipped` makes it fail.
-fn print_coverage(target: &str, output: &GeneratedOutput, deny: bool) -> Result<()> {
+pub(crate) fn print_coverage(target: &str, output: &GeneratedOutput, deny: bool) -> Result<()> {
     let unsupported = output.coverage().unsupported();
     if unsupported.is_empty() {
         return Ok(());
@@ -1110,6 +1111,7 @@ host_targets = ["current"]
                 target,
                 Generation::new("missing-java-target/Cargo.toml"),
             )],
+            false,
         )
         .expect_err("failed matrix generation must identify its build target");
 

--- a/boltffi_cli/src/commands/generate/mod.rs
+++ b/boltffi_cli/src/commands/generate/mod.rs
@@ -1,6 +1,6 @@
 mod generator;
 mod header;
-mod ir;
+pub(crate) mod ir;
 pub(crate) mod java;
 mod languages;
 
@@ -178,8 +178,9 @@ pub fn run_generate_java_with_generations(
     output: Option<PathBuf>,
     artifact_name: &str,
     generations: impl IntoIterator<Item = java::TargetGeneration>,
+    deny_skipped: bool,
 ) -> Result<()> {
-    ir::run_java_generations(config, output, artifact_name, generations)
+    ir::run_java_generations(config, output, artifact_name, generations, deny_skipped)
 }
 
 #[cfg(test)]
@@ -236,6 +237,7 @@ pub fn run_generate_kmp_with_manifest(
     artifact_name: String,
     cargo_args: Vec<String>,
     toolchain_selector: Option<String>,
+    deny_skipped: bool,
 ) -> Result<()> {
     ir::run_kmp_generation(
         config,
@@ -244,6 +246,7 @@ pub fn run_generate_kmp_with_manifest(
         artifact_name,
         cargo_args,
         toolchain_selector,
+        deny_skipped,
     )
 }
 

--- a/boltffi_cli/src/commands/pack/request.rs
+++ b/boltffi_cli/src/commands/pack/request.rs
@@ -17,6 +17,8 @@ pub struct PackExecutionOptions {
     pub release: bool,
     pub regenerate: bool,
     pub no_build: bool,
+    /// Fail instead of emitting a binding with declarations left out.
+    pub deny_skipped: bool,
     pub cargo_args: Vec<String>,
 }
 

--- a/boltffi_cli/src/pack/android/mod.rs
+++ b/boltffi_cli/src/pack/android/mod.rs
@@ -90,7 +90,7 @@ pub(crate) fn pack_android(
                 experimental: false,
                 ir: false,
                 cargo_args: build_cargo_args.clone(),
-                deny_skipped: false,
+                deny_skipped: options.execution.deny_skipped,
             },
         )?;
         step.finish_success();
@@ -104,7 +104,7 @@ pub(crate) fn pack_android(
                 experimental: false,
                 ir: false,
                 cargo_args: build_cargo_args.clone(),
-                deny_skipped: false,
+                deny_skipped: options.execution.deny_skipped,
             },
         )?;
         step.finish_success();

--- a/boltffi_cli/src/pack/apple/mod.rs
+++ b/boltffi_cli/src/pack/apple/mod.rs
@@ -15,6 +15,7 @@ use crate::build::{
     failed_targets,
 };
 use crate::cli::{CliError, Result};
+use crate::commands::generate::ir::print_coverage;
 use crate::commands::pack::PackAppleOptions;
 use crate::config::{Config, SpmDistribution, SpmLayout};
 use crate::pack::PackError;
@@ -81,7 +82,14 @@ pub(crate) fn pack_apple(
     if options.execution.regenerate {
         scratch_directory.recreate()?;
         let step = reporter.step("Generating Apple bindings");
-        generate_apple_bindings(config, layout, &package_root, &headers_dir, &selected_crate)?;
+        generate_apple_bindings(
+            config,
+            layout,
+            &package_root,
+            &headers_dir,
+            &selected_crate,
+            options.execution.deny_skipped,
+        )?;
         step.finish_success();
     }
 
@@ -225,6 +233,7 @@ fn generate_apple_bindings(
     package_root: &Path,
     header_output_directory: &Path,
     selected_crate: &BindingExpansion,
+    deny_skipped: bool,
 ) -> Result<()> {
     let swift_output_directory = match layout {
         SpmLayout::Bundled => config
@@ -244,7 +253,7 @@ fn generate_apple_bindings(
         .render(BindgenTarget::Swift)
         .map_err(swift_generation_error)?;
 
-    print_coverage(&output);
+    print_coverage(BindgenTarget::Swift.name(), &output, deny_skipped)?;
     write_apple_binding_output(output, &swift_output_directory, header_output_directory)
 }
 
@@ -292,24 +301,6 @@ fn write_generated_file(path: &Path, contents: &str) -> Result<()> {
         path: path.to_path_buf(),
         source,
     })
-}
-
-fn print_coverage(output: &GeneratedOutput) {
-    let unsupported = output.coverage().unsupported();
-    if unsupported.is_empty() {
-        return;
-    }
-
-    eprintln!("swift generation skipped unsupported declarations");
-    eprintln!("{:<12} {:<48} reason", "kind", "name");
-    unsupported.iter().for_each(|item| {
-        eprintln!(
-            "{:<12} {:<48} {}",
-            item.declaration().kind(),
-            item.declaration().name(),
-            item.reason()
-        );
-    });
 }
 
 fn swift_generation_error(error: GenerationError) -> CliError {

--- a/boltffi_cli/src/pack/csharp/mod.rs
+++ b/boltffi_cli/src/pack/csharp/mod.rs
@@ -60,9 +60,7 @@ pub(crate) fn pack_csharp(
             &plan.artifact_name,
             plan.generation_cargo_args.clone(),
             plan.generation_toolchain_selector.clone(),
-            // Pack pipelines keep the previous behaviour: the flag belongs to
-            // `generate`, where a caller can ask for it.
-            false,
+            options.execution.deny_skipped,
         )?;
         step.finish_success();
     }
@@ -833,6 +831,7 @@ mod tests {
                 release: false,
                 regenerate: true,
                 no_build: false,
+                deny_skipped: false,
                 cargo_args: Vec::new(),
             },
         }

--- a/boltffi_cli/src/pack/dart/mod.rs
+++ b/boltffi_cli/src/pack/dart/mod.rs
@@ -83,7 +83,7 @@ pub(crate) fn pack_dart(
                 experimental: options.experimental,
                 ir: false,
                 cargo_args: build_cargo_args.clone(),
-                deny_skipped: false,
+                deny_skipped: options.execution.deny_skipped,
             },
         )?;
 

--- a/boltffi_cli/src/pack/java/plan.rs
+++ b/boltffi_cli/src/pack/java/plan.rs
@@ -170,6 +170,7 @@ fn execute_java_pack(config: &Config, plan: JavaPackPlan, reporter: &Reporter) -
             packaging_targets
                 .iter()
                 .map(|target| target.binding_generation(&expansion)),
+            execution.deny_skipped,
         )?;
         step.finish_success();
     }

--- a/boltffi_cli/src/pack/kmp/mod.rs
+++ b/boltffi_cli/src/pack/kmp/mod.rs
@@ -71,6 +71,7 @@ pub(crate) fn pack_kmp(
             plan.artifact_name().to_string(),
             generation_cargo_args.clone(),
             generation_toolchain_selector.clone(),
+            options.execution.deny_skipped,
         )?;
         step.finish_success();
 

--- a/boltffi_cli/src/pack/python/mod.rs
+++ b/boltffi_cli/src/pack/python/mod.rs
@@ -47,9 +47,7 @@ pub(crate) fn pack_python(
             plan.cargo_context.artifact_name.clone(),
             plan.cargo_context.cargo_command_args.clone(),
             plan.cargo_context.toolchain_selector.clone(),
-            // Pack pipelines keep the previous behaviour: the flag belongs to
-            // `generate`, where a caller can ask for it.
-            false,
+            options.execution.deny_skipped,
         )?;
         step.finish_success();
     }
@@ -133,6 +131,7 @@ mod tests {
                     release: false,
                     regenerate: false,
                     no_build: true,
+                    deny_skipped: false,
                     cargo_args: Vec::new(),
                 },
                 python_interpreters: Vec::new(),

--- a/boltffi_cli/src/pack/wasm/mod.rs
+++ b/boltffi_cli/src/pack/wasm/mod.rs
@@ -114,7 +114,7 @@ pub(crate) fn pack_wasm(
                 experimental: false,
                 ir: true,
                 cargo_args: build_cargo_args.clone(),
-                deny_skipped: false,
+                deny_skipped: options.execution.deny_skipped,
             },
         )?;
         step.finish_success();


### PR DESCRIPTION
## Problem

`--deny-skipped` (#799) exists only on `generate`. `pack` rejects it — and `pack` is what builds the artifact that ships. Every pack pipeline generated bindings with the check hardcoded off, so a target that silently dropped declarations produced a truncated package with nothing to stop it.

This is a gap in #799: I wired the flag into `generate` and left `false` at the pack call sites with a comment saying the flag belonged to `generate`. It belongs wherever a binding is emitted.

## Change

`--deny-skipped` on `pack`, declared `global = true` so it works on either side of the target (`pack wasm --deny-skipped` and `pack --deny-skipped wasm`), matching the existing globals on the root command.

Threaded through `PackExecutionOptions` to every target that generates: wasm, dart, android (Kotlin + C header), csharp, python, kmp, java, apple.

`run_generate_java_with_generations` and `run_generate_kmp_with_manifest` had no parameter for it and passed `false` internally; they take one now.

`pack apple` carried a byte-for-byte copy of `print_coverage` minus the deny path, so it could report skipped declarations but never fail on them. It now calls the shared one.

`release` keeps the check off — its own generate step already runs with it off, and the command exposes no flag.

## Verification

A crate with one declaration TypeScript skips (`pub const HANDLERS: Vec<Box<dyn Handler>>`):

```
$ boltffi pack wasm --no-build
typescript generation skipped unsupported declarations
kind         name                                             reason
constant     handlers                                         callback handle codec read
   ✓ Generating TypeScript bindings          <- step passes, pack continues

$ boltffi pack wasm --no-build --deny-skipped
typescript generation skipped unsupported declarations
kind         name                                             reason
constant     handlers                                         callback handle codec read

error: command failed: generate typescript: 1 declaration(s) skipped
```

Regression test asserts all nine pack targets accept the flag in both argument positions and default to off. #799 shipped without a test that exercised the deny path at all.
