### PR TITLE
feat(typescript): support cancelling in-flight async calls via AbortSignal

### DIFF
--- a/boltffi_backend/src/target/typescript/mod.rs
+++ b/boltffi_backend/src/target/typescript/mod.rs
@@ -1276,8 +1276,13 @@ mod tests {
             .expect("browser module");
 
         assert!(browser.contents().contains(
-            "export async function asyncAdd(left: number, right: number): Promise<number>"
+            "export async function asyncAdd(left: number, right: number, options?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<number>"
         ));
+        assert!(
+            browser
+                .contents()
+                .contains("const __boltffiSignal = options?.signal;")
+        );
         assert!(
             browser
                 .contents()
@@ -1287,18 +1292,30 @@ mod tests {
         assert!(
             browser
                 .contents()
-                .contains("export async function asyncName(value: string): Promise<string>")
+                .contains("if (__boltffiSignal?.aborted) throw new BoltFFICancelledError();")
         );
-        assert!(browser.contents().contains("_module.takePackedUtf8String("));
-        assert!(browser.contents().contains(
-            "export async function asyncValues(value: readonly number[] | Int32Array): Promise<Int32Array>"
-        ));
-        assert!(browser.contents().contains("_module.takeSlotI32Array()"));
+        assert!(browser.contents().contains("__boltffiHandle) =>"));
         assert!(
             browser
                 .contents()
-                .contains("export async function asyncSize(): Promise<number>")
+                .contains(", __boltffiSignal, __boltffiCancelId)")
         );
+        assert!(
+            browser
+                .contents()
+                .contains("import { BoltFFICancelledError,")
+        );
+        assert!(browser.contents().contains(
+            "export async function asyncName(value: string, options?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<string>"
+        ));
+        assert!(browser.contents().contains("_module.takePackedUtf8String("));
+        assert!(browser.contents().contains(
+            "export async function asyncValues(value: readonly number[] | Int32Array, options?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<Int32Array>"
+        ));
+        assert!(browser.contents().contains("_module.takeSlotI32Array()"));
+        assert!(browser.contents().contains(
+            "export async function asyncSize(options?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<number>"
+        ));
         assert!(
             !browser
                 .contents()
@@ -1314,13 +1331,115 @@ mod tests {
                 "AsyncPointCodec.decode(_module.readerFromWriter(__boltffiReturnWriter))"
             )
         );
-        assert!(browser.contents().contains("async get(): Promise<number>"));
+        assert!(browser.contents().contains(
+            "async get(options?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<number>"
+        ));
+        assert!(browser.contents().contains(
+            "async duplicate(options?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<Worker>"
+        ));
+        assert!(browser.contents().contains("Worker._fromHandle("));
+    }
+
+    #[test]
+    fn checks_an_aborted_signal_before_any_parameter_setup_runs() {
+        // A `String` parameter's setup allocates ownership Rust will take on
+        // the native call -- if the pre-abort check ran after that setup
+        // instead of before it, an already-aborted call would leak the
+        // allocation with no cleanup path.
+        let output = TypeScriptHost::new("demo")
+            .expect("host constructs")
+            .into_target()
+            .render(&async_bindings())
+            .expect("target renders");
+        let browser = output
+            .files()
+            .iter()
+            .find(|file| file.path().as_path().ends_with("demo.ts"))
+            .expect("browser module");
+        let source = browser.contents();
+
+        let abort_check = source
+            .find("if (__boltffiSignal?.aborted) throw new BoltFFICancelledError();")
+            .expect("pre-abort check present");
+        let param_setup = source
+            .find("_module.allocOwnedString(value)")
+            .expect("string parameter setup present");
+        assert!(
+            abort_check < param_setup,
+            "pre-abort check must run before parameter setup:\n{source}"
+        );
+    }
+
+    #[test]
+    fn appends_an_internal_options_name_when_the_callable_already_has_one() {
+        let output = TypeScriptHost::new("demo")
+            .expect("host constructs")
+            .into_target()
+            .render(&async_bindings_with_options_param())
+            .expect("target renders");
+        let browser = output
+            .files()
+            .iter()
+            .find(|file| file.path().as_path().ends_with("demo.ts"))
+            .expect("browser module");
+
+        assert!(browser.contents().contains(
+            "export async function asyncEcho(options: string, __boltffiOptions?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<string>"
+        ));
         assert!(
             browser
                 .contents()
-                .contains("async duplicate(): Promise<Worker>")
+                .contains("const __boltffiSignal = __boltffiOptions?.signal;")
         );
-        assert!(browser.contents().contains("Worker._fromHandle("));
+    }
+
+    fn async_bindings_with_options_param() -> Bindings<Wasm32> {
+        let source = boltffi_scan::scan_file(
+            syn::parse_str(
+                r#"
+                #[export]
+                pub async fn async_echo(options: String) -> String { options }
+                "#,
+            )
+            .expect("valid source"),
+            PackageInfo::new("demo", None),
+        )
+        .expect("source scans");
+        lower::<Wasm32>(&source).expect("source lowers")
+    }
+
+    #[test]
+    fn falls_back_to_a_double_underscore_options_name_when_the_plain_fallback_also_collides() {
+        // A callable declaring both `options` and `boltffi_options` would
+        // make a plain `boltffiOptions` fallback collide too -- the
+        // generated name must stay collision-free either way.
+        let source = boltffi_scan::scan_file(
+            syn::parse_str(
+                r#"
+                #[export]
+                pub async fn async_echo(options: String, boltffi_options: String) -> String {
+                    format!("{options}{boltffi_options}")
+                }
+                "#,
+            )
+            .expect("valid source"),
+            PackageInfo::new("demo", None),
+        )
+        .expect("source scans");
+        let output = TypeScriptHost::new("demo")
+            .expect("host constructs")
+            .into_target()
+            .render(&lower::<Wasm32>(&source).expect("source lowers"))
+            .expect("target renders");
+        let browser = output
+            .files()
+            .iter()
+            .find(|file| file.path().as_path().ends_with("demo.ts"))
+            .expect("browser module");
+
+        assert!(browser.contents().contains(
+            "export async function asyncEcho(options: string, boltffiOptions: string, __boltffiOptions?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<string>"
+        ));
     }
 
     #[test]

--- a/boltffi_backend/src/target/typescript/mod.rs
+++ b/boltffi_backend/src/target/typescript/mod.rs
@@ -1276,12 +1276,17 @@ mod tests {
             .expect("browser module");
 
         assert!(browser.contents().contains(
-            "export async function asyncAdd(left: number, right: number, options?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<number>"
+            "export async function asyncAdd(left: number, right: number, options?: { signal?: AbortSignal; cancelId?: number }): Promise<number>"
         ));
         assert!(
             browser
                 .contents()
                 .contains("const __boltffiSignal = options?.signal;")
+        );
+        assert!(
+            browser
+                .contents()
+                .contains("const __boltffiCancelId = options?.cancelId;")
         );
         assert!(
             browser
@@ -1306,15 +1311,15 @@ mod tests {
                 .contains("import { BoltFFICancelledError,")
         );
         assert!(browser.contents().contains(
-            "export async function asyncName(value: string, options?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<string>"
+            "export async function asyncName(value: string, options?: { signal?: AbortSignal; cancelId?: number }): Promise<string>"
         ));
         assert!(browser.contents().contains("_module.takePackedUtf8String("));
         assert!(browser.contents().contains(
-            "export async function asyncValues(value: readonly number[] | Int32Array, options?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<Int32Array>"
+            "export async function asyncValues(value: readonly number[] | Int32Array, options?: { signal?: AbortSignal; cancelId?: number }): Promise<Int32Array>"
         ));
         assert!(browser.contents().contains("_module.takeSlotI32Array()"));
         assert!(browser.contents().contains(
-            "export async function asyncSize(options?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<number>"
+            "export async function asyncSize(options?: { signal?: AbortSignal; cancelId?: number }): Promise<number>"
         ));
         assert!(
             !browser
@@ -1332,10 +1337,10 @@ mod tests {
             )
         );
         assert!(browser.contents().contains(
-            "async get(options?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<number>"
+            "async get(options?: { signal?: AbortSignal; cancelId?: number }): Promise<number>"
         ));
         assert!(browser.contents().contains(
-            "async duplicate(options?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<Worker>"
+            "async duplicate(options?: { signal?: AbortSignal; cancelId?: number }): Promise<Worker>"
         ));
         assert!(browser.contents().contains("Worker._fromHandle("));
     }
@@ -1384,12 +1389,17 @@ mod tests {
             .expect("browser module");
 
         assert!(browser.contents().contains(
-            "export async function asyncEcho(options: string, __boltffiOptions?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<string>"
+            "export async function asyncEcho(options: string, __boltffiOptions?: { signal?: AbortSignal; cancelId?: number }): Promise<string>"
         ));
         assert!(
             browser
                 .contents()
                 .contains("const __boltffiSignal = __boltffiOptions?.signal;")
+        );
+        assert!(
+            browser
+                .contents()
+                .contains("const __boltffiCancelId = __boltffiOptions?.cancelId;")
         );
     }
 
@@ -1438,7 +1448,7 @@ mod tests {
             .expect("browser module");
 
         assert!(browser.contents().contains(
-            "export async function asyncEcho(options: string, boltffiOptions: string, __boltffiOptions?: { signal?: AbortSignal }, __boltffiCancelId?: number): Promise<string>"
+            "export async function asyncEcho(options: string, boltffiOptions: string, __boltffiOptions?: { signal?: AbortSignal; cancelId?: number }): Promise<string>"
         ));
     }
 

--- a/boltffi_backend/src/target/typescript/render/function.rs
+++ b/boltffi_backend/src/target/typescript/render/function.rs
@@ -29,6 +29,7 @@ pub struct Function {
     returns: TypeName,
     body: Vec<Statement>,
     asynchronous: bool,
+    async_options: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -48,6 +49,13 @@ struct Return {
     arguments: Vec<Expression>,
     cleanup: Vec<Statement>,
     success: Vec<Statement>,
+}
+
+// `pre_setup` must run before parameter setup, so an already-aborted call
+// bails out before transferring anything to Rust with no cleanup path.
+struct AsyncCall {
+    pre_setup: Vec<Statement>,
+    body: Vec<Statement>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -256,6 +264,7 @@ impl Function {
             body: &'function [Statement],
             static_method: bool,
             asynchronous: bool,
+            async_options: &'function Option<String>,
         }
 
         Ok(MethodDeclaration::new(
@@ -266,6 +275,7 @@ impl Function {
                 body: &self.body,
                 static_method,
                 asynchronous: self.asynchronous,
+                async_options: &self.async_options,
             }
             .render()?,
         ))
@@ -392,6 +402,7 @@ impl Function {
             returns: &'function TypeName,
             body: &'function [Statement],
             asynchronous: bool,
+            async_options: &'function Option<String>,
         }
 
         Ok(MethodDeclaration::new(
@@ -401,6 +412,7 @@ impl Function {
                 returns: &self.returns,
                 body: &self.body,
                 asynchronous: self.asynchronous,
+                async_options: &self.async_options,
             }
             .render()?,
         ))
@@ -516,7 +528,14 @@ impl Function {
             .iter()
             .flat_map(|parameter| parameter.cleanup.iter().cloned())
             .collect::<Vec<_>>();
-        let (call, asynchronous) = match callable.execution() {
+        // A `__boltffi`-prefixed fallback avoids colliding with a real
+        // `options` parameter, or with a plain `boltffiOptions` fallback
+        // colliding with a declared `boltffi_options`.
+        let options_name = match parameters.iter().any(|p| p.name.to_string() == "options") {
+            true => Identifier::known("__boltffiOptions"),
+            false => Identifier::known("options"),
+        };
+        let (pre_setup, call, asynchronous, async_options) = match callable.execution() {
             ExecutionDecl::Synchronous(_) => {
                 let arguments = arguments
                     .into_iter()
@@ -539,7 +558,7 @@ impl Function {
                         false => vec![Statement::try_finally(call, returns.cleanup.clone())],
                     })
                     .collect();
-                (call, false)
+                (Vec::new(), call, false, None)
             }
             ExecutionDecl::Asynchronous(protocol) => {
                 if receiver
@@ -548,13 +567,19 @@ impl Function {
                 {
                     return Err(Self::unsupported("asynchronous mutable receiver"));
                 }
+                let async_call = returns.render_async(
+                    Expression::native_call(symbol, arguments),
+                    protocol,
+                    &failure,
+                    &options_name,
+                )?;
                 (
-                    returns.render_async(
-                        Expression::native_call(symbol, arguments),
-                        protocol,
-                        &failure,
-                    )?,
+                    async_call.pre_setup,
+                    async_call.body,
                     true,
+                    Some(format!(
+                        "{options_name}?: {{ signal?: AbortSignal }}, __boltffiCancelId?: number"
+                    )),
                 )
             }
             _ => return Err(Self::unsupported("unknown execution protocol")),
@@ -563,7 +588,9 @@ impl Function {
             .as_ref()
             .into_iter()
             .flat_map(|receiver| receiver.setup.iter().cloned());
-        let body = receiver_setup
+        let body = pre_setup
+            .into_iter()
+            .chain(receiver_setup)
             .chain(parameter_setup)
             .chain(match parameter_cleanup.is_empty() {
                 true => call,
@@ -583,6 +610,7 @@ impl Function {
             returns: return_type,
             body,
             asynchronous,
+            async_options,
         })
     }
 
@@ -1434,14 +1462,15 @@ impl Return {
         start: Expression,
         protocol: &wasm32::AsyncProtocol,
         failure: &Failure,
-    ) -> Result<Vec<Statement>> {
+        options_name: &Identifier,
+    ) -> Result<AsyncCall> {
         let wasm32::AsyncProtocol::PollHandle {
             handle,
             poll_sync,
             complete,
+            cancel,
             free,
             panic_message,
-            ..
         } = protocol
         else {
             return Err(Function::unsupported("unknown asynchronous protocol"));
@@ -1453,7 +1482,7 @@ impl Return {
         let awaited = Identifier::known("__boltffiAwaitedFuture");
         let callback_handle = Identifier::known("__boltffiHandle");
         let callback_value = Expression::identifier(callback_handle.clone());
-        let lifecycle = [poll_sync, panic_message, free]
+        let lifecycle = [poll_sync, panic_message, free, cancel]
             .into_iter()
             .map(|symbol| {
                 Ok(Expression::parameter_lambda(
@@ -1467,6 +1496,30 @@ impl Return {
                 ))
             })
             .collect::<Result<Vec<_>>>()?;
+        let signal = Identifier::known("__boltffiSignal");
+        // A separate trailing parameter, not nested in `options`, for
+        // callers that can pass a bare number but not build a JS object
+        // cheaply. `signal` stays the only mechanism idiomatic callers see.
+        let cancel_id = Identifier::known("__boltffiCancelId");
+        // Reading off a plain optional options parameter, rather than
+        // destructuring it in the signature, avoids allocating a fresh `{}`
+        // on every call that omits it.
+        let signal_binding = Statement::constant(
+            signal.clone(),
+            Expression::optional_property(
+                Expression::identifier(options_name.clone()),
+                Identifier::known("signal"),
+            ),
+        );
+        // Runs before parameter setup, matching `fetch()`: an already-
+        // aborted signal rejects immediately, before anything is allocated.
+        let signal_check = Statement::throw_when(
+            Expression::optional_property(
+                Expression::identifier(signal.clone()),
+                Identifier::known("aborted"),
+            ),
+            Expression::construct("BoltFFICancelledError", ArgumentList::default()),
+        );
         let poll = Expression::call(
             Expression::property(
                 Expression::identifier(Identifier::known("_module")),
@@ -1475,6 +1528,10 @@ impl Return {
             Identifier::known("pollAsync"),
             std::iter::once(Expression::identifier(future.clone()))
                 .chain(lifecycle)
+                .chain([
+                    Expression::identifier(signal),
+                    Expression::identifier(cancel_id),
+                ])
                 .collect::<ArgumentList>(),
         )
         .await_value();
@@ -1490,11 +1547,14 @@ impl Return {
                 .into_iter()
                 .collect::<ArgumentList>(),
         ));
-        Ok(vec![
-            Statement::constant(future, start),
-            Statement::constant(awaited, poll),
-            Statement::try_finally(completion, vec![release]),
-        ])
+        Ok(AsyncCall {
+            pre_setup: vec![signal_binding, signal_check],
+            body: vec![
+                Statement::constant(future, start),
+                Statement::constant(awaited, poll),
+                Statement::try_finally(completion, vec![release]),
+            ],
+        })
     }
 
     fn render_async_completion(

--- a/boltffi_backend/src/target/typescript/render/function.rs
+++ b/boltffi_backend/src/target/typescript/render/function.rs
@@ -578,7 +578,7 @@ impl Function {
                     async_call.body,
                     true,
                     Some(format!(
-                        "{options_name}?: {{ signal?: AbortSignal }}, __boltffiCancelId?: number"
+                        "{options_name}?: {{ signal?: AbortSignal; cancelId?: number }}"
                     )),
                 )
             }
@@ -1497,9 +1497,10 @@ impl Return {
             })
             .collect::<Result<Vec<_>>>()?;
         let signal = Identifier::known("__boltffiSignal");
-        // A separate trailing parameter, not nested in `options`, for
-        // callers that can pass a bare number but not build a JS object
-        // cheaply. `signal` stays the only mechanism idiomatic callers see.
+        // Nested in `options` next to `signal` so every async export keeps a
+        // single optional bag -- no trailing public parameter. Callers that
+        // can only pass a bare int (dart-web / KMP) still allocate only when
+        // they actually request cancellation via `{ cancelId }`.
         let cancel_id = Identifier::known("__boltffiCancelId");
         // Reading off a plain optional options parameter, rather than
         // destructuring it in the signature, avoids allocating a fresh `{}`
@@ -1509,6 +1510,13 @@ impl Return {
             Expression::optional_property(
                 Expression::identifier(options_name.clone()),
                 Identifier::known("signal"),
+            ),
+        );
+        let cancel_id_binding = Statement::constant(
+            cancel_id.clone(),
+            Expression::optional_property(
+                Expression::identifier(options_name.clone()),
+                Identifier::known("cancelId"),
             ),
         );
         // Runs before parameter setup, matching `fetch()`: an already-
@@ -1548,7 +1556,7 @@ impl Return {
                 .collect::<ArgumentList>(),
         ));
         Ok(AsyncCall {
-            pre_setup: vec![signal_binding, signal_check],
+            pre_setup: vec![signal_binding, cancel_id_binding, signal_check],
             body: vec![
                 Statement::constant(future, start),
                 Statement::constant(awaited, poll),

--- a/boltffi_backend/src/target/typescript/syntax/expression.rs
+++ b/boltffi_backend/src/target/typescript/syntax/expression.rs
@@ -117,6 +117,12 @@ impl Expression {
         Self(format!("{receiver}.{property}"))
     }
 
+    /// Same as [`Self::property`], but short-circuits to `undefined`
+    /// instead of throwing when `receiver` is itself `null`/`undefined`.
+    pub fn optional_property(receiver: Self, property: Identifier) -> Self {
+        Self(format!("{receiver}?.{property}"))
+    }
+
     pub fn static_call(ty: impl fmt::Display, method: Identifier, arguments: ArgumentList) -> Self {
         Self(format!("{ty}.{method}({arguments})"))
     }

--- a/boltffi_backend/templates/target/typescript/browser.ts
+++ b/boltffi_backend/templates/target/typescript/browser.ts
@@ -1,4 +1,4 @@
-import { BoltFFIHandle, BoltFFIModule, CallbackRegistry, StreamCancellable, StreamSession, WASM_ABI_VERSION, instantiateBoltFFI, matchWireResult, utf8ByteCount, wireArraySize, wireMapSize, wireOptionalSize, wireResultSize, wireStringSize, writeUnexpectedCallbackError } from {{ runtime_package }};
+import { BoltFFICancelledError, BoltFFIHandle, BoltFFIModule, CallbackRegistry, StreamCancellable, StreamSession, WASM_ABI_VERSION, instantiateBoltFFI, matchWireResult, utf8ByteCount, wireArraySize, wireMapSize, wireOptionalSize, wireResultSize, wireStringSize, writeUnexpectedCallbackError } from {{ runtime_package }};
 import type { BoltFFIExports, Duration, WireCodec, WireResult } from {{ runtime_package }};
 
 let _module: BoltFFIModule;
@@ -14,4 +14,9 @@ export default async function init(source: BufferSource | Response | WebAssembly
   _module = await instantiateBoltFFI(source, WASM_ABI_VERSION, { env: _callbackImports });
   _exports = _module.exports;
 {{ constant_initializers }}
+}
+
+// Lower-level counterpart to `options.signal` -- see AsyncFutureManager.cancelById.
+export function __boltffiCancelById(callId: number): void {
+  _module.asyncManager.cancelById(callId);
 }

--- a/boltffi_backend/templates/target/typescript/browser.ts
+++ b/boltffi_backend/templates/target/typescript/browser.ts
@@ -16,7 +16,8 @@ export default async function init(source: BufferSource | Response | WebAssembly
 {{ constant_initializers }}
 }
 
-// Lower-level counterpart to `options.signal` -- see AsyncFutureManager.cancelById.
+// Lower-level counterpart to `options.signal` / `options.cancelId`.
+// `callId` must be unique among in-flight calls -- see AsyncFutureManager.cancelById.
 export function __boltffiCancelById(callId: number): void {
   _module.asyncManager.cancelById(callId);
 }

--- a/boltffi_backend/templates/target/typescript/class_method.ts
+++ b/boltffi_backend/templates/target/typescript/class_method.ts
@@ -1,3 +1,3 @@
-{% if static_method %}static {% endif %}{% if asynchronous %}async {% endif %}{{ name }}({% for parameter in parameters %}{{ parameter.name }}: {{ parameter.ty }}{% if !loop.last %}, {% endif %}{% endfor %}): {% if asynchronous %}Promise<{{ returns }}>{% else %}{{ returns }}{% endif %} {
+{% if static_method %}static {% endif %}{% if asynchronous %}async {% endif %}{{ name }}({% for parameter in parameters %}{{ parameter.name }}: {{ parameter.ty }}{% if !loop.last %}, {% endif %}{% endfor %}{% if let Some(options) = async_options %}{% if !parameters.is_empty() %}, {% endif %}{{ options }}{% endif %}): {% if asynchronous %}Promise<{{ returns }}>{% else %}{{ returns }}{% endif %} {
 {% for statement in body %}  {{ statement }}
 {% endfor %}}

--- a/boltffi_backend/templates/target/typescript/function.ts
+++ b/boltffi_backend/templates/target/typescript/function.ts
@@ -1,6 +1,6 @@
 
 
-export {% if asynchronous %}async {% endif %}function {{ name }}({% for parameter in parameters %}{{ parameter.name }}: {{ parameter.ty }}{% if !loop.last %}, {% endif %}{% endfor %}): {% if asynchronous %}Promise<{{ returns }}>{% else %}{{ returns }}{% endif %} {
+export {% if asynchronous %}async {% endif %}function {{ name }}({% for parameter in parameters %}{{ parameter.name }}: {{ parameter.ty }}{% if !loop.last %}, {% endif %}{% endfor %}{% if let Some(options) = async_options %}{% if !parameters.is_empty() %}, {% endif %}{{ options }}{% endif %}): {% if asynchronous %}Promise<{{ returns }}>{% else %}{{ returns }}{% endif %} {
 {% for statement in body %}  {{ statement }}
 {% endfor %}
 }

--- a/boltffi_backend/templates/target/typescript/method.ts
+++ b/boltffi_backend/templates/target/typescript/method.ts
@@ -1,3 +1,3 @@
-{% if asynchronous %}async {% endif %}{{ name }}({% for parameter in parameters %}{{ parameter.name }}: {{ parameter.ty }}{% if !loop.last %}, {% endif %}{% endfor %}): {% if asynchronous %}Promise<{{ returns }}>{% else %}{{ returns }}{% endif %} {
+{% if asynchronous %}async {% endif %}{{ name }}({% for parameter in parameters %}{{ parameter.name }}: {{ parameter.ty }}{% if !loop.last %}, {% endif %}{% endfor %}{% if let Some(options) = async_options %}{% if !parameters.is_empty() %}, {% endif %}{{ options }}{% endif %}): {% if asynchronous %}Promise<{{ returns }}>{% else %}{{ returns }}{% endif %} {
 {% for statement in body %}  {{ statement }}
 {% endfor %}},

--- a/boltffi_backend/templates/target/typescript/node.ts
+++ b/boltffi_backend/templates/target/typescript/node.ts
@@ -1,4 +1,4 @@
-import { BoltFFIHandle, BoltFFIModule, CallbackRegistry, StreamCancellable, StreamSession, WASM_ABI_VERSION, instantiateBoltFFISync, matchWireResult, utf8ByteCount, wireArraySize, wireMapSize, wireOptionalSize, wireResultSize, wireStringSize, writeUnexpectedCallbackError } from {{ runtime_package }};
+import { BoltFFICancelledError, BoltFFIHandle, BoltFFIModule, CallbackRegistry, StreamCancellable, StreamSession, WASM_ABI_VERSION, instantiateBoltFFISync, matchWireResult, utf8ByteCount, wireArraySize, wireMapSize, wireOptionalSize, wireResultSize, wireStringSize, writeUnexpectedCallbackError } from {{ runtime_package }};
 import type { BoltFFIExports, Duration, WireCodec, WireResult } from {{ runtime_package }};
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";

--- a/boltffi_backend/templates/target/typescript/node_init.ts
+++ b/boltffi_backend/templates/target/typescript/node_init.ts
@@ -7,3 +7,8 @@ const _exports: BoltFFIExports = _module.exports;
 
 export const initialized = Promise.resolve();
 export default function init(): Promise<void> { return initialized; }
+
+// Lower-level counterpart to `options.signal` -- see AsyncFutureManager.cancelById.
+export function __boltffiCancelById(callId: number): void {
+  _module.asyncManager.cancelById(callId);
+}

--- a/boltffi_backend/templates/target/typescript/node_init.ts
+++ b/boltffi_backend/templates/target/typescript/node_init.ts
@@ -8,7 +8,8 @@ const _exports: BoltFFIExports = _module.exports;
 export const initialized = Promise.resolve();
 export default function init(): Promise<void> { return initialized; }
 
-// Lower-level counterpart to `options.signal` -- see AsyncFutureManager.cancelById.
+// Lower-level counterpart to `options.signal` / `options.cancelId`.
+// `callId` must be unique among in-flight calls -- see AsyncFutureManager.cancelById.
 export function __boltffiCancelById(callId: number): void {
   _module.asyncManager.cancelById(callId);
 }

--- a/examples/demo/src/classes/async_methods.rs
+++ b/examples/demo/src/classes/async_methods.rs
@@ -1,4 +1,25 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
 use boltffi::*;
+
+// Self-rewaking rather than a real timer/thread: wasm32 has neither.
+struct Yield(u32);
+
+impl Future for Yield {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.0 == 0 {
+            Poll::Ready(())
+        } else {
+            self.0 -= 1;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
 
 pub struct AsyncWorker {
     prefix: String,
@@ -39,5 +60,10 @@ impl AsyncWorker {
             .into_iter()
             .map(|input| format!("{}: {}", self.prefix, input))
             .collect()
+    }
+
+    pub async fn process_after_polls(&self, input: String, polls: u32) -> String {
+        Yield(polls).await;
+        format!("{}: {}", self.prefix, input)
     }
 }

--- a/examples/platforms/apple/Tests/DemoConsumerTests/classes/AsyncMethodsTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/classes/AsyncMethodsTests.swift
@@ -16,6 +16,8 @@ final class AsyncMethodsTests: DemoTestCase {
         XCTAssertNil(missingItem)
         let processedBatch = try await worker.processBatch(inputs: ["x", "y"])
         XCTAssertEqual(processedBatch, ["test: x", "test: y"])
+        let processedAfterPolls = try await worker.processAfterPolls(input: "data", polls: 5)
+        XCTAssertEqual(processedAfterPolls, "test: data")
     }
 }
 

--- a/examples/platforms/wasm/tests/classes/async_methods.test.mjs
+++ b/examples/platforms/wasm/tests/classes/async_methods.test.mjs
@@ -9,5 +9,36 @@ export async function run() {
   assert.equal(await worker.findItem(42), "test_42");
   assert.equal(await worker.findItem(-1), null);
   assertArrayEqual(await worker.processBatch(["x", "y"]), ["test: x", "test: y"]);
+  // Unlike every other method here, this one genuinely suspends across
+  // several polls instead of resolving on the first one -- real regression
+  // coverage for a genuine Pending/wake/re-poll cycle on an async class
+  // method.
+  assert.equal(await worker.processAfterPolls("data", 50), "test: data");
+
+  await assertPreAbortedSignalRejectsImmediately(worker);
+  await assertMidFlightCancelRejects(worker);
+  assert.equal(
+    await worker.process("still works", { signal: new AbortController().signal }),
+    "test: still works"
+  );
+
   worker.dispose();
+}
+
+async function assertPreAbortedSignalRejectsImmediately(worker) {
+  const controller = new AbortController();
+  controller.abort();
+  await assertRejectsWithMessage(
+    () => worker.processAfterPolls("never-seen", 5, { signal: controller.signal }),
+    "cancelled"
+  );
+}
+
+async function assertMidFlightCancelRejects(worker) {
+  const controller = new AbortController();
+  const pending = worker.processAfterPolls("never-seen", 1_000_000, {
+    signal: controller.signal,
+  });
+  controller.abort();
+  await assertRejectsWithMessage(() => pending, "cancelled");
 }

--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -70,10 +70,12 @@ interface PendingFuture {
   pollSync: (handle: number) => number;
   panicMessage: (handle: number) => number;
   free: (handle: number) => void;
+  cancel: (handle: number) => void;
 }
 
 export class AsyncFutureManager {
   private pendingFutures = new Map<number, PendingFuture>();
+  private cancelIds = new Map<number, number>();
   private wokenHandles = new Set<number>();
   private drainScheduled = false;
   private _module: BoltFFIModule | null = null;
@@ -115,6 +117,25 @@ export class AsyncFutureManager {
     }
   }
 
+  // Cancelling only marks the future's state, so this forces a repoll --
+  // deferred rather than immediate, since `cancel` can fire synchronously
+  // from within a Rust future's own poll (e.g. a callback that aborts its
+  // own signal), and repolling right here would reenter it mid-poll.
+  private cancel(handle: number): void {
+    const entry = this.pendingFutures.get(handle);
+    if (!entry) return;
+    entry.cancel(handle);
+    queueMicrotask(() => this.repollHandle(handle));
+  }
+
+  // A lower-level counterpart to `signal` for callers that can pass a
+  // plain int but not cheaply build a real AbortController.
+  cancelById(callId: number): void {
+    const handle = this.cancelIds.get(callId);
+    if (handle === undefined) return;
+    this.cancel(handle);
+  }
+
   private extractAsyncError(
     handle: number,
     status: number,
@@ -140,7 +161,10 @@ export class AsyncFutureManager {
     handle: number,
     pollSync: (handle: number) => number,
     panicMessage: (handle: number) => number,
-    free: (handle: number) => void
+    free: (handle: number) => void,
+    cancel: (handle: number) => void,
+    signal?: AbortSignal,
+    cancelId?: number
   ): Promise<number> {
     // Poll before registering. An async fn that never yields — the common
     // case, and the whole of `async_add` — was paying a Map insert, a Map
@@ -157,8 +181,46 @@ export class AsyncFutureManager {
         this.extractAsyncError(handle, status, panicMessage, free)
       );
     }
+    // The signal may have aborted before this poll returned, or reentrantly
+    // during it -- AbortSignal never replays a past event, so a listener
+    // registered only below would miss it and leave the future running.
+    if (signal?.aborted) {
+      cancel(handle);
+      const cancelledStatus = pollSync(handle);
+      return Promise.reject(
+        this.extractAsyncError(handle, cancelledStatus, panicMessage, free)
+      );
+    }
     return new Promise((resolve, reject) => {
-      this.pendingFutures.set(handle, { resolve, reject, pollSync, panicMessage, free });
+      let onAbort: (() => void) | undefined;
+      if (signal) {
+        onAbort = () => this.cancel(handle);
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+      if (cancelId !== undefined) {
+        this.cancelIds.set(cancelId, handle);
+      }
+      // Detach on settle: a signal shared across many calls would otherwise
+      // accumulate one dead listener per finished call, and a stale cancelId
+      // could reach a different, unrelated call once `handle` is recycled.
+      const detach = (): void => {
+        if (onAbort) signal!.removeEventListener("abort", onAbort);
+        if (cancelId !== undefined) this.cancelIds.delete(cancelId);
+      };
+      this.pendingFutures.set(handle, {
+        resolve: (h) => {
+          detach();
+          resolve(h);
+        },
+        reject: (error) => {
+          detach();
+          reject(error);
+        },
+        pollSync,
+        panicMessage,
+        free,
+        cancel,
+      });
     });
   }
 }

--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -128,8 +128,12 @@ export class AsyncFutureManager {
     queueMicrotask(() => this.repollHandle(handle));
   }
 
-  // A lower-level counterpart to `signal` for callers that can pass a
-  // plain int but not cheaply build a real AbortController.
+  // Lower-level counterpart to `options.signal` for callers that can pass a
+  // plain int but not cheaply build a real AbortController (dart-web / KMP).
+  // `callId` must be unique among in-flight calls: reusing an id while the
+  // first call is still pending overwrites the mapping, and settling either
+  // call removes the key for both. Prefer an autoincrement or thread-local
+  // counter when the id is produced by another language's codegen.
   cancelById(callId: number): void {
     const handle = this.cancelIds.get(callId);
     if (handle === undefined) return;
@@ -192,6 +196,21 @@ export class AsyncFutureManager {
       );
     }
     return new Promise((resolve, reject) => {
+      // Most suspended calls never cancel. Skip the three extra closures and
+      // the abort listener setup unless the caller asked for cancellation.
+      const wantsCancel = signal !== undefined || cancelId !== undefined;
+      if (!wantsCancel) {
+        this.pendingFutures.set(handle, {
+          resolve,
+          reject,
+          pollSync,
+          panicMessage,
+          free,
+          cancel,
+        });
+        return;
+      }
+
       let onAbort: (() => void) | undefined;
       if (signal) {
         onAbort = () => this.cancel(handle);

--- a/runtime/typescript/test/runtime.test.ts
+++ b/runtime/typescript/test/runtime.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { AsyncFutureManager, BoltFFIModule, instantiateBoltFFI } from "../src/module.js";
+import {
+  AsyncFutureManager,
+  BoltFFICancelledError,
+  BoltFFIModule,
+  instantiateBoltFFI,
+} from "../src/module.js";
 import { CallbackRegistry } from "../src/callback.js";
 import { StreamPollManager, StreamPollResult, StreamSession } from "../src/stream.js";
 import {
@@ -561,6 +566,96 @@ describe("BoltFFIModule async completion", () => {
     ).toThrow("invalid argument");
 
     expect(freedAllocations).toContainEqual([256, 4]);
+  });
+});
+
+describe("AsyncFutureManager cancellation", () => {
+  const PENDING = 0;
+  const CANCELLED = -1;
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const { module } = createHarness();
+    const controller = new AbortController();
+    controller.abort();
+    const pollSync = vi.fn().mockReturnValue(PENDING);
+    const cancel = vi.fn();
+
+    // A real Rust poll_sync unconditionally reports Cancelled once marked,
+    // so the mock does the same once `cancel` has been invoked.
+    pollSync.mockImplementation(() => (cancel.mock.calls.length > 0 ? CANCELLED : PENDING));
+
+    await expect(
+      module.asyncManager.pollAsync(
+        1,
+        pollSync,
+        () => 0,
+        () => {},
+        cancel,
+        controller.signal
+      )
+    ).rejects.toThrow(BoltFFICancelledError);
+    expect(cancel).toHaveBeenCalledWith(1);
+  });
+
+  it("rejects when the signal aborts reentrantly during the initial poll", async () => {
+    const { module } = createHarness();
+    const controller = new AbortController();
+    const cancel = vi.fn(() => controller.abort());
+    let polls = 0;
+    const pollSync = vi.fn(() => {
+      polls += 1;
+      // First poll: nothing has cancelled the future yet, so it's still
+      // running -- but the abort happens to fire during this exact call
+      // (simulating a signal aborted reentrantly mid-poll, not just before
+      // the call started), which is the scenario `signal.aborted` must
+      // still catch since AbortSignal never replays a past event.
+      if (polls === 1) {
+        controller.abort();
+        return PENDING;
+      }
+      return CANCELLED;
+    });
+
+    await expect(
+      module.asyncManager.pollAsync(
+        2,
+        pollSync,
+        () => 0,
+        () => {},
+        cancel,
+        controller.signal
+      )
+    ).rejects.toThrow(BoltFFICancelledError);
+    expect(polls).toBe(2);
+  });
+
+  it("cancels a pending call via cancelById using the id passed to pollAsync", async () => {
+    const { module } = createHarness();
+    const cancel = vi.fn();
+    let cancelled = false;
+    const pollSync = vi.fn(() => (cancelled ? CANCELLED : PENDING));
+    cancel.mockImplementation(() => {
+      cancelled = true;
+    });
+
+    const pending = module.asyncManager.pollAsync(
+      3,
+      pollSync,
+      () => 0,
+      () => {},
+      cancel,
+      undefined,
+      42
+    );
+    module.asyncManager.cancelById(42);
+
+    await expect(pending).rejects.toThrow(BoltFFICancelledError);
+    expect(cancel).toHaveBeenCalledWith(3);
+  });
+
+  it("treats cancelById as a no-op for an unknown or already-settled id", () => {
+    const { module } = createHarness();
+    expect(() => module.asyncManager.cancelById(999)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary
- Async calls on the TypeScript/wasm target now accept an optional `{ signal?: AbortSignal; cancelId?: number }` parameter, letting a caller cancel an in-flight call using the standard Web `AbortController`/`AbortSignal` primitives, or a bare numeric id for non-JS frontends (dart-web / KMP) via `__boltffiCancelById`.
- Adds a `throw_when` pre-abort check so an already-aborted signal rejects immediately instead of starting the call.
- Wires the wasm async protocol's existing `cancel` export (previously unused) through `AsyncFutureManager`, which cancels the in-flight future on the Rust side and forces a repoll to deliver the resulting `BoltFFICancelledError`.
- The options bag is read via optional property access rather than a defaulted `{}` object, avoiding a per-call allocation for callers that don't use cancellation. Cancel setup (abort listener + resolve/reject wrappers) only runs when `signal` or `cancelId` is provided.
- Streams are out of scope for this PR; only async functions and methods take `signal` / `cancelId`.

## Test plan
- [x] Built the wasm target and ran the generated bindings against real `AbortController` instances in Node.js, verifying both pre-abort rejection and mid-flight cancellation.
- [x] Verified non-cancelled calls behave unchanged.
- [x] Runtime tests cover `cancelById` and reentrant abort-during-poll.
