### PR TITLE
feat(dart): add Windows native target support (x86_64 + arm64)

### DIFF
--- a/BOLTFFI_TOML_SPEC.md
+++ b/BOLTFFI_TOML_SPEC.md
@@ -504,4 +504,4 @@ Generates a binary-only SwiftPM package intended to be depended on by a separate
 - `output` (path): Generated Dart package root directory.
   - Default: `dist/dart`
 - `native_targets` (array of strings, optional): Dart native build targets.
-  - Default: `["android:arm64", "android:armv7", "android:x86_64", "ios:arm64", "ios_sim:arm64", "ios_sim:x86_64", "linux:arm64", "linux:x86_64", "macos:arm64", "macos:x86_64"]`.
+  - Default: `["android:arm64", "android:armv7", "android:x86_64", "ios:arm64", "ios_sim:arm64", "ios_sim:x86_64", "linux:arm64", "linux:x86_64", "macos:arm64", "macos:x86_64", "windows:x86_64", "windows:arm64"]`.

--- a/boltffi_backend/templates/target/dart/build.dart
+++ b/boltffi_backend/templates/target/dart/build.dart
@@ -28,6 +28,9 @@ String targetTripleFromCodeConfig(CodeConfig codeConfig) {
     (OS.macOS, Architecture.arm64) => 'aarch64-apple-darwin',
     (OS.macOS, Architecture.x64) => 'x86_64-apple-darwin',
 
+    (OS.windows, Architecture.arm64) => 'aarch64-pc-windows-msvc',
+    (OS.windows, Architecture.x64) => 'x86_64-pc-windows-msvc',
+
     (_, _) => throw UnsupportedError(
       'Unsupported target: $codeConfig.targetOS on $codeConfig.targetArchitecture',
     ),

--- a/boltffi_cli/src/cargo/metadata.rs
+++ b/boltffi_cli/src/cargo/metadata.rs
@@ -134,7 +134,12 @@ impl CargoMetadata {
         for t in package_targets {
             for crate_type in &library_target.crate_types {
                 let prefix = if crate_type.is_staticlib() {
-                    "lib"
+                    // MSVC's `.lib` archives drop the Unix `lib` prefix;
+                    // every other staticlib-producing toolchain keeps it.
+                    match t.platform() {
+                        Platform::Windows => "",
+                        _ => "lib",
+                    }
                 } else {
                     match t.platform() {
                         Platform::Wasm | Platform::Windows => "",
@@ -153,7 +158,10 @@ impl CargoMetadata {
                         Platform::Windows => "dll",
                     }
                 } else if crate_type.is_staticlib() {
-                    "a"
+                    match t.platform() {
+                        Platform::Windows => "lib",
+                        _ => "a",
+                    }
                 } else {
                     continue;
                 };

--- a/boltffi_cli/src/cargo/metadata.rs
+++ b/boltffi_cli/src/cargo/metadata.rs
@@ -137,7 +137,7 @@ impl CargoMetadata {
                     "lib"
                 } else {
                     match t.platform() {
-                        Platform::Wasm => "",
+                        Platform::Wasm | Platform::Windows => "",
                         Platform::Android
                         | Platform::Ios
                         | Platform::IosSimulator
@@ -150,6 +150,7 @@ impl CargoMetadata {
                         Platform::Wasm => "wasm",
                         Platform::Android | Platform::Linux => "so",
                         Platform::MacOs | Platform::Ios | Platform::IosSimulator => "dylib",
+                        Platform::Windows => "dll",
                     }
                 } else if crate_type.is_staticlib() {
                     "a"

--- a/boltffi_cli/src/target.rs
+++ b/boltffi_cli/src/target.rs
@@ -11,6 +11,7 @@ pub enum Platform {
     Android,
     Wasm,
     Linux,
+    Windows,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -414,6 +415,18 @@ impl RustTarget {
         architecture: Architecture::Arm64,
     };
 
+    pub const WINDOWS_X86_64: Self = Self {
+        triple: "x86_64-pc-windows-msvc",
+        platform: Platform::Windows,
+        architecture: Architecture::X86_64,
+    };
+
+    pub const WINDOWS_ARM64: Self = Self {
+        triple: "aarch64-pc-windows-msvc",
+        platform: Platform::Windows,
+        architecture: Architecture::Arm64,
+    };
+
     pub const ALL_IOS: &'static [Self] =
         &[Self::IOS_ARM64, Self::IOS_SIM_ARM64, Self::IOS_SIM_X86_64];
 
@@ -437,6 +450,8 @@ impl RustTarget {
         Self::LINUX_X86_64,
         Self::MACOS_ARM64,
         Self::MACOS_X86_64,
+        Self::WINDOWS_X86_64,
+        Self::WINDOWS_ARM64,
     ];
 
     pub const fn from_axes(platform: Platform, architecture: Architecture) -> Option<Self> {
@@ -453,6 +468,8 @@ impl RustTarget {
             (Platform::Wasm, Architecture::Wasm32) => Some(Self::WASM32_UNKNOWN_UNKNOWN),
             (Platform::Linux, Architecture::Arm64) => Some(Self::LINUX_ARM64),
             (Platform::Linux, Architecture::X86_64) => Some(Self::LINUX_X86_64),
+            (Platform::Windows, Architecture::X86_64) => Some(Self::WINDOWS_X86_64),
+            (Platform::Windows, Architecture::Arm64) => Some(Self::WINDOWS_ARM64),
             _ => None,
         }
     }
@@ -477,6 +494,8 @@ impl RustTarget {
             "linux:x86_64" => Some(Self::LINUX_X86_64),
             "macos:arm64" => Some(Self::MACOS_ARM64),
             "macos:x86_64" => Some(Self::MACOS_X86_64),
+            "windows:x86_64" => Some(Self::WINDOWS_X86_64),
+            "windows:arm64" => Some(Self::WINDOWS_ARM64),
             _ => None,
         }
     }
@@ -493,6 +512,8 @@ impl RustTarget {
             (Platform::Linux, Architecture::X86_64) => Some("linux:x86_64"),
             (Platform::MacOs, Architecture::Arm64) => Some("macos:arm64"),
             (Platform::MacOs, Architecture::X86_64) => Some("macos:x86_64"),
+            (Platform::Windows, Architecture::X86_64) => Some("windows:x86_64"),
+            (Platform::Windows, Architecture::Arm64) => Some("windows:arm64"),
             _ => None,
         }
     }
@@ -525,6 +546,7 @@ impl RustTarget {
             // entry on the build-machine path, which breaks on-device loading.
             Platform::Android => format!("lib{}.a", lib_name),
             Platform::Linux => format!("lib{}.so", lib_name),
+            Platform::Windows => format!("{}.dll", lib_name),
         };
 
         target_dir
@@ -543,6 +565,7 @@ impl Platform {
             Self::Android => "android",
             Self::Wasm => "wasm",
             Self::Linux => "linux",
+            Self::Windows => "windows",
         }
     }
 
@@ -553,6 +576,7 @@ impl Platform {
             Platform::Android => Architecture::ANDROID,
             Platform::Wasm => Architecture::WASM,
             Platform::Linux => Architecture::LINUX,
+            Platform::Windows => Architecture::WINDOWS,
         }
     }
 
@@ -570,6 +594,7 @@ impl Architecture {
     pub const ANDROID: &'static [Self] = &[Self::Arm64, Self::Armv7, Self::X86_64, Self::X86];
     pub const WASM: &'static [Self] = &[Self::Wasm32];
     pub const LINUX: &'static [Self] = &[Self::Arm64, Self::X86_64];
+    pub const WINDOWS: &'static [Self] = &[Self::Arm64, Self::X86_64];
 
     pub const fn canonical_name(self) -> &'static str {
         match self {
@@ -825,8 +850,42 @@ mod tests {
                 "aarch64-unknown-linux-gnu",
                 "x86_64-unknown-linux-gnu",
                 "aarch64-apple-darwin",
-                "x86_64-apple-darwin"
+                "x86_64-apple-darwin",
+                "x86_64-pc-windows-msvc",
+                "aarch64-pc-windows-msvc"
             ]
+        );
+    }
+
+    #[test]
+    fn windows_targets_use_dynamic_libraries_for_packaging() {
+        let library_path = RustTarget::WINDOWS_X86_64.library_path_for_profile(
+            Path::new("target"),
+            "demo",
+            "debug",
+        );
+
+        assert_eq!(RustTarget::WINDOWS_X86_64.platform(), Platform::Windows);
+        assert!(library_path.ends_with("target/x86_64-pc-windows-msvc/debug/demo.dll"));
+    }
+
+    #[test]
+    fn round_trips_windows_dart_native_names() {
+        assert_eq!(
+            RustTarget::from_dart_native_name("windows:x86_64"),
+            Some(RustTarget::WINDOWS_X86_64)
+        );
+        assert_eq!(
+            RustTarget::from_dart_native_name("windows:arm64"),
+            Some(RustTarget::WINDOWS_ARM64)
+        );
+        assert_eq!(
+            RustTarget::WINDOWS_X86_64.dart_native_name(),
+            Some("windows:x86_64")
+        );
+        assert_eq!(
+            RustTarget::WINDOWS_ARM64.dart_native_name(),
+            Some("windows:arm64")
         );
     }
 }


### PR DESCRIPTION
Part of #686 that v0.29.0 did not add.

## Summary

The Dart native backend (`dart:ffi`) currently has no notion of Windows anywhere in the target-resolution pipeline — `Platform` has no `Windows` variant, and `RustTarget::ALL_DART_NATIVE` / `from_dart_native_name` / `dart_native_name` only cover Android, iOS, Linux, and macOS. Setting `targets.dart.native_targets = ["windows:x86_64"]` in `boltffi.toml` fails to resolve, and there's no way to ship Dart bindings for a Windows desktop app at all today.

This PR adds Windows (x86_64 + arm64) as a first-class Dart native target, following the exact pattern already used for Linux/macOS/Android/iOS — no new cross-compilation machinery, just wiring Windows into the same generic `RustTarget` plumbing every other platform already goes through.

## Changes

- `boltffi_cli/src/target.rs`: add `Platform::Windows`, `RustTarget::WINDOWS_X86_64` (`x86_64-pc-windows-msvc`) and `RustTarget::WINDOWS_ARM64` (`aarch64-pc-windows-msvc`), wired through `from_axes`, `from_dart_native_name`/`dart_native_name` (`"windows:x86_64"` / `"windows:arm64"`), `Architecture::WINDOWS`, and `RustTarget::ALL_DART_NATIVE` (the default target list, matching how every other platform is already unconditionally included there).
- `boltffi_cli/src/target.rs` / `boltffi_cli/src/cargo/metadata.rs`: teach artifact-naming logic that Windows cdylibs are `{name}.dll` (no `lib` prefix), unlike the `lib{name}.so`/`.dylib` convention used elsewhere.
- `boltffi_backend/templates/target/dart/build.dart`: add the missing `(OS.windows, Architecture.x64)` and `(OS.windows, Architecture.arm64)` cases to the generated Dart Native Assets build hook, so it can locate the matching prebuilt library at build/link time on Windows.
- `BOLTFFI_TOML_SPEC.md`: document `windows:x86_64` / `windows:arm64` in the default `native_targets` list.
