### PR TITLE
feat(bindgen): register the experimental C target

### DIFF
--- a/boltffi_bindgen/src/generate.rs
+++ b/boltffi_bindgen/src/generate.rs
@@ -436,7 +436,7 @@ impl Generation {
             }
             Target::Swift => self.render_swift(),
             Target::TypeScript => self.render_typescript(),
-            Target::Header => Err(GenerationError::UnsupportedTarget { target }),
+            Target::Header | Target::C => Err(GenerationError::UnsupportedTarget { target }),
         }
     }
 
@@ -471,7 +471,7 @@ impl Generation {
             Target::KotlinMultiplatform => self.render_kmp_bindings(bindings),
             Target::CSharp => self.render_csharp_bindings(bindings),
             Target::Dart => self.render_dart_bindings(bindings),
-            Target::Swift | Target::TypeScript | Target::Header => {
+            Target::Swift | Target::TypeScript | Target::Header | Target::C => {
                 Err(GenerationError::UnsupportedTarget { target })
             }
         }

--- a/boltffi_bindgen/src/target.rs
+++ b/boltffi_bindgen/src/target.rs
@@ -11,6 +11,7 @@ pub enum Target {
     Dart,
     Python,
     CSharp,
+    C,
 }
 
 impl Target {
@@ -25,6 +26,7 @@ impl Target {
             Target::Dart => "dart",
             Target::Python => "python",
             Target::CSharp => "csharp",
+            Target::C => "c",
         }
     }
 }
@@ -32,5 +34,15 @@ impl Target {
 impl fmt::Display for Target {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(self.name())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Target;
+
+    #[test]
+    fn c_target_name_is_c() {
+        assert_eq!(Target::C.name(), "c");
     }
 }

--- a/boltffi_cli/src/config/mod.rs
+++ b/boltffi_cli/src/config/mod.rs
@@ -757,6 +757,7 @@ impl Config {
             Target::Dart => self.is_dart_enabled(),
             Target::Python => self.is_python_enabled(),
             Target::CSharp => self.is_csharp_enabled(),
+            Target::C => false,
         }
     }
 


### PR DESCRIPTION
This is the first slice of an experimental C target, following [Adding a new target language](https://github.com/boltffi/boltffi/blob/main/docs/contributors/adding-a-target.md). Related: #61.

## This PR

Registers `Target::C` (`name() == "c"`) and fills the exhaustive-match arms so later host, CLI, and pack work can hang off it. Generation still returns `UnsupportedTarget`, and config treats C as disabled. Nothing is user-reachable yet.

## Approach (later PRs)

C consumes the Native surface and calls `CBridge` directly — no extra runtime bridge. The public surface is a package-prefixed, static-inline facade in a single header on top of the existing ABI. Packaging is a header plus host shared/static libraries (`include/` + `lib/`); there is no standard C package format, so we leave the rest of the build system to the consumer.

Intended supported surface for the experimental landing:

- synchronous free functions
- `#[repr(C)]` records
- C-style enums
- constants
- classes as opaque handles
- synchronous callback traits
- typed results

## Proposed follow-up sequence

We already have this work internally and can send it either as one follow-up or as the slices below. Prefer the sliced path unless you would rather review one larger experimental-C PR.

1. **Host scaffold and syntax model** — `boltffi_backend/src/target/c/`, `HostBackend` with unsupported capabilities, C syntax fragments.
2. **Portable C ABI header** — C11 / C++ / MSVC atomics and helpers so the generated header is actually includable.
3. **Ergonomic C facade** — typed wrappers over the ABI (functions, records, enums, classes, callbacks, results). Internally this is one commit because `assemble` / surface / callable / result are coupled; we can try to split it further if you want smaller review units.
4. **CLI and config** — `[targets.c]`, `Experimental::WholeTarget(Target::C)`, `boltffi generate c --experimental`.
5. **Pack** — `boltffi pack c --experimental` stages `{output}/include/<library>.h` and host libraries under `{output}/lib`.
6. **Demo platform and audit** — C11 smoke consumer, `exclude(c, …)` for shapes not supported yet, `just demo-test-audit` green.
7. **Docs** — C page plus configuration / experimental / overview / packaging.

## Deferred

- async, streams, custom types, payload/complex enums, encoded value shapes, inline closures
- a C++-idiomatic target (C++ can consume the C header)
- cross-compilation and a fully validated Windows pack story

## Question for maintainers

Do you want this upstreamed **one PR per step** as above, or as **one larger experimental-C PR** after this registration lands? Happy to file a dedicated tracking issue (rather than continuing on #61) if that is the preferred place for the checklist.