### PR TITLE
fix(scan): name the root module after the crate, not the package

### DIFF
--- a/boltffi_macros/src/expansion/expander.rs
+++ b/boltffi_macros/src/expansion/expander.rs
@@ -704,6 +704,30 @@ mod tests {
         assert_generated_crate_checks("expander_ownerless_stream", ownerless_stream_crate(tokens));
     }
 
+    /// A hyphenated package scans and expands as one chain.
+    ///
+    /// `root_type` decides whether a declaration is local by comparing the id's
+    /// first segment against the package name with hyphens replaced, so the
+    /// scan has to write the id with the module name rather than the package
+    /// name. Constructing the contract by hand proves nothing here: the two
+    /// halves have to meet. Every fixture is named `demo`, which has no second
+    /// spelling to disagree about.
+    #[test]
+    fn scans_and_expands_a_hyphenated_package() {
+        let source = boltffi_scan::scan_file(
+            syn::parse_str("#[data]\n#[repr(C)]\npub struct Point { pub x: u8 }\n")
+                .expect("valid source"),
+            PackageInfo::new("my-root", None),
+        )
+        .expect("source scans");
+        let lowered = lower_with_declarations::<Native>(&source).expect("contract lowers");
+        let expansion = Expansion::new(&lowered);
+
+        expander::Expander::new(&source)
+            .native(&expansion)
+            .expect("a declaration of this crate expands");
+    }
+
     #[test]
     fn renders_associated_constant_access_through_its_owner() {
         let mut source = SourceContract::new(PackageInfo::new("demo", None));

--- a/boltffi_scan/src/path.rs
+++ b/boltffi_scan/src/path.rs
@@ -8,16 +8,24 @@ pub(super) struct ModulePath {
     segments: Vec<String>,
 }
 
+/// The module a package is reachable under.
+///
+/// Segments of a path are Rust identifiers, and a package name is not one:
+/// cargo allows a hyphen where the module tree has an underscore. Ids are
+/// compared against this spelling in several places, so it has one definition.
+pub(crate) fn module_name(package: &str) -> String {
+    package.replace('-', "_")
+}
+
 impl ModulePath {
     /// Root of a crate's module path.
     ///
-    /// Segments are Rust identifiers, and a package name is not one: cargo
-    /// allows hyphens where the module tree has underscores. Dependencies
-    /// arrive already normalised, through `ExportedPackage::module_name`, so
-    /// only the root reaches this with a raw package name.
+    /// Dependencies arrive already normalised, through
+    /// `ExportedPackage::module_name`, so only the root reaches this with a
+    /// raw package name.
     pub(super) fn root(crate_name: impl Into<String>) -> Self {
         Self {
-            segments: vec![crate_name.into().replace('-', "_")],
+            segments: vec![module_name(&crate_name.into())],
         }
     }
 

--- a/boltffi_scan/src/path.rs
+++ b/boltffi_scan/src/path.rs
@@ -9,9 +9,15 @@ pub(super) struct ModulePath {
 }
 
 impl ModulePath {
+    /// Root of a crate's module path.
+    ///
+    /// Segments are Rust identifiers, and a package name is not one: cargo
+    /// allows hyphens where the module tree has underscores. Dependencies
+    /// arrive already normalised, through `ExportedPackage::module_name`, so
+    /// only the root reaches this with a raw package name.
     pub(super) fn root(crate_name: impl Into<String>) -> Self {
         Self {
-            segments: vec![crate_name.into()],
+            segments: vec![crate_name.into().replace('-', "_")],
         }
     }
 

--- a/boltffi_scan/src/scan.rs
+++ b/boltffi_scan/src/scan.rs
@@ -450,6 +450,32 @@ mod tests {
         SourceTree::in_memory(crate_name, parse(source).items).expect("source tree")
     }
 
+    /// Declaration ids are Rust paths, so the crate segment is the module name.
+    ///
+    /// Cargo allows a hyphen in a package name where the module tree has an
+    /// underscore. Carrying the package name through unchanged produced ids
+    /// like `my-root::Point`, which no consumer can match against a crate
+    /// path: the macro compares them to `CARGO_PKG_NAME` with hyphens
+    /// replaced, and rejects the declaration as belonging to another crate.
+    /// Every fixture here is named `demo`, so nothing caught it.
+    #[test]
+    fn declaration_ids_use_the_module_name_of_a_hyphenated_package() {
+        let contract = scan_file(
+            parse("#[data]\npub struct Point { pub x: f64 }\n"),
+            PackageInfo::new("my-root", None),
+        )
+        .expect("scan");
+
+        assert_eq!(
+            contract
+                .records
+                .iter()
+                .map(|record| record.id.as_str())
+                .collect::<Vec<_>>(),
+            ["my_root::Point"],
+        );
+    }
+
     fn point(contract: &SourceContract) -> &RecordDef {
         contract
             .records

--- a/boltffi_scan/src/scan.rs
+++ b/boltffi_scan/src/scan.rs
@@ -7,7 +7,7 @@ use crate::declared_types::DeclaredTypes;
 use crate::input::ScanInput;
 use crate::marked::MarkedItems;
 use crate::package_graph::{ExportedPackage, LoadError, PackageGraph};
-use crate::path::ImportLookup;
+use crate::path::{ImportLookup, module_name};
 use crate::source_tree::SourceTree;
 use crate::{ModuleScope, ScanError, items};
 
@@ -129,11 +129,15 @@ pub fn scan_package(input: &ScanInput) -> Result<PackageScan, ScanError> {
         scan_marked_with_declarations(&root_marked, &declared_types, input.package().clone())?;
     let complete =
         scan_marked_with_declarations(&complete_marked, &declared_types, input.package().clone())?;
+    // The ids being matched here carry the module name, so the root has to be
+    // spelled the same way: a hyphenated package would match nothing, and its
+    // own items would be emitted unqualified.
+    let root_module = module_name(&input.package().name);
     let root_visible_paths = root_visible_paths(
         &declared_types,
         &complete_tree,
         &complete_marked,
-        &input.package().name,
+        &root_module,
         &direct_dependency_modules,
     );
     Ok(PackageScan {

--- a/boltffi_scan/tests/hyphenated_package.rs
+++ b/boltffi_scan/tests/hyphenated_package.rs
@@ -1,0 +1,75 @@
+//! A package name is not a module name, and ids are written with the latter.
+//!
+//! Every fixture in the unit suites is named `demo`, which has only one
+//! spelling, so the two never disagree there. These go through `scan_package`,
+//! which is where the root name reaches visible-path discovery.
+
+use std::fs;
+use std::path::PathBuf;
+
+use boltffi_ast::{PackageInfo, PathRoot};
+use boltffi_scan::{ScanInput, scan_package};
+
+const SOURCE: &str = r#"
+pub mod api {
+    #[data]
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct Info { pub a: u32 }
+
+    #[export]
+    pub fn nested(value: Info) -> u32 { value.a }
+}
+"#;
+
+/// `case` keeps concurrent tests off each other's files: the scratch directory
+/// is shared between them, and two writers of the same path race.
+fn scan(case: &str, package: &str) -> boltffi_scan::PackageScan {
+    let directory = PathBuf::from(env!("CARGO_TARGET_TMPDIR"))
+        .join(case)
+        .join(package);
+    fs::create_dir_all(&directory).expect("scratch directory");
+    let source = directory.join("lib.rs");
+    fs::write(&source, SOURCE).expect("source file");
+
+    scan_package(&ScanInput::new(&source, PackageInfo::new(package, None))).expect("package scans")
+}
+
+#[test]
+fn nested_items_stay_crate_rooted_under_a_hyphenated_package() {
+    for package in ["my-root", "myroot"] {
+        let scanned = scan("nested", package);
+        let paths = scanned.root_visible_paths().collect::<Vec<_>>();
+
+        let (_, path) = paths
+            .iter()
+            .find(|(id, _)| id.ends_with("::Info"))
+            .unwrap_or_else(|| panic!("`{package}` should expose a visible path for `Info`"));
+
+        // Relative here means the item was read as belonging to some other
+        // crate, and the expander would emit `Info` with nothing in front.
+        assert_eq!(
+            path.root,
+            PathRoot::Crate,
+            "`{package}` should reach its own nested item through `crate`",
+        );
+        assert_eq!(
+            path.segments
+                .iter()
+                .map(|segment| segment.name.as_str())
+                .collect::<Vec<_>>(),
+            ["api", "Info"],
+        );
+    }
+}
+
+#[test]
+fn declaration_ids_use_the_module_name() {
+    let ids = scan("ids", "my-root")
+        .root()
+        .records
+        .iter()
+        .map(|record| record.id.as_str().to_owned())
+        .collect::<Vec<_>>();
+
+    assert_eq!(ids, ["my_root::api::Info"]);
+}


### PR DESCRIPTION
## Problem

Any `#[data]` or `#[error]` in a crate whose package name contains a hyphen fails to compile.

```toml
[package]
name = "my-root"
```

```rust
use boltffi::*;
#[data]
#[derive(Clone, Copy, Debug, Default)]
pub struct Info { pub a: u32 }
```

```
error: BoltFFI macro expansion failed: source data declaration belongs to another crate
```

No dependencies needed. Renaming the package to `myroot` compiles.

## Cause

`scan_package` builds the root module path from the package name as written:

```rust
SourceTree::load_with_cfg(input.root(), &input.package().name, input.cfg())
```

`ModulePath::root` takes that as the first segment, so declaration ids carry the package spelling. Dependencies do not: they arrive through `ExportedPackage::module_name`, which is the import name and already normalised. Only the root reaches this with a raw package name.

`Expander::root_type` then decides whether a declaration belongs to the crate being expanded by comparing the id's first segment against the package name with hyphens replaced. Instrumenting the failing build:

```
root_type id="whatsapp-rust-bridge-boltffi::HkdfInfo" package="whatsapp_rust_bridge_boltffi"
  -> MISMATCH
```

The two spellings never meet, so every local declaration is rejected as foreign.

`record_and_enum_imports` has the same comparison and silently drops instead of failing, so a hyphenated crate was also emitting no imports for its own records and enums.

The root name reaches a second consumer, raised in review. `root_visible_paths` also received the package name as written, and both `root_visible_path` and `contract_path` compare an id's first segment against it exactly. So a nested item under a hyphenated package matched nothing, got no visible path, and the crate-root wrapper called it unqualified:

```rust
pub mod api {
    #[export]
    pub fn nested(value: Info) -> u32 { value.a }
}
```

```
error[E0425]: cannot find function `nested` in this scope
```

## Fix

One definition of the spelling, `path::module_name`, used by `ModulePath::root` and by visible-path discovery. A module path segment is a Rust identifier; a package name is not one. Dependencies already arrive normalised, so they are unaffected.

## Tests

Every fixture in the scan and macro suites is named `demo`, which has no second spelling to disagree about. That is why nothing caught this.

`declaration_ids_use_the_module_name_of_a_hyphenated_package` scans a source under package `my-root` and asserts the id is `my_root::Point`. Without the fix:

```
  left: ["my-root::Point"]
 right: ["my_root::Point"]
```

`scans_and_expands_a_hyphenated_package` runs the scan and the expander together, since either half alone can be made to pass with a hand-built contract. It is the chain that broke. Without the fix it fails at the expander.

`boltffi_scan/tests/hyphenated_package.rs` goes through `scan_package`, which is where the root name reaches visibility and which nothing exercised before. It asserts a nested item resolves under `crate`, and runs the hyphenated and plain spellings against the same source, so a fix that only moves the failure elsewhere shows up as a difference between them. With the root module normalised but visibility left raw, it fails with no visible path for the nested record at all.

## Verification

`cargo test --workspace` green, `cargo clippy --workspace --all-targets` clean.

Checked against the crate that reported this, built with this branch patched in: it now compiles. Before the fix it failed at its `#[error]` declaration.

