### PR TITLE
feat(cli): wire the experimental C target into CLI and config

### DIFF
--- a/BOLTFFI_TOML_SPEC.md
+++ b/BOLTFFI_TOML_SPEC.md
@@ -498,6 +498,28 @@ Generates a binary-only SwiftPM package intended to be depended on by a separate
 - Generated Swift bindings are written to `{swift.output}/BoltFFIGenerated/{module_name}.swift` so you can include them in your wrapper target.
 ## Dart
 
+### `[targets.c]` (experimental, optional)
+
+The C host target is experimental. `boltffi generate c --experimental` (or
+listing `c` under `[experimental]`) writes an intermediate `boltffi.h`.
+Packaging for C is not wired up yet; only generation is available.
+
+- `enabled` (bool): Whether C generation is active.
+  - Default: `false`
+- `output` (path): C output root.
+  - Default: `dist/c`
+  - `generate c` writes `{output}/boltffi.h`.
+- The normal API is the package-prefixed ergonomic facade. Raw `boltffi_*`,
+  `Ffi*`, and `___*` declarations in the same header are bridge details.
+- The intended supported surface is synchronous free functions, direct
+  `#[repr(C)]` records, repr-integer C-style enums, constants, classes, and
+  sync callback traits. Streams, custom types, payload enums, async callbacks,
+  futures, encoded value shapes, and inline closures have no supported
+  ergonomic C representation.
+- C consumers require C11 or later. The public header is also checked in
+  C++03 mode and newer on GCC/Clang; its C++ atomics use compiler intrinsics
+  (and MSVC uses interlocked intrinsics).
+
 ### `[targets.dart]` (optional)
 - `enabled` (bool): Whether Dart generation and packaging are active.
   - Default: `false`

