### PR TITLE
fix(wasm): surface a thrown callback error instead of aborting

### DIFF
--- a/boltffi_backend/templates/target/typescript/browser.ts
+++ b/boltffi_backend/templates/target/typescript/browser.ts
@@ -1,4 +1,4 @@
-import { BoltFFIHandle, BoltFFIModule, CallbackRegistry, StreamCancellable, StreamSession, WASM_ABI_VERSION, instantiateBoltFFI, matchWireResult, utf8ByteCount, wireArraySize, wireMapSize, wireOptionalSize, wireResultSize, wireStringSize } from {{ runtime_package }};
+import { BoltFFIHandle, BoltFFIModule, CallbackRegistry, StreamCancellable, StreamSession, WASM_ABI_VERSION, instantiateBoltFFI, matchWireResult, utf8ByteCount, wireArraySize, wireMapSize, wireOptionalSize, wireResultSize, wireStringSize, writeUnexpectedCallbackError } from {{ runtime_package }};
 import type { BoltFFIExports, Duration, WireCodec, WireResult } from {{ runtime_package }};
 
 let _module: BoltFFIModule;

--- a/boltffi_backend/templates/target/typescript/callback.ts
+++ b/boltffi_backend/templates/target/typescript/callback.ts
@@ -60,9 +60,7 @@ _callbackImports[{{ clone_import }}] = (handle: number): number => {
   try {
     callback = {{ registry }}.get(handle);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    const errorWriter = _module.allocWriter(4 + message.length * 3);
-    errorWriter.writeString(message);
+    const errorWriter = writeUnexpectedCallbackError(_module, error);
     complete(requestId, -2, errorWriter.ptr, errorWriter.len, errorWriter.capacity);
     return;
   }
@@ -83,9 +81,7 @@ _callbackImports[{{ clone_import }}] = (handle: number): number => {
 {% endfor %}      complete(requestId, 0, resultWriter.ptr, resultWriter.len, resultWriter.capacity);
 {% endif %}{% endmatch %}    })
     .catch((error) => {
-      const message = error instanceof Error ? error.message : String(error);
-      const errorWriter = _module.allocWriter(4 + message.length * 3);
-      errorWriter.writeString(message);
+      const errorWriter = writeUnexpectedCallbackError(_module, error);
       complete(requestId, -2, errorWriter.ptr, errorWriter.len, errorWriter.capacity);
     });
 };

--- a/boltffi_backend/templates/target/typescript/node.ts
+++ b/boltffi_backend/templates/target/typescript/node.ts
@@ -1,4 +1,4 @@
-import { BoltFFIHandle, BoltFFIModule, CallbackRegistry, StreamCancellable, StreamSession, WASM_ABI_VERSION, instantiateBoltFFISync, matchWireResult, utf8ByteCount, wireArraySize, wireMapSize, wireOptionalSize, wireResultSize, wireStringSize } from {{ runtime_package }};
+import { BoltFFIHandle, BoltFFIModule, CallbackRegistry, StreamCancellable, StreamSession, WASM_ABI_VERSION, instantiateBoltFFISync, matchWireResult, utf8ByteCount, wireArraySize, wireMapSize, wireOptionalSize, wireResultSize, wireStringSize, writeUnexpectedCallbackError } from {{ runtime_package }};
 import type { BoltFFIExports, Duration, WireCodec, WireResult } from {{ runtime_package }};
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";

--- a/boltffi_macros/src/experimental/expansion/mod.rs
+++ b/boltffi_macros/src/experimental/expansion/mod.rs
@@ -7414,8 +7414,19 @@ mod tests {
         ));
     }
 
+    /// Only the async half of the wasm surface carries the protocol.
+    ///
+    /// An async completion reports failure through a status code that cannot
+    /// distinguish a thrown host error from the declared one, and a cancelled
+    /// request carries no payload at all, so the payload has to be classified
+    /// before it is decoded. A synchronous callback has no such status: the
+    /// only thing it can hand back is its declared error, so classifying there
+    /// would be reading a discriminator that was never written.
+    ///
+    /// The contract has one method of each kind, so a single `classify_payload`
+    /// is the async one and pins the sync one as untouched.
     #[test]
