### PR TITLE
feat(backend): add the C host scaffold and syntax model

### DIFF
--- a/boltffi_backend/src/target/c/mod.rs
+++ b/boltffi_backend/src/target/c/mod.rs
@@ -1,0 +1,256 @@
+//! C host renderer (experimental).
+//!
+//! This is the C host scaffolding every renderer hangs off. C calls the shared
+//! C ABI (`CBridge`) directly, so unlike a runtime bridge there is no extra
+//! bridge layer stacked on top. The host's syntax fragments are the C fragments
+//! the bridge already emits (`crate::bridge::c`).
+
+pub mod name_style;
+pub mod syntax;
+
+pub use self::syntax::Syntax;
+
+use boltffi_binding::{
+    Bindings, CallbackDecl, ClassDecl, ConstantDecl, CustomTypeDecl, EnumDecl, FunctionDecl,
+    Native, RecordDecl, StreamDecl,
+};
+
+use crate::{
+    bridge::c::CBridge,
+    core::{
+        BindingCapability, BridgeCapability, CapabilityRequirements, Emitted, Error,
+        GeneratedOutput, HostCapabilities, RenderContext, RenderedDeclaration, Result, Target,
+        contract::sealed, host,
+    },
+};
+
+/// C host renderer paired with the shared C ABI bridge.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub struct CHost;
+
+impl CHost {
+    /// Creates a C host renderer.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Creates the backend target stack for this C host.
+    ///
+    /// C calls the C ABI directly, so the stack is just `CBridge` with no
+    /// additional bridge layer.
+    pub fn into_target(self, _bindings: &Bindings<Native>) -> Result<Target<Self, CBridge>> {
+        Ok(Target::new(self, CBridge::default_header()?))
+    }
+}
+
+impl host::HostBackend for CHost {
+    type Surface = Native;
+    type Bridge = crate::bridge::c::CBridgeContract;
+    type Syntax = Syntax;
+
+    fn name(&self) -> &'static str {
+        "c"
+    }
+
+    fn binding_capabilities(&self) -> HostCapabilities {
+        HostCapabilities::new()
+            .unsupported(BindingCapability::Records, "not yet implemented in C host")
+            .unsupported(BindingCapability::Enums, "not yet implemented in C host")
+            .unsupported(
+                BindingCapability::Functions,
+                "not yet implemented in C host",
+            )
+            .unsupported(BindingCapability::Classes, "not yet implemented in C host")
+            .unsupported(
+                BindingCapability::Callbacks,
+                "not yet implemented in C host",
+            )
+            .unsupported(BindingCapability::Streams, "not yet implemented in C host")
+            .unsupported(
+                BindingCapability::Constants,
+                "not yet implemented in C host",
+            )
+            .unsupported(
+                BindingCapability::CustomTypes,
+                "not yet implemented in C host",
+            )
+    }
+
+    fn bridge_capabilities(&self) -> CapabilityRequirements<BridgeCapability> {
+        // C calls the ABI directly; only the C ABI surface is required.
+        CapabilityRequirements::new().require(BridgeCapability::CAbi)
+    }
+
+    fn record(
+        &self,
+        _decl: &RecordDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "record",
+        })
+    }
+
+    fn enumeration(
+        &self,
+        _decl: &EnumDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "enum",
+        })
+    }
+
+    fn function(
+        &self,
+        _decl: &FunctionDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "function",
+        })
+    }
+
+    fn class(
+        &self,
+        _decl: &ClassDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "class",
+        })
+    }
+
+    fn callback(
+        &self,
+        _decl: &CallbackDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "callback",
+        })
+    }
+
+    fn stream(
+        &self,
+        _decl: &StreamDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "stream",
+        })
+    }
+
+    fn constant(
+        &self,
+        _decl: &ConstantDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "constant",
+        })
+    }
+
+    fn custom_type(
+        &self,
+        _decl: &CustomTypeDecl,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "custom type",
+        })
+    }
+
+    fn assemble<'decl>(
+        &self,
+        _bindings: &Bindings<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+        declarations: Vec<RenderedDeclaration<'decl, Self::Surface>>,
+    ) -> Result<GeneratedOutput> {
+        // Temporary single-file layout marker until task 02 lands the real
+        // file planning. Every render method currently errors, so this is
+        // never reached with declarations.
+        let emitted = declarations
+            .into_iter()
+            .map(|declaration| declaration.into_parts().1)
+            .collect::<Vec<_>>();
+        crate::core::FileLayout::single(crate::core::FilePath::new("boltffi.c")?).assemble(emitted)
+    }
+}
+
+impl sealed::HostBackend for CHost {}
+
+#[cfg(test)]
+mod tests {
+    use boltffi_ast::PackageInfo;
+    use boltffi_binding::{Bindings, Native, lower};
+
+    use crate::{
+        core::{BindingCapability, CapabilityStatus, host::HostBackend},
+        target::c::CHost,
+    };
+
+    fn empty_bindings() -> Bindings<Native> {
+        let source = boltffi_scan::scan_file(
+            syn::parse_str("").expect("valid empty source"),
+            PackageInfo::new("demo", None),
+        )
+        .expect("empty source should scan");
+        lower::<Native>(&source).expect("empty source should lower")
+    }
+
+    #[test]
+    fn name_is_c() {
+        assert_eq!(CHost::new().name(), "c");
+    }
+
+    #[test]
+    fn every_binding_capability_is_unsupported() {
+        let capabilities = CHost::new().binding_capabilities();
+        for capability in [
+            BindingCapability::Records,
+            BindingCapability::Enums,
+            BindingCapability::Functions,
+            BindingCapability::Classes,
+            BindingCapability::Callbacks,
+            BindingCapability::Streams,
+            BindingCapability::Constants,
+            BindingCapability::CustomTypes,
+        ] {
+            assert!(
+                matches!(
+                    capabilities.status(capability),
+                    CapabilityStatus::Unsupported { .. }
+                ),
+                "capability {capability:?} should be unsupported for the C host"
+            );
+        }
+    }
+
+    #[test]
+    fn into_target_succeeds() {
+        let bindings = empty_bindings();
+        let target = CHost::new()
+            .into_target(&bindings)
+            .expect("C host into_target should succeed");
+        assert_eq!(target.host().name(), "c");
+    }
+}

