### PR TITLE
test(wasm): run the wasm link on stable, where the flag is gone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,31 @@ jobs:
           prefix-key: v1-rust
       - run: cargo test --workspace --all-features
 
+  wasm-link-stable:
+    name: WASM link (stable)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # caching handled by Swatinem/rust-cache below
+          cache: false
+          toolchain: stable
+          target: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-bin: false
+          prefix-key: v1-rust-stable
+      # `rust-toolchain.toml` pins 1.95.0, and only the environment variable
+      # outranks it. The pin is what hides wasm link regressions: rustc stopped
+      # passing `--allow-undefined` on a wasm cdylib link between 1.95 and 1.97,
+      # so a host import left undeclared resolves there and fails for everyone
+      # building on current stable.
+      - run: cargo test -p boltffi_cli --test wasm_wake_link
+        env:
+          RUSTUP_TOOLCHAIN: stable
+
   build:
     name: Build
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [workspace]
 resolver = "3"
 members = ["boltffi", "boltffi_core", "boltffi_macros", "boltffi_bindgen", "boltffi_cli", "boltffi_ast", "boltffi_binding", "boltffi_backend", "boltffi_scan", "boltffi_verify", "boltffi_tests"]
-exclude = ["benchmarks/adapters/uniffi", "examples/demo"]
+exclude = [
+  "benchmarks/adapters/uniffi",
+  "examples/demo",
+  "boltffi_cli/tests/fixtures/wasm_wake_link",
+]
 
 [workspace.package]
 version = "0.29.3"

--- a/boltffi_cli/tests/fixtures/wasm_wake_link/Cargo.toml
+++ b/boltffi_cli/tests/fixtures/wasm_wake_link/Cargo.toml
@@ -1,0 +1,14 @@
+# Its own workspace: the repository root must not adopt a fixture as a member.
+[package]
+name = "wasm_wake_link_fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+boltffi = { path = "../../../../boltffi", default-features = false }
+
+[workspace]

--- a/boltffi_cli/tests/fixtures/wasm_wake_link/boltffi.toml
+++ b/boltffi_cli/tests/fixtures/wasm_wake_link/boltffi.toml
@@ -1,0 +1,5 @@
+[package]
+name = "wasm_wake_link_fixture"
+
+[targets.wasm]
+enabled = true

--- a/boltffi_cli/tests/fixtures/wasm_wake_link/src/lib.rs
+++ b/boltffi_cli/tests/fixtures/wasm_wake_link/src/lib.rs
@@ -1,0 +1,13 @@
+//! One async export is all it takes.
+//!
+//! Awaiting across the boundary reaches `boltffi_core`'s wasm waker, which
+//! calls `__boltffi_wake`. That function is provided by the host at
+//! instantiation, so it has to be declared as a wasm import; otherwise the
+//! linker looks for a definition and does not find one.
+
+use boltffi::export;
+
+#[export]
+pub async fn answer() -> u32 {
+    42
+}

--- a/boltffi_cli/tests/wasm_wake_link.rs
+++ b/boltffi_cli/tests/wasm_wake_link.rs
@@ -1,0 +1,49 @@
+//! A wasm build has to link once a crate exports anything async.
+//!
+//! `boltffi_core` declares `__boltffi_wake` and `__boltffi_stream_wake` as
+//! `extern "C"`. The host supplies them at instantiation, so they have to be
+//! declared as wasm imports; left bare, the linker looks for a definition and
+//! does not find one.
+//!
+//! This is only observable on a toolchain that does not pass
+//! `--allow-undefined` on a wasm cdylib link, which rustc stopped doing
+//! between 1.95 and 1.97. `rust-toolchain.toml` pins 1.95.0, so running this
+//! the ordinary way proves nothing; CI runs it again under `stable`, where the
+//! flag is gone and an undeclared import is a hard error.
+//!
+//! It is also why `examples/demo` never caught this. It exports async and
+//! streams and is packed for wasm in CI, but at the pinned toolchain.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn fixture() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/wasm_wake_link")
+}
+
+#[test]
+fn a_crate_exporting_an_async_function_links_for_wasm() {
+    let output = Command::new(env!("CARGO_BIN_EXE_boltffi"))
+        .args(["build", "wasm"])
+        .current_dir(fixture())
+        // Keeps the fixture's artifacts out of the repository, and off the
+        // package lock this test already holds.
+        .env("CARGO_TARGET_DIR", env!("CARGO_TARGET_TMPDIR"))
+        .output()
+        .expect("the boltffi binary runs");
+
+    assert!(
+        output.status.success(),
+        "`boltffi build wasm` failed for a crate whose only export is an async \
+         function.\n\n\
+         If the linker names `__boltffi_wake` or `__boltffi_stream_wake`, their \
+         declarations in `boltffi_core` are missing \
+         `#[link(wasm_import_module = \"env\")]`, the attribute the generated \
+         callback imports already carry. `build` does not forward the linker's \
+         message; run `boltffi -vv pack wasm` in {} to read it.\n\n\
+         --- stdout ---\n{}\n--- stderr ---\n{}",
+        fixture().display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}


### PR DESCRIPTION
Rebased on `main` now that #821 has merged, so this is green. It was red before, which is what it was for.

## Why CI missed the bug #821 fixed

`rust-toolchain.toml` pins `1.95.0`, and rustc stopped passing `--allow-undefined` on a wasm cdylib link between 1.95 and 1.97. At the pinned toolchain an undeclared host import still resolves, so the missing `#[link(wasm_import_module = "env")]` was invisible here while anyone on current stable hit it.

Same crate, only the toolchain changes:

```rust
// src/lib.rs, crate-type = ["cdylib"]
#[export]
pub async fn answer() -> u32 { 42 }
```

```
RUSTUP_TOOLCHAIN=1.95.0  boltffi build wasm   # Built 1/1 targets successfully
RUSTUP_TOOLCHAIN=1.97.1  boltffi build wasm   # undefined symbol: __boltffi_wake
```

Run that outside the repository, otherwise `rust-toolchain.toml` wins and both pass.

It is also why `examples/demo` never caught this. It exports async and streams and is packed for wasm in CI, but at the pinned toolchain.

## What this adds

A fixture whose only export is one async function, which is enough to reach the waker, and a test that builds it through `boltffi build wasm`.

The test passes at the pinned toolchain, so `cargo test --workspace` is unaffected. A new job runs the same test with `RUSTUP_TOOLCHAIN=stable`, the only source that outranks `rust-toolchain.toml`, where the flag is gone and an undeclared import is a hard error.

`build` does not forward the linker's message, so the assertion says what to look for and how to see it.

Checked that it still bites: dropping the attribute #821 added turns the stable job red again, and restoring it turns it green.

## Scope

This guards one class of thing: wasm links that only fail on a toolchain newer than the pin. The pin itself is worth a separate conversation, since it is roughly two years of rustc behaviour that this repository does not exercise, and this bug is one instance of what that hides.

I have not touched the pin here.