--- a/boltffi_backend/src/target/c/mod.rs
+++ b/boltffi_backend/src/target/c/mod.rs
@@ -159,6 +159,12 @@ impl host::HostBackend for CHost {
         _context: &RenderContext<Self::Surface>,
         declarations: Vec<RenderedDeclaration<'decl, Self::Surface>>,
     ) -> Result<GeneratedOutput> {
+        // Partial coverage may skip declarations; the semantic surface may
+        // only emit types whose declarations actually rendered.
+        let rendered: std::collections::HashSet<boltffi_binding::DeclarationId> = declarations
+            .iter()
+            .map(|declaration| declaration.declaration().id())
+            .collect();
         let emitted = declarations
             .into_iter()
             .map(|declaration| declaration.into_parts().1)
@@ -170,7 +176,7 @@ impl host::HostBackend for CHost {
         let file = crate::core::FilePlan::all(crate::core::FilePath::new("boltffi.h")?)
             .with_preamble(format!(
                 "\n{}\n#ifdef __cplusplus\nextern \"C\" {{\n#endif\n{}",
-                render::surface::render(_bindings, _context)?,
+                render::surface::render(_bindings, _context, &rendered)?,
                 render::result::preamble()
             ))
             .with_postamble("\n#ifdef __cplusplus\n}\n#endif\n");

--- a/boltffi_backend/src/target/c/mod.rs
+++ b/boltffi_backend/src/target/c/mod.rs
@@ -379,6 +379,19 @@ mod tests {
             #[export]
             pub fn greet(name: String) -> String { name }
 
+            #[repr(C)]
+            #[data]
+            pub struct Pair {
+                pub a: i32,
+                pub b: i32,
+            }
+
+            #[export]
+            pub fn total(pairs: Vec<crate::Pair>) -> u32 { 0 }
+
+            #[export]
+            pub fn measure(pairs: &[crate::Pair]) -> u32 { 0 }
+
             #[repr(i32)]
             #[data]
             pub enum DivisionError { DivideByZero = 1 }
@@ -405,6 +418,15 @@ mod tests {
             .find(|file| file.path().as_path() == std::path::Path::new("boltffi.h"))
             .expect("boltffi.h")
             .contents();
+        // "total" takes Vec<direct record>: a packed direct vector, whose
+        // pointer crosses the ABI as opaque bytes with a byte count. The facade
+        // must cast the typed slice pointer and scale the element count; either
+        // half missing fails the compile below. "measure" takes a shared slice
+        // of the same record, which packs through an encoded slice instead.
+        assert!(header.contains(
+            "boltffi_function_demo_total((const uint8_t *)pairs.ptr, pairs.len * sizeof(DemoPair))"
+        ));
+
         let dir = std::env::temp_dir().join(format!("boltffi_c_test_{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("temp dir");
         std::fs::write(dir.join("boltffi.h"), header).expect("write header");

--- a/boltffi_backend/src/target/c/render/callable.rs
+++ b/boltffi_backend/src/target/c/render/callable.rs
@@ -238,7 +238,15 @@ impl<'a> State<'a> {
                 let c = surface::direct_vector_type(element, self.context, use_)?;
                 self.params.push(format!("{c} {name}"));
                 self.args.push(format!("{name}.ptr"));
-                self.args.push(format!("{name}.len"));
+                // Packed direct-record vectors carry a byte count; typed
+                // primitive vectors carry an element count.
+                self.args.push(match element {
+                    boltffi_binding::DirectVectorElementType::Record(_) => format!(
+                        "{name}.len * sizeof({})",
+                        surface::direct_vector_element_type(element, self.context)?
+                    ),
+                    _ => format!("{name}.len"),
+                });
             }
             ParamPlan::Handle {
                 target: HandleTarget::Callback(id),
@@ -250,6 +258,7 @@ impl<'a> State<'a> {
             }
             ParamPlan::Handle {
                 target: HandleTarget::Class(id),
+                receive,
                 ..
             } => {
                 let class = self.context.class(*id).ok_or(Error::BrokenBridgeContract {
@@ -258,8 +267,17 @@ impl<'a> State<'a> {
                 })?;
                 let c = PackagePrefix::from_context(self.context)
                     .type_name(&Name::new(class.name()).r#type());
-                self.params.push(format!("const {c} *{name}"));
-                self.args.push(format!("{name}->_boltffi_handle"));
+                if *receive == Receive::ByValue {
+                    // Ownership transfers to the Rust side, which frees the
+                    // handle after the call; invalidate the caller's copy.
+                    self.params.push(format!("{c} *{name}"));
+                    self.args.push(format!("{name}->_boltffi_handle"));
+                    self.cleanup
+                        .push(format!("    {name}->_boltffi_handle = 0;"));
+                } else {
+                    self.params.push(format!("const {c} *{name}"));
+                    self.args.push(format!("{name}->_boltffi_handle"));
+                }
             }
             _ => return unsupported("callable parameter plan"),
         }

--- a/boltffi_backend/src/target/c/render/callable.rs
+++ b/boltffi_backend/src/target/c/render/callable.rs
@@ -230,23 +230,36 @@ impl<'a> State<'a> {
                 self.pack_scalar_option(&name, *primitive);
             }
             ParamPlan::DirectVec { element, receive } => {
-                let use_ = if *receive == Receive::ByMutRef {
+                let mutable = *receive == Receive::ByMutRef;
+                let use_ = if mutable {
                     surface::ValueUse::ParamMut
                 } else {
                     surface::ValueUse::Param
                 };
                 let c = surface::direct_vector_type(element, self.context, use_)?;
                 self.params.push(format!("{c} {name}"));
-                self.args.push(format!("{name}.ptr"));
-                // Packed direct-record vectors carry a byte count; typed
-                // primitive vectors carry an element count.
-                self.args.push(match element {
-                    boltffi_binding::DirectVectorElementType::Record(_) => format!(
-                        "{name}.len * sizeof({})",
-                        surface::direct_vector_element_type(element, self.context)?
-                    ),
-                    _ => format!("{name}.len"),
-                });
+                match element {
+                    // Packed direct-record vectors cross the C ABI as opaque bytes with a
+                    // byte count, so the typed slice pointer needs a byte-pointer cast: the
+                    // bridge parameter is a const/non-const uint8_t pointer, never the
+                    // element pointer this facade slice type carries.
+                    boltffi_binding::DirectVectorElementType::Record(_) => {
+                        self.args.push(format!(
+                            "({}uint8_t *){name}.ptr",
+                            if mutable { "" } else { "const " }
+                        ));
+                        self.args.push(format!(
+                            "{name}.len * sizeof({})",
+                            surface::direct_vector_element_type(element, self.context)?
+                        ));
+                    }
+                    // Typed primitive vectors carry an element pointer and an element count,
+                    // matching the typed bridge parameter.
+                    _ => {
+                        self.args.push(format!("{name}.ptr"));
+                        self.args.push(format!("{name}.len"));
+                    }
+                }
             }
             ParamPlan::Handle {
                 target: HandleTarget::Callback(id),

--- a/boltffi_backend/src/target/c/render/surface.rs
+++ b/boltffi_backend/src/target/c/render/surface.rs
@@ -10,7 +10,19 @@ use crate::{
 
 use super::prefix::PackagePrefix;
 
-pub fn render(bindings: &Bindings<Native>, context: &RenderContext<Native>) -> Result<String> {
+pub fn render(
+    bindings: &Bindings<Native>,
+    context: &RenderContext<Native>,
+    rendered: &std::collections::HashSet<boltffi_binding::DeclarationId>,
+) -> Result<String> {
+    // Partial coverage may skip declarations. Everything record-shaped uses
+    // the closure of rendered records: a rendered encoded record may embed
+    // another record whose codec the emitted helpers call, so those records
+    // must be included even when their own declaration was skipped.
+    let record_ids = included_record_ids(bindings, rendered);
+    let is_rendered = |decl: &boltffi_binding::Decl<Native>| {
+        rendered.contains(&boltffi_binding::DeclarationRef::from(decl).id())
+    };
     let prefix = PackagePrefix::from_context(context);
     let mut out = String::new();
     out.push_str("#include <stdlib.h>\n#include <string.h>\n\n");
@@ -32,6 +44,9 @@ pub fn render(bindings: &Bindings<Native>, context: &RenderContext<Native>) -> R
     for decl in bindings.decls() {
         match boltffi_binding::DeclarationRef::from(decl) {
             boltffi_binding::DeclarationRef::Enum(EnumDecl::CStyle(enumeration)) => {
+                if !is_rendered(decl) {
+                    continue;
+                }
                 out.push_str(&format!(
                     "typedef ___{} {};\n",
                     Name::new(enumeration.name()).r#type(),
@@ -39,6 +54,9 @@ pub fn render(bindings: &Bindings<Native>, context: &RenderContext<Native>) -> R
                 ));
             }
             boltffi_binding::DeclarationRef::Record(RecordDecl::Direct(record)) => {
+                if !is_rendered(decl) {
+                    continue;
+                }
                 out.push_str(&format!(
                     "typedef ___{} {};\n",
                     Name::new(record.name()).r#type(),
@@ -46,6 +64,9 @@ pub fn render(bindings: &Bindings<Native>, context: &RenderContext<Native>) -> R
                 ));
             }
             boltffi_binding::DeclarationRef::Class(class) => {
+                if !is_rendered(decl) {
+                    continue;
+                }
                 let ty = type_name(&prefix, class.name());
                 out.push_str(&format!(
                     "typedef struct {{ uint64_t _boltffi_handle; }} {ty};\n"
@@ -60,6 +81,9 @@ pub fn render(bindings: &Bindings<Native>, context: &RenderContext<Native>) -> R
         if let boltffi_binding::DeclarationRef::Record(RecordDecl::Encoded(record)) =
             boltffi_binding::DeclarationRef::from(decl)
         {
+            if !record_ids.contains(&record.id()) {
+                continue;
+            }
             let ty = type_name(&prefix, record.name());
             out.push_str(&format!(
                 "typedef struct {ty}View {ty}View;\ntypedef struct {ty} {ty};\n"
@@ -83,6 +107,9 @@ pub fn render(bindings: &Bindings<Native>, context: &RenderContext<Native>) -> R
         if let boltffi_binding::DeclarationRef::Record(record) =
             boltffi_binding::DeclarationRef::from(decl)
         {
+            if !record_ids.contains(&record.id()) {
+                continue;
+            }
             let ty = type_name(&prefix, record.name());
             let slice_element = if matches!(record, RecordDecl::Encoded(_)) {
                 format!("{ty}View")
@@ -101,6 +128,9 @@ pub fn render(bindings: &Bindings<Native>, context: &RenderContext<Native>) -> R
         if let boltffi_binding::DeclarationRef::Record(RecordDecl::Encoded(record)) =
             boltffi_binding::DeclarationRef::from(decl)
         {
+            if !record_ids.contains(&record.id()) {
+                continue;
+            }
             let ty = type_name(&prefix, record.name());
             out.push_str(&format!("struct {ty}View {{\n"));
             for field in record.fields() {
@@ -140,11 +170,72 @@ pub fn render(bindings: &Bindings<Native>, context: &RenderContext<Native>) -> R
         if let boltffi_binding::DeclarationRef::Record(RecordDecl::Encoded(record)) =
             boltffi_binding::DeclarationRef::from(decl)
         {
+            if !record_ids.contains(&record.id()) {
+                continue;
+            }
             out.push_str(&record_codec(record, context)?);
         }
     }
-    out.push_str(&free_helpers(bindings, context)?);
+    out.push_str(&free_helpers(bindings, context, &record_ids)?);
     Ok(out)
+}
+
+/// Collects the records whose surface must be emitted: every rendered record
+/// plus the encoded records they transitively reference through fields.
+fn included_record_ids(
+    bindings: &Bindings<Native>,
+    rendered: &std::collections::HashSet<boltffi_binding::DeclarationId>,
+) -> std::collections::HashSet<boltffi_binding::RecordId> {
+    use std::collections::{HashMap, HashSet};
+
+    let encoded: HashMap<boltffi_binding::RecordId, &boltffi_binding::EncodedRecordDecl<Native>> =
+        bindings
+            .decls()
+            .iter()
+            .filter_map(|decl| match boltffi_binding::DeclarationRef::from(decl) {
+                boltffi_binding::DeclarationRef::Record(RecordDecl::Encoded(record)) => {
+                    Some((record.id(), &**record))
+                }
+                _ => None,
+            })
+            .collect();
+    let mut included: HashSet<boltffi_binding::RecordId> = rendered
+        .iter()
+        .filter_map(|id| match id {
+            boltffi_binding::DeclarationId::Record(record) => Some(*record),
+            _ => None,
+        })
+        .collect();
+    let mut queue: Vec<boltffi_binding::RecordId> = included.iter().copied().collect();
+    while let Some(id) = queue.pop() {
+        let Some(record) = encoded.get(&id) else {
+            continue;
+        };
+        for field in record.fields() {
+            collect_record_refs(field.ty(), &encoded, &mut included, &mut queue);
+        }
+    }
+    included
+}
+
+fn collect_record_refs(
+    ty: &TypeRef,
+    encoded: &std::collections::HashMap<
+        boltffi_binding::RecordId,
+        &boltffi_binding::EncodedRecordDecl<Native>,
+    >,
+    included: &mut std::collections::HashSet<boltffi_binding::RecordId>,
+    queue: &mut Vec<boltffi_binding::RecordId>,
+) {
+    match ty {
+        TypeRef::Record(id) if encoded.contains_key(id) && !included.contains(id) => {
+            included.insert(*id);
+            queue.push(*id);
+        }
+        TypeRef::Optional(inner) => collect_record_refs(inner, encoded, included, queue),
+        TypeRef::Sequence(element) => collect_record_refs(element, encoded, included, queue),
+        _ => {}
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -840,7 +931,11 @@ fn wire_read_stmt(primitive: Primitive, expr: &str, package: &str) -> String {
     format!("{expr} = {};", wire_read_expr(primitive, package))
 }
 
-fn free_helpers(bindings: &Bindings<Native>, context: &RenderContext<Native>) -> Result<String> {
+fn free_helpers(
+    bindings: &Bindings<Native>,
+    context: &RenderContext<Native>,
+    record_ids: &std::collections::HashSet<boltffi_binding::RecordId>,
+) -> Result<String> {
     let mut out = String::new();
     let p = package_member(context);
     let package_type_prefix = package_pascal(context);
@@ -856,6 +951,9 @@ fn free_helpers(bindings: &Bindings<Native>, context: &RenderContext<Native>) ->
         if let boltffi_binding::DeclarationRef::Record(record) =
             boltffi_binding::DeclarationRef::from(decl)
         {
+            if !record_ids.contains(&record.id()) {
+                continue;
+            }
             let ty = type_name(&prefix, record.name());
             let m = Name::new(record.name()).member();
             if matches!(record, RecordDecl::Encoded(encoded) if encoded.fields().iter().any(|field| type_owns(field.ty(), context)))

--- a/boltffi_bindgen/src/generate.rs
+++ b/boltffi_bindgen/src/generate.rs
@@ -6,6 +6,7 @@ use boltffi_backend::bridge::c::CBridge;
 use boltffi_backend::core::bridge::BridgeBackend;
 use boltffi_backend::core::{CoverageMode, bridge, host};
 use boltffi_backend::target::{
+    c::CHost,
     csharp::CSharpHost,
     dart::DartHost,
     java::{JavaDesktopLoader, JavaHost, JavaVersion},
@@ -436,7 +437,11 @@ impl Generation {
             }
             Target::Swift => self.render_swift(),
             Target::TypeScript => self.render_typescript(),
-            Target::Header | Target::C => Err(GenerationError::UnsupportedTarget { target }),
+            Target::C => {
+                let bindings = self.bindings::<Native>()?;
+                self.render_native_bindings(target, &bindings)
+            }
+            Target::Header => Err(GenerationError::UnsupportedTarget { target }),
         }
     }
 
@@ -471,7 +476,8 @@ impl Generation {
             Target::KotlinMultiplatform => self.render_kmp_bindings(bindings),
             Target::CSharp => self.render_csharp_bindings(bindings),
             Target::Dart => self.render_dart_bindings(bindings),
-            Target::Swift | Target::TypeScript | Target::Header | Target::C => {
+            Target::C => self.render_c_bindings(bindings),
+            Target::Swift | Target::TypeScript | Target::Header => {
                 Err(GenerationError::UnsupportedTarget { target })
             }
         }
@@ -648,6 +654,16 @@ impl Generation {
         bridge
             .render_bridge(bindings, &contract)
             .map_err(GenerationError::Render)
+    }
+
+    fn render_c_bindings(
+        &self,
+        bindings: &Bindings<Native>,
+    ) -> Result<GeneratedOutput, GenerationError> {
+        let target = CHost::new()
+            .into_target(bindings)
+            .map_err(GenerationError::Render)?;
+        self.render_backend(&target, bindings)
     }
 
     fn render_csharp_bindings(

--- a/boltffi_cli/src/cli.rs
+++ b/boltffi_cli/src/cli.rs
@@ -196,6 +196,8 @@ pub(crate) enum GenerateTargetArg {
     Python,
     #[value(help = "Generate C# bindings")]
     Csharp,
+    #[value(help = "Generate experimental C bindings (sync surface)")]
+    C,
     #[value(help = "Generate all bindings")]
     All,
 }
@@ -479,6 +481,7 @@ pub(crate) fn execute_command(
                         GenerateTargetArg::Dart => GenerateTarget::Dart,
                         GenerateTargetArg::Python => GenerateTarget::Python,
                         GenerateTargetArg::Csharp => GenerateTarget::CSharp,
+                        GenerateTargetArg::C => GenerateTarget::C,
                         GenerateTargetArg::All => GenerateTarget::All,
                     })
                     .unwrap_or(GenerateTarget::All),
@@ -1426,6 +1429,21 @@ enabled = true
             Commands::Generate {
                 target: Some(GenerateTargetArg::Csharp),
                 experimental: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn cli_parses_generate_c_target() {
+        let cli = Cli::try_parse_from(["boltffi", "generate", "c", "--experimental"])
+            .expect("cli parse should succeed");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Generate {
+                target: Some(GenerateTargetArg::C),
+                experimental: true,
                 ..
             }
         ));

--- a/boltffi_cli/src/commands/generate/bindings.rs
+++ b/boltffi_cli/src/commands/generate/bindings.rs
@@ -92,6 +92,7 @@ pub fn run_generation(config: &Config, options: &GenerateOptions) -> Result<()> 
         GenerateTarget::Dart => generate_dart(config, options),
         GenerateTarget::CSharp => generate_csharp(config, options),
         GenerateTarget::Header => generate_header(config, options),
+        GenerateTarget::C => generate_c(config, options),
         other => Err(CliError::CommandFailed {
             command: format!("cannot directly generate {}", target_label(other)),
             status: None,
@@ -457,6 +458,45 @@ fn generate_python(config: &Config, options: &GenerateOptions) -> Result<()> {
         expansion.toolchain_selector().map(str::to_owned),
         options.deny_skipped,
     )
+}
+
+fn generate_c(config: &Config, options: &GenerateOptions) -> Result<()> {
+    if !config.is_c_enabled() {
+        return Err(CliError::CommandFailed {
+            command: "targets.c.enabled = false".to_string(),
+            status: None,
+        });
+    }
+
+    if !config.should_process(Target::C, options.experimental) {
+        return Err(CliError::CommandFailed {
+            command: format!(
+                "{} is experimental, use --experimental flag or add \"{}\" to [experimental]",
+                Target::C.name(),
+                Target::C.name()
+            ),
+            status: None,
+        });
+    }
+
+    let expansion = BindingExpansion::resolve_for_commands(
+        config,
+        &["build", "generate"],
+        &options.cargo_args,
+    )?;
+    let output_directory = options.output.clone().unwrap_or_else(|| config.c_output());
+
+    expansion
+        .generation()
+        .coverage_mode(CoverageMode::Partial)
+        .render(Target::C)
+        .map_err(|error| generation_error(Target::C.name(), error))
+        .and_then(|output| {
+            print_coverage(Target::C.name(), &output, options.deny_skipped)?;
+            Generation::write_output(output, &output_directory)
+                .map(drop)
+                .map_err(|error| generation_error(Target::C.name(), error))
+        })
 }
 
 fn generate_kotlin(config: &Config, options: &GenerateOptions) -> Result<()> {
@@ -856,6 +896,7 @@ fn target_label(target: &GenerateTarget) -> &'static str {
         GenerateTarget::Dart => "dart",
         GenerateTarget::Python => "python",
         GenerateTarget::CSharp => "csharp",
+        GenerateTarget::C => "c",
         GenerateTarget::All => "all",
     }
 }

--- a/boltffi_cli/src/commands/generate/mod.rs
+++ b/boltffi_cli/src/commands/generate/mod.rs
@@ -18,6 +18,7 @@ pub enum GenerateTarget {
     Dart,
     Python,
     CSharp,
+    C,
     All,
 }
 
@@ -41,6 +42,7 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
         GenerateTarget::Dart => bindings::run_generation(config, &options),
         GenerateTarget::Python => bindings::run_generation(config, &options),
         GenerateTarget::CSharp => bindings::run_generation(config, &options),
+        GenerateTarget::C => bindings::run_generation(config, &options),
         GenerateTarget::All => {
             if config.should_process(Target::Swift, options.experimental) {
                 bindings::run_generation(
@@ -125,6 +127,19 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
                     config,
                     &GenerateOptions {
                         target: GenerateTarget::Python,
+                        output: options.output.clone(),
+                        experimental: options.experimental,
+                        cargo_args: options.cargo_args.clone(),
+                        deny_skipped: options.deny_skipped,
+                    },
+                )?;
+            }
+
+            if config.should_process(Target::C, options.experimental) {
+                bindings::run_generation(
+                    config,
+                    &GenerateOptions {
+                        target: GenerateTarget::C,
                         output: options.output.clone(),
                         experimental: options.experimental,
                         cargo_args: options.cargo_args.clone(),

--- a/boltffi_cli/src/commands/init.rs
+++ b/boltffi_cli/src/commands/init.rs
@@ -2,10 +2,10 @@ use std::path::{Path, PathBuf};
 
 use crate::cli::Result;
 use crate::config::{
-    AndroidConfig, AndroidLinkConfig, AndroidPackConfig, AppleConfig, CSharpConfig, CargoConfig,
-    Config, DartConfig, DebugSymbolsConfig, ErrorStyle, HeaderConfig, JavaConfig, KotlinConfig,
-    KotlinFactoryStyle, KotlinMultiplatformConfig, PackageConfig, PythonConfig, SpmConfig,
-    SwiftConfig, TargetsConfig, WasmConfig, XcframeworkConfig,
+    AndroidConfig, AndroidLinkConfig, AndroidPackConfig, AppleConfig, CConfig, CSharpConfig,
+    CargoConfig, Config, DartConfig, DebugSymbolsConfig, ErrorStyle, HeaderConfig, JavaConfig,
+    KotlinConfig, KotlinFactoryStyle, KotlinMultiplatformConfig, PackageConfig, PythonConfig,
+    SpmConfig, SwiftConfig, TargetsConfig, WasmConfig, XcframeworkConfig,
 };
 
 pub struct InitOptions {
@@ -135,6 +135,7 @@ fn create_default_config(package_name: &str) -> Config {
             dart: DartConfig::default(),
             python: PythonConfig::default(),
             csharp: CSharpConfig::default(),
+            c: CConfig::default(),
         },
     }
 }

--- a/boltffi_cli/src/config/experimental.rs
+++ b/boltffi_cli/src/config/experimental.rs
@@ -14,6 +14,7 @@ impl Experimental {
         },
         Experimental::WholeTarget(Target::Dart),
         Experimental::WholeTarget(Target::KotlinMultiplatform),
+        Experimental::WholeTarget(Target::C),
     ];
 
     pub fn is_target_experimental(target: Target) -> bool {

--- a/boltffi_cli/src/config/mod.rs
+++ b/boltffi_cli/src/config/mod.rs
@@ -16,8 +16,8 @@ pub use cargo::{CargoConfig, PackageConfig};
 pub use experimental::Experimental;
 pub use symbols::{DebugSymbolsBundle, DebugSymbolsConfig, DebugSymbolsFormat};
 pub use targets::{
-    AndroidConfig, AndroidLinkConfig, AndroidPackConfig, AppleConfig, CSharpConfig, DartConfig,
-    HeaderConfig, JavaConfig, KotlinApiStyle, KotlinConfig, KotlinDesktopLoader,
+    AndroidConfig, AndroidLinkConfig, AndroidPackConfig, AppleConfig, CConfig, CSharpConfig,
+    DartConfig, HeaderConfig, JavaConfig, KotlinApiStyle, KotlinConfig, KotlinDesktopLoader,
     KotlinFactoryStyle, KotlinMultiplatformConfig, PythonConfig, SpmConfig, SpmDistribution,
     SpmLayout, SwiftConfig, TargetsConfig, WasmConfig, WasmNpmTarget, WasmOptimizeLevel,
     WasmOptimizeOnMissing, WasmProfile, XcframeworkConfig,
@@ -401,6 +401,10 @@ impl Config {
         self.targets.csharp.enabled
     }
 
+    pub fn is_c_enabled(&self) -> bool {
+        self.targets.c.enabled
+    }
+
     pub fn is_kotlin_multiplatform_enabled(&self) -> bool {
         self.targets.kotlin_multiplatform.enabled
     }
@@ -761,7 +765,7 @@ impl Config {
             Target::Dart => self.is_dart_enabled(),
             Target::Python => self.is_python_enabled(),
             Target::CSharp => self.is_csharp_enabled(),
-            Target::C => false,
+            Target::C => self.is_c_enabled(),
         }
     }
 
@@ -912,6 +916,10 @@ impl Config {
 
     pub fn csharp_output(&self) -> PathBuf {
         self.targets.csharp.output.clone()
+    }
+
+    pub fn c_output(&self) -> PathBuf {
+        self.targets.c.output.clone()
     }
 
     pub fn csharp_namespace(&self) -> Option<&str> {
@@ -2720,5 +2728,35 @@ extra_args = ["-Wl,-z,max-page-size=16384"]
             config.android_extra_link_args(),
             &["-Wl,-z,max-page-size=16384".to_string()]
         );
+    }
+
+    #[test]
+    fn c_target_is_experimental_and_requires_opt_in() {
+        assert!(Experimental::is_target_experimental(Target::C));
+        let config = parse_config(
+            r#"
+[package]
+name = "my-lib"
+
+[targets.c]
+enabled = true
+"#,
+        );
+        assert!(!config.should_process(Target::C, false));
+        assert!(config.should_process(Target::C, true));
+        // Opt in via [experimental].
+        let config = parse_config(
+            r#"
+experimental = ["c"]
+
+[package]
+name = "my-lib"
+
+[targets.c]
+enabled = true
+"#,
+        );
+        assert!(config.should_process(Target::C, false));
+        assert_eq!(config.c_output(), PathBuf::from("dist/c"));
     }
 }

--- a/boltffi_cli/src/config/targets/c.rs
+++ b/boltffi_cli/src/config/targets/c.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// `[targets.c]` configuration for the experimental C host target.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CConfig {
+    #[serde(default = "default_c_output")]
+    pub output: PathBuf,
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl Default for CConfig {
+    fn default() -> Self {
+        Self {
+            output: default_c_output(),
+            enabled: false,
+        }
+    }
+}
+
+fn default_c_output() -> PathBuf {
+    PathBuf::from("dist/c")
+}

--- a/boltffi_cli/src/config/targets/mod.rs
+++ b/boltffi_cli/src/config/targets/mod.rs
@@ -1,4 +1,5 @@
 pub mod apple;
+pub mod c;
 pub mod c_header;
 pub mod csharp;
 pub mod dart;
@@ -11,6 +12,7 @@ pub mod wasm;
 pub use apple::{
     AppleConfig, SpmConfig, SpmDistribution, SpmLayout, SwiftConfig, XcframeworkConfig,
 };
+pub use c::CConfig;
 pub use c_header::HeaderConfig;
 pub use csharp::CSharpConfig;
 #[cfg(test)]
@@ -49,4 +51,6 @@ pub struct TargetsConfig {
     pub python: PythonConfig,
     #[serde(default)]
     pub csharp: CSharpConfig,
+    #[serde(default)]
+    pub c: CConfig,
 }


### PR DESCRIPTION
Fifth layer of the experimental C target (continuation of #841). Depends on #841.

Exposes the C target behind the experimental gate: adds the `[targets.c]` config section (output path, enabled flag), registers the whole C target as `Experimental`, and threads it through the generate command and CLI so `boltffi generate c --experimental` renders the C facade into the configured output directory. Seeds the config in `init` and documents the `[targets.c]` keys in the TOML spec.