### PR TITLE
fix(wasm): declare async/stream wake callbacks as wasm imports

### DIFF
--- a/boltffi_core/src/runtime/future.rs
+++ b/boltffi_core/src/runtime/future.rs
@@ -20,6 +20,7 @@ pub enum WasmPollStatus {
 }
 
 #[cfg(target_arch = "wasm32")]
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn __boltffi_wake(handle: u32);
 }

--- a/boltffi_core/src/runtime/subscription.rs
+++ b/boltffi_core/src/runtime/subscription.rs
@@ -17,6 +17,7 @@ pub enum StreamPollResult {
 pub type StreamContinuationCallback = extern "C" fn(callback_data: u64, StreamPollResult);
 
 #[cfg(target_arch = "wasm32")]
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn __boltffi_stream_wake(subscription_handle: u32, result: StreamPollResult);
 }


### PR DESCRIPTION
## Summary

Fixes #820.

`__boltffi_wake` and `__boltffi_stream_wake` were the only two bare `unsafe extern "C"` declarations in `boltffi_core` without a `#[link(wasm_import_module = "env")]` attribute — every other generated wasm callback import already carries it (see `boltffi_macros`' callback import codegen). Without it, wasm-ld treats the symbol as a normal undefined reference requiring link-time resolution instead of a host-provided wasm import resolved at instantiation time, so linking failed as soon as a crate exported a stream or an async function.

Adding the attribute these two were missing fixes the link error directly, matching the existing convention already used everywhere else in the crate, instead of working around wasm-ld's default policy from the build tooling side (as #819 did).

This supersedes #819 — same problem, but the fix belongs in `boltffi_core`'s own declarations rather than in `boltffi_cli`'s build invocation, and doesn't need any `RUSTFLAGS`/rustc-argument handling at all. Credit to @jlucaso1 for pointing out `boltffi_core` was the outlier here.

## Test plan
- [x] `cargo test -p boltffi_core --lib`
- [x] `cargo build -p boltffi_core --target wasm32-unknown-unknown`
- [x] `cargo fmt --check`, `cargo clippy --all-targets`
- [x] Verified against a real crate with a fully clean rebuild (`target/` and `dist/wasm/` removed) and no `RUSTFLAGS`/`CARGO_TARGET_*_RUSTFLAGS` set anywhere: `boltffi pack wasm` succeeds