-    fn wasm_typed_callback_errors_do_not_claim_native_unexpected_error_protocol() {
+    fn wasm_typed_callback_errors_claim_the_unexpected_error_protocol_when_async() {
         let source = typed_fallible_listener_contract();
         let lowered = lower_with_declarations::<Wasm32>(&source).expect("lowered bindings");
         let expansion = Expansion::new(&lowered);
@@ -7425,8 +7436,13 @@ mod tests {
         let rendered = tokens.to_string();
         syn::parse2::<syn::File>(tokens).expect("expanded callback parses");
 
-        assert!(!rendered.contains("UnexpectedFfiCallbackPayload"));
-        assert!(!rendered.contains("classify_payload"));
+        assert_eq!(rendered.matches("classify_payload").count(), 1);
+        assert!(rendered.contains("UnexpectedFfiCallbackPayload :: Unexpected"));
+        assert!(rendered.contains("UnexpectedFfiCallbackPayload :: Malformed"));
+        assert!(rendered.contains(
+            "Status as :: core :: convert :: From < :: boltffi :: __private :: UnexpectedFfiCallbackError"
+        ));
+        assert!(rendered.contains("async callback reported a failure without a payload"));
     }
 
     #[test]

--- a/boltffi_macros/src/experimental/expansion/mod.rs
+++ b/boltffi_macros/src/experimental/expansion/mod.rs
@@ -7417,9 +7417,9 @@ mod tests {
     /// Only the async half of the wasm surface carries the protocol.
     ///
     /// An async completion reports failure through a status code that cannot
-    /// distinguish a thrown host error from the declared one, and a cancelled
-    /// request carries no payload at all, so the payload has to be classified
-    /// before it is decoded. A synchronous callback has no such status: the
+    /// distinguish a thrown host error from the declared one, so the payload
+    /// has to be classified before it is decoded. Cancellation is the failure
+    /// the code does identify, and is matched there. A synchronous callback has no such status: the
     /// only thing it can hand back is its declared error, so classifying there
     /// would be reading a discriminator that was never written.
     ///
@@ -7442,7 +7442,8 @@ mod tests {
         assert!(rendered.contains(
             "Status as :: core :: convert :: From < :: boltffi :: __private :: UnexpectedFfiCallbackError"
         ));
-        assert!(rendered.contains("async callback reported a failure without a payload"));
+        assert!(rendered.contains("async callback request was cancelled"));
+        assert!(rendered.contains("AsyncCallbackCompletionCode :: Cancelled"));
     }
 
     #[test]

--- a/boltffi_macros/src/experimental/wrapper/callback.rs
+++ b/boltffi_macros/src/experimental/wrapper/callback.rs
@@ -2295,8 +2295,11 @@ where
     }
 
     fn wasm_async_foreign_body(&self, call: TokenStream) -> Result<TokenStream, Error> {
-        if let ErrorDecl::EncodedViaReturnSlot { codec, shape, .. } = self.error {
-            return self.wasm_async_fallible_body(call, codec.root(), *shape);
+        if let ErrorDecl::EncodedViaReturnSlot {
+            ty, codec, shape, ..
+        } = self.error
+        {
+            return self.wasm_async_fallible_body(call, codec.root(), *shape, ty);
         }
 
         match InfallibleMethodReturn::new(self.plan, self.error)? {
@@ -2564,14 +2567,14 @@ where
         call: TokenStream,
         error_codec: &CodecNode,
         error_shape: S::BufferShape,
+        error_ty: &TypeRef,
     ) -> Result<TokenStream, Error> {
         S::callback_encoded_error(error_shape)?;
-        let success =
-            self.async_fallible_success_value(quote! { __boltffi_completion.data.as_slice() })?;
-        let error = self.async_fallible_error_value(
-            error_codec,
-            quote! { __boltffi_completion.data.as_slice() },
-        )?;
+        let error_type = self.source.fallible()?.error_written_type()?;
+        let bytes = quote! { __boltffi_completion.data.as_slice() };
+        let success = self.async_fallible_success_value(bytes.clone())?;
+        let declared_error = self.async_fallible_error_value(error_codec, bytes.clone())?;
+        let error = wasm_foreign_callback_error_value(error_ty, &error_type, bytes, declared_error);
         Ok(self.wasm_async_result_body(call, success, error))
     }
 
@@ -4379,7 +4382,7 @@ enum CallbackEncodedError {
 }
 
 /// Classifies reserved native payloads for typed errors before using their declared decoder.
-fn native_foreign_callback_error_value(
+fn classified_callback_error_value(
     error_ty: &TypeRef,
     error_type: &Type,
     bytes: TokenStream,
@@ -4399,6 +4402,47 @@ fn native_foreign_callback_error_value(
                 }
             }
         },
+        _ => declared_error,
+    }
+}
+
+/// Classifies a wasm async failure payload before decoding it as the declared error.
+///
+/// A completion code says the callback failed, not how. A host callback that
+/// threw and one that returned its declared error arrive under codes that
+/// `AsyncCallbackCompletionCode` cannot tell apart, and a cancelled request
+/// arrives with no payload at all. Decoding a thrown message, or nothing, as
+/// the declared type fails, and that failure is a panic — under
+/// `panic = "abort"` on wasm it takes the module down instead of surfacing.
+///
+/// Restricted to the error types that carry `From<UnexpectedFfiCallbackError>`,
+/// matching the native surface.
+fn wasm_foreign_callback_error_value(
+    error_ty: &TypeRef,
+    error_type: &Type,
+    bytes: TokenStream,
+    declared_error: TokenStream,
+) -> TokenStream {
+    match error_ty {
+        TypeRef::Record(_) | TypeRef::Enum(_) => {
+            let classified = classified_callback_error_value(
+                error_ty,
+                error_type,
+                bytes.clone(),
+                declared_error,
+            );
+            quote! {
+                if #bytes.is_empty() {
+                    <#error_type as ::core::convert::From<
+                        ::boltffi::__private::UnexpectedFfiCallbackError
+                    >>::from(::boltffi::__private::UnexpectedFfiCallbackError::new(
+                        "async callback reported a failure without a payload",
+                    ))
+                } else {
+                    #classified
+                }
+            }
+        }
         _ => declared_error,
     }
 }
@@ -4444,7 +4488,7 @@ impl CallbackEncodedError {
     ) -> TokenStream {
         match self {
             Self::NativeBuffer => {
-                native_foreign_callback_error_value(error_ty, error_type, bytes, declared_error)
+                classified_callback_error_value(error_ty, error_type, bytes, declared_error)
             }
             Self::WasmPacked => declared_error,
         }

--- a/boltffi_macros/src/experimental/wrapper/callback.rs
+++ b/boltffi_macros/src/experimental/wrapper/callback.rs
@@ -4381,6 +4381,30 @@ enum CallbackEncodedError {
     WasmPacked,
 }
 
+/// Reads the envelope out of a payload, falling back to the declared decoder.
+///
+/// Callers gate this on the error types that carry
+/// `From<UnexpectedFfiCallbackError>`; it does not check that itself.
+fn classify_callback_error_payload(
+    error_type: &Type,
+    bytes: TokenStream,
+    declared_error: TokenStream,
+) -> TokenStream {
+    quote! {
+        match ::boltffi::__private::UnexpectedFfiCallbackError::classify_payload(#bytes) {
+            ::boltffi::__private::UnexpectedFfiCallbackPayload::NotUnexpected => {
+                #declared_error
+            }
+            ::boltffi::__private::UnexpectedFfiCallbackPayload::Unexpected(error)
+            | ::boltffi::__private::UnexpectedFfiCallbackPayload::Malformed(error) => {
+                <#error_type as ::core::convert::From<
+                    ::boltffi::__private::UnexpectedFfiCallbackError
+                >>::from(error)
+            }
+        }
+    }
+}
+
 /// Classifies reserved native payloads for typed errors before using their declared decoder.
 fn classified_callback_error_value(
     error_ty: &TypeRef,
@@ -4389,19 +4413,9 @@ fn classified_callback_error_value(
     declared_error: TokenStream,
 ) -> TokenStream {
     match error_ty {
-        TypeRef::Record(_) | TypeRef::Enum(_) => quote! {
-            match ::boltffi::__private::UnexpectedFfiCallbackError::classify_payload(#bytes) {
-                ::boltffi::__private::UnexpectedFfiCallbackPayload::NotUnexpected => {
-                    #declared_error
-                }
-                ::boltffi::__private::UnexpectedFfiCallbackPayload::Unexpected(error)
-                | ::boltffi::__private::UnexpectedFfiCallbackPayload::Malformed(error) => {
-                    <#error_type as ::core::convert::From<
-                        ::boltffi::__private::UnexpectedFfiCallbackError
-                    >>::from(error)
-                }
-            }
-        },
+        TypeRef::Record(_) | TypeRef::Enum(_) => {
+            classify_callback_error_payload(error_type, bytes, declared_error)
+        }
         _ => declared_error,
     }
 }
@@ -4409,14 +4423,21 @@ fn classified_callback_error_value(
 /// Classifies a wasm async failure payload before decoding it as the declared error.
 ///
 /// A completion code says the callback failed, not how. A host callback that
-/// threw and one that returned its declared error arrive under codes that
-/// `AsyncCallbackCompletionCode` cannot tell apart, and a cancelled request
-/// arrives with no payload at all. Decoding a thrown message, or nothing, as
-/// the declared type fails, and that failure is a panic — under
+/// threw and one that returned its declared error arrive under codes
+/// `AsyncCallbackCompletionCode` cannot tell apart, so the payload carries the
+/// distinction and has to be read before it is decoded. Decoding a thrown
+/// message as the declared type fails, and that failure is a panic — under
 /// `panic = "abort"` on wasm it takes the module down instead of surfacing.
 ///
-/// Restricted to the error types that carry `From<UnexpectedFfiCallbackError>`,
-/// matching the native surface.
+/// Cancellation is the one failure the code *does* identify, and it completes
+/// with no payload at all. It is matched on the code rather than on an empty
+/// payload: a declared error whose encoding happens to be zero bytes is also
+/// empty, and is not a cancellation.
+///
+/// Restricted to the error types that carry `From<UnexpectedFfiCallbackError>`.
+/// `String` is one of them, and unlike the native surface it has to be handled
+/// here: the TypeScript trampoline wraps every thrown error, so a `String`
+/// error left unclassified would decode the marker as its length prefix.
 fn wasm_foreign_callback_error_value(
     error_ty: &TypeRef,
     error_type: &Type,
@@ -4424,19 +4445,17 @@ fn wasm_foreign_callback_error_value(
     declared_error: TokenStream,
 ) -> TokenStream {
     match error_ty {
-        TypeRef::Record(_) | TypeRef::Enum(_) => {
-            let classified = classified_callback_error_value(
-                error_ty,
-                error_type,
-                bytes.clone(),
-                declared_error,
-            );
+        TypeRef::Record(_) | TypeRef::Enum(_) | TypeRef::String => {
+            let classified =
+                classify_callback_error_payload(error_type, bytes.clone(), declared_error);
             quote! {
-                if #bytes.is_empty() {
+                if __boltffi_completion.code
+                    == ::boltffi::__private::AsyncCallbackCompletionCode::Cancelled
+                {
                     <#error_type as ::core::convert::From<
                         ::boltffi::__private::UnexpectedFfiCallbackError
                     >>::from(::boltffi::__private::UnexpectedFfiCallbackError::new(
-                        "async callback reported a failure without a payload",
+                        "async callback request was cancelled",
                     ))
                 } else {
                     #classified

--- a/runtime/typescript/src/index.ts
+++ b/runtime/typescript/src/index.ts
@@ -10,8 +10,17 @@ export {
   wireOptionalSize,
   wireResultSize,
   wireStringSize,
+  writeUnexpectedCallbackError,
 } from "./wire.js";
-export type { Duration, WireOk, WireErr, WireResult, WasmWireWriterAllocator, WireCodec } from "./wire.js";
+export type {
+  Duration,
+  WireOk,
+  WireErr,
+  WireResult,
+  UnexpectedCallbackErrorAllocator,
+  WasmWireWriterAllocator,
+  WireCodec,
+} from "./wire.js";
 export { BoltFFIHandle } from "./handle.js";
 export { CallbackRegistry } from "./callback.js";
 export { StreamCancellable, StreamPollManager, StreamPollResult, StreamSession } from "./stream.js";

--- a/runtime/typescript/src/wire.ts
+++ b/runtime/typescript/src/wire.ts
@@ -874,3 +874,51 @@ export interface WireCodec<T> {
   encode(writer: WireWriter, value: T): void;
   decode(reader: WireReader): T;
 }
+
+/**
+ * Marks a callback error payload as a host-language failure rather than the
+ * error type the callback declared.
+ *
+ * Must stay in step with `UnexpectedFfiCallbackError::WIRE_MARKER` in
+ * `boltffi_core`, which is what reads this back.
+ */
+const UNEXPECTED_CALLBACK_ERROR_MARKER = "BOLTFFI_CALLBACK";
+
+/** Envelope format understood by the Rust side. */
+const UNEXPECTED_CALLBACK_ERROR_VERSION = 1;
+
+/** Allocates the wasm-backed writer an unexpected callback error is written into. */
+export interface UnexpectedCallbackErrorAllocator {
+  allocWriter(size: number): WireWriter;
+}
+
+/**
+ * Encodes a host error a callback threw, so Rust can tell it apart from the
+ * error type that callback declared.
+ *
+ * An async completion reports failure through a status code, and the code for
+ * "the callback threw" is indistinguishable from the one for a typed error
+ * once it reaches Rust. Without this envelope the thrown message is decoded as
+ * the declared error; that decode fails, and the failure is a panic, which
+ * under `panic = "abort"` takes the whole module down. The envelope routes it
+ * through `From<UnexpectedFfiCallbackError>` instead.
+ *
+ * The layout is the marker, a version byte, then the message as an ordinary
+ * wire string. `boltffiEncodeUnexpectedCallbackError` in the Swift runtime
+ * writes the same bytes.
+ */
+export function writeUnexpectedCallbackError(
+  allocator: UnexpectedCallbackErrorAllocator,
+  error: unknown
+): WireWriter {
+  const message = error instanceof Error ? error.message : String(error);
+  const writer = allocator.allocWriter(
+    UNEXPECTED_CALLBACK_ERROR_MARKER.length + 1 + 4 + utf8ByteCount(message)
+  );
+  for (let index = 0; index < UNEXPECTED_CALLBACK_ERROR_MARKER.length; index++) {
+    writer.writeU8(UNEXPECTED_CALLBACK_ERROR_MARKER.charCodeAt(index));
+  }
+  writer.writeU8(UNEXPECTED_CALLBACK_ERROR_VERSION);
+  writer.writeString(message);
+  return writer;
+}

--- a/runtime/typescript/test/unexpected-callback-error.test.ts
+++ b/runtime/typescript/test/unexpected-callback-error.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { WireReader, WireWriter, writeUnexpectedCallbackError } from "../src/wire.js";
+
+const MARKER = "BOLTFFI_CALLBACK";
+
+/** Stands in for the wasm module: hands out a plain writer and records the size asked for. */
+function allocator(): { allocWriter(size: number): WireWriter; requested: number[] } {
+  const requested: number[] = [];
+  return {
+    requested,
+    allocWriter(size: number) {
+      requested.push(size);
+      return new WireWriter();
+    },
+  };
+}
+
+function bytesOf(writer: WireWriter): Uint8Array {
+  return writer.getBytes();
+}
+
+/**
+ * Mirrors `UnexpectedFfiCallbackError::classify_payload` in `boltffi_core`.
+ * The envelope is only useful if that function reads back what this writes, so
+ * the assertions here are that decoder's steps rather than a byte snapshot.
+ */
+function classify(payload: Uint8Array): string {
+  const marker = new TextDecoder().decode(payload.subarray(0, MARKER.length));
+  expect(marker).toBe(MARKER);
+  expect(payload[MARKER.length]).toBe(1);
+
+  const reader = new WireReader(
+    payload.buffer as ArrayBuffer,
+    payload.byteOffset + MARKER.length + 1
+  );
+  const message = reader.readString();
+  // `classify_payload` rejects trailing bytes, so the message must end the payload.
+  expect(MARKER.length + 1 + 4 + new TextEncoder().encode(message).length).toBe(payload.length);
+  return message;
+}
+
+describe("writeUnexpectedCallbackError", () => {
+  it("wraps an Error message in the envelope Rust classifies", () => {
+    const writer = writeUnexpectedCallbackError(allocator(), new Error("boom from js"));
+    expect(classify(bytesOf(writer))).toBe("boom from js");
+  });
+
+  it("stringifies a thrown non-Error", () => {
+    const writer = writeUnexpectedCallbackError(allocator(), "just a string");
+    expect(classify(bytesOf(writer))).toBe("just a string");
+  });
+
+  it("keeps a multi-byte message intact", () => {
+    // The size request is in bytes but the message is measured in JS chars,
+    // so an under-sized request would surface as a truncated or throwing write.
+    const message = "não pôde: 日本語 🎉";
+    const writer = writeUnexpectedCallbackError(allocator(), new Error(message));
+    expect(classify(bytesOf(writer))).toBe(message);
+  });
+
+  it("asks for exactly the space the envelope occupies", () => {
+    const alloc = allocator();
+    const writer = writeUnexpectedCallbackError(alloc, new Error("é"));
+    expect(alloc.requested).toEqual([bytesOf(writer).length]);
+  });
+
+  it("carries an empty message rather than an empty payload", () => {
+    // An empty payload is how cancellation reports itself; a thrown error with
+    // no message must not be mistaken for one.
+    const writer = writeUnexpectedCallbackError(allocator(), new Error(""));
+    const bytes = bytesOf(writer);
+    expect(bytes.length).toBeGreaterThan(0);
+    expect(classify(bytes)).toBe("");
+  });
+});


### PR DESCRIPTION
## Problem

Any async callback that rejects takes the whole wasm module down.

```
ABORT: RuntimeError: unreachable
panic: async callback error conversion failed: InvalidValue(EnumTag)
```

The generated TypeScript completes a request with `1` for a typed error and `-2` for "the callback threw". `AsyncCallbackCompletionCode::from` maps every non-`0`/`-1` value to `Panicked`, so Rust cannot tell the two apart by code and decodes the payload as the declared error either way. For `-2` that payload is a bare message string, the decode fails, and the failure is a `panic!` — under `panic = "abort"` on wasm, a trap with no message.

Cancellation reaches the same branch. `AsyncCallbackRegistry` completes a cancelled request with `Cancelled` and `data: Vec::new()`, and `wasm_async_result_body` takes the error path for any non-success code, so an empty payload was decoded as the declared error and aborted too.

This is not the reserved-word bug in #801. Measured with `set`, which is not a reserved word, on a branch cut from `main`:

| callback | before |
|---|---|
| `set` throws | `RuntimeError: unreachable` |
| `delete` throws | `RuntimeError: unreachable` |

## Why it was only half-built

The envelope that separates a host-language failure from a declared error already exists: `UnexpectedFfiCallbackError::WIRE_MARKER`, `classify_payload`, and `UnexpectedFfiCallbackPayload` in `boltffi_core`, routed through `From<UnexpectedFfiCallbackError>`.

`43c90b79` ("Safely convert unexpected callback errors") introduced it for Swift and native. In the same commit it added `wasm_typed_callback_errors_do_not_claim_native_unexpected_error_protocol` — a negative assertion recording that wasm was left out. `CallbackEncodedError::foreign_error_value` says it in one line:

```rust
Self::WasmPacked => declared_error,
```

## Change

**TypeScript writes the envelope.** `writeUnexpectedCallbackError` in `@boltffi/runtime`, used at both `-2` sites in `callback.ts` (a dropped handle, and the `.catch`). Layout matches `classify_payload`: marker, version byte, then the message as an ordinary wire string — the same bytes `boltffiEncodeUnexpectedCallbackError` writes on Swift. It also sizes the allocation with `utf8ByteCount` instead of `message.length * 3`.

**wasm classifies before decoding.** `wasm_async_fallible_body` now takes the error `TypeRef` and classifies the payload before handing it to the declared decoder.

Applied to `Record`, `Enum` and `String` — the error payload types a callback can declare, all of which carry `From<UnexpectedFfiCallbackError>`. `Result<(), i32>` and `Result<(), Vec<u8>>` are dropped by the generator with reason `error payload type`, so nothing else reaches this code. Native keeps its narrower record/enum gate, so the shared body is extracted into `classify_callback_error_payload`.

Cancellation is matched on the completion code. `From<i32>` collapses `1` and `-2` into `Panicked`, but `-1` maps to `Cancelled` on its own, so it is identifiable without guessing from an empty payload — a declared error whose encoding is zero bytes is empty too, and is not a cancellation.

Nothing changes for synchronous callbacks. A sync callback has no status channel alongside its payload, so the only thing it can hand back is its declared error; classifying there would read a discriminator that was never written. Verified separately that a sync throw already propagates as an ordinary `Error` and leaves the process alive.

I put the encoder in the runtime rather than the generated preamble because the generated module already imports 15 symbols from `@boltffi/runtime` — one more is not a new class of risk, and a stale runtime fails loudly at ESM link time rather than silently. I hit exactly that while testing:

```
SyntaxError: The requested module '@boltffi/runtime' does not provide an export named 'writeUnexpectedCallbackError'
```

## Verification

Same probe, after:

```
  async set(...) throws     typed error: ProbeErrorException
     payload: {"tag":"Failed","reason":"unexpected ffi callback error: boom from js"}
  async delete(...) throws  typed error: ProbeErrorException
     payload: {"tag":"Failed","reason":"unexpected ffi callback error: callback._delete is not a function"}
```

The process survives and the message arrives intact. The second line is worth noting: this branch is cut from `main`, so #801's bug is still present here — and instead of a trap reporting `InvalidValue(EnumTag)`, it now names the missing method. Turning that class of failure from an abort into a message is most of the value.

Five runtime tests for the encoder, asserting against `classify_payload`'s steps — marker, version, string framing, no trailing bytes — rather than a byte snapshot, plus multi-byte messages, exact allocation sizing, and an empty message staying distinct from an empty payload.

The negative macro test is inverted with its reasoning: the contract has one sync and one async method, so a single `classify_payload` is the async one and pins the sync one as untouched.

`cargo test --workspace` green, `cargo clippy --workspace --all-targets` clean, 171 runtime tests pass.

## Adjacent, not fixed here

`From<i32>` still collapses a user's completion code `1` and the internal `-2` into `Panicked`. The envelope makes this harmless for the payload, but the code itself remains lossy.

A zero-length error payload never reaches the caller: the generated wrapper packs the error as `(len << 32) | ptr` and tests `!== 0n`, so a zero-field record error packs to `0n` and reads as success. Present on `main` too, and a different mechanism from this change.

