### PR TITLE
perf(wasm): return byte buffers without a length prefix

### DIFF
--- a/boltffi_backend/src/target/typescript/codec/read.rs
+++ b/boltffi_backend/src/target/typescript/codec/read.rs
@@ -19,6 +19,7 @@ pub enum ReadKind {
     String,
     Utf8String,
     Bytes,
+    RawBytes,
     ErrorRecord(RecordId),
     ErrorEnum(EnumId),
 }
@@ -115,6 +116,13 @@ impl ReadExpression {
         }
     }
 
+    fn raw_bytes(expression: Expression) -> Self {
+        Self {
+            expression,
+            kind: Some(ReadKind::RawBytes),
+        }
+    }
+
     fn primitive(primitive: Primitive, expression: Expression) -> Self {
         Self {
             expression,
@@ -194,6 +202,18 @@ impl CodecRead for Reader<'_> {
 
     fn bytes(&mut self) -> Self::Expr {
         Ok(ReadExpression::bytes(Expression::call(
+            Expression::identifier(self.reader.clone()),
+            Identifier::known("readBytes"),
+            ArgumentList::default(),
+        )))
+    }
+
+    /// Only ever the whole of a returned buffer, so there is no reader position
+    /// to advance and nothing to read a length from. The expression here is a
+    /// placeholder: the return path keys off the kind and takes the buffer
+    /// directly.
+    fn raw_bytes(&mut self) -> Self::Expr {
+        Ok(ReadExpression::raw_bytes(Expression::call(
             Expression::identifier(self.reader.clone()),
             Identifier::known("readBytes"),
             ArgumentList::default(),

--- a/boltffi_backend/src/target/typescript/mod.rs
+++ b/boltffi_backend/src/target/typescript/mod.rs
@@ -757,8 +757,10 @@ mod tests {
                 .contents()
                 .contains("const __boltffi_value_allocation = _module.allocWireBytes(value);")
         );
+        // The argument keeps its length prefix; the return does not need one,
+        // since the packed value already carries the length.
         assert!(browser.contents().contains(
-            "return _module.takePackedWireBytes((_exports.boltffi_function_demo_echo_bytes as Function)(__boltffi_value_allocation.ptr, __boltffi_value_allocation.len) as bigint);"
+            "return _module.takePackedBytes((_exports.boltffi_function_demo_echo_bytes as Function)(__boltffi_value_allocation.ptr, __boltffi_value_allocation.len) as bigint);"
         ));
         assert!(browser.contents().contains(
             "export function echoVecI32(value: readonly number[] | Int32Array): Int32Array"

--- a/boltffi_backend/src/target/typescript/mod.rs
+++ b/boltffi_backend/src/target/typescript/mod.rs
@@ -341,6 +341,27 @@ mod tests {
         lower::<Wasm32>(&source).expect("source lowers")
     }
 
+    fn byte_return_bindings() -> Bindings<Wasm32> {
+        let source = boltffi_scan::scan_file(
+            syn::parse_str(
+                r#"
+                #[export]
+                pub fn owned() -> Vec<u8> { Vec::new() }
+
+                #[export]
+                pub fn borrowed() -> &'static [u8] { b"ffi" }
+
+                #[export]
+                pub const CONSTANT: &'static [u8] = b"ffi";
+                "#,
+            )
+            .expect("valid source"),
+            PackageInfo::new("demo", None),
+        )
+        .expect("source scans");
+        lower::<Wasm32>(&source).expect("source lowers")
+    }
+
     fn record_bindings() -> Bindings<Wasm32> {
         let source = boltffi_scan::scan_file(
             syn::parse_str(
@@ -1381,5 +1402,40 @@ mod tests {
                 .contents()
                 .contains("export function keepTimestamp(value: Timestamp): Timestamp")
         );
+    }
+    /// Only an owned `Vec<u8>` crosses unframed.
+    ///
+    /// A borrowed slice is written by `borrowed_buffer`, which always frames,
+    /// so reading it unframed hands back the four-byte length prefix as the
+    /// start of the payload. Nothing downstream would notice: the array is
+    /// simply four bytes too long and starts with a little-endian length.
+    #[test]
+    fn only_owned_byte_returns_skip_the_length_prefix() {
+        let output = TypeScriptHost::new("demo")
+            .expect("host constructs")
+            .into_target()
+            .render(&byte_return_bindings())
+            .expect("target renders");
+
+        let browser = output
+            .files()
+            .iter()
+            .find(|file| file.path().as_path().ends_with("demo.ts"))
+            .expect("browser module");
+        let contents = browser.contents();
+
+        assert!(
+            contents.contains("takePackedBytes((_exports.boltffi_function_demo_owned"),
+            "an owned Vec<u8> return should skip the prefix",
+        );
+        for framed in [
+            "boltffi_function_demo_borrowed",
+            "boltffi_const_demo_constant",
+        ] {
+            assert!(
+                contents.contains(&format!("takePackedWireBytes((_exports.{framed}")),
+                "`{framed}` is written framed and must be read framed",
+            );
+        }
     }
 }

--- a/boltffi_backend/src/target/typescript/render/function.rs
+++ b/boltffi_backend/src/target/typescript/render/function.rs
@@ -58,6 +58,7 @@ enum ReturnConversion {
     String,
     Utf8String,
     Bytes,
+    RawBytes,
     Encoded {
         reader: Identifier,
         decode: Expression,
@@ -756,6 +757,7 @@ impl Failure {
                     Some(ReadKind::Utf8String) => FailureValue::Utf8String,
                     Some(
                         ReadKind::Bytes
+                        | ReadKind::RawBytes
                         | ReadKind::Primitive(_)
                         | ReadKind::CustomPrimitive(_)
                         | ReadKind::OptionalPrimitive(_)
@@ -1549,6 +1551,13 @@ impl Return {
                     .into_iter()
                     .collect::<ArgumentList>(),
             ))],
+            ReturnConversion::RawBytes => vec![Statement::return_value(Expression::call(
+                Expression::identifier(Identifier::known("_module")),
+                Identifier::known("takePackedBytes"),
+                [call.cast(TypeName::bigint())]
+                    .into_iter()
+                    .collect::<ArgumentList>(),
+            ))],
             ReturnConversion::Bytes => vec![Statement::return_value(Expression::call(
                 Expression::identifier(Identifier::known("_module")),
                 Identifier::known("takePackedWireBytes"),
@@ -1854,6 +1863,10 @@ impl<'plan> ReturnPlanRender<'plan, Wasm32, boltffi_binding::OutOfRust> for Retu
                 Type::from_ref(ty, self.context)?,
                 ReturnConversion::Bytes,
             )),
+            (ReturnValueSlot::ReturnSlot, Some(ReadKind::RawBytes)) => Ok(Return::new(
+                Type::from_ref(ty, self.context)?,
+                ReturnConversion::RawBytes,
+            )),
             (ReturnValueSlot::ReturnSlot, Some(ReadKind::OptionalPrimitive(primitive))) => {
                 Ok(Return::new(
                     Type::from_ref(ty, self.context)?,
@@ -1911,6 +1924,13 @@ impl<'plan> ReturnPlanRender<'plan, Wasm32, boltffi_binding::OutOfRust> for Retu
                             Identifier::known("takePackedWireBytes"),
                             [packed].into_iter().collect::<ArgumentList>(),
                         ))],
+                        Some(ReadKind::RawBytes) => {
+                            vec![Statement::return_value(Expression::call(
+                                Expression::identifier(Identifier::known("_module")),
+                                Identifier::known("takePackedBytes"),
+                                [packed].into_iter().collect::<ArgumentList>(),
+                            ))]
+                        }
                         Some(
                             ReadKind::Primitive(_)
                             | ReadKind::CustomPrimitive(_)

--- a/boltffi_backend/src/target/typescript/render/stream.rs
+++ b/boltffi_backend/src/target/typescript/render/stream.rs
@@ -174,6 +174,7 @@ impl<'plan> StreamItemPlanRender<'plan, Wasm32> for ItemRenderer<'_> {
                 ReadKind::String
                 | ReadKind::Utf8String
                 | ReadKind::Bytes
+                | ReadKind::RawBytes
                 | ReadKind::CustomPrimitive(_)
                 | ReadKind::OptionalPrimitive(_)
                 | ReadKind::ErrorRecord(_)

--- a/boltffi_binding/src/ir/codec.rs
+++ b/boltffi_binding/src/ir/codec.rs
@@ -173,6 +173,7 @@ pub enum OwnedWireEncoding {
     String,
     Utf8String,
     Bytes,
+    RawBytes,
 }
 
 impl CodecPlan {
@@ -242,6 +243,14 @@ pub enum CodecNode {
     String,
     #[doc(hidden)]
     Utf8String,
+    /// Byte buffer whose length is carried by the call, not by the buffer.
+    ///
+    /// Only reachable at the root of an exported return, and only on surfaces
+    /// that ask for it. Framing a returned `Vec<u8>` means shifting every byte
+    /// to make room for the prefix, which costs about as much as building the
+    /// buffer did; the caller already knows the length either way.
+    #[doc(hidden)]
+    RawBytes,
     /// Tagged interned-string value (static pool id or dynamic UTF-8 bytes).
     ///
     /// Wire format: `tag (u8)` where `0` = `u32` pool index, `1` = length-prefixed
@@ -311,6 +320,7 @@ impl CodecNode {
             Self::String => OwnedWireEncoding::String,
             Self::Utf8String => OwnedWireEncoding::Utf8String,
             Self::Bytes => OwnedWireEncoding::Bytes,
+            Self::RawBytes => OwnedWireEncoding::RawBytes,
             Self::Custom { representation, .. } => representation.owned_wire_encoding(),
             _ => OwnedWireEncoding::Generic,
         }
@@ -354,6 +364,7 @@ impl CodecNode {
             | Self::Utf8String
             | Self::InternedString { .. }
             | Self::Bytes
+            | Self::RawBytes
             | Self::Builtin(_) => {}
         }
     }
@@ -443,6 +454,11 @@ pub trait CodecRead {
         self.string()
     }
 
+    #[doc(hidden)]
+    fn raw_bytes(&mut self) -> Self::Expr {
+        self.bytes()
+    }
+
     /// Reads a tagged interned string (static pool id or dynamic UTF-8 bytes).
     fn interned_string(&mut self, static_values: &[String]) -> Self::Expr;
 
@@ -508,6 +524,10 @@ impl CodecRead for InternedStringDetector {
     }
 
     fn utf8_string(&mut self) -> Self::Expr {
+        false
+    }
+
+    fn raw_bytes(&mut self) -> Self::Expr {
         false
     }
 
@@ -590,6 +610,11 @@ pub trait CodecWrite {
     #[doc(hidden)]
     fn utf8_string(&mut self, value: &ValueRef) -> Vec<Self::Stmt> {
         self.string(value)
+    }
+
+    #[doc(hidden)]
+    fn raw_bytes(&mut self, value: &ValueRef) -> Vec<Self::Stmt> {
+        self.bytes(value)
     }
 
     /// Writes a tagged interned string (static pool id or dynamic UTF-8 bytes).
@@ -691,6 +716,11 @@ pub trait CodecSize {
         self.string(value)
     }
 
+    #[doc(hidden)]
+    fn raw_bytes(&mut self, value: &ValueRef) -> Self::Expr {
+        self.bytes(value)
+    }
+
     /// Returns the encoded size of a tagged interned string.
     fn interned_string(&mut self, static_values: &[String], value: &ValueRef) -> Self::Expr;
 
@@ -770,6 +800,7 @@ impl CodecWalker {
             CodecNode::Primitive(primitive) => renderer.primitive(*primitive),
             CodecNode::String => renderer.string(),
             CodecNode::Utf8String => renderer.utf8_string(),
+            CodecNode::RawBytes => renderer.raw_bytes(),
             CodecNode::InternedString { static_values } => renderer.interned_string(static_values),
             CodecNode::Bytes => renderer.bytes(),
             CodecNode::DirectRecord(id) => renderer.direct_record(*id),
@@ -840,6 +871,7 @@ impl CodecWalker {
             CodecNode::Primitive(primitive) => renderer.primitive(*primitive, value),
             CodecNode::String => renderer.string(value),
             CodecNode::Utf8String => renderer.utf8_string(value),
+            CodecNode::RawBytes => renderer.raw_bytes(value),
             CodecNode::InternedString { static_values } => {
                 renderer.interned_string(static_values, value)
             }
@@ -931,6 +963,7 @@ impl CodecWalker {
             CodecNode::Primitive(primitive) => renderer.primitive(*primitive, value),
             CodecNode::String => renderer.string(value),
             CodecNode::Utf8String => renderer.utf8_string(value),
+            CodecNode::RawBytes => renderer.raw_bytes(value),
             CodecNode::InternedString { static_values } => {
                 renderer.interned_string(static_values, value)
             }

--- a/boltffi_binding/src/lower/callable/mod.rs
+++ b/boltffi_binding/src/lower/callable/mod.rs
@@ -288,7 +288,7 @@ pub fn lower_exported_method<S: SurfaceLower>(
         ids,
         allocator,
         owner,
-        codecs::RootEncoding::Surface,
+        codecs::RootEncoding::SurfaceReturn,
         &method.returns,
     )?;
     let execution = lower_execution::<S>(allocator, method.execution, start_symbol_name)?;
@@ -606,7 +606,7 @@ pub fn lower_function<S: SurfaceLower>(
         ids,
         allocator,
         owner,
-        codecs::RootEncoding::Surface,
+        codecs::RootEncoding::SurfaceReturn,
         &function.returns,
     )?;
     let execution = lower_execution::<S>(allocator, function.execution, start_symbol_name)?;
@@ -638,7 +638,7 @@ pub fn lower_constant_accessor<S: SurfaceLower>(
         ids,
         allocator,
         owner,
-        codecs::RootEncoding::Surface,
+        codecs::RootEncoding::SurfaceReturn,
         &return_def,
     )?;
 

--- a/boltffi_binding/src/lower/codecs.rs
+++ b/boltffi_binding/src/lower/codecs.rs
@@ -8,7 +8,12 @@ use super::{
 
 #[derive(Clone, Copy)]
 pub enum RootEncoding {
+    /// Root of a value handed to the surface, where the surface picks the shape.
     Surface,
+    /// Root of a value returned to the surface, which additionally knows the
+    /// buffer length from the call itself.
+    SurfaceReturn,
+    /// Root of a value the wire frames itself, because nothing carries its length.
     Framed,
 }
 
@@ -21,7 +26,12 @@ impl RootEncoding {
         value: ValueRef,
     ) -> Result<CodecNode, LowerError> {
         match (self, type_expr) {
-            (Self::Surface, TypeExpr::String) => Ok(S::root_string_codec()),
+            (Self::Surface | Self::SurfaceReturn, TypeExpr::String) => Ok(S::root_string_codec()),
+            (Self::SurfaceReturn, TypeExpr::Vec(inner) | TypeExpr::Slice(inner))
+                if types::is_byte_primitive(inner) =>
+            {
+                Ok(S::root_bytes_return_codec())
+            }
             _ => node(index, ids, type_expr, value),
         }
     }

--- a/boltffi_binding/src/lower/codecs.rs
+++ b/boltffi_binding/src/lower/codecs.rs
@@ -27,9 +27,11 @@ impl RootEncoding {
     ) -> Result<CodecNode, LowerError> {
         match (self, type_expr) {
             (Self::Surface | Self::SurfaceReturn, TypeExpr::String) => Ok(S::root_string_codec()),
-            (Self::SurfaceReturn, TypeExpr::Vec(inner) | TypeExpr::Slice(inner))
-                if types::is_byte_primitive(inner) =>
-            {
+            // Owned only, the same reason `String` is here and `Str` is not: a
+            // borrowed value is written by `borrowed_buffer`, which always
+            // frames. Handing `Slice` an unframed reader would surface the
+            // length prefix as the first four bytes of the payload.
+            (Self::SurfaceReturn, TypeExpr::Vec(inner)) if types::is_byte_primitive(inner) => {
                 Ok(S::root_bytes_return_codec())
             }
             _ => node(index, ids, type_expr, value),

--- a/boltffi_binding/src/lower/surface.rs
+++ b/boltffi_binding/src/lower/surface.rs
@@ -80,6 +80,15 @@ pub trait SurfaceLower:
     #[doc(hidden)]
     fn root_string_codec() -> crate::CodecNode;
 
+    /// Codec for a byte buffer returned from an exported callable.
+    ///
+    /// Surfaces that carry the buffer length alongside the pointer can take the
+    /// bytes unframed and skip the shift that making room for a length prefix
+    /// costs.
+    fn root_bytes_return_codec() -> crate::CodecNode {
+        crate::CodecNode::Bytes
+    }
+
     #[doc(hidden)]
     fn direct_record_return_slot() -> ReturnValueSlot;
 
@@ -210,6 +219,10 @@ impl SurfaceLower for Wasm32 {
 
     fn root_string_codec() -> crate::CodecNode {
         crate::CodecNode::Utf8String
+    }
+
+    fn root_bytes_return_codec() -> crate::CodecNode {
+        crate::CodecNode::RawBytes
     }
 
     fn direct_record_return_slot() -> ReturnValueSlot {

--- a/boltffi_core/src/wasm.rs
+++ b/boltffi_core/src/wasm.rs
@@ -1,4 +1,7 @@
-pub const WASM_ABI_VERSION: u32 = 2;
+/// 3: byte buffers returned from an exported callable cross unframed. A host
+/// built for 2 reads the length prefix it expects and hands back four bytes of
+/// header as payload, which nothing else would catch.
+pub const WASM_ABI_VERSION: u32 = 3;
 
 #[cfg(any(test, target_arch = "wasm32"))]
 use std::alloc::{Layout, alloc, dealloc};
@@ -243,7 +246,7 @@ mod tests {
 
     #[test]
     fn wasm_abi_version_is_stable() {
-        assert_eq!(WASM_ABI_VERSION, 2);
+        assert_eq!(WASM_ABI_VERSION, 3);
     }
 
     #[test]

--- a/boltffi_macros/src/experimental/expansion/mod.rs
+++ b/boltffi_macros/src/experimental/expansion/mod.rs
@@ -9418,8 +9418,50 @@ mod tests {
         );
     }
 
+    /// The unframed return is a wasm choice, not a change to the wire.
+    ///
+    /// Native hands back an `FfiBuf` through a different path, and its readers
+    /// still expect the length prefix, so the same contract has to keep framing
+    /// there. This pins that the surface picks the shape.
     #[test]
-    fn wasm_bytes_return_expansion_uses_wire_framing() {
+    fn native_bytes_return_expansion_keeps_wire_framing() {
+        let source = bytes_return_contract();
+        let lowered = lower_with_declarations::<Native>(&source).expect("lowered bindings");
+        let expansion = Expansion::new(&lowered);
+        let syntax = syn::parse_quote! {
+            pub fn payload() -> Vec<u8> {
+                vec![1, 2, 3]
+            }
+        };
+
+        let tokens =
+            expand_function(&expansion, &source.functions[0], syntax).expect("expanded function");
+
+        assert_eq!(
+            tokens.to_string(),
+            quote! {
+                pub fn payload() -> Vec<u8> {
+                    vec![1, 2, 3]
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                #[unsafe(no_mangle)]
+                pub extern "C" fn boltffi_function_demo_payload() -> ::boltffi::__private::FfiBuf {
+                    let __boltffi_result: Vec<u8> = payload();
+                    ::boltffi::__private::FfiBuf::wire_encode_owned_bytes(__boltffi_result)
+                }
+            }
+            .to_string()
+        );
+    }
+
+    /// A returned byte buffer crosses as it was allocated.
+    ///
+    /// Framing it means shifting every byte to make room for a length prefix
+    /// the caller never needs: the packed return value carries the length, and
+    /// the host reader checked the prefix agreed with it rather than learning
+    /// anything from it. The `String` return above already crosses this way.
+    #[test]
+    fn wasm_bytes_return_expansion_hands_back_the_buffer_unframed() {
         let source = bytes_return_contract();
         let lowered = lower_with_declarations::<Wasm32>(&source).expect("lowered bindings");
         let expansion = Expansion::new(&lowered);
@@ -9442,7 +9484,7 @@ mod tests {
                 #[unsafe(no_mangle)]
                 pub extern "C" fn boltffi_function_demo_payload() -> u64 {
                     let __boltffi_result: Vec<u8> = payload();
-                    ::boltffi::__private::FfiBuf::wire_encode_owned_bytes(__boltffi_result).into_packed()
+                    ::boltffi::__private::FfiBuf::from_vec(__boltffi_result).into_packed()
                 }
             }
             .to_string()

--- a/boltffi_macros/src/experimental/wrapper/encoded/mod.rs
+++ b/boltffi_macros/src/experimental/wrapper/encoded/mod.rs
@@ -25,6 +25,7 @@ impl RuntimeWireCodec {
             | CodecNode::Utf8String
             | CodecNode::InternedString { .. }
             | CodecNode::Bytes
+            | CodecNode::RawBytes
             | CodecNode::DirectRecord(_)
             | CodecNode::EncodedRecord(_)
             | CodecNode::CStyleEnum(_)

--- a/boltffi_macros/src/experimental/wrapper/encoded/outgoing.rs
+++ b/boltffi_macros/src/experimental/wrapper/encoded/outgoing.rs
@@ -60,6 +60,11 @@ impl<'expansion, 'lowered, S: RenderSurface> Value<'expansion, 'lowered, S> {
             OwnedWireEncoding::Bytes => {
                 quote! { ::boltffi::__private::FfiBuf::wire_encode_owned_bytes(#value) }
             }
+            // The call hands back the length, so the buffer does not have to
+            // carry one, and the bytes stay where they were allocated.
+            OwnedWireEncoding::RawBytes => {
+                quote! { ::boltffi::__private::FfiBuf::from_vec(#value) }
+            }
             _ => {
                 quote! { ::boltffi::__private::FfiBuf::wire_encode(&#value) }
             }

--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -1178,6 +1178,31 @@ export class BoltFFIModule {
     }
   }
 
+  /**
+   * Takes a returned byte buffer whose length came with the call.
+   *
+   * The framed counterpart, `takePackedWireBytes`, reads a `u32` the buffer
+   * carries and then checks it equals `length - 4`, so the prefix never told
+   * it anything the packed value had not. Writing that prefix costs the Rust
+   * side a shift of the whole payload, which is why this shape exists.
+   */
+  takePackedBytes(packed: bigint): Uint8Array {
+    const { pointer, length } = this.unpackPacked(packed);
+    if (pointer === 0 || length === 0) {
+      return new Uint8Array(0);
+    }
+    try {
+      const bytes = this.getBytes();
+      if (pointer + length > bytes.length) {
+        throw new Error("Invalid packed bytes length");
+      }
+      // One allocation: building a view and then copying it made two.
+      return bytes.slice(pointer, pointer + length);
+    } finally {
+      this.freePacked(pointer, length);
+    }
+  }
+
   takePackedWireString(packed: bigint): string {
     const { pointer, length } = this.unpackPacked(packed);
     if (pointer === 0 || length < 4) {

--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -163,7 +163,10 @@ export class AsyncFutureManager {
   }
 }
 
-export const WASM_ABI_VERSION = 2;
+// 3: byte buffers returned from an exported callable cross unframed. Checked
+// at instantiation, so a mismatched artifact fails there instead of handing
+// back a payload with the old length prefix still on the front.
+export const WASM_ABI_VERSION = 3;
 
 export interface BoltFFIExports {
   memory: WebAssembly.Memory;


### PR DESCRIPTION
## Problem

A `Vec<u8>` returned from an exported function is framed with a `u32` length prefix. `FfiBuf::wire_encode_owned_bytes` makes room for it by growing the vector and shifting the whole payload forward:

```rust
value.reserve_exact(core::mem::size_of::<u32>());
unsafe {
    value.set_len(byte_count + 4);
    core::ptr::copy(value.as_ptr(), value.as_mut_ptr().add(4), byte_count);
}
```

The caller never needed that prefix. `takePackedWireBytes` reads it and then checks it agrees with the length it already had:

```ts
const payloadLength = this.getView().getUint32(pointer, true);
if (payloadLength !== length - 4 || ...) { throw ... }
```

`length` comes from the packed `u64` the call returned. The prefix could only ever confirm what was already known.

## Precedent

A root return may already differ from the nested wire form. `RootEncoding::Surface` asks the surface for the codec, and `Wasm32::root_string_codec` answers `Utf8String`, which crosses through `FfiBuf::from_vec` with no prefix. Byte buffers had no such variant, so the same generated module does this:

```js
probeReserve → _module.takePackedUtf8String(...)   // String, raw
makeBytes    → _module.takePackedWireBytes(...)    // Vec<u8>, framed
```

This adds `root_bytes_return_codec`, defaulting to the framed `CodecNode::Bytes`, which native keeps. Only wasm asks for the raw shape, so no other target changes. `native_bytes_return_expansion_keeps_wire_framing` pins that.

Owned returns only, matching the existing arm, which takes `TypeExpr::String` and not `TypeExpr::Str`. A borrowed value is written by `borrowed_buffer`, which frames unconditionally, so `&[u8]` and `&'static [u8]` constants keep the framed reader. `only_owned_byte_returns_skip_the_length_prefix` covers all three shapes.

The wasm ABI version moves to 3. The return layout changed, so a host and an artifact built either side of this must not load together: the check at instantiation now reports `ABI version mismatch: expected 3, got 2` instead of handing back a payload with the old prefix on the front.

Parameters are untouched. An argument is written into a fresh allocation, so there is no shift to avoid, and nothing but the buffer carries its length, so the prefix is not redundant there. The argument path keeps `allocWireBytes` and `RootEncoding::Surface`.

## Measurements

Isolating the encoder, native, alternating order, median of 9:

| size | `from_vec` | `wire_encode_owned_bytes` | shift |
|---|---:|---:|---:|
| 4 KB | 28ns | 48ns | 20ns |
| 64 KB | 607ns | 713ns | 106ns |
| 256 KB | 2.4us | 4.7us | 2.3us |
| 1 MB | 11.8us | 23.0us | 11.2us |

Both sides include allocating and filling. At 1 MB the shift costs about as much as building the buffer did.

End to end, both artifacts loaded in one process and measured paired, order flipped each repetition, 21 repetitions, ratio is raw over framed. Both sides are built from this branch, differing only in what `root_bytes_return_codec` answers, so nothing else moves between them:

| size | framed | raw | ratio | p25-p75 | verdict |
|---|---:|---:|---:|---:|---|
| 4 KB | 1260ns | 1133ns | 0.91x | 0.85-1.01 | unresolved |
| 64 KB | 20.2us | 20.1us | 0.99x | 0.90-1.10 | unresolved |
| 256 KB | 28.7us | 27.4us | 0.95x | 0.93-0.99 | faster |
| 1 MB | 119.6us | 107.4us | 0.93x | 0.87-0.98 | faster |

So 5 to 7 percent at 256 KB and above, and nothing this machine can resolve below that. An earlier unpaired run suggested far more at 64 KB; it did not survive pairing, and the honest reading is that the small sizes are noise.

`reserve_exact` does not reallocate here, on the host allocator or under wasm, so this removes a copy rather than an allocation:

```
len=1048576  cap 1048576->1048580  realloc=no
```

## Verification

Correctness over the boundary sizes and the free path:

```
n=0, 1, 3, 4, 4096, 65536, 1048576 all round trip with correct length and contents
5000 repeated 1 KB calls, no corruption
borrowed &[u8] returning b"abcde" arrives as 5 bytes, not 9
```

Mixed versions now stop at instantiation:

```
BoltFFI ABI version mismatch: expected 3, got 2
```

Two tests pinned the old shape. The TypeScript emission assertion was updated, and `wasm_bytes_return_expansion_uses_wire_framing` was renamed to say what it now pins. Three were added: `native_bytes_return_expansion_keeps_wire_framing`, so the framed form cannot be lost from the surfaces that need it; `only_owned_byte_returns_skip_the_length_prefix`, which fails if a borrowed slice or a `&'static [u8]` constant is read unframed; and `wasm_abi_version_is_stable` moved to 3.

`cargo test --workspace` green, `cargo clippy --workspace --all-targets` clean, 166 runtime tests pass.