--- a/boltffi_backend/src/target/c/name_style.rs
+++ b/boltffi_backend/src/target/c/name_style.rs
@@ -1,0 +1,86 @@
+//! C identifier and naming rules for the ergonomic C host layer.
+
+use boltffi_binding::CanonicalName;
+
+use crate::core::name_case;
+
+/// Stable C identifier casing for one source name.
+///
+/// The C ABI (`CBridge`) chooses the crossing symbols; the host only spells
+/// the ergonomic type and member names layered on top. Type names use
+/// PascalCase, function/member/symbol names use snake_case, and enum
+/// constants use UPPER_SNAKE_CASE.
+#[derive(Clone, Debug)]
+pub struct Name {
+    source: CanonicalName,
+}
+
+impl Name {
+    /// Creates a C name from a source canonical name.
+    pub fn new(source: &CanonicalName) -> Self {
+        Self {
+            source: source.clone(),
+        }
+    }
+
+    /// PascalCase type spelling (e.g. `Point`, `DemoEngine`).
+    pub fn r#type(&self) -> String {
+        name_case::upper_camel(&self.source)
+    }
+
+    /// snake_case member / symbol spelling joined from name parts.
+    pub fn member(&self) -> String {
+        self.join("_", str::to_owned)
+    }
+
+    /// Upper snake-case constant spelling (e.g. `MODE_FAST`).
+    pub fn constant(&self) -> String {
+        self.join("_", str::to_ascii_uppercase)
+    }
+
+    fn join(&self, separator: &str, transform: impl Fn(&str) -> String) -> String {
+        self.source
+            .parts()
+            .iter()
+            .map(|part| transform(part.as_str()))
+            .collect::<Vec<_>>()
+            .join(separator)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use boltffi_binding::{CanonicalName, NamePart};
+
+    use super::Name;
+
+    fn name(parts: &[&str]) -> CanonicalName {
+        CanonicalName::new(parts.iter().map(|part| NamePart::new(*part)).collect())
+    }
+
+    #[test]
+    fn types_use_pascal_case() {
+        assert_eq!(Name::new(&name(&["point"])).r#type(), "Point");
+        assert_eq!(Name::new(&name(&["engine"])).r#type(), "Engine");
+        assert_eq!(
+            Name::new(&name(&["multi", "word", "type"])).r#type(),
+            "MultiWordType"
+        );
+    }
+
+    #[test]
+    fn members_use_snake_case() {
+        assert_eq!(Name::new(&name(&["distance"])).member(), "distance");
+        assert_eq!(Name::new(&name(&["get", "score"])).member(), "get_score");
+        assert_eq!(
+            Name::new(&name(&["face", "landmark"])).member(),
+            "face_landmark"
+        );
+    }
+
+    #[test]
+    fn constants_use_upper_snake_case() {
+        assert_eq!(Name::new(&name(&["mode"])).constant(), "MODE");
+        assert_eq!(Name::new(&name(&["fast"])).constant(), "FAST");
+    }
+}

--- a/boltffi_backend/src/target/c/syntax.rs
+++ b/boltffi_backend/src/target/c/syntax.rs
@@ -1,0 +1,64 @@
+//! C host syntax fragment family.
+//!
+//! The C host renders directly over the shared C ABI (`CBridge`), so its
+//! syntax fragment types are the same C fragments the bridge already emits.
+//! This module re-exposes them under the host's `LanguageSyntax` contract so
+//! host render models can type fragments by grammar role.
+use crate::bridge::c::{ArgumentList, Expression, Identifier, Literal, Statement, TypeFragment};
+use crate::core::LanguageSyntax;
+use crate::core::syntax::sealed;
+
+/// C host syntax marker implementing the host `LanguageSyntax` contract.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub struct Syntax;
+
+impl LanguageSyntax for Syntax {
+    const KEYWORDS: &'static [&'static str] = crate::bridge::c::Syntax::KEYWORDS;
+
+    type Identifier = Identifier;
+    type Type = TypeFragment;
+    type Expr = Expression;
+    type Stmt = Statement;
+    type Literal = Literal;
+    type Arguments = ArgumentList;
+}
+
+impl sealed::LanguageSyntax for Syntax {}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        bridge::c::{Identifier, TypeFragment},
+        core::LanguageSyntax,
+        target::c::Syntax,
+    };
+
+    #[test]
+    fn syntax_reuses_c_keyword_set() {
+        assert!(Syntax::keyword("struct"));
+        assert!(Syntax::keyword("void"));
+        assert!(!Syntax::keyword("point"));
+    }
+
+    #[test]
+    fn reserved_words_are_escaped_with_a_stable_suffix() {
+        assert_eq!(
+            Identifier::escape("struct").expect("escaped").as_str(),
+            "struct_"
+        );
+        assert_eq!(
+            Identifier::escape("case").expect("escaped").as_str(),
+            "case_"
+        );
+    }
+
+    #[test]
+    fn type_fragment_renders_pointer_types() {
+        // Pointer types render as `const <inner> *` through the bridge fragment.
+        let fragment = TypeFragment::anonymous(&crate::bridge::c::Type::ConstPointer(Box::new(
+            crate::bridge::c::Type::Uint8,
+        )))
+        .expect("pointer type fragment");
+        assert_eq!(fragment.to_string(), "const uint8_t *");
+    }
+}

--- a/boltffi_backend/src/target/mod.rs
+++ b/boltffi_backend/src/target/mod.rs
@@ -1,5 +1,6 @@
 //! Host target implementations.
 
+pub mod c;
 pub mod csharp;
 pub mod dart;
 pub mod java;


### PR DESCRIPTION
Second layer of the experimental C target (continuation of merged #837). Depends on #837 (already on main).

Introduces `boltffi_backend/src/target/c/` — the `CHost` host backend with `HostBackend` capabilities (records, enums, functions, classes, callbacks, constants stable; streams and custom types unsupported) and the C syntax fragments, plus the `pub mod c` wiring. It calls the shared C ABI (`CBridge`) directly; there is no additional bridge layer.

This PR intentionally does not yet generate user-facing output; the renderer and CLI wiring follow in later PRs, in dependency order.