### PR TITLE
fix(scan): resolve re-exported types and restore active-feature detection for the Dart cdylib build

### DIFF
--- a/boltffi_cli/src/build.rs
+++ b/boltffi_cli/src/build.rs
@@ -136,13 +136,7 @@ pub struct BuildOptions {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BuildSelection {
-    Default {
-        cargo_args: Vec<String>,
-    },
-    Package {
-        package: String,
-        cargo_args: Vec<String>,
-    },
+    Default { cargo_args: Vec<String> },
     Expanded(Box<BindingExpansion>),
 }
 
@@ -241,7 +235,6 @@ impl<'a> Builder<'a> {
     fn package_spec(&self) -> &str {
         match &self.options.selection {
             BuildSelection::Default { .. } => self.config.library_name(),
-            BuildSelection::Package { package, .. } => package,
             BuildSelection::Expanded(expansion) => expansion.package_id(),
         }
     }
@@ -266,7 +259,7 @@ impl<'a> Builder<'a> {
                 command.arg("--lib");
                 expansion.configure_rustc(command)
             }
-            BuildSelection::Default { .. } | BuildSelection::Package { .. } => Ok(()),
+            BuildSelection::Default { .. } => Ok(()),
         }
     }
 
@@ -286,7 +279,7 @@ impl<'a> Builder<'a> {
 
     fn cargo_build_command_args(&self) -> CargoBuildCommandArgs {
         match &self.options.selection {
-            BuildSelection::Default { cargo_args } | BuildSelection::Package { cargo_args, .. } => {
+            BuildSelection::Default { cargo_args } => {
                 CargoBuildCommandArgs::from_passthrough_args(cargo_args)
             }
             BuildSelection::Expanded(expansion) => CargoBuildCommandArgs {

--- a/boltffi_cli/src/build/expansion.rs
+++ b/boltffi_cli/src/build/expansion.rs
@@ -342,6 +342,10 @@ impl BindingExpansion {
         self.features = features.into();
         self
     }
+
+    pub(crate) fn surface(&self) -> BindingMetadataSurface {
+        self.surface
+    }
 }
 
 #[cfg(test)]

--- a/boltffi_cli/src/build/expansion.rs
+++ b/boltffi_cli/src/build/expansion.rs
@@ -68,6 +68,16 @@ impl BindingExpansion {
         Self::resolve_selection(config, build_cargo_args, surface, None)
     }
 
+    /// Like [`Self::resolve_preferred`], but for a non-`Native` surface.
+    pub fn resolve_preferred_for_surface(
+        config: &Config,
+        build_cargo_args: &[String],
+        surface: BindingMetadataSurface,
+        preferred_artifact: &str,
+    ) -> Result<Self> {
+        Self::resolve_selection(config, build_cargo_args, surface, Some(preferred_artifact))
+    }
+
     fn resolve_selection(
         config: &Config,
         build_cargo_args: &[String],

--- a/boltffi_cli/src/commands/build.rs
+++ b/boltffi_cli/src/commands/build.rs
@@ -1,3 +1,5 @@
+use boltffi_binding::BindingMetadataSurface;
+
 use crate::build::{
     BindingExpansion, BuildOptions, BuildResult, BuildSelection, Builder, all_successful,
     count_successful, failed_targets, resolve_build_profile,
@@ -43,7 +45,7 @@ pub fn run_build(config: &Config, options: BuildCommandOptions) -> Result<Vec<Bu
                 return Ok(Vec::new());
             }
             println!("Building for Apple ({})...", profile);
-            apple_builder(config, release, cargo_args.clone())?
+            expanded_builder(config, release, cargo_args.clone())?
                 .build_targets(&config.apple_targets())?
         }
         BuildPlatform::Android => {
@@ -51,7 +53,7 @@ pub fn run_build(config: &Config, options: BuildCommandOptions) -> Result<Vec<Bu
                 return Ok(Vec::new());
             }
             println!("Building for Android ({})...", profile);
-            plain_builder(config, release, cargo_args.clone())
+            expanded_builder(config, release, cargo_args.clone())?
                 .build_android(&config.android_targets())?
         }
         BuildPlatform::Wasm => {
@@ -59,7 +61,7 @@ pub fn run_build(config: &Config, options: BuildCommandOptions) -> Result<Vec<Bu
                 return Ok(Vec::new());
             }
             println!("Building for wasm ({})...", profile);
-            plain_builder(config, release, cargo_args.clone())
+            wasm_builder(config, release, cargo_args.clone())?
                 .build_wasm_with_triple(config.wasm_triple())?
         }
         BuildPlatform::Dart => {
@@ -67,7 +69,7 @@ pub fn run_build(config: &Config, options: BuildCommandOptions) -> Result<Vec<Bu
                 return Ok(Vec::new());
             }
             println!("Building for dart ({})...", profile);
-            plain_builder(config, release, cargo_args.clone())
+            expanded_builder(config, release, cargo_args.clone())?
                 .build_targets(&config.dart_targets())?
         }
         BuildPlatform::All => {
@@ -75,25 +77,25 @@ pub fn run_build(config: &Config, options: BuildCommandOptions) -> Result<Vec<Bu
             let mut all_results = Vec::new();
             if config.is_apple_enabled() {
                 all_results.extend(
-                    apple_builder(config, release, cargo_args.clone())?
+                    expanded_builder(config, release, cargo_args.clone())?
                         .build_targets(&config.apple_targets())?,
                 );
             }
             if config.is_android_enabled() {
                 all_results.extend(
-                    plain_builder(config, release, cargo_args.clone())
+                    expanded_builder(config, release, cargo_args.clone())?
                         .build_android(&config.android_targets())?,
                 );
             }
             if config.is_wasm_enabled() {
                 all_results.extend(
-                    plain_builder(config, release, cargo_args.clone())
+                    wasm_builder(config, release, cargo_args.clone())?
                         .build_wasm_with_triple(config.wasm_triple())?,
                 );
             }
             if config.is_dart_enabled() {
                 all_results.extend(
-                    plain_builder(config, release, cargo_args.clone())
+                    expanded_builder(config, release, cargo_args.clone())?
                         .build_targets(&config.dart_targets())?,
                 );
             }
@@ -118,19 +120,42 @@ pub fn run_build(config: &Config, options: BuildCommandOptions) -> Result<Vec<Bu
     }
 }
 
