### PR TITLE
feat(backend): make the shared C ABI header portable

### DIFF
--- a/boltffi_backend/fixtures/c_bridge_declaration_surface.h
+++ b/boltffi_backend/fixtures/c_bridge_declaration_surface.h
@@ -3,7 +3,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif !defined(__cplusplus)
 #include <stdatomic.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,12 +17,25 @@ typedef struct {
     int32_t code;
 } FfiStatus;
 
+#ifdef __cplusplus
+static inline FfiStatus boltffi_status_from_code(int32_t code) {
+    FfiStatus status = { code };
+    return status;
+}
+#define FFI_STATUS_OK boltffi_status_from_code(0)
+#define FFI_STATUS_NULL_POINTER boltffi_status_from_code(1)
+#define FFI_STATUS_BUFFER_TOO_SMALL boltffi_status_from_code(2)
+#define FFI_STATUS_INVALID_ARG boltffi_status_from_code(3)
+#define FFI_STATUS_CANCELLED boltffi_status_from_code(4)
+#define FFI_STATUS_INTERNAL_ERROR boltffi_status_from_code(100)
+#else
 #define FFI_STATUS_OK ((FfiStatus){0})
 #define FFI_STATUS_NULL_POINTER ((FfiStatus){1})
 #define FFI_STATUS_BUFFER_TOO_SMALL ((FfiStatus){2})
 #define FFI_STATUS_INVALID_ARG ((FfiStatus){3})
 #define FFI_STATUS_CANCELLED ((FfiStatus){4})
 #define FFI_STATUS_INTERNAL_ERROR ((FfiStatus){100})
+#endif
 
 typedef struct {
     uint8_t *ptr;
@@ -48,6 +65,41 @@ typedef int32_t WaitResult;
 typedef void (*RustFutureContinuationCallback)(uint64_t callback_data, int8_t poll_result);
 typedef void (*StreamContinuationCallback)(uint64_t callback_data, StreamPollResult result);
 
+#if defined(_MSC_VER)
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return _InterlockedCompareExchange8((volatile char *)state, (char)desired, (char)expected) == (char)expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return (uint64_t)_InterlockedExchange64((volatile __int64 *)slot, (__int64)value);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, (__int64)desired, (__int64)expected) == expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, 0, 0);
+}
+#elif defined(__cplusplus) && (defined(__clang__) || defined(__GNUC__))
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return __atomic_compare_exchange_n(state, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return __atomic_exchange_n(slot, value, __ATOMIC_ACQ_REL);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return __atomic_compare_exchange_n(slot, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return __atomic_load_n(slot, __ATOMIC_ACQUIRE);
+}
+#elif defined(__cplusplus)
+#error "BoltFFI C++ atomics require GCC, Clang, or MSVC"
+#else
 static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
     return atomic_compare_exchange_strong_explicit((_Atomic uint8_t *)state, &expected, desired, memory_order_acq_rel, memory_order_acquire);
 }
@@ -63,6 +115,7 @@ static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uin
 static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
     return atomic_load_explicit((_Atomic uint64_t *)slot, memory_order_acquire);
 }
