### PR TITLE
Add Dart demo pack and tests to CI host-defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,10 @@ jobs:
         uses: Aandreba/setup-binaryen@v1.0.0
         with:
           token: ${{ github.token }}
+      - if: matrix.python-version == '3.13'
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 3.10.8
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'

--- a/examples/demo/verify-platform-demos.sh
+++ b/examples/demo/verify-platform-demos.sh
@@ -10,6 +10,7 @@ java_dir="$repo_root/examples/platforms/java"
 csharp_dir="$repo_root/examples/platforms/csharp"
 wasm_dir="$repo_root/examples/platforms/wasm"
 python_dir="$repo_root/examples/platforms/python"
+dart_dir="$repo_root/examples/platforms/dart"
 workspace_manifest="$repo_root/Cargo.toml"
 
 selected_platforms=()
@@ -29,13 +30,66 @@ run_boltffi() {
     )
 }
 
+# pack dart defaults to every Dart native triple. CI/host verification only
+# needs the current machine, otherwise cargo tries Android/iOS/etc.
+host_dart_native_target() {
+    local os
+    local arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+    case "$os" in
+        Darwin)
+            case "$arch" in
+                arm64) printf '%s\n' "macos:arm64" ;;
+                x86_64) printf '%s\n' "macos:x86_64" ;;
+                *)
+                    printf 'unsupported Darwin architecture for Dart demo: %s\n' "$arch" >&2
+                    return 1
+                    ;;
+            esac
+            ;;
+        Linux)
+            case "$arch" in
+                x86_64) printf '%s\n' "linux:x86_64" ;;
+                aarch64|arm64) printf '%s\n' "linux:arm64" ;;
+                *)
+                    printf 'unsupported Linux architecture for Dart demo: %s\n' "$arch" >&2
+                    return 1
+                    ;;
+            esac
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            case "$arch" in
+                x86_64|AMD64) printf '%s\n' "windows:x86_64" ;;
+                aarch64|arm64|ARM64) printf '%s\n' "windows:arm64" ;;
+                *)
+                    printf 'unsupported Windows architecture for Dart demo: %s\n' "$arch" >&2
+                    return 1
+                    ;;
+            esac
+            ;;
+        *)
+            printf 'unsupported host for Dart demo: %s\n' "$os" >&2
+            return 1
+            ;;
+    esac
+}
+
+pack_host_dart() {
+    local overlay
+    overlay="$(mktemp "${TMPDIR:-/tmp}/boltffi-dart-host.XXXXXX.toml")"
+    printf '[targets.dart]\nnative_targets = ["%s"]\n' "$(host_dart_native_target)" >"$overlay"
+    run_boltffi --overlay "$overlay" pack dart --release
+    rm -f "$overlay"
+}
+
 host_default_platforms() {
     case "$(uname -s)" in
         Darwin)
-            printf '%s\n' apple kotlin java csharp wasm python
+            printf '%s\n' apple kotlin java csharp wasm python dart
             ;;
         Linux|MINGW*|MSYS*|CYGWIN*)
-            printf '%s\n' java csharp wasm python
+            printf '%s\n' java csharp wasm python dart
             ;;
         *)
             printf 'unsupported host for demo verification: %s\n' "$(uname -s)" >&2
@@ -93,7 +147,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             printf 'Unknown argument: %s\n' "$1" >&2
-            printf 'Usage: %s [--platform <apple|kotlin|java|csharp|wasm|python>] [--python <interpreter>] [--host-defaults]\n' "$0" >&2
+            printf 'Usage: %s [--platform <apple|kotlin|java|csharp|wasm|python|dart>] [--python <interpreter>] [--host-defaults]\n' "$0" >&2
             exit 2
             ;;
     esac
@@ -135,6 +189,10 @@ for selected_platform in "${selected_platforms[@]}"; do
                 run_step "pack python" run_boltffi pack python --release
                 run_step "python demo" "$python_dir/test-demo.sh"
             fi
+            ;;
+        dart)
+            run_step "pack dart" pack_host_dart
+            run_step "dart demo" "$dart_dir/test-demo.sh"
             ;;
         *)
             printf 'Unsupported demo platform: %s\n' "$selected_platform" >&2

--- a/examples/platforms/dart/pubspec.yaml
+++ b/examples/platforms/dart/pubspec.yaml
@@ -6,6 +6,8 @@ publish_to: none
 environment:
   sdk: ^3.10.8
 
+workspace:
+  - pkgs/demo
 
 dependencies:
   test: ^1.31.0

--- a/examples/platforms/dart/test-demo.sh
+++ b/examples/platforms/dart/test-demo.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+package_dir="$script_dir/pkgs/demo"
+
+if ! command -v dart >/dev/null 2>&1; then
+    printf 'Missing dart executable\n' >&2
+    exit 127
+fi
+
+if [[ ! -d "$package_dir" ]]; then
+    printf 'Missing generated Dart package: %s\n' "$package_dir" >&2
+    printf 'Pack the Dart demo first (`boltffi pack dart`).\n' >&2
+    exit 1
+fi
+
+(
+    cd "$script_dir"
+    dart pub get
+    dart test
+)


### PR DESCRIPTION
## Summary

Run the existing Dart demo consumer in the same `demo-platforms` host-defaults job as Java, C#, WASM, and Python.

Dart bindings and `examples/platforms/dart/test/` were already in the tree. Nothing packed them or ran `dart test`, so native Dart codegen never failed CI.

## Changes

- Install Dart 3.10.8 on the host-defaults matrix (Python 3.13).
- Add `dart` to `verify-platform-demos.sh` host defaults.
- Pack Dart for the **current host triple only** (default `pack dart` builds every Dart native target).
- Add `examples/platforms/dart/test-demo.sh` (`dart pub get` + `dart test`).
- Declare `pkgs/demo` as a pub workspace member so generated packages with `resolution: workspace` resolve.

## Expected CI

This should go **red** on current `main` at `dart test` compile time:

1. Async encoded out-pointer returns use `_l$result` before it is declared.
2. `StreamPollResult` is generated as `Int32` but the prelude callback is `Int8`.
3. Stream delivery calls `controller.addAll`, which `StreamController` does not have.

Those are pre-existing generator bugs. This PR only makes CI see them.