-fn apple_builder(config: &Config, release: bool, cargo_args: Vec<String>) -> Result<Builder<'_>> {
+// Cargo only sets CARGO_FEATURE_* for build scripts, so every platform here
+// must build as a binding expansion for the #[data]/#[error] macros to see
+// active features -- a plain `cargo build` silently drops feature-gated
+// modules from the FFI surface (same bug fixed for `pack dart` and, before
+// that, `pack python` in 8bd6ab4a).
+fn expanded_builder(
+    config: &Config,
+    release: bool,
+    cargo_args: Vec<String>,
+) -> Result<Builder<'_>> {
     let expansion = BindingExpansion::resolve(config, &cargo_args)?;
     Ok(Builder::new(
         config,
-        build_options(release, BuildSelection::Expanded(Box::new(expansion))),
+        expanded_build_options(expansion, release),
     ))
 }
 
-fn plain_builder(config: &Config, release: bool, cargo_args: Vec<String>) -> Builder<'_> {
-    Builder::new(
+// Wasm needs its own surface: `pack wasm` and wasm binding generation both
+// resolve with `BindingMetadataSurface::Wasm32`, and the macro picks
+// surface-specific lowering off it. The generic `expanded_builder` above
+// defaults to `Native`, which would compile the wrong ABI for a wasm32
+// target.
+fn wasm_builder(config: &Config, release: bool, cargo_args: Vec<String>) -> Result<Builder<'_>> {
+    let expansion = wasm_expansion(config, &cargo_args)?;
+    Ok(Builder::new(
         config,
-        build_options(release, BuildSelection::Default { cargo_args }),
-    )
+        expanded_build_options(expansion, release),
+    ))
+}
+
+fn wasm_expansion(config: &Config, cargo_args: &[String]) -> Result<BindingExpansion> {
+    BindingExpansion::resolve_for_surface(config, cargo_args, BindingMetadataSurface::Wasm32)
+}
+
+fn expanded_build_options(expansion: BindingExpansion, release: bool) -> BuildOptions {
+    build_options(release, BuildSelection::Expanded(Box::new(expansion)))
 }
 
 fn build_options(release: bool, selection: BuildSelection) -> BuildOptions {
@@ -168,5 +193,60 @@ fn print_build_results(results: &[BuildResult]) {
         failed_targets(results).iter().for_each(|triple| {
             println!("  - {}", triple);
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use boltffi_binding::BindingMetadataSurface;
+
+    use super::{BindingExpansion, BuildSelection, expanded_build_options, wasm_expansion};
+    use crate::config::Config;
+
+    fn demo_manifest_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../examples/demo/Cargo.toml")
+    }
+
+    fn parse_config(input: &str) -> Config {
+        let parsed: Config = toml::from_str(input).expect("toml parse failed");
+        parsed.validate().expect("config validation failed");
+        parsed
+    }
+
+    /// `boltffi build` (apple/android/wasm/dart/all) must go through the same
+    /// binding expansion `pack` does, or the #[data]/#[error] macros never
+    /// see active features and silently drop feature-gated modules from the
+    /// FFI surface.
+    #[test]
+    fn build_command_uses_a_binding_expansion() {
+        let expansion = BindingExpansion::fixture(
+            "/workspace/Cargo.toml",
+            "/workspace/demo/Cargo.toml",
+            ["--features".to_string(), "ffi".to_string()],
+        );
+
+        let options = expanded_build_options(expansion, false);
+
+        assert!(matches!(options.selection, BuildSelection::Expanded(_)));
+    }
+
+    /// `boltffi build wasm` must resolve with the wasm32 surface, not the
+    /// generic builder's `Native` default -- `pack wasm` and wasm binding
+    /// generation both use `Wasm32`, and the macro's surface-specific
+    /// lowering has to agree with the TypeScript bindings the wasm build
+    /// will be paired with.
+    #[test]
+    fn wasm_build_resolves_the_wasm32_surface() {
+        let config = parse_config("[package]\nname = \"demo\"\n");
+        let cargo_args = vec![
+            "--manifest-path".to_string(),
+            demo_manifest_path().display().to_string(),
+        ];
+
+        let expansion = wasm_expansion(&config, &cargo_args).expect("wasm expansion resolves");
+
+        assert_eq!(expansion.surface(), BindingMetadataSurface::Wasm32);
     }
 }

--- a/boltffi_cli/src/commands/build.rs
+++ b/boltffi_cli/src/commands/build.rs
@@ -124,13 +124,16 @@ pub fn run_build(config: &Config, options: BuildCommandOptions) -> Result<Vec<Bu
 // must build as a binding expansion for the #[data]/#[error] macros to see
 // active features -- a plain `cargo build` silently drops feature-gated
 // modules from the FFI surface (same bug fixed for `pack dart` and, before
-// that, `pack python` in 8bd6ab4a).
+// that, `pack python` in 8bd6ab4a). resolve_preferred keeps the configured/
+// default artifact selected even when the package has more than one
+// FFI-capable cargo target.
 fn expanded_builder(
     config: &Config,
     release: bool,
     cargo_args: Vec<String>,
 ) -> Result<Builder<'_>> {
-    let expansion = BindingExpansion::resolve(config, &cargo_args)?;
+    let expansion =
+        BindingExpansion::resolve_preferred(config, &cargo_args, &config.crate_artifact_name())?;
     Ok(Builder::new(
         config,
         expanded_build_options(expansion, release),
@@ -151,7 +154,12 @@ fn wasm_builder(config: &Config, release: bool, cargo_args: Vec<String>) -> Resu
 }
 
 fn wasm_expansion(config: &Config, cargo_args: &[String]) -> Result<BindingExpansion> {
-    BindingExpansion::resolve_for_surface(config, cargo_args, BindingMetadataSurface::Wasm32)
+    BindingExpansion::resolve_preferred_for_surface(
+        config,
+        cargo_args,
+        BindingMetadataSurface::Wasm32,
+        &config.crate_artifact_name(),
+    )
 }
 
 fn expanded_build_options(expansion: BindingExpansion, release: bool) -> BuildOptions {
@@ -199,10 +207,14 @@ fn print_build_results(results: &[BuildResult]) {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use boltffi_binding::BindingMetadataSurface;
 
-    use super::{BindingExpansion, BuildSelection, expanded_build_options, wasm_expansion};
+    use super::{
+        BindingExpansion, BuildSelection, expanded_build_options, expanded_builder, wasm_builder,
+        wasm_expansion,
+    };
     use crate::config::Config;
 
     fn demo_manifest_path() -> PathBuf {
@@ -213,6 +225,49 @@ mod tests {
         let parsed: Config = toml::from_str(input).expect("toml parse failed");
         parsed.validate().expect("config validation failed");
         parsed
+    }
+
+    /// A crate with a second FFI-capable cargo target (here, a cdylib
+    /// example) alongside its normal lib -- reproduces the ambiguity
+    /// `SelectedLibrary::resolve` rejects when nothing tells it which
+    /// target to prefer.
+    fn write_multi_ffi_target_fixture() -> PathBuf {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let crate_dir =
+            std::env::temp_dir().join(format!("boltffi-multi-ffi-target-test-{unique_suffix}"));
+        std::fs::create_dir_all(crate_dir.join("src")).expect("create src dir");
+        std::fs::create_dir_all(crate_dir.join("examples")).expect("create examples dir");
+        std::fs::write(
+            crate_dir.join("Cargo.toml"),
+            "[package]\n\
+             name = \"demo_multi\"\n\
+             version = \"0.1.0\"\n\
+             edition = \"2021\"\n\n\
+             [lib]\n\
+             crate-type = [\"cdylib\", \"rlib\"]\n\n\
+             [[example]]\n\
+             name = \"extra\"\n\
+             crate-type = [\"cdylib\"]\n",
+        )
+        .expect("write Cargo.toml");
+        std::fs::write(crate_dir.join("src/lib.rs"), "").expect("write lib.rs");
+        std::fs::write(crate_dir.join("examples/extra.rs"), "fn main() {}\n")
+            .expect("write example");
+        crate_dir
+    }
+
+    fn multi_ffi_target_config() -> Config {
+        parse_config("[package]\nname = \"demo_multi\"\n")
+    }
+
+    fn multi_ffi_target_cargo_args(crate_dir: &std::path::Path) -> Vec<String> {
+        vec![
+            "--manifest-path".to_string(),
+            crate_dir.join("Cargo.toml").display().to_string(),
+        ]
     }
 
     /// `boltffi build` (apple/android/wasm/dart/all) must go through the same
@@ -248,5 +303,33 @@ mod tests {
         let expansion = wasm_expansion(&config, &cargo_args).expect("wasm expansion resolves");
 
         assert_eq!(expansion.surface(), BindingMetadataSurface::Wasm32);
+    }
+
+    /// A crate whose only other FFI-capable target is a cdylib example must
+    /// still resolve through the configured/default artifact rather than
+    /// erroring on the ambiguity -- regresses to the old plain-`cargo
+    /// build` behavior otherwise.
+    #[test]
+    fn expanded_builder_prefers_the_configured_artifact_over_an_ambiguous_ffi_target_set() {
+        let crate_dir = write_multi_ffi_target_fixture();
+        let config = multi_ffi_target_config();
+        let cargo_args = multi_ffi_target_cargo_args(&crate_dir);
+
+        let builder = expanded_builder(&config, false, cargo_args);
+
+        std::fs::remove_dir_all(&crate_dir).expect("cleanup temp dir");
+        assert!(builder.is_ok(), "{:?}", builder.err());
+    }
+
+    #[test]
+    fn wasm_builder_prefers_the_configured_artifact_over_an_ambiguous_ffi_target_set() {
+        let crate_dir = write_multi_ffi_target_fixture();
+        let config = multi_ffi_target_config();
+        let cargo_args = multi_ffi_target_cargo_args(&crate_dir);
+
+        let builder = wasm_builder(&config, false, cargo_args);
+
+        std::fs::remove_dir_all(&crate_dir).expect("cleanup temp dir");
+        assert!(builder.is_ok(), "{:?}", builder.err());
     }
 }

--- a/boltffi_cli/src/pack/dart/mod.rs
+++ b/boltffi_cli/src/pack/dart/mod.rs
@@ -1,7 +1,9 @@
+use boltffi_binding::BindingMetadataSurface;
+
 use crate::{
     build::{
-        BuildOptions, BuildSelection, Builder, CargoBuildProfile, OutputCallback, all_successful,
-        failed_targets, resolve_build_profile,
+        BindingExpansion, BuildOptions, BuildSelection, Builder, CargoBuildProfile, OutputCallback,
+        all_successful, failed_targets, resolve_build_profile,
     },
     cargo::Cargo,
     cli::{CliError, Result},
@@ -26,15 +28,16 @@ fn build_dart_targets(
         None
     };
 
-    let build_options = BuildOptions {
-        release,
-        selection: BuildSelection::Package {
-            package: config.library_name().to_string(),
-            cargo_args: build_cargo_args.to_vec(),
-        },
-        on_output,
-    };
-    let builder = Builder::new(config, build_options);
+    // Cargo only sets CARGO_FEATURE_* for build scripts, so this must build
+    // as a binding expansion for the macros to see active features (same
+    // fix as the Python target's cdylib build).
+    let expansion = BindingExpansion::resolve_for_surface(
+        config,
+        build_cargo_args,
+        BindingMetadataSurface::Native,
+    )?;
+
+    let builder = Builder::new(config, dart_build_options(expansion, release, on_output));
     let results = builder.build_targets(&config.dart_targets())?;
 
     if all_successful(&results) {
@@ -43,6 +46,18 @@ fn build_dart_targets(
 
     let failed = failed_targets(&results);
     Err(CliError::Pack(PackError::BuildFailed { targets: failed }))
+}
+
+fn dart_build_options(
+    expansion: BindingExpansion,
+    release: bool,
+    on_output: Option<OutputCallback>,
+) -> BuildOptions {
+    BuildOptions {
+        release,
+        selection: BuildSelection::Expanded(Box::new(expansion)),
+        on_output,
+    }
 }
 
 pub(crate) fn pack_dart(
@@ -138,4 +153,27 @@ pub(crate) fn pack_dart(
 
     reporter.finish();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BindingExpansion, BuildSelection, dart_build_options};
+
+    /// `pack dart` must build the cdylib as a binding expansion, not a plain
+    /// `cargo build`: the #[data]/#[error] macros read active features from
+    /// BINDING_METADATA_FEATURES_ENV, which only `BuildSelection::Expanded`
+    /// wires up (see `Builder::apply_expansion`). A plain build silently
+    /// drops every #[cfg(feature = ...)]-gated module from the FFI surface.
+    #[test]
+    fn dart_cdylib_builds_as_a_binding_expansion() {
+        let expansion = BindingExpansion::fixture(
+            "/workspace/Cargo.toml",
+            "/workspace/demo/Cargo.toml",
+            ["--features".to_string(), "ffi".to_string()],
+        );
+
+        let options = dart_build_options(expansion, false, None);
+
+        assert!(matches!(options.selection, BuildSelection::Expanded(_)));
+    }
 }

--- a/boltffi_cli/src/pack/dart/mod.rs
+++ b/boltffi_cli/src/pack/dart/mod.rs
@@ -1,5 +1,3 @@
-use boltffi_binding::BindingMetadataSurface;
-
 use crate::{
     build::{
         BindingExpansion, BuildOptions, BuildSelection, Builder, CargoBuildProfile, OutputCallback,
@@ -28,14 +26,7 @@ fn build_dart_targets(
         None
     };
 
-    // Cargo only sets CARGO_FEATURE_* for build scripts, so this must build
-    // as a binding expansion for the macros to see active features (same
-    // fix as the Python target's cdylib build).
-    let expansion = BindingExpansion::resolve_for_surface(
-        config,
-        build_cargo_args,
-        BindingMetadataSurface::Native,
-    )?;
+    let expansion = dart_expansion(config, build_cargo_args)?;
 
     let builder = Builder::new(config, dart_build_options(expansion, release, on_output));
     let results = builder.build_targets(&config.dart_targets())?;
@@ -46,6 +37,15 @@ fn build_dart_targets(
 
     let failed = failed_targets(&results);
     Err(CliError::Pack(PackError::BuildFailed { targets: failed }))
+}
+
+// Cargo only sets CARGO_FEATURE_* for build scripts, so this must build as
+// a binding expansion for the macros to see active features (same fix as
+// the Python target's cdylib build). resolve_preferred (not
+// resolve_for_surface) keeps the configured/default artifact selected
+// even when the package has more than one FFI-capable cargo target.
+fn dart_expansion(config: &Config, build_cargo_args: &[String]) -> Result<BindingExpansion> {
+    BindingExpansion::resolve_preferred(config, build_cargo_args, &config.crate_artifact_name())
 }
 
 fn dart_build_options(
@@ -157,7 +157,16 @@ pub(crate) fn pack_dart(
 
 #[cfg(test)]
 mod tests {
-    use super::{BindingExpansion, BuildSelection, dart_build_options};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::{BindingExpansion, BuildSelection, dart_build_options, dart_expansion};
+    use crate::config::Config;
+
+    fn parse_config(input: &str) -> Config {
+        let parsed: Config = toml::from_str(input).expect("toml parse failed");
+        parsed.validate().expect("config validation failed");
+        parsed
+    }
 
     /// `pack dart` must build the cdylib as a binding expansion, not a plain
     /// `cargo build`: the #[data]/#[error] macros read active features from
@@ -175,5 +184,48 @@ mod tests {
         let options = dart_build_options(expansion, false, None);
 
         assert!(matches!(options.selection, BuildSelection::Expanded(_)));
+    }
+
+    /// A crate whose only other FFI-capable target is a cdylib example must
+    /// still resolve through the configured/default artifact rather than
+    /// erroring on the ambiguity.
+    #[test]
+    fn dart_expansion_prefers_the_configured_artifact_over_an_ambiguous_ffi_target_set() {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let crate_dir = std::env::temp_dir().join(format!(
+            "boltffi-dart-multi-ffi-target-test-{unique_suffix}"
+        ));
+        std::fs::create_dir_all(crate_dir.join("src")).expect("create src dir");
+        std::fs::create_dir_all(crate_dir.join("examples")).expect("create examples dir");
+        std::fs::write(
+            crate_dir.join("Cargo.toml"),
+            "[package]\n\
+             name = \"demo_multi\"\n\
+             version = \"0.1.0\"\n\
+             edition = \"2021\"\n\n\
+             [lib]\n\
+             crate-type = [\"cdylib\", \"rlib\"]\n\n\
+             [[example]]\n\
+             name = \"extra\"\n\
+             crate-type = [\"cdylib\"]\n",
+        )
+        .expect("write Cargo.toml");
+        std::fs::write(crate_dir.join("src/lib.rs"), "").expect("write lib.rs");
+        std::fs::write(crate_dir.join("examples/extra.rs"), "fn main() {}\n")
+            .expect("write example");
+
+        let config = parse_config("[package]\nname = \"demo_multi\"\n");
+        let cargo_args = vec![
+            "--manifest-path".to_string(),
+            crate_dir.join("Cargo.toml").display().to_string(),
+        ];
+
+        let expansion = dart_expansion(&config, &cargo_args);
+
+        std::fs::remove_dir_all(&crate_dir).expect("cleanup temp dir");
+        assert!(expansion.is_ok(), "{:?}", expansion.err());
     }
 }

--- a/boltffi_scan/src/declared_types.rs
+++ b/boltffi_scan/src/declared_types.rs
@@ -164,11 +164,24 @@ impl DeclaredTypes {
         let Some(path) = self.resolve_source_path(scope, path, || spelling::path(path))? else {
             return Ok(SourceType::Unknown);
         };
-        Ok(match self.by_path.get(&path) {
-            Some(declared_type) => SourceType::Declared(declared_type),
-            None if self.source_types.contains_path(&path) => SourceType::Unregistered,
-            None => SourceType::External(path),
-        })
+        if let Some(declared_type) = self.by_path.get(&path) {
+            return Ok(SourceType::Declared(declared_type));
+        }
+        if self.source_types.contains_path(&path) {
+            return Ok(SourceType::Unregistered);
+        }
+        // `path` can itself be a re-export, not a declaration site; chase it
+        // down before giving up as external.
+        if let TypeResolution::Known(declaration_path) = self.source_types.resolve_reexported(&path)
+        {
+            if let Some(declared_type) = self.by_path.get(&declaration_path) {
+                return Ok(SourceType::Declared(declared_type));
+            }
+            if self.source_types.contains_path(&declaration_path) {
+                return Ok(SourceType::Unregistered);
+            }
+        }
+        Ok(SourceType::External(path))
     }
 
     pub(super) fn root_visible_path(
@@ -546,7 +559,10 @@ impl TypeNamespace {
         match scope.expand(path) {
             PathExpansion::Relative(path) => self.resolve_relative(scope, path),
             PathExpansion::Imported { local, path } => self.resolve_imported(scope, &local, path),
-            PathExpansion::Qualified(path) => self.resolve_qualified(path),
+            // Fall back to reexport resolution, same as resolve_public_path:
+            // a qualified path can name a type through its reexport, not
+            // just its declaration site.
+            PathExpansion::Qualified(path) => self.resolve_public_path(path),
             PathExpansion::Ambiguous => TypeResolution::Ambiguous,
             PathExpansion::Unsupported => TypeResolution::Unknown,
         }

--- a/boltffi_scan/src/scan.rs
+++ b/boltffi_scan/src/scan.rs
@@ -770,6 +770,26 @@ mod tests {
     }
 
     #[test]
+    fn qualified_path_resolves_type_reexported_by_name() {
+        let contract = scan(
+            "pub mod model { #[data] pub enum ForeignKind { Guest, Member } } \
+             pub mod session { pub use crate::model::ForeignKind; } \
+             pub mod api { \
+                 #[export] pub fn echo(kind: crate::session::ForeignKind) -> crate::session::ForeignKind { kind } \
+             }",
+        );
+
+        assert_eq!(
+            contract.functions[0].parameters[0].type_expr,
+            enumeration("demo::model::ForeignKind", "crate::session::ForeignKind")
+        );
+        assert_eq!(
+            value_return(&contract.functions[0].returns),
+            &enumeration("demo::model::ForeignKind", "crate::session::ForeignKind")
+        );
+    }
+
+    #[test]
     fn c_style_enum_scan_accepts_borrowed_string_export_return() {
         let contract = scan(
             "#[data] \


### PR DESCRIPTION
## What broke

`820343e7` ("Promote Binding IR generation", [#808](https://github.com/boltffi/boltffi/pull/808)) broke two things for any crate that splits types across modules and/or gates modules behind a Cargo feature.

### 1. Types referenced through a re-export, not their declaration path, fail to scan

```rust
// src/shapes/mod.rs
mod point;
pub use point::*;   // Point is declared in `point`, re-exported here

#[error]
pub enum ShapeError {
    InvalidOrigin { at: crate::shapes::Point },  // via the re-export, not the declaration path
}
```
Fails with `unsupported source type`, even though this compiles fine as plain Rust. `boltffi_scan`'s qualified-path resolution (`crate::`/absolute paths) only matched a type's exact declaration path — never falling back to chase `pub use` re-export chains the way relative-path resolution already did.

### 2. The Dart cdylib build never learns which Cargo features are active

```rust
#[cfg(feature = "a")]
pub mod a;  // silently dropped from the FFI surface
```
`pack dart` built the actual cdylib with a plain `cargo build`. Cargo only exposes `CARGO_FEATURE_*` to build scripts — never to a normal `rustc` invocation — so the `#[data]`/`#[error]` macros saw no active features. `generate dart` was unaffected (it injects the feature list explicitly), which made this easy to miss in the real packaged build.

Same failure mode already fixed for Python in `8bd6ab4a` — this applies the same fix to Dart.

## `boltffi build` had the same bug

`pack dart` wasn't the only place building this way — the standalone `boltffi build` command (`apple`/`android`/`wasm`/`dart`/`all`) used a separate, still-broken `plain_builder` that constructed the exact same plain-`cargo build` selection. Unified both onto one `expanded_builder` helper so there's a single code path left to get this wrong, and removed `BuildSelection::Package`, which had zero callers left once both were fixed.

## Test plan

- `cargo test -p boltffi_scan --lib` and `cargo test -p boltffi_cli --bin boltffi`
- Three new regression tests, each confirmed to fail against the pre-fix code and pass with the fix: `qualified_path_resolves_type_reexported_by_name`, `dart_cdylib_builds_as_a_binding_expansion`, `build_command_uses_a_binding_expansion`
- Verified against a real multi-module, feature-gated crate: both `pack dart` and `boltffi build dart` now succeed end to end where they previously failed