+#endif
 
 typedef struct {
     uint64_t handle;
@@ -71,6 +124,7 @@ typedef struct {
 
 void boltffi_free_string(FfiString string);
 void boltffi_free_buf(FfiBuf_u8 buf);
+FfiString boltffi_buf_into_string(FfiBuf_u8 buf);
 FfiBuf_u8 boltffi_buf_from_bytes(const uint8_t *ptr, uintptr_t len);
 FfiBuf_u8 boltffi_buf_with_len(uintptr_t len);
 FfiStatus boltffi_last_error_message(FfiString *out);

--- a/boltffi_backend/src/bridge/c/identifier.rs
+++ b/boltffi_backend/src/bridge/c/identifier.rs
@@ -22,10 +22,11 @@ impl Identifier {
         }
     }
 
-    /// Creates a C identifier, appending an underscore when the input is a keyword.
+    /// Creates a valid portable ABI identifier, appending an underscore when the
+    /// input is reserved by C or C++ (the header is compilable under both).
     pub fn escape(identifier: impl Into<String>) -> Result<Self> {
         let identifier = identifier.into();
-        match Syntax::keyword(&identifier) {
+        match Syntax::reserved(&identifier) {
             true => Self::parse(format!("{identifier}_")),
             false => Self::parse(identifier),
         }

--- a/boltffi_backend/src/bridge/c/support.rs
+++ b/boltffi_backend/src/bridge/c/support.rs
@@ -25,6 +25,11 @@ impl SupportFunctions {
                     Type::Void,
                 )?,
                 Function::new(
+                    "boltffi_buf_into_string",
+                    vec![Parameter::new("buf", Type::Buffer)?],
+                    Type::String,
+                )?,
+                Function::new(
                     "boltffi_buf_from_bytes",
                     vec![
                         Parameter::new("ptr", Type::ConstPointer(Box::new(Type::Uint8)))?,

--- a/boltffi_backend/src/bridge/c/syntax.rs
+++ b/boltffi_backend/src/bridge/c/syntax.rs
@@ -31,6 +31,79 @@ pub struct Literal(String);
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ArgumentList(Vec<Expression>);
 
+/// C++-only reserved words. These are valid C identifiers but not valid C++
+/// identifiers, so the portable C ABI header (compilable under both languages)
+/// must escape them too. C keywords live in [`Syntax::KEYWORDS`].
+const CXX_ONLY_KEYWORDS: &[&str] = &[
+    "alignas",
+    "alignof",
+    "and",
+    "and_eq",
+    "asm",
+    "bitand",
+    "bitor",
+    "bool",
+    "catch",
+    "char16_t",
+    "char32_t",
+    "char8_t",
+    "class",
+    "compl",
+    "concept",
+    "consteval",
+    "constexpr",
+    "constinit",
+    "const_cast",
+    "co_await",
+    "co_return",
+    "co_yield",
+    "decltype",
+    "delete",
+    "dynamic_cast",
+    "explicit",
+    "export",
+    "false",
+    "friend",
+    "mutable",
+    "namespace",
+    "new",
+    "noexcept",
+    "not",
+    "not_eq",
+    "nullptr",
+    "operator",
+    "or",
+    "or_eq",
+    "private",
+    "protected",
+    "public",
+    "reinterpret_cast",
+    "requires",
+    "static_assert",
+    "static_cast",
+    "template",
+    "this",
+    "thread_local",
+    "throw",
+    "true",
+    "try",
+    "typeid",
+    "typename",
+    "using",
+    "virtual",
+    "wchar_t",
+    "xor",
+    "xor_eq",
+];
+
+impl Syntax {
+    /// Returns whether `identifier` is reserved by either C or C++ — the
+    /// effective reserved-word set of the portable C ABI header.
+    pub(crate) fn reserved(identifier: &str) -> bool {
+        Self::keyword(identifier) || CXX_ONLY_KEYWORDS.contains(&identifier)
+    }
+}
+
 impl LanguageSyntax for Syntax {
     const KEYWORDS: &'static [&'static str] = &[
         "auto", "break", "case", "char", "const", "continue", "default", "do", "double", "else",

--- a/boltffi_backend/src/target/c/syntax.rs
+++ b/boltffi_backend/src/target/c/syntax.rs
@@ -53,6 +53,18 @@ mod tests {
     }
 
     #[test]
+    fn cpp_only_keywords_are_escaped_for_portable_header() {
+        assert_eq!(
+            Identifier::escape("class").expect("escaped").as_str(),
+            "class_"
+        );
+        assert_eq!(
+            Identifier::escape("namespace").expect("escaped").as_str(),
+            "namespace_"
+        );
+    }
+
+    #[test]
     fn type_fragment_renders_pointer_types() {
         // Pointer types render as `const <inner> *` through the bridge fragment.
         let fragment = TypeFragment::anonymous(&crate::bridge::c::Type::ConstPointer(Box::new(

--- a/boltffi_backend/templates/bridge/c/header.h
+++ b/boltffi_backend/templates/bridge/c/header.h
@@ -3,7 +3,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif !defined(__cplusplus)
 #include <stdatomic.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,12 +17,25 @@ typedef struct {
     int32_t code;
 } FfiStatus;
 
+#ifdef __cplusplus
+static inline FfiStatus boltffi_status_from_code(int32_t code) {
+    FfiStatus status = { code };
+    return status;
+}
+#define FFI_STATUS_OK boltffi_status_from_code(0)
+#define FFI_STATUS_NULL_POINTER boltffi_status_from_code(1)
+#define FFI_STATUS_BUFFER_TOO_SMALL boltffi_status_from_code(2)
+#define FFI_STATUS_INVALID_ARG boltffi_status_from_code(3)
+#define FFI_STATUS_CANCELLED boltffi_status_from_code(4)
+#define FFI_STATUS_INTERNAL_ERROR boltffi_status_from_code(100)
+#else
 #define FFI_STATUS_OK ((FfiStatus){0})
 #define FFI_STATUS_NULL_POINTER ((FfiStatus){1})
 #define FFI_STATUS_BUFFER_TOO_SMALL ((FfiStatus){2})
 #define FFI_STATUS_INVALID_ARG ((FfiStatus){3})
 #define FFI_STATUS_CANCELLED ((FfiStatus){4})
 #define FFI_STATUS_INTERNAL_ERROR ((FfiStatus){100})
+#endif
 
 typedef struct {
     uint8_t *ptr;
@@ -48,6 +65,41 @@ typedef int32_t WaitResult;
 typedef void (*RustFutureContinuationCallback)(uint64_t callback_data, int8_t poll_result);
 typedef void (*StreamContinuationCallback)(uint64_t callback_data, StreamPollResult result);
 
+#if defined(_MSC_VER)
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return _InterlockedCompareExchange8((volatile char *)state, (char)desired, (char)expected) == (char)expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return (uint64_t)_InterlockedExchange64((volatile __int64 *)slot, (__int64)value);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, (__int64)desired, (__int64)expected) == expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, 0, 0);
+}
+#elif defined(__cplusplus) && (defined(__clang__) || defined(__GNUC__))
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return __atomic_compare_exchange_n(state, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return __atomic_exchange_n(slot, value, __ATOMIC_ACQ_REL);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return __atomic_compare_exchange_n(slot, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return __atomic_load_n(slot, __ATOMIC_ACQUIRE);
+}
+#elif defined(__cplusplus)
+#error "BoltFFI C++ atomics require GCC, Clang, or MSVC"
+#else
 static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
     return atomic_compare_exchange_strong_explicit((_Atomic uint8_t *)state, &expected, desired, memory_order_acq_rel, memory_order_acquire);
 }
@@ -63,6 +115,7 @@ static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uin
 static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
     return atomic_load_explicit((_Atomic uint64_t *)slot, memory_order_acquire);
 }
+#endif
 
 typedef struct {
     uint64_t handle;

--- a/boltffi_backend/tests/java.rs
+++ b/boltffi_backend/tests/java.rs
@@ -2512,7 +2512,7 @@ fn java_target_rejects_generated_name_collisions() {
         matches!(
             &error,
             Error::JavaNameCollision { scope, name }
-            if scope == "boltffi_function_demo_collision" && name == "_class"
+            if scope == "boltffi_function_demo_collision" && name == "class_"
         ),
         "{error:?}"
     );

--- a/boltffi_backend/tests/jni/snapshots/jni__native_methods__jni_bridge_renders_shared_support_fragments.snap
+++ b/boltffi_backend/tests/jni/snapshots/jni__native_methods__jni_bridge_renders_shared_support_fragments.snap
@@ -8,7 +8,11 @@ expression: "rendered_fixture_with_support(\"exports/closure_result_return\")"
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif !defined(__cplusplus)
 #include <stdatomic.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,12 +22,25 @@ typedef struct {
     int32_t code;
 } FfiStatus;
 
+#ifdef __cplusplus
+static inline FfiStatus boltffi_status_from_code(int32_t code) {
+    FfiStatus status = { code };
+    return status;
+}
+#define FFI_STATUS_OK boltffi_status_from_code(0)
+#define FFI_STATUS_NULL_POINTER boltffi_status_from_code(1)
+#define FFI_STATUS_BUFFER_TOO_SMALL boltffi_status_from_code(2)
+#define FFI_STATUS_INVALID_ARG boltffi_status_from_code(3)
+#define FFI_STATUS_CANCELLED boltffi_status_from_code(4)
+#define FFI_STATUS_INTERNAL_ERROR boltffi_status_from_code(100)
+#else
 #define FFI_STATUS_OK ((FfiStatus){0})
 #define FFI_STATUS_NULL_POINTER ((FfiStatus){1})
 #define FFI_STATUS_BUFFER_TOO_SMALL ((FfiStatus){2})
 #define FFI_STATUS_INVALID_ARG ((FfiStatus){3})
 #define FFI_STATUS_CANCELLED ((FfiStatus){4})
 #define FFI_STATUS_INTERNAL_ERROR ((FfiStatus){100})
+#endif
 
 typedef struct {
     uint8_t *ptr;
@@ -53,6 +70,41 @@ typedef int32_t WaitResult;
 typedef void (*RustFutureContinuationCallback)(uint64_t callback_data, int8_t poll_result);
 typedef void (*StreamContinuationCallback)(uint64_t callback_data, StreamPollResult result);
 
+#if defined(_MSC_VER)
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return _InterlockedCompareExchange8((volatile char *)state, (char)desired, (char)expected) == (char)expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return (uint64_t)_InterlockedExchange64((volatile __int64 *)slot, (__int64)value);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, (__int64)desired, (__int64)expected) == expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, 0, 0);
+}
+#elif defined(__cplusplus) && (defined(__clang__) || defined(__GNUC__))
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return __atomic_compare_exchange_n(state, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return __atomic_exchange_n(slot, value, __ATOMIC_ACQ_REL);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return __atomic_compare_exchange_n(slot, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return __atomic_load_n(slot, __ATOMIC_ACQUIRE);
+}
+#elif defined(__cplusplus)
+#error "BoltFFI C++ atomics require GCC, Clang, or MSVC"
+#else
 static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
     return atomic_compare_exchange_strong_explicit((_Atomic uint8_t *)state, &expected, desired, memory_order_acq_rel, memory_order_acquire);
 }
@@ -68,6 +120,7 @@ static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uin
 static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
     return atomic_load_explicit((_Atomic uint64_t *)slot, memory_order_acquire);
 }
+#endif
 
 typedef struct {
     uint64_t handle;
@@ -76,6 +129,7 @@ typedef struct {
 
 void boltffi_free_string(FfiString string);
 void boltffi_free_buf(FfiBuf_u8 buf);
+FfiString boltffi_buf_into_string(FfiBuf_u8 buf);
 FfiBuf_u8 boltffi_buf_from_bytes(const uint8_t *ptr, uintptr_t len);
 FfiBuf_u8 boltffi_buf_with_len(uintptr_t len);
 FfiStatus boltffi_last_error_message(FfiString *out);

--- a/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_uses_configured_c_header_in_jni_bridge.snap
+++ b/boltffi_backend/tests/kotlin/snapshots/kotlin__exports__kotlin_target_uses_configured_c_header_in_jni_bridge.snap
@@ -8,7 +8,11 @@ expression: rendered_files(&files)
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif !defined(__cplusplus)
 #include <stdatomic.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,12 +22,25 @@ typedef struct {
     int32_t code;
 } FfiStatus;
 
+#ifdef __cplusplus
+static inline FfiStatus boltffi_status_from_code(int32_t code) {
+    FfiStatus status = { code };
+    return status;
+}
+#define FFI_STATUS_OK boltffi_status_from_code(0)
+#define FFI_STATUS_NULL_POINTER boltffi_status_from_code(1)
+#define FFI_STATUS_BUFFER_TOO_SMALL boltffi_status_from_code(2)
+#define FFI_STATUS_INVALID_ARG boltffi_status_from_code(3)
+#define FFI_STATUS_CANCELLED boltffi_status_from_code(4)
+#define FFI_STATUS_INTERNAL_ERROR boltffi_status_from_code(100)
+#else
 #define FFI_STATUS_OK ((FfiStatus){0})
 #define FFI_STATUS_NULL_POINTER ((FfiStatus){1})
 #define FFI_STATUS_BUFFER_TOO_SMALL ((FfiStatus){2})
 #define FFI_STATUS_INVALID_ARG ((FfiStatus){3})
 #define FFI_STATUS_CANCELLED ((FfiStatus){4})
 #define FFI_STATUS_INTERNAL_ERROR ((FfiStatus){100})
+#endif
 
 typedef struct {
     uint8_t *ptr;
@@ -53,6 +70,41 @@ typedef int32_t WaitResult;
 typedef void (*RustFutureContinuationCallback)(uint64_t callback_data, int8_t poll_result);
 typedef void (*StreamContinuationCallback)(uint64_t callback_data, StreamPollResult result);
 
+#if defined(_MSC_VER)
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return _InterlockedCompareExchange8((volatile char *)state, (char)desired, (char)expected) == (char)expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return (uint64_t)_InterlockedExchange64((volatile __int64 *)slot, (__int64)value);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, (__int64)desired, (__int64)expected) == expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, 0, 0);
+}
+#elif defined(__cplusplus) && (defined(__clang__) || defined(__GNUC__))
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return __atomic_compare_exchange_n(state, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return __atomic_exchange_n(slot, value, __ATOMIC_ACQ_REL);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return __atomic_compare_exchange_n(slot, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return __atomic_load_n(slot, __ATOMIC_ACQUIRE);
+}
+#elif defined(__cplusplus)
+#error "BoltFFI C++ atomics require GCC, Clang, or MSVC"
+#else
 static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
     return atomic_compare_exchange_strong_explicit((_Atomic uint8_t *)state, &expected, desired, memory_order_acq_rel, memory_order_acquire);
 }
@@ -68,6 +120,7 @@ static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uin
 static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
     return atomic_load_explicit((_Atomic uint64_t *)slot, memory_order_acquire);
 }
+#endif
 
 typedef struct {
     uint64_t handle;
@@ -76,6 +129,7 @@ typedef struct {
 
 void boltffi_free_string(FfiString string);
 void boltffi_free_buf(FfiBuf_u8 buf);
+FfiString boltffi_buf_into_string(FfiBuf_u8 buf);
 FfiBuf_u8 boltffi_buf_from_bytes(const uint8_t *ptr, uintptr_t len);
 FfiBuf_u8 boltffi_buf_with_len(uintptr_t len);
 FfiStatus boltffi_last_error_message(FfiString *out);

--- a/boltffi_core/src/types/buf.rs
+++ b/boltffi_core/src/types/buf.rs
@@ -126,6 +126,31 @@ pub extern "C" fn boltffi_free_buf(buf: FfiBuf) {
     drop(buf);
 }
 
+/// Decodes an owned, wire-encoded UTF-8 string buffer into an [`FfiString`].
+///
+/// The returned string is length-delimited and is **not** NUL-terminated.
+#[unsafe(no_mangle)]
+pub extern "C" fn boltffi_buf_into_string(buf: FfiBuf) -> crate::FfiString {
+    let mut bytes = unsafe { buf.into_vec::<u8>() };
+    let Some(length) = bytes
+        .get(..core::mem::size_of::<u32>())
+        .and_then(|prefix| prefix.try_into().ok())
+        .map(u32::from_le_bytes)
+        .and_then(|length| usize::try_from(length).ok())
+    else {
+        return crate::FfiString::default();
+    };
+    let prefix_len = core::mem::size_of::<u32>();
+    if bytes.len() != prefix_len.saturating_add(length) {
+        return crate::FfiString::default();
+    }
+    bytes.copy_within(prefix_len.., 0);
+    bytes.truncate(length);
+    String::from_utf8(bytes)
+        .map(crate::FfiString::from)
+        .unwrap_or_default()
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn boltffi_buf_from_bytes(ptr: *const u8, len: usize) -> FfiBuf {
     if ptr.is_null() || len == 0 {
@@ -264,5 +289,21 @@ mod tests {
         assert_eq!(unsafe { actual.as_byte_slice() }, unsafe {
             expected.as_byte_slice()
         });
+    }
+
+    #[test]
+    fn encoded_string_buffer_converts_to_owned_ffi_string() {
+        let encoded = FfiBuf::wire_encode(&String::from("not NUL-terminated"));
+        let decoded = boltffi_buf_into_string(encoded);
+
+        assert_eq!(decoded.as_str(), Some("not NUL-terminated"));
+    }
+
+    #[test]
+    fn malformed_encoded_string_buffer_converts_to_empty_string() {
+        let malformed = FfiBuf::from_vec(vec![5_u8, 0, 0, 0, b'x']);
+        let decoded = boltffi_buf_into_string(malformed);
+
+        assert!(decoded.is_empty());
     }
 }


### PR DESCRIPTION
Third layer of the experimental C target (continuation of #839). Depends on #839.

Makes the active Askama C ABI header (`boltffi_backend/templates/bridge/c/header.h`) includable across C11 / C++ / MSVC: portable atomics using compiler intrinsics (MSVC interlocked intrinsics), plus the `boltffi_buf_into_string` helper in the bridge support module. Updates the C bridge declaration fixture.

No user-facing output yet; the ergonomic facade renderer follows.