### PR TITLE
fix(macros): read the data declaration column as 1-indexed

### DIFF
--- a/boltffi_macros/src/data/scope.rs
+++ b/boltffi_macros/src/data/scope.rs
@@ -205,11 +205,11 @@ impl Declaration {
 
     /// Byte offset of a `proc_macro::Span` location.
     ///
-    /// Both fields arrive 1-indexed from the compiler. `LineColumn` is a
-    /// `proc_macro2` type whose own column convention is 0-indexed, so reading
-    /// the column straight out of it lands one byte past the identifier: for
-    /// `pub struct S`, on the space after `S`, and no declaration is found
-    /// there.
+    /// The compiler counts both fields from one, and counts the column in
+    /// characters while everything downstream works in bytes. Adding the
+    /// column to a byte offset is only correct for a line that is entirely
+    /// ASCII up to the declaration; `pub /* \u{3b1} */ struct S` is off by the
+    /// extra byte, and the identifier is missed.
     fn source_offset(source: &str, location: LineColumn) -> Option<usize> {
         let line_start = std::iter::once(0)
             .chain(
@@ -219,7 +219,14 @@ impl Declaration {
                     .filter_map(|(index, byte)| (byte == b'\n').then_some(index + 1)),
             )
             .nth(location.line.checked_sub(1)?)?;
-        Some(line_start + location.column.checked_sub(1)?)
+        let line = source[line_start..]
+            .split_once('\n')
+            .map_or(&source[line_start..], |(line, _)| line);
+        let column = line
+            .char_indices()
+            .nth(location.column.checked_sub(1)?)
+            .map(|(column, _)| column)?;
+        Some(line_start + column)
     }
 
     fn declaration_ordinal(
@@ -363,18 +370,32 @@ mod tests {
     /// `source_offset` feeds `declaration_ordinal`, and the two agree only if
     /// the offset lands inside the identifier.
     ///
-    /// The compiler reports both line and column 1-indexed. Reading the column
-    /// as 0-indexed puts the offset one byte past the name, which still lands
-    /// inside anything at least two characters long: every declaration in this
-    /// repository, and so nothing here caught it. A one-character name is the
-    /// only case where the off-by-one leaves the identifier.
+    /// The compiler counts both fields from one, and counts the column in
+    /// characters. Two separate things can put the offset outside the name:
+    /// reading the column as 0-indexed moves it one byte forward, and adding a
+    /// character column to a byte offset moves it back by one for every extra
+    /// byte earlier in the line.
+    ///
+    /// Either slip stays hidden behind a name of two characters or more, which
+    /// every declaration in this repository has. The one-character rows are
+    /// what make the arithmetic observable.
     #[test]
-    fn locates_a_declaration_from_a_one_indexed_column() {
+    fn locates_a_declaration_from_a_one_indexed_character_column() {
         for (source, name, line, column) in [
             ("#[data]\npub struct S { pub a: u32 }\n", "S", 2, 12),
             ("#[data]\npub struct Point { pub a: u32 }\n", "Point", 2, 12),
             ("    #[data]\n    pub struct T;\n", "T", 2, 16),
             ("#[data]\npub enum E { A }\n", "E", 2, 10),
+            // One multi-byte character before the name, then two: the column
+            // and the byte offset drift apart by one byte each.
+            ("#[data]\npub /* \u{3b1} */ struct S;\n", "S", 2, 20),
+            ("#[data]\npub /* \u{3b1}\u{3b2} */ struct S;\n", "S", 2, 21),
+            (
+                "#[data]\npub /* \u{1f600} */ struct Point;\n",
+                "Point",
+                2,
+                20,
+            ),
         ] {
             let kind = match source.contains("enum") {
                 true => DeclarationKind::Enumeration,

--- a/boltffi_macros/src/data/scope.rs
+++ b/boltffi_macros/src/data/scope.rs
@@ -203,6 +203,13 @@ impl Declaration {
         path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
     }
 
+    /// Byte offset of a `proc_macro::Span` location.
+    ///
+    /// Both fields arrive 1-indexed from the compiler. `LineColumn` is a
+    /// `proc_macro2` type whose own column convention is 0-indexed, so reading
+    /// the column straight out of it lands one byte past the identifier: for
+    /// `pub struct S`, on the space after `S`, and no declaration is found
+    /// there.
     fn source_offset(source: &str, location: LineColumn) -> Option<usize> {
         let line_start = std::iter::once(0)
             .chain(
@@ -212,7 +219,7 @@ impl Declaration {
                     .filter_map(|(index, byte)| (byte == b'\n').then_some(index + 1)),
             )
             .nth(location.line.checked_sub(1)?)?;
-        Some(line_start + location.column)
+        Some(line_start + location.column.checked_sub(1)?)
     }
 
     fn declaration_ordinal(
@@ -350,7 +357,43 @@ impl<'syntax> Visit<'syntax> for ScopeFinder<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::{DeclarationKind, Scope, ScopeFinder};
+    use super::{Declaration, DeclarationKind, Scope, ScopeFinder};
+    use proc_macro2::LineColumn;
+
+    /// `source_offset` feeds `declaration_ordinal`, and the two agree only if
+    /// the offset lands inside the identifier.
+    ///
+    /// The compiler reports both line and column 1-indexed. Reading the column
+    /// as 0-indexed puts the offset one byte past the name, which still lands
+    /// inside anything at least two characters long: every declaration in this
+    /// repository, and so nothing here caught it. A one-character name is the
+    /// only case where the off-by-one leaves the identifier.
+    #[test]
+    fn locates_a_declaration_from_a_one_indexed_column() {
+        for (source, name, line, column) in [
+            ("#[data]\npub struct S { pub a: u32 }\n", "S", 2, 12),
+            ("#[data]\npub struct Point { pub a: u32 }\n", "Point", 2, 12),
+            ("    #[data]\n    pub struct T;\n", "T", 2, 16),
+            ("#[data]\npub enum E { A }\n", "E", 2, 10),
+        ] {
+            let kind = match source.contains("enum") {
+                true => DeclarationKind::Enumeration,
+                false => DeclarationKind::Record,
+            };
+            let offset = Declaration::source_offset(source, LineColumn { line, column })
+                .unwrap_or_else(|| panic!("`{name}` has an offset"));
+            assert_eq!(
+                &source[offset..offset + name.len()],
+                name,
+                "offset for `{name}` should land on the name",
+            );
+            assert_eq!(
+                Declaration::declaration_ordinal(source, name, kind, offset),
+                Some(0),
+                "`{name}` should resolve to its own declaration",
+            );
+        }
+    }
 
     #[test]
     fn finds_data_declarations_in_their_function_block() {

--- a/boltffi_tests/src/records_direct.rs
+++ b/boltffi_tests/src/records_direct.rs
@@ -75,3 +75,16 @@ impl FixturePoint {
         }
     }
 }
+
+/// Deliberately one character.
+///
+/// `#[data]` locates its own declaration by byte offset, and an offset that is
+/// off by one still lands inside any longer name. Every other declaration in
+/// this crate is long enough to hide that, so this one is the tripwire: it
+/// fails to compile if the offset leaves the identifier.
+#[data]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub struct R {
+    pub value: u32,
+}


### PR DESCRIPTION
## Problem

`#[data]` does not compile when the declaration's name is one character.

```rust
use boltffi::*;
#[data]
#[derive(Clone, Debug, Default)]
pub struct S { pub a: Option<String> }
#[export]
pub fn f(s: S) -> u32 { let _ = s; 1 }
```

```
error: locate data declaration `S` at 4:12 in `src/lib.rs`
error[E0425]: cannot find type `S` in the crate root
```

Bisected to #808, which introduced `boltffi_macros/src/data/scope.rs`:

| commit | |
|---|---|
| `bd8995c0` #806 | ok |
| `c7f92e80` #804 | ok |
| `464b86a2` #808 | fails |
| `364c31b6` #801 | fails, on top of #808 |

## Cause

`Declaration::from_macro_input` takes `item.ident.span().unwrap()`, so line and column come from `proc_macro::Span`, where both are 1-indexed. They are stored in `proc_macro2::LineColumn`, whose own column convention is 0-indexed, and `source_offset` used the column as-is:

```rust
.nth(location.line.checked_sub(1)?)?;   // line treated as 1-indexed
Some(line_start + location.column)      // column treated as 0-indexed
```

Instrumenting the failing build shows where it lands:

```
name=S line=3 column=12
offset=Some(36)
at_offset=" { pub a: u3"
```

The identifier starts at 35. The offset is 36, the space after `S`.

`declaration_ordinal` then matches with:

```rust
offset <= target_offset && target_offset < offset + spelling.len()
```

which is why this stayed hidden. One byte past the start is still inside any name of two characters or more:

```
struct S       fails
struct Sx      ok
struct Config  ok
```

Every `#[data]` declaration in this repository is longer than one character, so the whole suite passed.

There is a second slip in the same expression, raised in review. The column counts *characters*, while `line_start` and everything downstream are byte offsets, so a multi-byte character earlier in the line moves the two apart:

```
pub /* α */ struct S;
```

`column()` reports 20 and `S` also begins at byte 20 of the line, because `α` takes two bytes. Reading the column as 0-indexed landed on 20 by cancelling exactly that, which is why this particular line used to work. Two such characters, or one four-byte character, and it misses again in the other direction.

## Fix

Take the column as 1-indexed and map it through the line's `char_indices`, so it is a byte offset before it meets one.

## Tests

`locates_a_declaration_from_a_one_indexed_character_column` covers `source_offset` feeding `declaration_ordinal`, over a one-character record, a longer record, an indented declaration, an enum, and three lines carrying multi-byte characters before the name. The existing tests in this file call `ScopeFinder::find` with an ordinal already computed, so nothing exercised that join.

It fails against both wrong spellings: the original `+ column`, and `+ column - 1` taken as bytes.

`boltffi_tests` gains a one-character record, which makes the case compile rather than only be reasoned about. Reverting the fix breaks the build of that crate:

```
error: locate data declaration `R` at 88:12 in `boltffi_tests/src/records_direct.rs`
```

`cargo test --workspace` green, `cargo clippy --workspace --all-targets` clean, and these all compile:

```
pub struct S { pub a: Option<String> }        // the reported case
pub /* α */ struct S { pub a: u32 }           // one multi-byte character
pub /* αβ */ struct S { pub a: u32 }          // two
pub /* 🎉 */ struct S { pub a: u32 }          // four bytes
```

## Not fixed here

Two `#[data]` declarations with the same name in sibling modules still fail with `E0252: the name T is defined multiple times`. That is a separate limitation of the scope resolution added in #808, not the offset.
