### PR TITLE
feat(cli): package C headers with shared and static libraries

### DIFF
--- a/BOLTFFI_TOML_SPEC.md
+++ b/BOLTFFI_TOML_SPEC.md
@@ -498,6 +498,33 @@ Generates a binary-only SwiftPM package intended to be depended on by a separate
 - Generated Swift bindings are written to `{swift.output}/BoltFFIGenerated/{module_name}.swift` so you can include them in your wrapper target.
 ## Dart
 
+### `[targets.c]` (experimental, optional)
+
+The C host target is experimental. `boltffi generate c --experimental` (or
+listing `c` under `[experimental]`) writes an intermediate `boltffi.h`; use
+`boltffi pack c --experimental` to stage a consumer package.
+
+- `enabled` (bool): Whether C generation and packaging are active.
+  - Default: `false`
+- `output` (path): C output root.
+  - Default: `dist/c`
+  - `generate c` writes `{output}/boltffi.h`.
+  - `pack c` stages `{output}/include/<library>.h`, a host shared library, and
+    a static archive beneath `{output}/lib`.
+- The normal API is the package-prefixed ergonomic facade. Raw `boltffi_*`,
+  `Ffi*`, and `___*` declarations in the same header are bridge details.
+- The intended supported surface is synchronous free functions, direct
+  `#[repr(C)]` records, repr-integer C-style enums, constants, classes, and
+  sync callback traits. Streams, custom types, payload enums, async callbacks,
+  futures, encoded value shapes, and inline closures have no supported
+  ergonomic C representation.
+- C consumers require C11 or later. The public header is also checked in
+  C++03 mode and newer on GCC/Clang; its C++ atomics use compiler intrinsics
+  (and MSVC uses interlocked intrinsics).
+
+C packaging is currently host-oriented and Unix-validated. Cross-target and
+Windows artifact staging should not be relied on until separately validated.
+
 ### `[targets.dart]` (optional)
 - `enabled` (bool): Whether Dart generation and packaging are active.
   - Default: `false`

--- a/boltffi_backend/fixtures/c_bridge_declaration_surface.h
+++ b/boltffi_backend/fixtures/c_bridge_declaration_surface.h
@@ -3,7 +3,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif !defined(__cplusplus)
 #include <stdatomic.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,12 +17,25 @@ typedef struct {
     int32_t code;
 } FfiStatus;
 
+#ifdef __cplusplus
+static inline FfiStatus boltffi_status_from_code(int32_t code) {
+    FfiStatus status = { code };
+    return status;
+}
+#define FFI_STATUS_OK boltffi_status_from_code(0)
+#define FFI_STATUS_NULL_POINTER boltffi_status_from_code(1)
+#define FFI_STATUS_BUFFER_TOO_SMALL boltffi_status_from_code(2)
+#define FFI_STATUS_INVALID_ARG boltffi_status_from_code(3)
+#define FFI_STATUS_CANCELLED boltffi_status_from_code(4)
+#define FFI_STATUS_INTERNAL_ERROR boltffi_status_from_code(100)
+#else
 #define FFI_STATUS_OK ((FfiStatus){0})
 #define FFI_STATUS_NULL_POINTER ((FfiStatus){1})
 #define FFI_STATUS_BUFFER_TOO_SMALL ((FfiStatus){2})
 #define FFI_STATUS_INVALID_ARG ((FfiStatus){3})
 #define FFI_STATUS_CANCELLED ((FfiStatus){4})
 #define FFI_STATUS_INTERNAL_ERROR ((FfiStatus){100})
+#endif
 
 typedef struct {
     uint8_t *ptr;
@@ -48,6 +65,41 @@ typedef int32_t WaitResult;
 typedef void (*RustFutureContinuationCallback)(uint64_t callback_data, int8_t poll_result);
 typedef void (*StreamContinuationCallback)(uint64_t callback_data, StreamPollResult result);
 
+#if defined(_MSC_VER)
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return _InterlockedCompareExchange8((volatile char *)state, (char)desired, (char)expected) == (char)expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return (uint64_t)_InterlockedExchange64((volatile __int64 *)slot, (__int64)value);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, (__int64)desired, (__int64)expected) == expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, 0, 0);
+}
+#elif defined(__cplusplus) && (defined(__clang__) || defined(__GNUC__))
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return __atomic_compare_exchange_n(state, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return __atomic_exchange_n(slot, value, __ATOMIC_ACQ_REL);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return __atomic_compare_exchange_n(slot, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return __atomic_load_n(slot, __ATOMIC_ACQUIRE);
+}
+#elif defined(__cplusplus)
+#error "BoltFFI C++ atomics require GCC, Clang, or MSVC"
+#else
 static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
     return atomic_compare_exchange_strong_explicit((_Atomic uint8_t *)state, &expected, desired, memory_order_acq_rel, memory_order_acquire);
 }
@@ -63,6 +115,7 @@ static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uin
 static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
     return atomic_load_explicit((_Atomic uint64_t *)slot, memory_order_acquire);
 }
+#endif
 
 typedef struct {
     uint64_t handle;
@@ -71,6 +124,7 @@ typedef struct {
 
 void boltffi_free_string(FfiString string);
 void boltffi_free_buf(FfiBuf_u8 buf);
+FfiString boltffi_buf_into_string(FfiBuf_u8 buf);
 FfiBuf_u8 boltffi_buf_from_bytes(const uint8_t *ptr, uintptr_t len);
 FfiBuf_u8 boltffi_buf_with_len(uintptr_t len);
 FfiStatus boltffi_last_error_message(FfiString *out);

--- a/boltffi_backend/src/bridge/c/support.rs
+++ b/boltffi_backend/src/bridge/c/support.rs
@@ -25,6 +25,11 @@ impl SupportFunctions {
                     Type::Void,
                 )?,
                 Function::new(
+                    "boltffi_buf_into_string",
+                    vec![Parameter::new("buf", Type::Buffer)?],
+                    Type::String,
+                )?,
+                Function::new(
                     "boltffi_buf_from_bytes",
                     vec![
                         Parameter::new("ptr", Type::ConstPointer(Box::new(Type::Uint8)))?,

--- a/boltffi_backend/src/target/c/mod.rs
+++ b/boltffi_backend/src/target/c/mod.rs
@@ -1,0 +1,256 @@
+//! C host renderer (experimental).
+//!
+//! This is the C host scaffolding every renderer hangs off. C calls the shared
+//! C ABI (`CBridge`) directly, so unlike a runtime bridge there is no extra
+//! bridge layer stacked on top. The host's syntax fragments are the C fragments
+//! the bridge already emits (`crate::bridge::c`).
+
+pub mod name_style;
+pub mod syntax;
+
+pub use self::syntax::Syntax;
+
+use boltffi_binding::{
+    Bindings, CallbackDecl, ClassDecl, ConstantDecl, CustomTypeDecl, EnumDecl, FunctionDecl,
+    Native, RecordDecl, StreamDecl,
+};
+
+use crate::{
+    bridge::c::CBridge,
+    core::{
+        BindingCapability, BridgeCapability, CapabilityRequirements, Emitted, Error,
+        GeneratedOutput, HostCapabilities, RenderContext, RenderedDeclaration, Result, Target,
+        contract::sealed, host,
+    },
+};
+
+/// C host renderer paired with the shared C ABI bridge.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub struct CHost;
+
+impl CHost {
+    /// Creates a C host renderer.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Creates the backend target stack for this C host.
+    ///
+    /// C calls the C ABI directly, so the stack is just `CBridge` with no
+    /// additional bridge layer.
+    pub fn into_target(self, _bindings: &Bindings<Native>) -> Result<Target<Self, CBridge>> {
+        Ok(Target::new(self, CBridge::default_header()?))
+    }
+}
+
+impl host::HostBackend for CHost {
+    type Surface = Native;
+    type Bridge = crate::bridge::c::CBridgeContract;
+    type Syntax = Syntax;
+
+    fn name(&self) -> &'static str {
+        "c"
+    }
+
+    fn binding_capabilities(&self) -> HostCapabilities {
+        HostCapabilities::new()
+            .unsupported(BindingCapability::Records, "not yet implemented in C host")
+            .unsupported(BindingCapability::Enums, "not yet implemented in C host")
+            .unsupported(
+                BindingCapability::Functions,
+                "not yet implemented in C host",
+            )
+            .unsupported(BindingCapability::Classes, "not yet implemented in C host")
+            .unsupported(
+                BindingCapability::Callbacks,
+                "not yet implemented in C host",
+            )
+            .unsupported(BindingCapability::Streams, "not yet implemented in C host")
+            .unsupported(
+                BindingCapability::Constants,
+                "not yet implemented in C host",
+            )
+            .unsupported(
+                BindingCapability::CustomTypes,
+                "not yet implemented in C host",
+            )
+    }
+
+    fn bridge_capabilities(&self) -> CapabilityRequirements<BridgeCapability> {
+        // C calls the ABI directly; only the C ABI surface is required.
+        CapabilityRequirements::new().require(BridgeCapability::CAbi)
+    }
+
+    fn record(
+        &self,
+        _decl: &RecordDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "record",
+        })
+    }
+
+    fn enumeration(
+        &self,
+        _decl: &EnumDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "enum",
+        })
+    }
+
+    fn function(
+        &self,
+        _decl: &FunctionDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "function",
+        })
+    }
+
+    fn class(
+        &self,
+        _decl: &ClassDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "class",
+        })
+    }
+
+    fn callback(
+        &self,
+        _decl: &CallbackDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "callback",
+        })
+    }
+
+    fn stream(
+        &self,
+        _decl: &StreamDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "stream",
+        })
+    }
+
+    fn constant(
+        &self,
+        _decl: &ConstantDecl<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "constant",
+        })
+    }
+
+    fn custom_type(
+        &self,
+        _decl: &CustomTypeDecl,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+    ) -> Result<Emitted> {
+        Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "custom type",
+        })
+    }
+
+    fn assemble<'decl>(
+        &self,
+        _bindings: &Bindings<Self::Surface>,
+        _bridge: &Self::Bridge,
+        _context: &RenderContext<Self::Surface>,
+        declarations: Vec<RenderedDeclaration<'decl, Self::Surface>>,
+    ) -> Result<GeneratedOutput> {
+        // Temporary single-file layout marker until task 02 lands the real
+        // file planning. Every render method currently errors, so this is
+        // never reached with declarations.
+        let emitted = declarations
+            .into_iter()
+            .map(|declaration| declaration.into_parts().1)
+            .collect::<Vec<_>>();
+        crate::core::FileLayout::single(crate::core::FilePath::new("boltffi.c")?).assemble(emitted)
+    }
+}
+
+impl sealed::HostBackend for CHost {}
+
+#[cfg(test)]
+mod tests {
+    use boltffi_ast::PackageInfo;
+    use boltffi_binding::{Bindings, Native, lower};
+
+    use crate::{
+        core::{BindingCapability, CapabilityStatus, host::HostBackend},
+        target::c::CHost,
+    };
+
+    fn empty_bindings() -> Bindings<Native> {
+        let source = boltffi_scan::scan_file(
+            syn::parse_str("").expect("valid empty source"),
+            PackageInfo::new("demo", None),
+        )
+        .expect("empty source should scan");
+        lower::<Native>(&source).expect("empty source should lower")
+    }
+
+    #[test]
+    fn name_is_c() {
+        assert_eq!(CHost::new().name(), "c");
+    }
+
+    #[test]
+    fn every_binding_capability_is_unsupported() {
+        let capabilities = CHost::new().binding_capabilities();
+        for capability in [
+            BindingCapability::Records,
+            BindingCapability::Enums,
+            BindingCapability::Functions,
+            BindingCapability::Classes,
+            BindingCapability::Callbacks,
+            BindingCapability::Streams,
+            BindingCapability::Constants,
+            BindingCapability::CustomTypes,
+        ] {
+            assert!(
+                matches!(
+                    capabilities.status(capability),
+                    CapabilityStatus::Unsupported { .. }
+                ),
+                "capability {capability:?} should be unsupported for the C host"
+            );
+        }
+    }
+
+    #[test]
+    fn into_target_succeeds() {
+        let bindings = empty_bindings();
+        let target = CHost::new()
+            .into_target(&bindings)
+            .expect("C host into_target should succeed");
+        assert_eq!(target.host().name(), "c");
+    }
+}

--- a/boltffi_backend/src/target/c/mod.rs
+++ b/boltffi_backend/src/target/c/mod.rs
@@ -6,6 +6,7 @@
 //! the bridge already emits (`crate::bridge::c`).
 
 pub mod name_style;
+mod render;
 pub mod syntax;
 
 pub use self::syntax::Syntax;
@@ -55,22 +56,13 @@ impl host::HostBackend for CHost {
 
     fn binding_capabilities(&self) -> HostCapabilities {
         HostCapabilities::new()
-            .unsupported(BindingCapability::Records, "not yet implemented in C host")
-            .unsupported(BindingCapability::Enums, "not yet implemented in C host")
-            .unsupported(
-                BindingCapability::Functions,
-                "not yet implemented in C host",
-            )
-            .unsupported(BindingCapability::Classes, "not yet implemented in C host")
-            .unsupported(
-                BindingCapability::Callbacks,
-                "not yet implemented in C host",
-            )
+            .stable(BindingCapability::Records)
+            .stable(BindingCapability::Enums)
+            .stable(BindingCapability::Functions)
+            .stable(BindingCapability::Classes)
+            .stable(BindingCapability::Callbacks)
             .unsupported(BindingCapability::Streams, "not yet implemented in C host")
-            .unsupported(
-                BindingCapability::Constants,
-                "not yet implemented in C host",
-            )
+            .stable(BindingCapability::Constants)
             .unsupported(
                 BindingCapability::CustomTypes,
                 "not yet implemented in C host",
@@ -84,62 +76,47 @@ impl host::HostBackend for CHost {
 
     fn record(
         &self,
-        _decl: &RecordDecl<Self::Surface>,
-        _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        decl: &RecordDecl<Self::Surface>,
+        bridge: &Self::Bridge,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        Err(Error::UnsupportedTarget {
-            target: "c",
-            shape: "record",
-        })
+        render::record::render(decl, bridge, context)
     }
 
     fn enumeration(
         &self,
-        _decl: &EnumDecl<Self::Surface>,
-        _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        decl: &EnumDecl<Self::Surface>,
+        bridge: &Self::Bridge,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        Err(Error::UnsupportedTarget {
-            target: "c",
-            shape: "enum",
-        })
+        render::enumeration::render(decl, bridge, context)
     }
 
     fn function(
         &self,
-        _decl: &FunctionDecl<Self::Surface>,
-        _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        decl: &FunctionDecl<Self::Surface>,
+        bridge: &Self::Bridge,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        Err(Error::UnsupportedTarget {
-            target: "c",
-            shape: "function",
-        })
+        render::function::render(decl, bridge, context)
     }
 
     fn class(
         &self,
-        _decl: &ClassDecl<Self::Surface>,
-        _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        decl: &ClassDecl<Self::Surface>,
+        bridge: &Self::Bridge,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        Err(Error::UnsupportedTarget {
-            target: "c",
-            shape: "class",
-        })
+        render::class::render(decl, bridge, context)
     }
 
     fn callback(
         &self,
-        _decl: &CallbackDecl<Self::Surface>,
-        _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        decl: &CallbackDecl<Self::Surface>,
+        bridge: &Self::Bridge,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        Err(Error::UnsupportedTarget {
-            target: "c",
-            shape: "callback",
-        })
+        render::callback::render(decl, bridge, context)
     }
 
     fn stream(
@@ -156,14 +133,11 @@ impl host::HostBackend for CHost {
 
     fn constant(
         &self,
-        _decl: &ConstantDecl<Self::Surface>,
-        _bridge: &Self::Bridge,
-        _context: &RenderContext<Self::Surface>,
+        decl: &ConstantDecl<Self::Surface>,
+        bridge: &Self::Bridge,
+        context: &RenderContext<Self::Surface>,
     ) -> Result<Emitted> {
-        Err(Error::UnsupportedTarget {
-            target: "c",
-            shape: "constant",
-        })
+        render::constant::render(decl, bridge, context)
     }
 
     fn custom_type(
@@ -185,14 +159,24 @@ impl host::HostBackend for CHost {
         _context: &RenderContext<Self::Surface>,
         declarations: Vec<RenderedDeclaration<'decl, Self::Surface>>,
     ) -> Result<GeneratedOutput> {
-        // Temporary single-file layout marker until task 02 lands the real
-        // file planning. Every render method currently errors, so this is
-        // never reached with declarations.
         let emitted = declarations
             .into_iter()
             .map(|declaration| declaration.into_parts().1)
             .collect::<Vec<_>>();
-        crate::core::FileLayout::single(crate::core::FilePath::new("boltffi.c")?).assemble(emitted)
+        // The host appends its ergonomic wrappers to the same `boltffi.h`
+        // header the C ABI bridge produced, so both layers combine into one
+        // consumable header. The bridge closes its own C++ linkage block before
+        // this appended layer, so open a second block for the facade.
+        let file = crate::core::FilePlan::all(crate::core::FilePath::new("boltffi.h")?)
+            .with_preamble(format!(
+                "\n{}\n#ifdef __cplusplus\nextern \"C\" {{\n#endif\n{}",
+                render::surface::render(_bindings, _context)?,
+                render::result::preamble()
+            ))
+            .with_postamble("\n#ifdef __cplusplus\n}\n#endif\n");
+        crate::core::FileLayout::new()
+            .with_file(file)
+            .assemble(emitted)
     }
 }
 
@@ -207,6 +191,25 @@ mod tests {
         core::{BindingCapability, CapabilityStatus, host::HostBackend},
         target::c::CHost,
     };
+
+    fn bindings(source: &str) -> Bindings<Native> {
+        let source = boltffi_scan::scan_file(
+            syn::parse_str(source).expect("valid source"),
+            PackageInfo::new("demo", None),
+        )
+        .expect("source should scan");
+        lower::<Native>(&source).expect("source should lower")
+    }
+
+    fn render_header(output: &crate::core::GeneratedOutput) -> String {
+        output
+            .files()
+            .iter()
+            .find(|file| file.path().as_path() == std::path::Path::new("boltffi.h"))
+            .expect("boltffi.h")
+            .contents()
+            .to_owned()
+    }
 
     fn empty_bindings() -> Bindings<Native> {
         let source = boltffi_scan::scan_file(
@@ -223,18 +226,22 @@ mod tests {
     }
 
     #[test]
-    fn every_binding_capability_is_unsupported() {
+    fn sync_value_capabilities_are_stable() {
         let capabilities = CHost::new().binding_capabilities();
         for capability in [
             BindingCapability::Records,
             BindingCapability::Enums,
             BindingCapability::Functions,
+            BindingCapability::Constants,
             BindingCapability::Classes,
             BindingCapability::Callbacks,
-            BindingCapability::Streams,
-            BindingCapability::Constants,
-            BindingCapability::CustomTypes,
         ] {
+            assert!(
+                capabilities.status(capability).is_stable(),
+                "capability {capability:?} should be stable for the C host"
+            );
+        }
+        for capability in [BindingCapability::Streams, BindingCapability::CustomTypes] {
             assert!(
                 matches!(
                     capabilities.status(capability),
@@ -246,11 +253,625 @@ mod tests {
     }
 
     #[test]
+    fn renders_primitive_function_wrapper() {
+        let bindings = bindings(
+            r#"
+            #[export]
+            pub fn add(left: i32, right: i32) -> i32 {
+                left + right
+            }
+            "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let output = target.render(&bindings).expect("render");
+        let header = output
+            .files()
+            .iter()
+            .find(|file| file.path().as_path() == std::path::Path::new("boltffi.h"))
+            .expect("boltffi.h")
+            .contents();
+        assert!(header.contains("static inline int32_t demo_add(int32_t left, int32_t right) {"));
+        assert!(header.contains("boltffi_function_demo_add(left, right)"));
+    }
+
+    #[test]
+    fn c_header_uses_msvc_intrinsics_without_requiring_c11_atomics() {
+        let bindings = empty_bindings();
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let header = render_header(&target.render(&bindings).expect("render"));
+        assert!(header.contains("#if defined(_MSC_VER)\n#include <intrin.h>"));
+        assert!(
+            header.contains(
+                "#elif defined(__cplusplus) && (defined(__clang__) || defined(__GNUC__))"
+            )
+        );
+        assert!(!header.contains("#if defined(__cplusplus) && defined(_MSC_VER)"));
+    }
+
+    #[test]
     fn into_target_succeeds() {
         let bindings = empty_bindings();
         let target = CHost::new()
             .into_target(&bindings)
             .expect("C host into_target should succeed");
         assert_eq!(target.host().name(), "c");
+    }
+
+    #[test]
+    fn renders_record_enum_and_constant_surface() {
+        let bindings = bindings(
+            r#"
+            #[repr(C)]
+            #[data]
+            pub struct Point {
+                pub x: f64,
+                pub y: f64,
+            }
+
+            #[repr(u8)]
+            #[data]
+            pub enum Mode {
+                Fast = 1,
+                Slow = 2,
+            }
+
+            #[export]
+            pub const ANSWER: u32 = 42;
+
+            #[export]
+            pub fn add(left: i32, right: i32) -> i32 { left + right }
+            "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let output = target.render(&bindings).expect("render");
+        let header = output
+            .files()
+            .iter()
+            .find(|file| file.path().as_path() == std::path::Path::new("boltffi.h"))
+            .expect("boltffi.h")
+            .contents()
+            .to_owned();
+        eprintln!("===== HEADER =====\n{header}\n===================");
+        assert!(header.contains("typedef ___Point DemoPoint;"));
+        assert!(header.contains("typedef ___Mode DemoMode;"));
+        assert!(header.contains("#define DEMO_ANSWER 42"));
+        assert!(header.contains("static inline int32_t demo_add(int32_t left, int32_t right) {"));
+    }
+
+    /// Compiles the emitted ergonomic header with the system C toolchain
+    /// (skipped when none is available). Proves the host wrappers line up with
+    /// the locked C ABI by turning the header into a valid object file.
+    #[test]
+    fn emitted_header_compiles_with_cc() {
+        use std::process::Command;
+        if Command::new("cc").arg("--version").output().is_err() {
+            eprintln!("skipping: no C toolchain");
+            return;
+        }
+        let bindings = bindings(
+            r#"
+            #[repr(C)]
+            #[data]
+            pub struct Point {
+                pub x: f64,
+                pub y: f64,
+            }
+
+            #[repr(u8)]
+            #[data]
+            pub enum Mode {
+                Fast = 1,
+                Slow = 2,
+            }
+
+            #[export]
+            pub const ANSWER: u32 = 42;
+
+            #[export]
+            pub fn add(left: i32, right: i32) -> i32 { left + right }
+
+            #[export]
+            pub fn greet(name: String) -> String { name }
+
+            #[repr(i32)]
+            #[data]
+            pub enum DivisionError { DivideByZero = 1 }
+
+            #[export]
+            pub fn divide(value: i32, b: i32) -> Result<i32, DivisionError> {
+                if b == 0 { Err(DivisionError::DivideByZero) } else { Ok(value / b) }
+            }
+
+            pub struct Engine;
+
+            #[export(single_threaded)]
+            impl Engine {
+                pub fn new(seed: u64) -> Self { todo!() }
+                pub fn score(&self, point: crate::Point) -> u32 { 0 }
+            }
+            "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let output = target.render(&bindings).expect("render");
+        let header = output
+            .files()
+            .iter()
+            .find(|file| file.path().as_path() == std::path::Path::new("boltffi.h"))
+            .expect("boltffi.h")
+            .contents();
+        let dir = std::env::temp_dir().join(format!("boltffi_c_test_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        std::fs::write(dir.join("boltffi.h"), header).expect("write header");
+        let source = "\n#include \"boltffi.h\"\nint main(void) { return demo_add(1, 2); }\n";
+        std::fs::write(dir.join("demo.c"), source).expect("write source");
+        let out = Command::new("cc")
+            .current_dir(&dir)
+            .args(["-c", "demo.c", "-o", "demo.o", "-Werror"])
+            .output()
+            .expect("cc runs");
+        assert!(
+            out.status.success(),
+            "cc failed:\n{}\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        if Command::new("c++").arg("--version").output().is_err() {
+            eprintln!("skipping: no C++ toolchain");
+            return;
+        }
+        std::fs::write(
+            dir.join("demo.cpp"),
+            "\n#include \"boltffi.h\"\nint main() {\n    uint8_t state = 0;\n    uint64_t slot = 0;\n    (void)boltffi_atomic_u8_cas(&state, 0, 1);\n    (void)boltffi_atomic_u64_exchange(&slot, 2);\n    (void)boltffi_atomic_u64_cas(&slot, 2, 3);\n    (void)boltffi_atomic_u64_load(&slot);\n    return FFI_STATUS_INTERNAL_ERROR.code == 100 && demo_add(1, 2) == 3 ? 0 : 1;\n}\n",
+        )
+        .expect("write C++ source");
+        let out = Command::new("c++")
+            .current_dir(&dir)
+            .args([
+                "-std=c++03",
+                "-pedantic-errors",
+                "-Werror",
+                "-c",
+                "demo.cpp",
+                "-o",
+                "demo_cpp.o",
+            ])
+            .output()
+            .expect("c++ runs");
+        assert!(
+            out.status.success(),
+            "c++ failed:\n{}\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    #[test]
+    fn renders_class_handle_and_wrappers() {
+        let bindings = bindings(
+            r#"
+            pub struct Engine;
+
+            #[export(single_threaded)]
+            impl Engine {
+                pub fn new(seed: u64) -> Self { todo!() }
+                pub fn score(&self, point: crate::Point) -> u32 { 0 }
+                pub fn advance(&mut self, delta: u32) {}
+            }
+
+            #[repr(C)]
+            #[data]
+            pub struct Point {
+                pub x: f64,
+                pub y: f64,
+            }
+            "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let output = target.render(&bindings).expect("render");
+        let header = render_header(&output);
+        eprintln!("===== CLASS HEADER =====\n{header}\n===================");
+        assert!(header.contains("typedef struct { uint64_t _boltffi_handle; } DemoEngine;"));
+        assert!(header.contains("static inline DemoEngine demo_engine_new(uint64_t seed)"));
+        assert!(header.contains(
+            "boltffi_result._boltffi_handle = boltffi_init_class_demo_engine_new(seed);"
+        ));
+        assert!(header.contains(
+            "static inline uint32_t demo_engine_score(const DemoEngine *receiver, DemoPoint point)"
+        ));
+        assert!(header.contains("static inline void demo_engine_free(DemoEngine *value)"));
+        assert!(header.contains(
+            "static inline void demo_engine_advance(DemoEngine *receiver, uint32_t delta)"
+        ));
+        assert!(
+            header.contains(
+                "boltffi_method_class_demo_engine_score(receiver->_boltffi_handle, point)"
+            )
+        );
+        assert!(header.contains("value->_boltffi_handle=0;"));
+    }
+
+    #[test]
+    fn renders_and_runs_sync_callback_interface() {
+        use std::process::Command;
+
+        let bindings = bindings(
+            r#"
+            #[export]
+            pub trait Listener {
+                fn notify(&self, code: u32);
+                fn on_value(&self, value: u32) -> i64;
+            }
+
+            #[export]
+            pub fn install(listener: impl Listener, code: u32, value: u32) -> i64 {
+                listener.notify(code);
+                listener.on_value(value)
+            }
+            "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let output = target.render(&bindings).expect("render");
+        let header = render_header(&output);
+        assert!(header.contains("typedef ___ListenerVTable DemoListener;"));
+        assert!(
+            header.contains(
+                "typedef struct {\n    BoltFFICallbackHandle raw;\n} DemoListenerHandle;"
+            )
+        );
+        assert!(header.contains("boltffi_register_callback_demo_listener"));
+        assert!(header.contains(
+            "static inline DemoListenerHandle demo_listener_create(const DemoListener *vtable)"
+        ));
+        assert!(header.contains(
+            "int64_t boltffi_function_demo_install(BoltFFICallbackHandle listener, uint32_t code, uint32_t value)"
+        ));
+        assert!(header.contains(
+            "static inline int64_t demo_install(DemoListenerHandle listener, uint32_t code, uint32_t value)"
+        ));
+        assert!(header.contains("boltffi_function_demo_install(listener.raw, code, value)"));
+
+        if Command::new("cc").arg("--version").output().is_err() {
+            eprintln!("skipping: no C toolchain");
+            return;
+        }
+        let dir =
+            std::env::temp_dir().join(format!("boltffi_c_callback_test_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        std::fs::write(dir.join("boltffi.h"), header).expect("write header");
+        // This file is link-only ABI plumbing. The caller below deliberately
+        // never includes or invokes an unergonomic callback API spelling.
+        let abi_shim = r#"
+#include "boltffi.h"
+
+static const ___ListenerVTable *registered_listener;
+
+void boltffi_register_callback_demo_listener(const ___ListenerVTable *vtable) {
+    registered_listener = vtable;
+}
+
+BoltFFICallbackHandle boltffi_create_callback_demo_listener(uint64_t handle) {
+    BoltFFICallbackHandle callback = {handle, registered_listener};
+    return callback;
+}
+
+int64_t boltffi_function_demo_install(BoltFFICallbackHandle listener, uint32_t code, uint32_t value) {
+    const ___ListenerVTable *vtable = (const ___ListenerVTable *)listener.vtable;
+    vtable->notify(listener.handle, code);
+    return vtable->on_value(listener.handle, value);
+}
+"#;
+        // This is the consumer-facing C program. It uses only ergonomic types
+        // and helpers; the raw callback carrier stays confined to abi_shim.c.
+        let source = r#"
+#include "boltffi.h"
+#include <stdio.h>
+
+static void listener_free(uint64_t handle) { (void)handle; }
+static uint64_t listener_clone(uint64_t handle) { return handle; }
+static void listener_notify(uint64_t handle, uint32_t code) {
+    (void)handle;
+    printf("notify:%u\n", code);
+}
+static int64_t listener_on_value(uint64_t handle, uint32_t value) {
+    (void)handle;
+    printf("on_value:%u\n", value);
+    return (int64_t)value;
+}
+
+int main(void) {
+    DemoListener listener = {
+        .free = listener_free,
+        .clone = listener_clone,
+        .notify = listener_notify,
+        .on_value = listener_on_value,
+    };
+    DemoListenerHandle callback = demo_listener_create(&listener);
+    return demo_install(callback, 7, 9) == 9 ? 0 : 1;
+}
+"#;
+        std::fs::write(dir.join("abi_shim.c"), abi_shim).expect("write ABI shim");
+        std::fs::write(dir.join("demo.c"), source).expect("write ergonomic caller");
+        let out = Command::new("cc")
+            .current_dir(&dir)
+            .args(["demo.c", "abi_shim.c", "-o", "demo", "-Werror"])
+            .output()
+            .expect("cc runs");
+        assert!(
+            out.status.success(),
+            "cc failed:\n{}\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let out = Command::new(dir.join("demo"))
+            .output()
+            .expect("run generated C callback test");
+        assert!(
+            out.status.success(),
+            "callback program failed:\n{}\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            "notify:7\non_value:9\n"
+        );
+    }
+
+    #[test]
+    fn rejects_async_callback_interface() {
+        let bindings = bindings(
+            r#"
+            #[export]
+            #[allow(async_fn_in_trait)]
+            pub trait Listener {
+                async fn load(&self, key: u32) -> String;
+            }
+            "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let error = target
+            .render(&bindings)
+            .expect_err("async callback trait should be unsupported");
+        assert!(format!("{error:?}").contains("async callback"));
+    }
+
+    #[test]
+    fn renders_typed_result_for_c_style_error() {
+        let bindings = bindings(
+            r#"
+            #[repr(i32)]
+            #[data]
+            pub enum DivisionError { DivideByZero = 1 }
+            #[export]
+            pub fn divide(value: i32, b: i32) -> Result<i32, DivisionError> {
+                if b == 0 { Err(DivisionError::DivideByZero) } else { Ok(value / b) }
+            }
+        "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let header = render_header(&target.render(&bindings).expect("render"));
+        assert!(header.contains("typedef struct {\n    bool ok;\n    union {\n        int32_t value;\n        DemoDivisionError error;\n    } data;\n} DemoDivideResult;"));
+        assert!(
+            header.contains("static inline DemoDivideResult demo_divide(int32_t value, int32_t b)")
+        );
+        assert!(header.contains(
+            "FfiBuf_u8 boltffi_encoded_error = boltffi_function_demo_divide(value, b, &boltffi_value);"
+        ));
+        assert!(!header.contains("boltffi_status_t"));
+    }
+
+    #[test]
+    fn renders_owned_string_errors_for_fallible_functions() {
+        let bindings = bindings(
+            r#"
+            #[export]
+            pub fn parse(value: i32) -> Result<i32, String> {
+                if value >= 0 { Ok(value) } else { Err("negative".to_owned()) }
+            }
+            "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let header = render_header(&target.render(&bindings).expect("render"));
+
+        assert!(header.contains("DemoString error;"));
+        assert!(header.contains("BoltFFICWireReader boltffi_error_reader"));
+        assert!(header.contains("copy_string(&boltffi_error_reader,&boltffi_result.data.error)"));
+        assert!(header.contains("static inline DemoParseResult demo_parse(int32_t value)"));
+    }
+
+    #[test]
+    fn renders_fallible_class_initializers_with_owned_string_errors() {
+        let bindings = bindings(
+            r#"
+            pub struct Engine;
+
+            #[export(single_threaded)]
+            impl Engine {
+                pub fn new(seed: u32) -> Result<Self, String> {
+                    if seed == 0 { Err("zero".to_owned()) } else { Ok(Self) }
+                }
+            }
+            "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let header = render_header(&target.render(&bindings).expect("render"));
+
+        assert!(header.contains("} DemoEngineNewResult;"));
+        assert!(header.contains("DemoEngine value;"));
+        assert!(header.contains("DemoString error;"));
+        assert!(
+            header.contains("static inline DemoEngineNewResult demo_engine_new(uint32_t seed)")
+        );
+        assert!(header.contains("boltffi_result.data.value._boltffi_handle=boltffi_success;"));
+        assert!(header.contains("copy_string(&boltffi_error_reader,&boltffi_result.data.error)"));
+    }
+
+    #[test]
+    fn encoded_record_facade_compiles_and_round_trips_at_runtime() {
+        use std::process::Command;
+        if Command::new("cc").arg("--version").output().is_err() {
+            return;
+        }
+        let bindings = bindings(
+            r#"
+            #[repr(u8)]
+            #[data]
+            pub enum Mode { Fast = 1, Slow = 2 }
+
+            #[data]
+            pub struct Payload {
+                pub name: String,
+                pub bytes: Vec<u8>,
+                pub count: Option<u32>,
+                pub values: Vec<f32>,
+                pub mode: Mode,
+            }
+
+            #[export]
+            pub fn echo_payload(value: Payload) -> Payload { value }
+
+            #[export]
+            pub fn echo_string(value: String) -> String { value }
+        "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let header = render_header(&target.render(&bindings).expect("render"));
+        assert!(
+            header.contains("static inline DemoPayload demo_echo_payload(DemoPayloadView value)")
+        );
+        assert!(header.contains("static inline DemoString demo_echo_string(DemoStringView value)"));
+        for signature in header
+            .split('{')
+            .filter(|part| part.contains("static inline") && part.contains("demo_"))
+        {
+            assert!(
+                !signature.contains("FfiBuf_u8"),
+                "raw buffer leaked: {signature}"
+            );
+            assert!(
+                !signature.contains("___"),
+                "raw typedef leaked: {signature}"
+            );
+        }
+
+        let dir = std::env::temp_dir().join(format!("boltffi_c_codec_test_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        std::fs::write(dir.join("boltffi.h"), header).expect("header");
+        std::fs::write(dir.join("test.c"),r#"
+#include "boltffi.h"
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+FfiBuf_u8 boltffi_buf_with_len(uintptr_t len) {
+    FfiBuf_u8 b = {(uint8_t *)malloc(len), len, len, 1}; return b;
+}
+void boltffi_free_buf(FfiBuf_u8 b) { free(b.ptr); }
+FfiBuf_u8 boltffi_function_demo_echo_payload(const uint8_t *ptr, uintptr_t len) {
+    FfiBuf_u8 b=boltffi_buf_with_len(len); if (len) memcpy(b.ptr,ptr,len); return b;
+}
+FfiBuf_u8 boltffi_function_demo_echo_string(const uint8_t *ptr, uintptr_t len) {
+    FfiBuf_u8 b=boltffi_buf_with_len(len); if (len) memcpy(b.ptr,ptr,len); return b;
+}
+int main(void) {
+    uint8_t bytes[] = {1,2,3}; float values[] = {1.5f,2.5f};
+    DemoPayloadView input;
+    memset(&input,0,sizeof(input));
+    input.name=demo_string_view("hello",5);
+    input.bytes=demo_bytes_view(bytes,3);
+    input.count.has_value=true; input.count.value=42;
+    input.values.ptr=values; input.values.len=2;
+    input.mode=(DemoMode)1;
+    DemoPayload output=demo_echo_payload(input);
+    if (output.name.len != 5 || memcmp(output.name.ptr,"hello",5) || output.bytes.len != 3 || output.count.value != 42 || output.values.len != 2 || fabsf(output.values.ptr[1]-2.5f)>.001f) return 1;
+    demo_payload_free(&output); demo_payload_free(&output);
+    DemoString text=demo_echo_string(demo_string_view("wire",4));
+    if (text.len != 4 || memcmp(text.ptr,"wire",4)) return 2;
+    demo_string_free(&text); demo_string_free(&text);
+    return 0;
+}
+"#).expect("source");
+        let compile = Command::new("cc")
+            .current_dir(&dir)
+            .args([
+                "-std=c11", "-Wall", "-Wextra", "-Werror", "test.c", "-lm", "-o", "test",
+            ])
+            .output()
+            .expect("cc");
+        assert!(
+            compile.status.success(),
+            "cc failed:\n{}\n{}",
+            String::from_utf8_lossy(&compile.stdout),
+            String::from_utf8_lossy(&compile.stderr)
+        );
+        assert!(
+            Command::new(dir.join("test"))
+                .status()
+                .expect("run")
+                .success()
+        );
+    }
+
+    #[test]
+    fn c_target_snapshot_primitive_function() {
+        let bindings = bindings(
+            r#"
+            #[export]
+            pub fn add(left: i32, right: i32) -> i32 { left + right }
+            "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let output = target.render(&bindings).expect("render");
+        insta::assert_snapshot!("c_primitive_function", render_header(&output));
+    }
+
+    #[test]
+    fn c_target_snapshot_direct_record_and_enum() {
+        let bindings = bindings(
+            r#"
+            #[repr(C)]
+            #[data]
+            pub struct Point {
+                pub x: f64,
+                pub y: f64,
+            }
+
+            #[repr(u8)]
+            #[data]
+            pub enum Mode {
+                Fast = 1,
+                Slow = 2,
+            }
+            "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let output = target.render(&bindings).expect("render");
+        insta::assert_snapshot!("c_direct_record_and_enum", render_header(&output));
+    }
+
+    #[test]
+    fn c_target_snapshot_class() {
+        let bindings = bindings(
+            r#"
+            pub struct Engine;
+
+            #[export(single_threaded)]
+            impl Engine {
+                pub fn new(seed: u64) -> Self { todo!() }
+                pub fn score(&self, point: crate::Point) -> u32 { 0 }
+            }
+
+            #[repr(C)]
+            #[data]
+            pub struct Point {
+                pub x: f64,
+                pub y: f64,
+            }
+            "#,
+        );
+        let target = CHost::new().into_target(&bindings).expect("target");
+        let output = target.render(&bindings).expect("render");
+        insta::assert_snapshot!("c_class", render_header(&output));
     }
 }

--- a/boltffi_backend/src/target/c/name_style.rs
+++ b/boltffi_backend/src/target/c/name_style.rs
@@ -1,0 +1,86 @@
+//! C identifier and naming rules for the ergonomic C host layer.
+
+use boltffi_binding::CanonicalName;
+
+use crate::core::name_case;
+
+/// Stable C identifier casing for one source name.
+///
+/// The C ABI (`CBridge`) chooses the crossing symbols; the host only spells
+/// the ergonomic type and member names layered on top. Type names use
+/// PascalCase, function/member/symbol names use snake_case, and enum
+/// constants use UPPER_SNAKE_CASE.
+#[derive(Clone, Debug)]
+pub struct Name {
+    source: CanonicalName,
+}
+
+impl Name {
+    /// Creates a C name from a source canonical name.
+    pub fn new(source: &CanonicalName) -> Self {
+        Self {
+            source: source.clone(),
+        }
+    }
+
+    /// PascalCase type spelling (e.g. `Point`, `DemoEngine`).
+    pub fn r#type(&self) -> String {
+        name_case::upper_camel(&self.source)
+    }
+
+    /// snake_case member / symbol spelling joined from name parts.
+    pub fn member(&self) -> String {
+        self.join("_", str::to_owned)
+    }
+
+    /// Upper snake-case constant spelling (e.g. `MODE_FAST`).
+    pub fn constant(&self) -> String {
+        self.join("_", str::to_ascii_uppercase)
+    }
+
+    fn join(&self, separator: &str, transform: impl Fn(&str) -> String) -> String {
+        self.source
+            .parts()
+            .iter()
+            .map(|part| transform(part.as_str()))
+            .collect::<Vec<_>>()
+            .join(separator)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use boltffi_binding::{CanonicalName, NamePart};
+
+    use super::Name;
+
+    fn name(parts: &[&str]) -> CanonicalName {
+        CanonicalName::new(parts.iter().map(|part| NamePart::new(*part)).collect())
+    }
+
+    #[test]
+    fn types_use_pascal_case() {
+        assert_eq!(Name::new(&name(&["point"])).r#type(), "Point");
+        assert_eq!(Name::new(&name(&["engine"])).r#type(), "Engine");
+        assert_eq!(
+            Name::new(&name(&["multi", "word", "type"])).r#type(),
+            "MultiWordType"
+        );
+    }
+
+    #[test]
+    fn members_use_snake_case() {
+        assert_eq!(Name::new(&name(&["distance"])).member(), "distance");
+        assert_eq!(Name::new(&name(&["get", "score"])).member(), "get_score");
+        assert_eq!(
+            Name::new(&name(&["face", "landmark"])).member(),
+            "face_landmark"
+        );
+    }
+
+    #[test]
+    fn constants_use_upper_snake_case() {
+        assert_eq!(Name::new(&name(&["mode"])).constant(), "MODE");
+        assert_eq!(Name::new(&name(&["fast"])).constant(), "FAST");
+    }
+}

--- a/boltffi_backend/src/target/c/render/associated.rs
+++ b/boltffi_backend/src/target/c/render/associated.rs
@@ -1,0 +1,37 @@
+//! Shared emission for `#[data(impl)]`/class associated callables.
+
+use boltffi_binding::{CanonicalName, ExportedMethodDecl, InitializerDecl, Native, NativeSymbol};
+
+use crate::{
+    bridge::c::{self, Identifier},
+    core::{Emitted, Result},
+};
+
+use super::{prefix::PackagePrefix, wrapper};
+use crate::target::c::name_style::Name;
+
+/// Renders forwarding wrappers for an owner's initializers and methods.
+pub fn render_associated(
+    owner: &CanonicalName,
+    bridge: &c::CBridgeContract,
+    initializers: &[InitializerDecl<Native>],
+    methods: &[ExportedMethodDecl<Native, NativeSymbol>],
+    prefix: &PackagePrefix,
+) -> Result<Vec<Emitted>> {
+    let owner_member = Name::new(owner).member();
+    let mut emitted = Vec::new();
+    for initializer in initializers {
+        let abi = wrapper::find_abi(bridge, initializer.symbol())?;
+        let init = Name::new(initializer.name()).member();
+        let wrapper_name = Identifier::escape(prefix.member(&format!("{owner_member}_{init}")))?;
+        emitted.push(wrapper::forward(abi, wrapper_name.as_str())?);
+    }
+    for method in methods {
+        let abi = wrapper::find_abi(bridge, method.target())?;
+        let method_name = Name::new(method.name()).member();
+        let wrapper_name =
+            Identifier::escape(prefix.member(&format!("{owner_member}_{method_name}")))?;
+        emitted.push(wrapper::forward(abi, wrapper_name.as_str())?);
+    }
+    Ok(emitted)
+}

--- a/boltffi_backend/src/target/c/render/callable.rs
+++ b/boltffi_backend/src/target/c/render/callable.rs
@@ -1,0 +1,731 @@
+//! Semantic sync callable rendering for the package-prefixed C facade.
+
+use super::{prefix::PackagePrefix, surface};
+use crate::{
+    bridge::c,
+    core::{Emitted, Error, RenderContext, Result},
+    target::c::name_style::Name,
+};
+use boltffi_binding::{
+    ErrorChannel, ErrorPlacement, ExportedCallable, HandleTarget, Native, ParamPlan, Primitive,
+    Receive, ReturnPlan, TypeRef,
+};
+
+pub enum Receiver<'a> {
+    None,
+    Class {
+        c_type: &'a str,
+        receive: Receive,
+    },
+    EncodedRecord {
+        c_type: &'a str,
+        id: boltffi_binding::RecordId,
+        receive: Receive,
+    },
+    DirectRecord {
+        c_type: &'a str,
+        receive: Receive,
+    },
+}
+
+pub fn render(
+    abi: &c::Function,
+    callable: &ExportedCallable<Native>,
+    wrapper_name: &str,
+    result_stem: &str,
+    receiver: Receiver<'_>,
+    context: &RenderContext<Native>,
+) -> Result<Emitted> {
+    if callable.execution().uses_async_execution() {
+        return unsupported("async callable");
+    }
+    let mut state = State::new(abi, context);
+    state.receiver(receiver)?;
+    for param in callable.params() {
+        let Some(plan) = param.payload().as_value() else {
+            return unsupported("closure callable parameter");
+        };
+        state.param(Name::new(param.name()).member(), plan)?;
+    }
+    let params = if state.params.is_empty() {
+        "void".to_owned()
+    } else {
+        state.params.join(", ")
+    };
+    let args = state.args.join(", ");
+    let error = callable.error().channel();
+    let output = match error {
+        ErrorChannel::None => {
+            state.render_infallible(callable.returns().plan(), wrapper_name, &params, &args)?
+        }
+        ErrorChannel::Status => return unsupported("status-channel semantic callable"),
+        ErrorChannel::Encoded {
+            placement: ErrorPlacement::ReturnSlot,
+            ty: TypeRef::String,
+            ..
+        } => state.render_result(
+            callable.returns().plan(),
+            wrapper_name,
+            result_stem,
+            &params,
+            &args,
+        )?,
+        ErrorChannel::Encoded { .. } => return unsupported("fallible callable error shape"),
+        _ => return unsupported("unknown callable error channel"),
+    };
+    Ok(Emitted::primary(output))
+}
+
+struct State<'a> {
+    abi: &'a c::Function,
+    context: &'a RenderContext<'a, Native>,
+    params: Vec<String>,
+    args: Vec<String>,
+    setup: Vec<String>,
+    cleanup: Vec<String>,
+    next: usize,
+}
+impl<'a> State<'a> {
+    fn new(abi: &'a c::Function, context: &'a RenderContext<'a, Native>) -> Self {
+        Self {
+            abi,
+            context,
+            params: vec![],
+            args: vec![],
+            setup: vec![],
+            cleanup: vec![],
+            next: 0,
+        }
+    }
+    fn local(&mut self, stem: &str) -> String {
+        let n = format!("boltffi_{stem}_{}", self.next);
+        self.next += 1;
+        n
+    }
+    fn receiver(&mut self, receiver: Receiver<'_>) -> Result<()> {
+        match receiver {
+            Receiver::None => {}
+            Receiver::Class { c_type, receive } => {
+                let q = if receive == Receive::ByRef {
+                    "const "
+                } else {
+                    ""
+                };
+                self.params.push(format!("{q}{c_type} *receiver"));
+                self.args.push("receiver->_boltffi_handle".into());
+            }
+            Receiver::EncodedRecord {
+                c_type,
+                id,
+                receive,
+            } => {
+                if receive == Receive::ByMutRef {
+                    return unsupported("mutable encoded record receiver");
+                }
+                let q = "const ";
+                self.params.push(format!("{q}{c_type} *receiver"));
+                self.pack_record("receiver", id, true)?;
+            }
+            Receiver::DirectRecord { c_type, receive } => match receive {
+                Receive::ByRef => {
+                    self.params.push(format!("const {c_type} *receiver"));
+                    self.args.push("*receiver".into())
+                }
+                Receive::ByValue => {
+                    self.params.push(format!("{c_type} receiver"));
+                    self.args.push("receiver".into())
+                }
+                Receive::ByMutRef => return unsupported("mutable direct record receiver"),
+                _ => return unsupported("unknown receiver"),
+            },
+        }
+        Ok(())
+    }
+    fn param(
+        &mut self,
+        name: String,
+        plan: &ParamPlan<Native, boltffi_binding::IntoRust>,
+    ) -> Result<()> {
+        match plan {
+            ParamPlan::Direct { ty, receive } => {
+                let c = surface::direct_value_type(ty, self.context)?;
+                match (ty, receive) {
+                    (boltffi_binding::DirectValueType::Record(_), Receive::ByRef) => {
+                        self.params.push(format!("const {c} *{name}"));
+                        self.args.push(name)
+                    }
+                    (boltffi_binding::DirectValueType::Record(_), Receive::ByMutRef) => {
+                        return unsupported("mutable direct record parameter");
+                    }
+                    _ => {
+                        self.params.push(format!("{c} {name}"));
+                        self.args.push(name)
+                    }
+                }
+            }
+            ParamPlan::Encoded { ty, receive, .. } => {
+                if *receive == Receive::ByMutRef {
+                    return unsupported("mutable encoded parameter");
+                }
+                match ty {
+                    TypeRef::String | TypeRef::Bytes => {
+                        let c = surface::value_type(ty, self.context, surface::ValueUse::Param)?;
+                        self.params.push(format!("{c} {name}"));
+                        self.pack_view(&name);
+                    }
+                    TypeRef::Record(id) => {
+                        let c = surface::value_type(ty, self.context, surface::ValueUse::Param)?;
+                        let by_ptr = *receive == Receive::ByRef;
+                        self.params.push(if by_ptr {
+                            format!("const {c} *{name}")
+                        } else {
+                            format!("{c} {name}")
+                        });
+                        self.pack_record(&name, *id, by_ptr)?;
+                    }
+                    TypeRef::Optional(inner) if **inner == TypeRef::String => {
+                        let c = surface::value_type(ty, self.context, surface::ValueUse::Param)?;
+                        self.params.push(format!("{c} {name}"));
+                        self.pack_option_string(&name);
+                    }
+                    TypeRef::Sequence(element) => {
+                        let c = surface::value_type(ty, self.context, surface::ValueUse::Param)?;
+                        self.params.push(format!("{c} {name}"));
+                        self.pack_sequence(&name, element)?;
+                    }
+                    _ => return unsupported("encoded callable parameter"),
+                }
+            }
+            ParamPlan::ScalarOption { primitive }
+                if matches!(primitive, Primitive::U32 | Primitive::F32) =>
+            {
+                let c = surface::value_type(
+                    &TypeRef::Optional(Box::new(TypeRef::Primitive(*primitive))),
+                    self.context,
+                    surface::ValueUse::Param,
+                )?;
+                self.params.push(format!("{c} {name}"));
+                self.pack_scalar_option(&name, *primitive);
+            }
+            ParamPlan::DirectVec { element, .. } => {
+                let c =
+                    surface::direct_vector_type(element, self.context, surface::ValueUse::Param)?;
+                self.params.push(format!("{c} {name}"));
+                self.args.push(format!("{name}.ptr"));
+                self.args.push(format!("{name}.len"));
+            }
+            ParamPlan::Handle {
+                target: HandleTarget::Callback(id),
+                ..
+            } => {
+                let c = super::callback::handle_type_name(*id, self.context)?;
+                self.params.push(format!("{c} {name}"));
+                self.args.push(format!("{name}.raw"));
+            }
+            ParamPlan::Handle {
+                target: HandleTarget::Class(id),
+                ..
+            } => {
+                let class = self.context.class(*id).ok_or(Error::BrokenBridgeContract {
+                    bridge: "c",
+                    invariant: "missing class parameter",
+                })?;
+                let c = PackagePrefix::from_context(self.context)
+                    .type_name(&Name::new(class.name()).r#type());
+                self.params.push(format!("const {c} *{name}"));
+                self.args.push(format!("{name}->_boltffi_handle"));
+            }
+            _ => return unsupported("callable parameter plan"),
+        }
+        Ok(())
+    }
+    fn pack_record(
+        &mut self,
+        name: &str,
+        id: boltffi_binding::RecordId,
+        is_ptr: bool,
+    ) -> Result<()> {
+        if !matches!(
+            self.context.record(id),
+            Some(boltffi_binding::RecordDecl::Encoded(_))
+        ) {
+            return unsupported("encoded parameter references direct record");
+        }
+        let size = self.local("size");
+        let buf = self.local("buf");
+        let writer = self.local("writer");
+        let value = if is_ptr {
+            name.to_owned()
+        } else {
+            format!("&{name}")
+        };
+        self.setup.push(format!(
+            "    uintptr_t {size} = {}({value});",
+            surface::record_helper_name(id, self.context, "size")?
+        ));
+        self.setup.push(format!(
+            "    FfiBuf_u8 {buf} = boltffi_buf_with_len({size});"
+        ));
+        self.setup.push(format!(
+            "    BoltFFICWireWriter {writer} = {{ {buf}.ptr, {buf}.len, 0, true }};"
+        ));
+        self.setup.push(format!(
+            "    {}(&{writer}, {value});",
+            surface::record_helper_name(id, self.context, "encode")?
+        ));
+        self.args.push(format!("{buf}.ptr"));
+        self.args.push(format!("{buf}.len"));
+        self.cleanup.push(format!("    boltffi_free_buf({buf});"));
+        Ok(())
+    }
+    fn pack_view(&mut self, name: &str) {
+        let buf = self.local("buf");
+        let writer = self.local("writer");
+        let p = package_member(self.context);
+        self.setup.push(format!(
+            "    FfiBuf_u8 {buf}=boltffi_buf_with_len(4+{name}.len);"
+        ));
+        self.setup.push(format!(
+            "    BoltFFICWireWriter {writer}={{{buf}.ptr,{buf}.len,0,true}};"
+        ));
+        self.setup.push(format!("    boltffi_c_{p}_write_u32(&{writer},(uint32_t){name}.len); boltffi_c_{p}_write(&{writer},{name}.ptr,{name}.len);"));
+        self.args.push(format!("{buf}.ptr"));
+        self.args.push(format!("{buf}.len"));
+        self.cleanup.push(format!("    boltffi_free_buf({buf});"));
+    }
+    fn pack_sequence(&mut self, name: &str, element: &TypeRef) -> Result<()> {
+        let size = self.local("size");
+        let i = self.local("i");
+        let buf = self.local("buf");
+        let writer = self.local("writer");
+        let p = package_member(self.context);
+        let element_size = match element {
+            TypeRef::Primitive(v) => format!(
+                "{}",
+                match v {
+                    Primitive::Bool | Primitive::I8 | Primitive::U8 => 1,
+                    Primitive::I16 | Primitive::U16 => 2,
+                    Primitive::I32 | Primitive::U32 | Primitive::F32 => 4,
+                    _ => 8,
+                }
+            ),
+            TypeRef::Record(id)
+                if matches!(
+                    self.context.record(*id),
+                    Some(boltffi_binding::RecordDecl::Direct(_))
+                ) =>
+            {
+                format!(
+                    "sizeof({})",
+                    surface::value_type(element, self.context, surface::ValueUse::Field)?
+                )
+            }
+            TypeRef::Record(id) => format!(
+                "{}(&{name}.ptr[{i}])",
+                surface::record_helper_name(*id, self.context, "size")?
+            ),
+            _ => return unsupported("encoded sequence parameter element"),
+        };
+        self.setup.push(format!("    uintptr_t {size}=4; for (uintptr_t {i}=0; {i}<{name}.len; ++{i}) {size}+={element_size};"));
+        self.setup.push(format!("    FfiBuf_u8 {buf}=boltffi_buf_with_len({size}); BoltFFICWireWriter {writer}={{{buf}.ptr,{buf}.len,0,true}}; boltffi_c_{p}_write_u32(&{writer},(uint32_t){name}.len);"));
+        match element {
+            TypeRef::String => self.setup.push(format!("    for (uintptr_t {i}=0; {i}<{name}.len; ++{i}) {{ boltffi_c_{p}_write_u32(&{writer},(uint32_t){name}.ptr[{i}].len); boltffi_c_{p}_write(&{writer},{name}.ptr[{i}].ptr,{name}.ptr[{i}].len); }}")),
+            TypeRef::Record(id) if matches!(self.context.record(*id),Some(boltffi_binding::RecordDecl::Encoded(_)))=>self.setup.push(format!("    for (uintptr_t {i}=0; {i}<{name}.len; ++{i}) {}(&{writer},&{name}.ptr[{i}]);",surface::record_helper_name(*id,self.context,"encode")?)),
+            _=>self.setup.push(format!("    boltffi_c_{p}_write(&{writer},{name}.ptr,{name}.len*({element_size}));"))
+        }
+        self.args.push(format!("{buf}.ptr"));
+        self.args.push(format!("{buf}.len"));
+        self.cleanup.push(format!("    boltffi_free_buf({buf});"));
+        Ok(())
+    }
+    fn pack_scalar_option(&mut self, name: &str, _primitive: Primitive) {
+        let buf = self.local("buf");
+        let writer = self.local("writer");
+        let p = package_member(self.context);
+        self.setup.push(format!(
+            "    FfiBuf_u8 {buf}=boltffi_buf_with_len({name}.has_value ? 5 : 1);"
+        ));
+        self.setup.push(format!(
+            "    BoltFFICWireWriter {writer}={{{buf}.ptr,{buf}.len,0,true}};"
+        ));
+        self.setup.push(format!(
+            "    boltffi_c_{p}_write_u8(&{writer},{name}.has_value ? 1 : 0);"
+        ));
+        self.setup.push(format!(
+            "    if ({name}.has_value) boltffi_c_{p}_write(&{writer},&{name}.value,4);"
+        ));
+        self.args.push(format!("{buf}.ptr"));
+        self.args.push(format!("{buf}.len"));
+        self.cleanup.push(format!("    boltffi_free_buf({buf});"));
+    }
+    fn pack_option_string(&mut self, name: &str) {
+        let buf = self.local("buf");
+        let writer = self.local("writer");
+        let p = package_member(self.context);
+        self.setup.push(format!("    FfiBuf_u8 {buf}=boltffi_buf_with_len(1 + ({name}.has_value ? 4 + {name}.value.len : 0));"));
+        self.setup.push(format!(
+            "    BoltFFICWireWriter {writer}={{{buf}.ptr,{buf}.len,0,true}};"
+        ));
+        self.setup.push(format!(
+            "    boltffi_c_{p}_write_u8(&{writer},{name}.has_value ? 1 : 0);"
+        ));
+        self.setup.push(format!("    if ({name}.has_value) {{ boltffi_c_{p}_write_u32(&{writer},(uint32_t){name}.value.len); boltffi_c_{p}_write(&{writer},{name}.value.ptr,{name}.value.len); }}"));
+        self.args.push(format!("{buf}.ptr"));
+        self.args.push(format!("{buf}.len"));
+        self.cleanup.push(format!("    boltffi_free_buf({buf});"));
+    }
+    fn render_infallible(
+        &mut self,
+        plan: &ReturnPlan<Native, boltffi_binding::OutOfRust>,
+        name: &str,
+        params: &str,
+        args: &str,
+    ) -> Result<String> {
+        let semantic = return_type(plan, self.context)?;
+        let mut b = format!("static inline {semantic} {name}({params}) {{\n");
+        for l in &self.setup {
+            b.push_str(l);
+            b.push('\n')
+        }
+        match plan {
+            ReturnPlan::Void => {
+                b.push_str(&format!("    {}({args});\n", self.abi.name()));
+                for l in &self.cleanup {
+                    b.push_str(l);
+                    b.push('\n')
+                }
+            }
+            ReturnPlan::DirectViaReturnSlot { .. } => {
+                b.push_str(&format!(
+                    "    {semantic} boltffi_result = ({semantic}){}({args});\n",
+                    self.abi.name()
+                ));
+                for l in &self.cleanup {
+                    b.push_str(l);
+                    b.push('\n')
+                }
+                b.push_str("    return boltffi_result;\n")
+            }
+            ReturnPlan::HandleViaReturnSlot {
+                target: HandleTarget::Class(_),
+                ..
+            } => {
+                b.push_str(&format!(
+                    "    {semantic} boltffi_result; boltffi_result._boltffi_handle = {}({args});\n",
+                    self.abi.name()
+                ));
+                for l in &self.cleanup {
+                    b.push_str(l);
+                    b.push('\n')
+                }
+                b.push_str("    return boltffi_result;\n")
+            }
+            ReturnPlan::EncodedViaReturnSlot { ty, .. } => {
+                b.push_str(&format!(
+                    "    FfiBuf_u8 boltffi_raw = {}({args});\n",
+                    self.abi.name()
+                ));
+                for l in &self.cleanup {
+                    b.push_str(l);
+                    b.push('\n')
+                }
+                b.push_str(&decode_owned(
+                    ty,
+                    "boltffi_raw",
+                    "boltffi_result",
+                    self.context,
+                    true,
+                )?);
+                b.push_str("    return boltffi_result;\n")
+            }
+            ReturnPlan::ScalarOptionViaReturnSlot {
+                primitive: Primitive::U32 | Primitive::F32,
+                ..
+            } => {
+                let p = package_member(self.context);
+                b.push_str(&format!(
+                    "    FfiBuf_u8 boltffi_raw = {}({args});\n",
+                    self.abi.name()
+                ));
+                for l in &self.cleanup {
+                    b.push_str(l);
+                    b.push('\n');
+                }
+                b.push_str(&format!("    {semantic} boltffi_result; memset(&boltffi_result,0,sizeof(boltffi_result)); BoltFFICWireReader boltffi_reader={{boltffi_raw.ptr,boltffi_raw.len,0,true}}; uint8_t boltffi_tag=boltffi_c_{p}_read_u8(&boltffi_reader); if (boltffi_tag==1) {{ boltffi_result.has_value=true; boltffi_c_{p}_read(&boltffi_reader,&boltffi_result.value,4); }} boltffi_free_buf(boltffi_raw); return boltffi_result;\n"));
+            }
+            ReturnPlan::DirectVecViaReturnSlot { element } => {
+                b.push_str(&format!(
+                    "    FfiBuf_u8 boltffi_raw = {}({args});\n",
+                    self.abi.name()
+                ));
+                for l in &self.cleanup {
+                    b.push_str(l);
+                    b.push('\n')
+                }
+                let elem = surface::direct_vector_element_type(element, self.context)?;
+                b.push_str(&format!("    {semantic} boltffi_result; boltffi_result.len=boltffi_raw.len/sizeof({elem}); boltffi_result.ptr=({elem} *)malloc(boltffi_raw.len); if (boltffi_raw.len) memcpy(boltffi_result.ptr,boltffi_raw.ptr,boltffi_raw.len); boltffi_free_buf(boltffi_raw);\n    return boltffi_result;\n"));
+            }
+            _ => return unsupported("callable return plan"),
+        }
+        b.push_str("}\n");
+        Ok(b)
+    }
+    fn render_result(
+        &mut self,
+        plan: &ReturnPlan<Native, boltffi_binding::OutOfRust>,
+        name: &str,
+        stem: &str,
+        params: &str,
+        args: &str,
+    ) -> Result<String> {
+        let ok = return_type(plan, self.context)?;
+        let package_type_prefix = package_pascal(self.context);
+        let result_ty = format!("{stem}Result");
+        let raw_decl = raw_success_decl(plan)?;
+        let mut call_args = args.to_owned();
+        if !call_args.is_empty() {
+            call_args.push_str(", ")
+        }
+        call_args.push_str("&boltffi_success");
+        let mut b = format!(
+            "typedef struct {{ bool ok; union {{ {ok} value; {package_type_prefix}String error; }} data; }} {result_ty};\nstatic inline {result_ty} {name}({params}) {{\n"
+        );
+        for l in &self.setup {
+            b.push_str(l);
+            b.push('\n')
+        }
+        b.push_str(&format!(
+            "    {raw_decl} boltffi_success;\n    FfiBuf_u8 boltffi_error = {}({call_args});\n",
+            self.abi.name()
+        ));
+        for l in &self.cleanup {
+            b.push_str(l);
+            b.push('\n')
+        }
+        b.push_str(&format!("    {result_ty} boltffi_result; memset(&boltffi_result,0,sizeof(boltffi_result));\n    if (boltffi_error.len == 0) {{ boltffi_result.ok=true;\n"));
+        b.push_str(&decode_success(
+            plan,
+            "boltffi_success",
+            "boltffi_result.data.value",
+            self.context,
+        )?);
+        let package = package_member(self.context);
+        b.push_str(&format!("        return boltffi_result;\n    }}\n    boltffi_result.ok=false; BoltFFICWireReader boltffi_error_reader={{boltffi_error.ptr,boltffi_error.len,0,true}}; boltffi_c_{package}_copy_string(&boltffi_error_reader,&boltffi_result.data.error); boltffi_free_buf(boltffi_error); return boltffi_result;\n}}\n"));
+        let free_success = free_success_stmt(plan, "value", self.context)?;
+        b.push_str(&format!("static inline void {name}_result_free({result_ty} *value) {{ if (value == NULL) return; if (value->ok) {{ {free_success} }} else {{ {package}_string_free(&value->data.error); }} memset(value,0,sizeof(*value)); }}\n"));
+        Ok(b)
+    }
+}
+
+fn return_type(
+    plan: &ReturnPlan<Native, boltffi_binding::OutOfRust>,
+    context: &RenderContext<Native>,
+) -> Result<String> {
+    match plan {
+        ReturnPlan::Void => Ok("void".into()),
+        ReturnPlan::DirectViaReturnSlot { ty } | ReturnPlan::DirectViaOutPointer { ty } => {
+            surface::direct_value_type(ty, context)
+        }
+        ReturnPlan::EncodedViaReturnSlot { ty, .. }
+        | ReturnPlan::EncodedViaOutPointer { ty, .. } => {
+            surface::value_type(ty, context, surface::ValueUse::Return)
+        }
+        ReturnPlan::HandleViaReturnSlot {
+            target: HandleTarget::Class(id),
+            ..
+        }
+        | ReturnPlan::HandleViaOutPointer {
+            target: HandleTarget::Class(id),
+            ..
+        } => {
+            let c = context.class(*id).ok_or(Error::BrokenBridgeContract {
+                bridge: "c",
+                invariant: "missing returned class",
+            })?;
+            Ok(PackagePrefix::from_context(context).type_name(&Name::new(c.name()).r#type()))
+        }
+        ReturnPlan::ScalarOptionViaReturnSlot {
+            primitive: Primitive::U32,
+            ..
+        } => Ok(format!("{}OptionU32", package_pascal(context))),
+        ReturnPlan::ScalarOptionViaReturnSlot {
+            primitive: Primitive::F32,
+            ..
+        } => Ok(format!("{}OptionF32", package_pascal(context))),
+        ReturnPlan::DirectVecViaReturnSlot { element } => {
+            surface::direct_vector_type(element, context, surface::ValueUse::Return)
+        }
+        _ => unsupported("semantic return type"),
+    }
+}
+fn raw_success_decl(plan: &ReturnPlan<Native, boltffi_binding::OutOfRust>) -> Result<&'static str> {
+    match plan {
+        ReturnPlan::DirectViaOutPointer {
+            ty: boltffi_binding::DirectValueType::Primitive(Primitive::U32),
+        } => Ok("uint32_t"),
+        ReturnPlan::DirectViaOutPointer { .. } => Ok("uint64_t"),
+        ReturnPlan::EncodedViaOutPointer { .. } => Ok("FfiBuf_u8"),
+        ReturnPlan::HandleViaOutPointer { .. } => Ok("uint64_t"),
+        _ => unsupported("fallible success transport"),
+    }
+}
+fn decode_success(
+    plan: &ReturnPlan<Native, boltffi_binding::OutOfRust>,
+    raw: &str,
+    out: &str,
+    context: &RenderContext<Native>,
+) -> Result<String> {
+    match plan {
+        ReturnPlan::DirectViaOutPointer { .. } => Ok(format!(
+            "        {out}=({}){raw};\n",
+            return_type(plan, context)?
+        )),
+        ReturnPlan::HandleViaOutPointer { .. } => {
+            Ok(format!("        {out}._boltffi_handle={raw};\n"))
+        }
+        ReturnPlan::EncodedViaOutPointer { ty, .. } => decode_owned(ty, raw, out, context, false),
+        _ => unsupported("fallible success decode"),
+    }
+}
+fn free_success_stmt(
+    plan: &ReturnPlan<Native, boltffi_binding::OutOfRust>,
+    field: &str,
+    context: &RenderContext<Native>,
+) -> Result<String> {
+    let p = package_member(context);
+    match plan {
+        ReturnPlan::EncodedViaOutPointer {
+            ty: TypeRef::String,
+            ..
+        } => Ok(format!("{p}_string_free(&value->data.{field});")),
+        ReturnPlan::EncodedViaOutPointer {
+            ty: TypeRef::Bytes, ..
+        } => Ok(format!("{p}_bytes_free(&value->data.{field});")),
+        ReturnPlan::EncodedViaOutPointer {
+            ty: TypeRef::Record(id),
+            ..
+        } => Ok(format!(
+            "{p}_{}_free(&value->data.{field});",
+            Name::new(context.record(*id).expect("record").name()).member()
+        )),
+        ReturnPlan::EncodedViaOutPointer {
+            ty: TypeRef::Sequence(element),
+            ..
+        } => match element.as_ref() {
+            TypeRef::String => Ok(format!("{p}_string_sequence_free(&value->data.{field});")),
+            TypeRef::Record(id) => Ok(format!(
+                "{p}_{}_sequence_free(&value->data.{field});",
+                Name::new(context.record(*id).expect("record").name()).member()
+            )),
+            TypeRef::Primitive(v) => Ok(format!(
+                "{p}_{}_sequence_free(&value->data.{field});",
+                primitive_member(*v)
+            )),
+            _ => unsupported("result sequence free"),
+        },
+        ReturnPlan::HandleViaOutPointer {
+            target: HandleTarget::Class(id),
+            ..
+        } => {
+            let class = context.class(*id).expect("class");
+            Ok(format!(
+                "if (value->data.{field}._boltffi_handle) {}(value->data.{field}._boltffi_handle);",
+                class.release().name().as_str()
+            ))
+        }
+        ReturnPlan::DirectViaOutPointer { .. } => Ok(String::new()),
+        _ => unsupported("result success free"),
+    }
+}
+fn primitive_member(v: Primitive) -> &'static str {
+    match v {
+        Primitive::Bool => "bool",
+        Primitive::I8 => "i8",
+        Primitive::U8 => "u8",
+        Primitive::I16 => "i16",
+        Primitive::U16 => "u16",
+        Primitive::I32 => "i32",
+        Primitive::U32 => "u32",
+        Primitive::I64 => "i64",
+        Primitive::U64 => "u64",
+        Primitive::ISize => "isize",
+        Primitive::USize => "usize",
+        Primitive::F32 => "f32",
+        Primitive::F64 => "f64",
+        _ => "unsupported",
+    }
+}
+
+fn decode_owned(
+    ty: &TypeRef,
+    raw: &str,
+    out: &str,
+    context: &RenderContext<Native>,
+    declare: bool,
+) -> Result<String> {
+    let p = package_member(context);
+    let c = surface::value_type(ty, context, surface::ValueUse::Return)?;
+    let init = if declare {
+        format!("{c} {out}; ")
+    } else {
+        String::new()
+    };
+    match ty {
+        TypeRef::String => Ok(format!(
+            "    {init}memset(&{out},0,sizeof({out})); BoltFFICWireReader boltffi_reader={{{raw}.ptr,{raw}.len,0,true}}; boltffi_c_{p}_copy_string(&boltffi_reader,&{out}); boltffi_free_buf({raw});\n"
+        )),
+        TypeRef::Bytes => Ok(format!(
+            "    {init}memset(&{out},0,sizeof({out})); BoltFFICWireReader boltffi_reader={{{raw}.ptr,{raw}.len,0,true}}; boltffi_c_{p}_copy_bytes(&boltffi_reader,&{out}); boltffi_free_buf({raw});\n"
+        )),
+        TypeRef::Record(id) => Ok(format!(
+            "    {init}BoltFFICWireReader boltffi_reader={{{raw}.ptr,{raw}.len,0,true}}; {}(&boltffi_reader,&{out}); boltffi_free_buf({raw});\n",
+            surface::record_helper_name(*id, context, "decode")?
+        )),
+        TypeRef::Sequence(element) => {
+            let elem = surface::value_type(element, context, surface::ValueUse::Field)?;
+            let decode = match element.as_ref() {
+                TypeRef::String => format!(
+                    "if (!boltffi_c_{p}_copy_string(&boltffi_reader,&{out}.ptr[boltffi_i])) {{ {p}_string_sequence_free(&{out}); break; }}"
+                ),
+                TypeRef::Primitive(v) => format!(
+                    "boltffi_c_{p}_read(&boltffi_reader,&{out}.ptr[boltffi_i],{});",
+                    match v {
+                        Primitive::Bool | Primitive::I8 | Primitive::U8 => 1,
+                        Primitive::I16 | Primitive::U16 => 2,
+                        Primitive::I32 | Primitive::U32 | Primitive::F32 => 4,
+                        _ => 8,
+                    }
+                ),
+                TypeRef::Record(id)
+                    if matches!(
+                        context.record(*id),
+                        Some(boltffi_binding::RecordDecl::Direct(_))
+                    ) =>
+                {
+                    format!(
+                        "boltffi_c_{p}_read(&boltffi_reader,&{out}.ptr[boltffi_i],sizeof({elem}));"
+                    )
+                }
+                TypeRef::Record(id) => format!(
+                    "if (!{}(&boltffi_reader,&{out}.ptr[boltffi_i])) {{ {p}_{}_sequence_free(&{out}); break; }}",
+                    surface::record_helper_name(*id, context, "decode")?,
+                    Name::new(context.record(*id).expect("record").name()).member()
+                ),
+                _ => return unsupported("owned sequence return element"),
+            };
+            Ok(format!(
+                "    {init}memset(&{out},0,sizeof({out})); BoltFFICWireReader boltffi_reader={{{raw}.ptr,{raw}.len,0,true}}; uint32_t boltffi_count=boltffi_c_{p}_read_u32(&boltffi_reader); {out}.ptr=({elem} *)calloc(boltffi_count,sizeof({elem})); {out}.len=boltffi_count; if (boltffi_count && {out}.ptr == NULL) boltffi_reader.ok=false; for (uintptr_t boltffi_i=0; boltffi_reader.ok && boltffi_i<boltffi_count; ++boltffi_i) {{ {decode} }} boltffi_free_buf({raw});\n"
+            ))
+        }
+        _ => unsupported("owned encoded return"),
+    }
+}
+fn package_member(context: &RenderContext<Native>) -> String {
+    Name::new(context.bindings().package().name()).member()
+}
+fn package_pascal(context: &RenderContext<Native>) -> String {
+    Name::new(context.bindings().package().name()).r#type()
+}
+fn unsupported<T>(shape: &'static str) -> Result<T> {
+    Err(Error::UnsupportedTarget { target: "c", shape })
+}

--- a/boltffi_backend/src/target/c/render/callback.rs
+++ b/boltffi_backend/src/target/c/render/callback.rs
@@ -1,0 +1,76 @@
+//! Ergonomic C wrappers for callback traits and closure parameters.
+//!
+//! The ABI exposes callback traits as a vtable typedef, a global registration
+//! function, and a generic handle carrier. The host re-exports the vtable and
+//! wraps that carrier in a package- and trait-specific struct, preventing an
+//! unrelated callback trait from being passed to the wrong ergonomic function.
+
+use boltffi_binding::{CallbackDecl, CallbackId, Native};
+
+use crate::{
+    bridge::c::{self, ParameterGroup},
+    core::{Emitted, Error, RenderContext, Result},
+    target::c::name_style::Name,
+};
+
+use super::prefix::PackagePrefix;
+
+/// Returns the ergonomic typed-handle spelling for one callback trait.
+pub fn handle_type_name(id: CallbackId, context: &RenderContext<Native>) -> Result<String> {
+    let callback = context.callback(id).ok_or(Error::BrokenBridgeContract {
+        bridge: "c",
+        invariant: "callback handle target has no callback declaration",
+    })?;
+    let prefix = PackagePrefix::from_context(context);
+    let friendly = prefix.type_name(&Name::new(callback.name()).r#type());
+    Ok(format!("{friendly}Handle"))
+}
+
+/// Renders one callback trait's ergonomic surface.
+pub fn render(
+    decl: &CallbackDecl<Native>,
+    bridge: &c::CBridgeContract,
+    context: &RenderContext<Native>,
+) -> Result<Emitted> {
+    let callback = bridge
+        .source_callback(decl.id())
+        .ok_or(Error::BrokenBridgeContract {
+            bridge: "c",
+            invariant: "missing callback protocol",
+        })?;
+
+    // Sync-only guard: async callback methods emit completion payloads that are
+    // out of scope. Reject the whole trait rather than partially rendering.
+    let has_async = callback.methods().iter().any(|slot| {
+        slot.parameter_groups()
+            .iter()
+            .chain(slot.return_parameter_groups())
+            .any(|group| matches!(group, ParameterGroup::CallbackCompletion(_)))
+    });
+    if has_async {
+        return Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "async callback methods are out of scope",
+        });
+    }
+
+    let prefix = PackagePrefix::from_context(context);
+    let vtable_name = callback.vtable().name();
+    let friendly = prefix.type_name(&Name::new(callback.name()).r#type());
+    let handle = handle_type_name(decl.id(), context)?;
+    let member = Name::new(callback.name()).member();
+    let create = crate::bridge::c::Identifier::parse(prefix.member(&format!("{member}_create")))?;
+    let register_name = callback.register().name();
+    let create_name = callback.create_handle().name();
+
+    let mut chunk = format!(
+        "typedef {vtable_name} {friendly};\ntypedef struct {{\n    BoltFFICallbackHandle raw;\n}} {handle};\n"
+    );
+    chunk.push_str(&format!(
+        "/* A {friendly} vtable. The caller fills the function-pointer slots, then\n * passes it to {create}. The returned {handle} must be kept alive for the\n * duration of the call that consumes it.\n */\n"
+    ));
+    chunk.push_str(&format!(
+        "static inline {handle} {create}(const {friendly} *vtable) {{\n    {handle} result;\n    {register_name}((const {vtable_name} *)vtable);\n    result.raw = {create_name}(0);\n    return result;\n}}\n"
+    ));
+    Ok(Emitted::primary(chunk))
+}

--- a/boltffi_backend/src/target/c/render/class.rs
+++ b/boltffi_backend/src/target/c/render/class.rs
@@ -1,0 +1,53 @@
+//! Ergonomic owned class handles and semantic sync callables.
+use super::{callable, prefix::PackagePrefix, wrapper};
+use crate::{
+    bridge::c,
+    core::{Emitted, RenderContext, Result},
+    target::c::name_style::Name,
+};
+use boltffi_binding::{ClassDecl, Native};
+pub fn render(
+    decl: &ClassDecl<Native>,
+    bridge: &c::CBridgeContract,
+    context: &RenderContext<Native>,
+) -> Result<Emitted> {
+    let prefix = PackagePrefix::from_context(context);
+    let member = Name::new(decl.name()).member();
+    let ty = prefix.type_name(&Name::new(decl.name()).r#type());
+    let mut out = Emitted::primary("");
+    for init in decl.initializers() {
+        let abi = wrapper::find_abi(bridge, init.symbol())?;
+        let name = prefix.member(&format!("{}_{}", member, Name::new(init.name()).member()));
+        out.append(callable::render(
+            abi,
+            init.callable(),
+            &name,
+            &format!("{}{}", ty, Name::new(init.name()).r#type()),
+            callable::Receiver::None,
+            context,
+        )?)
+    }
+    for method in decl.methods() {
+        let abi = wrapper::find_abi(bridge, method.target())?;
+        let name = prefix.member(&format!("{}_{}", member, Name::new(method.name()).member()));
+        let recv = match method.callable().receiver() {
+            Some(r) => callable::Receiver::Class {
+                c_type: &ty,
+                receive: r,
+            },
+            None => callable::Receiver::None,
+        };
+        out.append(callable::render(
+            abi,
+            method.callable(),
+            &name,
+            &format!("{}{}", ty, Name::new(method.name()).r#type()),
+            recv,
+            context,
+        )?)
+    }
+    let release = wrapper::find_abi(bridge, decl.release())?;
+    let free = prefix.member(&format!("{}_free", member));
+    out.append(Emitted::primary(format!("static inline void {free}({ty} *value) {{ if (value == NULL || value->_boltffi_handle == 0) return; {}(value->_boltffi_handle); value->_boltffi_handle=0; }}\n",release.name())));
+    Ok(out)
+}

--- a/boltffi_backend/src/target/c/render/constant.rs
+++ b/boltffi_backend/src/target/c/render/constant.rs
@@ -1,0 +1,65 @@
+//! Ergonomic C wrappers for exported constants.
+//!
+//! Scalar inline constants are emitted as `#define` literals; accessor-backed
+//! constants (`boltffi_const_*`) are re-exposed as a `static inline` wrapper.
+//! Macro `#define`s are global to a translation unit, so every constant is
+//! prefixed with the library name to avoid colliding with macros and symbols
+//! from other headers.
+
+use boltffi_binding::{ConstantDecl, ConstantValueDecl, DefaultValue, Native};
+
+use crate::{
+    bridge::c::{self, Identifier},
+    core::{Emitted, RenderContext, Result},
+    target::c::name_style::Name,
+};
+
+use super::{prefix::PackagePrefix, wrapper};
+
+/// Renders one constant's ergonomic surface.
+pub fn render(
+    decl: &ConstantDecl<Native>,
+    bridge: &c::CBridgeContract,
+    context: &RenderContext<Native>,
+) -> Result<Emitted> {
+    let prefix = PackagePrefix::from_context(context);
+    match decl.value() {
+        ConstantValueDecl::Inline { value, .. } => {
+            let constant = prefix.constant(&Name::new(decl.name()).constant());
+            let literal = render_default(value);
+            Ok(Emitted::primary(format!("#define {constant} {literal}\n")))
+        }
+        ConstantValueDecl::Accessor { symbol, .. } => {
+            let abi = wrapper::find_abi(bridge, symbol)?;
+            let name = prefix.member(&Name::new(decl.name()).member());
+            let wrapper_name = Identifier::escape(name)?;
+            wrapper::forward(abi, wrapper_name.as_str())
+        }
+        _ => Ok(Emitted::primary(String::new())),
+    }
+}
+
+fn render_default(value: &DefaultValue) -> String {
+    match value {
+        DefaultValue::Bool(true) => "true".to_owned(),
+        DefaultValue::Bool(false) => "false".to_owned(),
+        DefaultValue::Integer(integer) => integer.get().to_string(),
+        DefaultValue::Float(float) => float.to_f64().to_string(),
+        DefaultValue::String(string) => format!("{string:?}"),
+        DefaultValue::EnumVariant {
+            enum_name,
+            variant_name,
+            ..
+        } => {
+            // The ABI spellings join owner and variant (e.g. `MODE_FAST`),
+            // unchanged by the ergonomic prefix.
+            format!(
+                "{}_{}",
+                Name::new(enum_name).constant(),
+                Name::new(variant_name).constant()
+            )
+        }
+        DefaultValue::Null => "0".to_owned(),
+        _ => "0".to_owned(),
+    }
+}

--- a/boltffi_backend/src/target/c/render/enumeration.rs
+++ b/boltffi_backend/src/target/c/render/enumeration.rs
@@ -1,0 +1,52 @@
+//! Ergonomic package-prefixed C-style enum callables.
+use super::{callable, prefix::PackagePrefix, wrapper};
+use crate::{
+    bridge::c,
+    core::{Emitted, Error, RenderContext, Result},
+    target::c::name_style::Name,
+};
+use boltffi_binding::{EnumDecl, Native};
+pub fn render(
+    decl: &EnumDecl<Native>,
+    bridge: &c::CBridgeContract,
+    context: &RenderContext<Native>,
+) -> Result<Emitted> {
+    let EnumDecl::CStyle(e) = decl else {
+        return Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "data enum",
+        });
+    };
+    let prefix = PackagePrefix::from_context(context);
+    let owner = Name::new(e.name()).member();
+    let ty = prefix.type_name(&Name::new(e.name()).r#type());
+    let mut out = Emitted::primary("");
+    for init in e.initializers() {
+        let abi = wrapper::find_abi(bridge, init.symbol())?;
+        let name = prefix.member(&format!("{}_{}", owner, Name::new(init.name()).member()));
+        out.append(callable::render(
+            abi,
+            init.callable(),
+            &name,
+            &format!("{}{}", ty, Name::new(init.name()).r#type()),
+            callable::Receiver::None,
+            context,
+        )?)
+    }
+    for method in e.methods() {
+        let abi = wrapper::find_abi(bridge, method.target())?;
+        let name = prefix.member(&format!("{}_{}", owner, Name::new(method.name()).member()));
+        out.append(callable::render(
+            abi,
+            method.callable(),
+            &name,
+            &format!("{}{}", ty, Name::new(method.name()).r#type()),
+            callable::Receiver::DirectRecord {
+                c_type: &ty,
+                receive: method.callable().receiver().expect("enum receiver"),
+            },
+            context,
+        )?)
+    }
+    Ok(out)
+}

--- a/boltffi_backend/src/target/c/render/function.rs
+++ b/boltffi_backend/src/target/c/render/function.rs
@@ -1,0 +1,53 @@
+//! Ergonomic wrappers for free functions.
+//!
+//! A sync `#[export] fn` maps to one ABI symbol (`boltffi_function_*`). The host
+//! layers a `static inline` wrapper under the source name so callers get a clean,
+//! keyword-safe API that lines up with the ABI.
+
+use boltffi_binding::{ErrorChannel, FunctionDecl, Native, TypeRef};
+
+use crate::{
+    bridge::c::{self, Identifier},
+    core::{Emitted, Error, RenderContext, Result},
+};
+
+use super::{prefix::PackagePrefix, wrapper};
+use crate::target::c::name_style::Name;
+
+/// Renders one free function's ergonomic wrapper.
+pub fn render(
+    decl: &FunctionDecl<Native>,
+    bridge: &c::CBridgeContract,
+    context: &RenderContext<Native>,
+) -> Result<Emitted> {
+    if decl.callable().execution().uses_async_execution() {
+        return Err(Error::UnsupportedTarget {
+            target: "c",
+            shape: "async free functions are out of scope",
+        });
+    }
+    let abi = wrapper::find_abi(bridge, decl.symbol())?;
+    let prefix = PackagePrefix::from_context(context);
+    let wrapper_name = Identifier::escape(prefix.member(&Name::new(decl.name()).member()))?;
+    if matches!(
+        decl.callable().error().channel(),
+        ErrorChannel::Encoded {
+            ty: TypeRef::Enum(_),
+            ..
+        }
+    ) {
+        return super::result::render_function(decl, bridge, context, wrapper_name.as_str())?
+            .ok_or(Error::UnsupportedTarget {
+                target: "c",
+                shape: "C-style enum result",
+            });
+    }
+    super::callable::render(
+        abi,
+        decl.callable(),
+        wrapper_name.as_str(),
+        &prefix.type_name(&Name::new(decl.name()).r#type()),
+        super::callable::Receiver::None,
+        context,
+    )
+}

--- a/boltffi_backend/src/target/c/render/mod.rs
+++ b/boltffi_backend/src/target/c/render/mod.rs
@@ -1,0 +1,18 @@
+//! Ergonomic C rendering for the sync value surface.
+//!
+//! The C host renders directly over the C ABI contract (`CBridgeContract`).
+//! Every renderer emits a `static inline` wrapper (and/or a `typedef`) into the
+//! same header the bridge produced, so the ergonomic API lines up with the
+//! already-locked ABI.
+
+pub mod callable;
+pub mod callback;
+pub mod class;
+pub mod constant;
+pub mod enumeration;
+pub mod function;
+pub mod prefix;
+pub mod record;
+pub mod result;
+pub mod surface;
+pub mod wrapper;

--- a/boltffi_backend/src/target/c/render/prefix.rs
+++ b/boltffi_backend/src/target/c/render/prefix.rs
@@ -1,0 +1,61 @@
+//! Package-prefix helper for the ergonomic C host surface.
+//!
+//! C has no namespaces, so every user-facing symbol (functions, constants,
+//! friendly type aliases, associated wrappers) is prefixed with the library
+//! (package) name so that multiple boltffi-generated headers can be included
+//! in one translation unit without colliding. Prefixing is idempotent: a name
+//! that already carries the package prefix is not doubled.
+
+use boltffi_binding::Native;
+
+use crate::core::RenderContext;
+
+use super::super::name_style::Name;
+
+/// The package prefix in the three C case forms.
+pub struct PackagePrefix {
+    member: String,
+    constant: String,
+    pascal: String,
+}
+
+impl PackagePrefix {
+    /// Builds the prefix from the render context's binding package name.
+    pub fn from_context(context: &RenderContext<Native>) -> Self {
+        let name = context.bindings().package().name();
+        Self {
+            member: Name::new(name).member(),
+            constant: Name::new(name).constant(),
+            pascal: Name::new(name).r#type(),
+        }
+    }
+
+    /// Prefixes a snake_case member/symbol name (idempotent).
+    pub fn member(&self, raw: &str) -> String {
+        let prefix = format!("{}_", self.member);
+        if raw == self.member || raw.starts_with(&prefix) {
+            raw.to_owned()
+        } else {
+            format!("{prefix}{raw}")
+        }
+    }
+
+    /// Prefixes an UPPER_SNAKE macro/constant name (idempotent).
+    pub fn constant(&self, raw: &str) -> String {
+        let prefix = format!("{}_", self.constant);
+        if raw == self.constant || raw.starts_with(&prefix) {
+            raw.to_owned()
+        } else {
+            format!("{prefix}{raw}")
+        }
+    }
+
+    /// Prefixes a PascalCase type name (idempotent), e.g. `Point` -> `DemoPoint`.
+    pub fn type_name(&self, pascal: &str) -> String {
+        if pascal.starts_with(&self.pascal) {
+            pascal.to_owned()
+        } else {
+            format!("{}{}", self.pascal, pascal)
+        }
+    }
+}

--- a/boltffi_backend/src/target/c/render/record.rs
+++ b/boltffi_backend/src/target/c/render/record.rs
@@ -1,0 +1,76 @@
+//! Ergonomic package-prefixed record callables.
+
+use super::{callable, prefix::PackagePrefix, wrapper};
+use crate::{
+    bridge::c,
+    core::{Emitted, RenderContext, Result},
+    target::c::name_style::Name,
+};
+use boltffi_binding::{Native, RecordDecl};
+
+pub fn render(
+    decl: &RecordDecl<Native>,
+    bridge: &c::CBridgeContract,
+    context: &RenderContext<Native>,
+) -> Result<Emitted> {
+    let prefix = PackagePrefix::from_context(context);
+    let owner_member = Name::new(decl.name()).member();
+    let owner_type = prefix.type_name(&Name::new(decl.name()).r#type());
+    let mut emitted = Emitted::primary("");
+    for init in decl.initializers() {
+        let abi = wrapper::find_abi(bridge, init.symbol())?;
+        let name = prefix.member(&format!(
+            "{}_{}",
+            owner_member,
+            Name::new(init.name()).member()
+        ));
+        emitted.append(callable::render(
+            abi,
+            init.callable(),
+            &name,
+            &format!("{}{}", owner_type, Name::new(init.name()).r#type()),
+            callable::Receiver::None,
+            context,
+        )?);
+    }
+    for method in decl.methods() {
+        let abi = wrapper::find_abi(bridge, method.target())?;
+        let name = prefix.member(&format!(
+            "{}_{}",
+            owner_member,
+            Name::new(method.name()).member()
+        ));
+        let receiver = match decl {
+            RecordDecl::Encoded(r) => callable::Receiver::EncodedRecord {
+                c_type: &owner_type,
+                id: r.id(),
+                receive: method
+                    .callable()
+                    .receiver()
+                    .expect("record method receiver"),
+            },
+            RecordDecl::Direct(_) => callable::Receiver::DirectRecord {
+                c_type: &owner_type,
+                receive: method
+                    .callable()
+                    .receiver()
+                    .expect("record method receiver"),
+            },
+            _ => {
+                return Err(crate::core::Error::UnsupportedTarget {
+                    target: "c",
+                    shape: "record declaration",
+                });
+            }
+        };
+        emitted.append(callable::render(
+            abi,
+            method.callable(),
+            &name,
+            &format!("{}{}", owner_type, Name::new(method.name()).r#type()),
+            receiver,
+            context,
+        )?);
+    }
+    Ok(emitted)
+}

--- a/boltffi_backend/src/target/c/render/result.rs
+++ b/boltffi_backend/src/target/c/render/result.rs
@@ -1,0 +1,145 @@
+//! Typed ergonomic C rendering for fallible free functions.
+
+use boltffi_binding::{EnumDecl, ErrorChannel, ErrorPlacement, FunctionDecl, Native, TypeRef};
+
+use crate::{
+    bridge::c::{self, Type, TypeFragment},
+    core::{Emitted, Error, RenderContext, Result},
+    target::c::name_style::Name,
+};
+
+use super::{prefix::PackagePrefix, wrapper};
+
+pub fn preamble() -> &'static str {
+    ""
+}
+
+pub fn render_function(
+    decl: &FunctionDecl<Native>,
+    bridge: &c::CBridgeContract,
+    context: &RenderContext<Native>,
+    wrapper_name: &str,
+) -> Result<Option<Emitted>> {
+    let ErrorChannel::Encoded {
+        placement: ErrorPlacement::ReturnSlot,
+        ty,
+        ..
+    } = decl.callable().error().channel()
+    else {
+        return Ok(None);
+    };
+    let prefix = PackagePrefix::from_context(context);
+    let (error_ty, error_comment, string_error) = match ty {
+        TypeRef::Enum(error_id) => {
+            let Some(EnumDecl::CStyle(error_decl)) = context.enumeration(*error_id) else {
+                return Err(Error::UnsupportedTarget {
+                    target: "c",
+                    shape: "fallible function error enum is not C-style",
+                });
+            };
+            (
+                prefix.type_name(&Name::new(error_decl.name()).r#type()),
+                "",
+                false,
+            )
+        }
+        TypeRef::String => (
+            "FfiString".to_owned(),
+            "/* On error, data.error is caller-owned UTF-8. FfiString is NOT NUL-terminated; use ptr and len, then call boltffi_free_string. */\n",
+            true,
+        ),
+        _ => {
+            return Err(Error::UnsupportedTarget {
+                target: "c",
+                shape: "fallible function error must be String or an exported C-style enum",
+            });
+        }
+    };
+    let abi = wrapper::find_abi(bridge, decl.symbol())?;
+    let value_name = wrapper::local_name(abi, "value");
+    let encoded_error_name = wrapper::local_name(abi, "encoded_error");
+    let result_name = wrapper::local_name(abi, "result");
+    let error_raw_name = wrapper::local_name(abi, "error_raw");
+    let index_name = wrapper::local_name(abi, "index");
+    let result_ty = format!(
+        "{}Result",
+        prefix.type_name(&Name::new(decl.name()).r#type())
+    );
+    let success = abi
+        .params()
+        .iter()
+        .find(|p| p.name() == "return_out")
+        .ok_or(Error::UnsupportedTarget {
+            target: "c",
+            shape: "fallible C facade requires an out-pointer success value",
+        })?;
+    let Type::MutPointer(success_ty) = success.ty() else {
+        return Err(Error::BrokenBridgeContract {
+            bridge: "c",
+            invariant: "fallible C function return_out is not a pointer",
+        });
+    };
+    let success_ty = TypeFragment::anonymous(success_ty)?.to_string();
+    let params = abi
+        .params()
+        .iter()
+        .filter(|p| p.name() != "return_out")
+        .map(|p| TypeFragment::declaration(p.ty(), p.name()).map(|v| v.to_string()))
+        .collect::<Result<Vec<_>>>()?;
+    let params = if params.is_empty() {
+        "void".to_owned()
+    } else {
+        params.join(", ")
+    };
+    let args = abi
+        .params()
+        .iter()
+        .map(|p| {
+            if p.name() == "return_out" {
+                format!("&{value_name}")
+            } else {
+                p.name().to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let error_decode = if string_error {
+        format!("    {result_name}.data.error = boltffi_buf_into_string({encoded_error_name});\n")
+    } else {
+        format!(
+            r#"    uint64_t {error_raw_name} = 0;
+    if ({encoded_error_name}.len == sizeof({result_name}.data.error)) {{
+        for (uintptr_t {index_name} = 0; {index_name} < {encoded_error_name}.len; ++{index_name}) {{
+            {error_raw_name} |= ((uint64_t){encoded_error_name}.ptr[{index_name}]) << ({index_name} * 8);
+        }}
+    }}
+    {result_name}.data.error = ({error_ty}){error_raw_name};
+    boltffi_free_buf({encoded_error_name});
+"#,
+        )
+    };
+    let body = format!(
+        r#"{error_comment}typedef struct {{
+    bool ok;
+    union {{
+        {success_ty} value;
+        {error_ty} error;
+    }} data;
+}} {result_ty};
+static inline {result_ty} {wrapper_name}({params}) {{
+    {success_ty} {value_name};
+    FfiBuf_u8 {encoded_error_name} = {}({args});
+    {result_ty} {result_name};
+    if ({encoded_error_name}.len == 0) {{
+        {result_name}.ok = true;
+        {result_name}.data.value = {value_name};
+        return {result_name};
+    }}
+    {result_name}.ok = false;
+{error_decode}    return {result_name};
+}}
+"#,
+        abi.name()
+    );
+    Ok(Some(Emitted::primary(body)))
+}

--- a/boltffi_backend/src/target/c/render/surface.rs
+++ b/boltffi_backend/src/target/c/render/surface.rs
@@ -1,0 +1,861 @@
+//! Package-prefixed C value types and the private wire codec used by the facade.
+
+use boltffi_binding::{Bindings, EnumDecl, FieldKey, Native, Primitive, RecordDecl, TypeRef};
+
+use crate::{
+    core::{Error, RenderContext, Result},
+    target::c::name_style::Name,
+};
+
+use super::prefix::PackagePrefix;
+
+pub fn render(bindings: &Bindings<Native>, context: &RenderContext<Native>) -> Result<String> {
+    let prefix = PackagePrefix::from_context(context);
+    let mut out = String::new();
+    out.push_str("#include <stdlib.h>\n#include <string.h>\n\n");
+    out.push_str(&format!(
+        "typedef struct {{ const uint8_t *ptr; uintptr_t len; }} {p}BytesView;\n\
+         typedef struct {{ const char *ptr; uintptr_t len; }} {p}StringView;\n\
+         typedef struct {{ uint8_t *ptr; uintptr_t len; }} {p}Bytes;\n\
+         typedef struct {{ char *ptr; uintptr_t len; }} {p}String;\n\
+         typedef struct {{ bool has_value; uint32_t value; }} {p}OptionU32;\n\
+         typedef struct {{ bool has_value; float value; }} {p}OptionF32;\n\
+         typedef struct {{ bool has_value; {p}StringView value; }} {p}OptionStringView;\n\
+         typedef struct {{ bool has_value; {p}String value; }} {p}OptionString;\n\
+         typedef struct {{ const {p}StringView *ptr; uintptr_t len; }} {p}StringSlice;\n\
+         typedef struct {{ {p}String *ptr; uintptr_t len; }} {p}StringSequence;\n",
+        p = package_pascal(context)
+    ));
+
+    // Raw bridge declarations precede this facade, so direct aliases are safe here.
+    for decl in bindings.decls() {
+        match boltffi_binding::DeclarationRef::from(decl) {
+            boltffi_binding::DeclarationRef::Enum(EnumDecl::CStyle(enumeration)) => {
+                out.push_str(&format!(
+                    "typedef ___{} {};\n",
+                    Name::new(enumeration.name()).r#type(),
+                    type_name(&prefix, enumeration.name())
+                ));
+            }
+            boltffi_binding::DeclarationRef::Record(RecordDecl::Direct(record)) => {
+                out.push_str(&format!(
+                    "typedef ___{} {};\n",
+                    Name::new(record.name()).r#type(),
+                    type_name(&prefix, record.name())
+                ));
+            }
+            boltffi_binding::DeclarationRef::Class(class) => {
+                let ty = type_name(&prefix, class.name());
+                out.push_str(&format!(
+                    "typedef struct {{ uint64_t _boltffi_handle; }} {ty};\n"
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    // Encoded records are named structs so mutually-referenced slice declarations work.
+    for decl in bindings.decls() {
+        if let boltffi_binding::DeclarationRef::Record(RecordDecl::Encoded(record)) =
+            boltffi_binding::DeclarationRef::from(decl)
+        {
+            let ty = type_name(&prefix, record.name());
+            out.push_str(&format!(
+                "typedef struct {ty}View {ty}View;\ntypedef struct {ty} {ty};\n"
+            ));
+        }
+    }
+
+    // Public primitive views and owned sequences. A Slice is borrowed; a Sequence is
+    // returned by value and released by its package-prefixed free helper.
+    for primitive in all_primitives() {
+        let stem = primitive_stem(*primitive);
+        let c = primitive_c(*primitive);
+        out.push_str(&format!(
+            "typedef struct {{ const {c} *ptr; uintptr_t len; }} {p}{stem}Slice;\n\
+             typedef struct {{ {c} *ptr; uintptr_t len; }} {p}{stem}Sequence;\n",
+            p = package_pascal(context)
+        ));
+    }
+    for decl in bindings.decls() {
+        if let boltffi_binding::DeclarationRef::Record(record) =
+            boltffi_binding::DeclarationRef::from(decl)
+        {
+            let ty = type_name(&prefix, record.name());
+            let slice_element = if matches!(record, RecordDecl::Encoded(_)) {
+                format!("{ty}View")
+            } else {
+                ty.clone()
+            };
+            out.push_str(&format!(
+                "typedef struct {{ const {slice_element} *ptr; uintptr_t len; }} {ty}Slice;\n\
+                 typedef struct {{ {ty} *ptr; uintptr_t len; }} {ty}Sequence;\n"
+            ));
+        }
+    }
+
+    for decl in bindings.decls() {
+        if let boltffi_binding::DeclarationRef::Record(RecordDecl::Encoded(record)) =
+            boltffi_binding::DeclarationRef::from(decl)
+        {
+            let ty = type_name(&prefix, record.name());
+            out.push_str(&format!("struct {ty}View {{\n"));
+            for field in record.fields() {
+                let field_name = match field.key() {
+                    FieldKey::Named(name) => Name::new(name).member(),
+                    _ => return unsupported("tuple encoded record fields"),
+                };
+                let field_ty = view_type(field.ty(), context)?;
+                out.push_str(&format!("    {field_ty} {field_name};\n"));
+            }
+            out.push_str("};\n");
+            out.push_str(&format!("struct {ty} {{\n"));
+            for field in record.fields() {
+                let field_name = match field.key() {
+                    FieldKey::Named(name) => Name::new(name).member(),
+                    FieldKey::Position(_) => {
+                        return Err(Error::UnsupportedTarget {
+                            target: "c",
+                            shape: "tuple encoded record fields",
+                        });
+                    }
+                    _ => return unsupported("unknown encoded record field key"),
+                };
+                let field_ty = value_type(field.ty(), context, ValueUse::Field)?;
+                out.push_str(&format!("    {field_ty} {field_name};\n"));
+            }
+            out.push_str("};\n");
+        }
+    }
+
+    out.push_str(&wire_runtime(context));
+    for decl in bindings.decls() {
+        if let boltffi_binding::DeclarationRef::Record(RecordDecl::Encoded(record)) =
+            boltffi_binding::DeclarationRef::from(decl)
+        {
+            out.push_str(&record_codec(record, context)?);
+        }
+    }
+    out.push_str(&free_helpers(bindings, context)?);
+    Ok(out)
+}
+
+#[derive(Clone, Copy)]
+pub enum ValueUse {
+    Param,
+    Field,
+    Return,
+}
+
+pub fn value_type(ty: &TypeRef, context: &RenderContext<Native>, use_: ValueUse) -> Result<String> {
+    let p = package_pascal(context);
+    let prefix = PackagePrefix::from_context(context);
+    match ty {
+        TypeRef::Primitive(primitive) => Ok(primitive_c(*primitive).to_owned()),
+        TypeRef::String => Ok(format!(
+            "{p}String{}",
+            if matches!(use_, ValueUse::Param) {
+                "View"
+            } else {
+                ""
+            }
+        )),
+        TypeRef::Bytes => Ok(format!(
+            "{p}Bytes{}",
+            if matches!(use_, ValueUse::Param) {
+                "View"
+            } else {
+                ""
+            }
+        )),
+        TypeRef::Record(id) => context
+            .record(*id)
+            .map(|record| {
+                let name = type_name(&prefix, record.name());
+                if matches!(use_, ValueUse::Param) && matches!(record, RecordDecl::Encoded(_)) {
+                    format!("{name}View")
+                } else {
+                    name
+                }
+            })
+            .ok_or(Error::BrokenBridgeContract {
+                bridge: "c",
+                invariant: "missing record declaration for semantic C type",
+            }),
+        TypeRef::Enum(id) => context
+            .enumeration(*id)
+            .map(|e| type_name(&prefix, e.name()))
+            .ok_or(Error::BrokenBridgeContract {
+                bridge: "c",
+                invariant: "missing enum declaration for semantic C type",
+            }),
+        TypeRef::Class(id) => context
+            .class(*id)
+            .map(|class| type_name(&prefix, class.name()))
+            .ok_or(Error::BrokenBridgeContract {
+                bridge: "c",
+                invariant: "missing class declaration for semantic C type",
+            }),
+        TypeRef::Optional(inner) if **inner == TypeRef::Primitive(Primitive::U32) => {
+            Ok(format!("{p}OptionU32"))
+        }
+        TypeRef::Optional(inner) if **inner == TypeRef::Primitive(Primitive::F32) => {
+            Ok(format!("{p}OptionF32"))
+        }
+        TypeRef::Optional(inner) if **inner == TypeRef::String => Ok(format!(
+            "{p}OptionString{}",
+            if matches!(use_, ValueUse::Param) {
+                "View"
+            } else {
+                ""
+            }
+        )),
+        TypeRef::Sequence(element) => sequence_type(element, context, use_),
+        _ => unsupported("encoded value type"),
+    }
+}
+
+fn view_type(ty: &TypeRef, context: &RenderContext<Native>) -> Result<String> {
+    let p = package_pascal(context);
+    let prefix = PackagePrefix::from_context(context);
+    match ty {
+        TypeRef::String => Ok(format!("{p}StringView")),
+        TypeRef::Bytes => Ok(format!("{p}BytesView")),
+        TypeRef::Primitive(v) => Ok(primitive_c(*v).into()),
+        TypeRef::Enum(id) => context
+            .enumeration(*id)
+            .map(|e| type_name(&prefix, e.name()))
+            .ok_or(Error::BrokenBridgeContract {
+                bridge: "c",
+                invariant: "missing view enum",
+            }),
+        TypeRef::Record(id) => context
+            .record(*id)
+            .map(|r| {
+                let n = type_name(&prefix, r.name());
+                if matches!(r, RecordDecl::Encoded(_)) {
+                    format!("{n}View")
+                } else {
+                    n
+                }
+            })
+            .ok_or(Error::BrokenBridgeContract {
+                bridge: "c",
+                invariant: "missing view record",
+            }),
+        TypeRef::Optional(inner) if **inner == TypeRef::Primitive(Primitive::U32) => {
+            Ok(format!("{p}OptionU32"))
+        }
+        TypeRef::Optional(inner) if **inner == TypeRef::String => {
+            Ok(format!("{p}OptionStringView"))
+        }
+        TypeRef::Sequence(element) => sequence_type(element, context, ValueUse::Param),
+        _ => unsupported("encoded record view field"),
+    }
+}
+
+pub fn sequence_type(
+    element: &TypeRef,
+    context: &RenderContext<Native>,
+    use_: ValueUse,
+) -> Result<String> {
+    let suffix = if matches!(use_, ValueUse::Param) {
+        "Slice"
+    } else {
+        "Sequence"
+    };
+    let p = package_pascal(context);
+    let prefix = PackagePrefix::from_context(context);
+    match element {
+        TypeRef::String => Ok(format!("{p}String{suffix}")),
+        TypeRef::Primitive(primitive) => Ok(format!("{p}{}{suffix}", primitive_stem(*primitive))),
+        TypeRef::Record(id) => context
+            .record(*id)
+            .map(|record| format!("{}{suffix}", type_name(&prefix, record.name())))
+            .ok_or(Error::BrokenBridgeContract {
+                bridge: "c",
+                invariant: "missing sequence record",
+            }),
+        _ => unsupported("sequence element type"),
+    }
+}
+
+pub fn direct_value_type(
+    ty: &boltffi_binding::DirectValueType,
+    context: &RenderContext<Native>,
+) -> Result<String> {
+    let prefix = PackagePrefix::from_context(context);
+    match ty {
+        boltffi_binding::DirectValueType::Primitive(p) => Ok(primitive_c(*p).to_owned()),
+        boltffi_binding::DirectValueType::Record(id) => context
+            .record(*id)
+            .map(|r| type_name(&prefix, r.name()))
+            .ok_or(Error::BrokenBridgeContract {
+                bridge: "c",
+                invariant: "missing direct record",
+            }),
+        boltffi_binding::DirectValueType::Enum(id) => context
+            .enumeration(*id)
+            .map(|e| type_name(&prefix, e.name()))
+            .ok_or(Error::BrokenBridgeContract {
+                bridge: "c",
+                invariant: "missing direct enum",
+            }),
+        _ => unsupported("direct value type"),
+    }
+}
+
+pub fn direct_vector_element_type(
+    element: &boltffi_binding::DirectVectorElementType,
+    context: &RenderContext<Native>,
+) -> Result<String> {
+    let prefix = PackagePrefix::from_context(context);
+    match element {
+        boltffi_binding::DirectVectorElementType::Primitive(p) => {
+            Ok(primitive_c(p.primitive()).to_owned())
+        }
+        boltffi_binding::DirectVectorElementType::Record(id) => context
+            .record(*id)
+            .map(|r| type_name(&prefix, r.name()))
+            .ok_or(Error::BrokenBridgeContract {
+                bridge: "c",
+                invariant: "missing vector record",
+            }),
+        _ => unsupported("direct vector element type"),
+    }
+}
+
+pub fn direct_vector_type(
+    element: &boltffi_binding::DirectVectorElementType,
+    context: &RenderContext<Native>,
+    use_: ValueUse,
+) -> Result<String> {
+    let suffix = if matches!(use_, ValueUse::Param) {
+        "Slice"
+    } else {
+        "Sequence"
+    };
+    let p = package_pascal(context);
+    let prefix = PackagePrefix::from_context(context);
+    match element {
+        boltffi_binding::DirectVectorElementType::Primitive(v) => {
+            Ok(format!("{p}{}{suffix}", primitive_stem(v.primitive())))
+        }
+        boltffi_binding::DirectVectorElementType::Record(id) => context
+            .record(*id)
+            .map(|r| format!("{}{suffix}", type_name(&prefix, r.name())))
+            .ok_or(Error::BrokenBridgeContract {
+                bridge: "c",
+                invariant: "missing vector record",
+            }),
+        _ => unsupported("direct vector type"),
+    }
+}
+
+pub fn record_helper_name(
+    id: boltffi_binding::RecordId,
+    context: &RenderContext<Native>,
+    op: &str,
+) -> Result<String> {
+    let record = context.record(id).ok_or(Error::BrokenBridgeContract {
+        bridge: "c",
+        invariant: "missing encoded record helper declaration",
+    })?;
+    Ok(format!(
+        "boltffi_c_{}_{}_{}",
+        package_member(context),
+        op,
+        Name::new(record.name()).member()
+    ))
+}
+
+fn record_codec(
+    record: &boltffi_binding::EncodedRecordDecl<Native>,
+    context: &RenderContext<Native>,
+) -> Result<String> {
+    let prefix = PackagePrefix::from_context(context);
+    let ty = type_name(&prefix, record.name());
+    let member = Name::new(record.name()).member();
+    let base = format!("boltffi_c_{}", package_member(context));
+    let mut size = Code::new();
+    size.line("(void)boltffi_value;");
+    size.line("uintptr_t boltffi_size = 0;");
+    let mut encode = Code::new();
+    let mut decode = Code::new();
+    decode.line("memset(boltffi_value, 0, sizeof(*boltffi_value));");
+    let mut free = Code::new();
+    for field in record.fields() {
+        let field_name = match field.key() {
+            FieldKey::Named(name) => Name::new(name).member(),
+            _ => return unsupported("tuple encoded record fields"),
+        };
+        size_value(
+            field.ty(),
+            &format!("boltffi_value->{field_name}"),
+            &mut size,
+            context,
+        )?;
+        encode_value(
+            field.ty(),
+            &format!("boltffi_value->{field_name}"),
+            &mut encode,
+            context,
+        )?;
+        decode_value(
+            field.ty(),
+            &format!("boltffi_value->{field_name}"),
+            &mut decode,
+            context,
+        )?;
+        free_value(
+            field.ty(),
+            &format!("boltffi_value->{field_name}"),
+            &mut free,
+            context,
+        )?;
+    }
+    size.line("return boltffi_size;");
+    encode.line("return boltffi_writer->ok;");
+    decode.line(format!(
+        "if (!boltffi_reader->ok) {{ {base}_free_{member}(boltffi_value); return false; }}"
+    ));
+    decode.line("return true;");
+    decode.text = decode.text.replace(
+        "return false;",
+        &format!("{{ {base}_free_{member}(boltffi_value); return false; }}"),
+    );
+    free.line("memset(boltffi_value, 0, sizeof(*boltffi_value));");
+    Ok(format!(
+        "static inline void {base}_free_{member}({ty} *boltffi_value);\n\
+         static inline uintptr_t {base}_size_{member}(const {ty}View *boltffi_value) {{\n{size}}}\n\
+         static inline bool {base}_encode_{member}(BoltFFICWireWriter *boltffi_writer, const {ty}View *boltffi_value) {{\n{encode}}}\n\
+         static inline bool {base}_decode_{member}(BoltFFICWireReader *boltffi_reader, {ty} *boltffi_value) {{\n{decode}}}\n\
+         static inline void {base}_free_{member}({ty} *boltffi_value) {{\n    if (boltffi_value == NULL) return;\n{free}}}\n",
+    ))
+}
+
+fn wire_runtime(context: &RenderContext<Native>) -> String {
+    let p = package_member(context);
+    format!(
+        r#"
+typedef struct {{ uint8_t *ptr; uintptr_t len; uintptr_t offset; bool ok; }} BoltFFICWireWriter;
+typedef struct {{ const uint8_t *ptr; uintptr_t len; uintptr_t offset; bool ok; }} BoltFFICWireReader;
+static inline void boltffi_c_{p}_write(BoltFFICWireWriter *w, const void *src, uintptr_t n) {{
+    if (!w->ok || n > w->len - w->offset) {{ w->ok = false; return; }}
+    if (n != 0) memcpy(w->ptr + w->offset, src, n);
+    w->offset += n;
+}}
+static inline void boltffi_c_{p}_read(BoltFFICWireReader *r, void *dst, uintptr_t n) {{
+    if (!r->ok || n > r->len - r->offset) {{ r->ok = false; return; }}
+    if (n != 0) memcpy(dst, r->ptr + r->offset, n);
+    r->offset += n;
+}}
+static inline void boltffi_c_{p}_write_u8(BoltFFICWireWriter *w, uint8_t v) {{ boltffi_c_{p}_write(w, &v, 1); }}
+static inline void boltffi_c_{p}_write_u32(BoltFFICWireWriter *w, uint32_t v) {{
+    uint8_t b[4] = {{(uint8_t)v, (uint8_t)(v >> 8), (uint8_t)(v >> 16), (uint8_t)(v >> 24)}};
+    boltffi_c_{p}_write(w, b, 4);
+}}
+static inline uint8_t boltffi_c_{p}_read_u8(BoltFFICWireReader *r) {{ uint8_t v = 0; boltffi_c_{p}_read(r, &v, 1); return v; }}
+static inline uint32_t boltffi_c_{p}_read_u32(BoltFFICWireReader *r) {{
+    uint8_t b[4] = {{0,0,0,0}}; boltffi_c_{p}_read(r, b, 4);
+    return (uint32_t)b[0] | ((uint32_t)b[1] << 8) | ((uint32_t)b[2] << 16) | ((uint32_t)b[3] << 24);
+}}
+static inline void *boltffi_c_{p}_alloc(uintptr_t count, uintptr_t size) {{
+    if (count == 0) return NULL;
+    if (size != 0 && count > (uintptr_t)-1 / size) return NULL;
+    return calloc((size_t)count, (size_t)size);
+}}
+static inline bool boltffi_c_{p}_copy_string(BoltFFICWireReader *r, {package_type_prefix}String *out) {{
+    uint32_t n = boltffi_c_{p}_read_u32(r); char *copy;
+    if (!r->ok || (uintptr_t)n > r->len - r->offset) return false;
+    copy = (char *)boltffi_c_{p}_alloc((uintptr_t)n + 1, 1);
+    if (copy == NULL) {{ r->ok = false; return false; }}
+    boltffi_c_{p}_read(r, copy, n); copy[n] = '\0'; out->ptr = copy; out->len = n; return r->ok;
+}}
+static inline bool boltffi_c_{p}_copy_bytes(BoltFFICWireReader *r, {package_type_prefix}Bytes *out) {{
+    uint32_t n = boltffi_c_{p}_read_u32(r); uint8_t *copy;
+    if (!r->ok || (uintptr_t)n > r->len - r->offset) return false;
+    copy = (uint8_t *)boltffi_c_{p}_alloc(n, 1);
+    if (n != 0 && copy == NULL) {{ r->ok = false; return false; }}
+    boltffi_c_{p}_read(r, copy, n); out->ptr = copy; out->len = n; return r->ok;
+}}
+"#,
+        package_type_prefix = package_pascal(context)
+    )
+}
+
+struct Code {
+    text: String,
+    indent: usize,
+    next: usize,
+}
+impl Code {
+    fn new() -> Self {
+        Self {
+            text: String::new(),
+            indent: 1,
+            next: 0,
+        }
+    }
+    fn line(&mut self, line: impl AsRef<str>) {
+        self.text.push_str(&"    ".repeat(self.indent));
+        self.text.push_str(line.as_ref());
+        self.text.push('\n');
+    }
+    fn open(&mut self, line: impl AsRef<str>) {
+        self.line(line);
+        self.indent += 1;
+    }
+    fn close(&mut self, line: impl AsRef<str>) {
+        self.indent -= 1;
+        self.line(line);
+    }
+    fn var(&mut self, stem: &str) -> String {
+        let v = format!("boltffi_{stem}_{}", self.next);
+        self.next += 1;
+        v
+    }
+}
+impl std::fmt::Display for Code {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.text)
+    }
+}
+
+fn size_value(
+    ty: &TypeRef,
+    expr: &str,
+    code: &mut Code,
+    context: &RenderContext<Native>,
+) -> Result<()> {
+    match ty {
+        TypeRef::Primitive(p) => code.line(format!("boltffi_size += {};", primitive_wire_size(*p))),
+        TypeRef::String | TypeRef::Bytes => code.line(format!("boltffi_size += 4 + {expr}.len;")),
+        TypeRef::Enum(id) => code.line(format!(
+            "boltffi_size += {};",
+            enum_wire_size(*id, context)?
+        )),
+        TypeRef::Record(id) => match context.record(*id) {
+            Some(RecordDecl::Direct(record)) => code.line(format!(
+                "boltffi_size += sizeof({});",
+                type_name(&PackagePrefix::from_context(context), record.name())
+            )),
+            Some(RecordDecl::Encoded(_)) => code.line(format!(
+                "boltffi_size += {}(&{expr});",
+                record_helper_name(*id, context, "size")?
+            )),
+            _ => return unsupported("record size codec"),
+        },
+        TypeRef::Optional(inner) => {
+            code.line("boltffi_size += 1;");
+            code.open(format!("if ({expr}.has_value) {{"));
+            size_value(inner, &format!("{expr}.value"), code, context)?;
+            code.close("}");
+        }
+        TypeRef::Sequence(element) => {
+            code.line("boltffi_size += 4;");
+            let i = code.var("i");
+            code.open(format!(
+                "for (uintptr_t {i} = 0; {i} < {expr}.len; ++{i}) {{"
+            ));
+            size_value(element, &format!("{expr}.ptr[{i}]"), code, context)?;
+            code.close("}");
+        }
+        _ => return unsupported("wire size type"),
+    }
+    Ok(())
+}
+
+fn encode_value(
+    ty: &TypeRef,
+    expr: &str,
+    code: &mut Code,
+    context: &RenderContext<Native>,
+) -> Result<()> {
+    let p = package_member(context);
+    match ty {
+        TypeRef::Primitive(primitive) => code.line(format!(
+            "boltffi_c_{p}_write(boltffi_writer, &{expr}, {});",
+            primitive_wire_size(*primitive)
+        )),
+        TypeRef::String | TypeRef::Bytes => {
+            code.line(format!(
+                "boltffi_c_{p}_write_u32(boltffi_writer, (uint32_t){expr}.len);"
+            ));
+            code.line(format!(
+                "boltffi_c_{p}_write(boltffi_writer, {expr}.ptr, {expr}.len);"
+            ));
+        }
+        TypeRef::Enum(id) => code.line(format!(
+            "boltffi_c_{p}_write(boltffi_writer, &{expr}, {});",
+            enum_wire_size(*id, context)?
+        )),
+        TypeRef::Record(id) => match context.record(*id) {
+            Some(RecordDecl::Direct(_)) => code.line(format!(
+                "boltffi_c_{p}_write(boltffi_writer, &{expr}, sizeof({expr}));"
+            )),
+            Some(RecordDecl::Encoded(_)) => code.line(format!(
+                "{}(boltffi_writer, &{expr});",
+                record_helper_name(*id, context, "encode")?
+            )),
+            _ => return unsupported("record encode codec"),
+        },
+        TypeRef::Optional(inner) => {
+            code.line(format!(
+                "boltffi_c_{p}_write_u8(boltffi_writer, {expr}.has_value ? 1 : 0);"
+            ));
+            code.open(format!("if ({expr}.has_value) {{"));
+            encode_value(inner, &format!("{expr}.value"), code, context)?;
+            code.close("}");
+        }
+        TypeRef::Sequence(element) => {
+            code.line(format!(
+                "boltffi_c_{p}_write_u32(boltffi_writer, (uint32_t){expr}.len);"
+            ));
+            let i = code.var("i");
+            code.open(format!("for (uintptr_t {i}=0; {i} < {expr}.len; ++{i}) {{"));
+            encode_value(element, &format!("{expr}.ptr[{i}]"), code, context)?;
+            code.close("}");
+        }
+        _ => return unsupported("wire encode type"),
+    }
+    Ok(())
+}
+
+fn decode_value(
+    ty: &TypeRef,
+    expr: &str,
+    code: &mut Code,
+    context: &RenderContext<Native>,
+) -> Result<()> {
+    let p = package_member(context);
+    match ty {
+        TypeRef::Primitive(primitive) => code.line(format!(
+            "boltffi_c_{p}_read(boltffi_reader, &{expr}, {});",
+            primitive_wire_size(*primitive)
+        )),
+        TypeRef::String => code.line(format!(
+            "if (!boltffi_c_{p}_copy_string(boltffi_reader, &{expr})) return false;"
+        )),
+        TypeRef::Bytes => code.line(format!(
+            "if (!boltffi_c_{p}_copy_bytes(boltffi_reader, &{expr})) return false;"
+        )),
+        TypeRef::Enum(id) => code.line(format!(
+            "boltffi_c_{p}_read(boltffi_reader, &{expr}, {});",
+            enum_wire_size(*id, context)?
+        )),
+        TypeRef::Record(id) => match context.record(*id) {
+            Some(RecordDecl::Direct(_)) => code.line(format!(
+                "boltffi_c_{p}_read(boltffi_reader, &{expr}, sizeof({expr}));"
+            )),
+            Some(RecordDecl::Encoded(_)) => code.line(format!(
+                "if (!{}(boltffi_reader, &{expr})) return false;",
+                record_helper_name(*id, context, "decode")?
+            )),
+            _ => return unsupported("record decode codec"),
+        },
+        TypeRef::Optional(inner) => {
+            let tag = code.var("tag");
+            code.line(format!(
+                "uint8_t {tag}=boltffi_c_{p}_read_u8(boltffi_reader);"
+            ));
+            code.line(format!("{expr}.has_value = ({tag} == 1);"));
+            code.open(format!("if ({tag} == 1) {{"));
+            decode_value(inner, &format!("{expr}.value"), code, context)?;
+            code.close(format!(
+                "}} else if ({tag} != 0) {{ boltffi_reader->ok=false; return false; }}"
+            ));
+        }
+        TypeRef::Sequence(element) => {
+            let n = code.var("count");
+            let i = code.var("i");
+            let elem_ty = value_type(element, context, ValueUse::Field)?;
+            code.line(format!(
+                "uint32_t {n}=boltffi_c_{p}_read_u32(boltffi_reader);"
+            ));
+            code.line(format!(
+                "{expr}.ptr=({elem_ty} *)boltffi_c_{p}_alloc({n}, sizeof({elem_ty}));"
+            ));
+            code.line(format!("{expr}.len={n};"));
+            code.line(format!(
+                "if ({n} != 0 && {expr}.ptr == NULL) {{ boltffi_reader->ok=false; return false; }}"
+            ));
+            code.open(format!("for (uintptr_t {i}=0; {i} < {n}; ++{i}) {{"));
+            decode_value(element, &format!("{expr}.ptr[{i}]"), code, context)?;
+            code.close("}");
+        }
+        _ => return unsupported("wire decode type"),
+    }
+    Ok(())
+}
+
+fn free_value(
+    ty: &TypeRef,
+    expr: &str,
+    code: &mut Code,
+    context: &RenderContext<Native>,
+) -> Result<()> {
+    match ty {
+        TypeRef::String | TypeRef::Bytes => {
+            code.line(format!("free((void *){expr}.ptr);"));
+            code.line(format!("{expr}.ptr=NULL; {expr}.len=0;"));
+        }
+        TypeRef::Record(id) => {
+            if matches!(context.record(*id), Some(RecordDecl::Encoded(_))) {
+                code.line(format!(
+                    "{}(&{expr});",
+                    record_helper_name(*id, context, "free")?
+                ));
+            }
+        }
+        TypeRef::Optional(inner) => {
+            code.open(format!("if ({expr}.has_value) {{"));
+            free_value(inner, &format!("{expr}.value"), code, context)?;
+            code.close("}");
+            code.line(format!("{expr}.has_value=false;"));
+        }
+        TypeRef::Sequence(element) => {
+            let i = code.var("i");
+            code.open(format!("for (uintptr_t {i}=0; {i} < {expr}.len; ++{i}) {{"));
+            free_value(element, &format!("{expr}.ptr[{i}]"), code, context)?;
+            code.close("}");
+            code.line(format!(
+                "free((void *){expr}.ptr); {expr}.ptr=NULL; {expr}.len=0;"
+            ));
+        }
+        TypeRef::Primitive(_) | TypeRef::Enum(_) => {}
+        _ => return unsupported("wire free type"),
+    }
+    Ok(())
+}
+
+fn free_helpers(bindings: &Bindings<Native>, context: &RenderContext<Native>) -> Result<String> {
+    let mut out = String::new();
+    let p = package_member(context);
+    let package_type_prefix = package_pascal(context);
+    out.push_str(&format!("static inline {package_type_prefix}StringView {p}_string_view(const char *ptr, uintptr_t len) {{ {package_type_prefix}StringView v={{ptr,len}}; return v; }}\nstatic inline {package_type_prefix}BytesView {p}_bytes_view(const uint8_t *ptr, uintptr_t len) {{ {package_type_prefix}BytesView v={{ptr,len}}; return v; }}\n"));
+    out.push_str(&format!("static inline void {p}_string_free({package_type_prefix}String *v) {{ if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }}\nstatic inline void {p}_string_sequence_free({package_type_prefix}StringSequence *v) {{ if (v == NULL) return; for (uintptr_t i=0;i<v->len;++i) {p}_string_free(&v->ptr[i]); free((void *)v->ptr); v->ptr=NULL; v->len=0; }}\nstatic inline void {p}_bytes_free({package_type_prefix}Bytes *v) {{ if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }}\n"));
+    for primitive in all_primitives() {
+        let stem = primitive_stem(*primitive);
+        let member = stem.to_ascii_lowercase();
+        out.push_str(&format!("static inline void {p}_{member}_sequence_free({package_type_prefix}{stem}Sequence *v) {{ if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }}\n"));
+    }
+    let prefix = PackagePrefix::from_context(context);
+    for decl in bindings.decls() {
+        if let boltffi_binding::DeclarationRef::Record(record) =
+            boltffi_binding::DeclarationRef::from(decl)
+        {
+            let ty = type_name(&prefix, record.name());
+            let m = Name::new(record.name()).member();
+            if matches!(record, RecordDecl::Encoded(encoded) if encoded.fields().iter().any(|field| type_owns(field.ty(), context)))
+            {
+                out.push_str(&format!(
+                    "static inline void {p}_{m}_free({ty} *v) {{ {}(v); }}\n",
+                    record_helper_name(record.id(), context, "free")?
+                ));
+            }
+            out.push_str(&format!("static inline void {p}_{m}_sequence_free({ty}Sequence *v) {{ if (v == NULL) return;"));
+            if matches!(record, RecordDecl::Encoded(_)) {
+                out.push_str(&format!(
+                    " for (uintptr_t i=0;i<v->len;++i) {}(&v->ptr[i]);",
+                    record_helper_name(record.id(), context, "free")?
+                ));
+            }
+            out.push_str(" free((void *)v->ptr); v->ptr=NULL; v->len=0; }\n");
+        }
+    }
+    Ok(out)
+}
+
+fn type_owns(ty: &TypeRef, context: &RenderContext<Native>) -> bool {
+    match ty {
+        TypeRef::String | TypeRef::Bytes | TypeRef::Sequence(_) => true,
+        TypeRef::Optional(inner) => type_owns(inner, context),
+        TypeRef::Record(id) => match context.record(*id) {
+            Some(RecordDecl::Encoded(r)) => r.fields().iter().any(|f| type_owns(f.ty(), context)),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn enum_wire_size(id: boltffi_binding::EnumId, context: &RenderContext<Native>) -> Result<usize> {
+    match context.enumeration(id) {
+        Some(EnumDecl::CStyle(e)) => Ok(primitive_wire_size(e.repr().primitive())),
+        _ => unsupported("data enum codec"),
+    }
+}
+fn primitive_wire_size(p: Primitive) -> usize {
+    match p {
+        Primitive::Bool | Primitive::I8 | Primitive::U8 => 1,
+        Primitive::I16 | Primitive::U16 => 2,
+        Primitive::I32 | Primitive::U32 | Primitive::F32 => 4,
+        Primitive::I64 | Primitive::U64 | Primitive::ISize | Primitive::USize | Primitive::F64 => 8,
+        _ => 0,
+    }
+}
+pub fn primitive_c(p: Primitive) -> &'static str {
+    match p {
+        Primitive::Bool => "bool",
+        Primitive::I8 => "int8_t",
+        Primitive::U8 => "uint8_t",
+        Primitive::I16 => "int16_t",
+        Primitive::U16 => "uint16_t",
+        Primitive::I32 => "int32_t",
+        Primitive::U32 => "uint32_t",
+        Primitive::I64 => "int64_t",
+        Primitive::U64 => "uint64_t",
+        Primitive::ISize => "intptr_t",
+        Primitive::USize => "uintptr_t",
+        Primitive::F32 => "float",
+        Primitive::F64 => "double",
+        _ => "void",
+    }
+}
+fn primitive_stem(p: Primitive) -> &'static str {
+    match p {
+        Primitive::Bool => "Bool",
+        Primitive::I8 => "I8",
+        Primitive::U8 => "U8",
+        Primitive::I16 => "I16",
+        Primitive::U16 => "U16",
+        Primitive::I32 => "I32",
+        Primitive::U32 => "U32",
+        Primitive::I64 => "I64",
+        Primitive::U64 => "U64",
+        Primitive::ISize => "ISize",
+        Primitive::USize => "USize",
+        Primitive::F32 => "F32",
+        Primitive::F64 => "F64",
+        _ => "Unsupported",
+    }
+}
+fn all_primitives() -> &'static [Primitive] {
+    &[
+        Primitive::Bool,
+        Primitive::I8,
+        Primitive::U8,
+        Primitive::I16,
+        Primitive::U16,
+        Primitive::I32,
+        Primitive::U32,
+        Primitive::I64,
+        Primitive::U64,
+        Primitive::ISize,
+        Primitive::USize,
+        Primitive::F32,
+        Primitive::F64,
+    ]
+}
+fn type_name(prefix: &PackagePrefix, name: &boltffi_binding::CanonicalName) -> String {
+    prefix.type_name(&Name::new(name).r#type())
+}
+fn package_pascal(context: &RenderContext<Native>) -> String {
+    Name::new(context.bindings().package().name()).r#type()
+}
+fn package_member(context: &RenderContext<Native>) -> String {
+    Name::new(context.bindings().package().name()).member()
+}
+fn unsupported<T>(shape: &'static str) -> Result<T> {
+    Err(Error::UnsupportedTarget { target: "c", shape })
+}

--- a/boltffi_backend/src/target/c/render/wrapper.rs
+++ b/boltffi_backend/src/target/c/render/wrapper.rs
@@ -1,0 +1,69 @@
+//! Shared `static inline` forwarding wrapper emission.
+
+use crate::{
+    bridge::c::{self, Type, TypeFragment},
+    core::{Emitted, Error, Result},
+};
+
+/// Allocates a wrapper-local identifier that cannot shadow an ABI parameter.
+pub fn local_name(function: &c::Function, stem: &str) -> String {
+    let mut name = format!("boltffi_{stem}");
+    while function
+        .params()
+        .iter()
+        .any(|parameter| parameter.name() == name)
+    {
+        name.push('_');
+    }
+    name
+}
+
+/// Emits a `static inline` wrapper under `wrapper_name` that forwards to the
+/// given ABI symbol with the same parameter list and return type.
+pub fn forward(function: &c::Function, wrapper_name: &str) -> Result<Emitted> {
+    let returns = TypeFragment::anonymous(function.returns())?.to_string();
+    let params = function
+        .params()
+        .iter()
+        .map(|parameter| {
+            TypeFragment::declaration(parameter.ty(), parameter.name()).map(|s| s.to_string())
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let params_text = if params.is_empty() {
+        "void".to_owned()
+    } else {
+        params.join(", ")
+    };
+    let args = function
+        .params()
+        .iter()
+        .map(|parameter| parameter.name().to_owned())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut body = format!("static inline {returns} {wrapper_name}({params_text}) {{\n");
+    match function.returns() {
+        Type::Void => {
+            body.push_str(&format!("    {}({});\n", function.name(), args));
+        }
+        _ => {
+            body.push_str(&format!("    return {}({});\n", function.name(), args));
+        }
+    }
+    body.push_str("}\n");
+    Ok(Emitted::primary(body))
+}
+
+/// Finds the ABI `Function` whose symbol name matches a source `NativeSymbol`.
+pub fn find_abi<'a>(
+    bridge: &'a c::CBridgeContract,
+    symbol: &boltffi_binding::NativeSymbol,
+) -> Result<&'a c::Function> {
+    bridge
+        .functions()
+        .iter()
+        .find(|function| function.name() == symbol.name().as_str())
+        .ok_or(Error::BrokenBridgeContract {
+            bridge: "c",
+            invariant: "missing ABI function for source callable",
+        })
+}

--- a/boltffi_backend/src/target/c/snapshots/boltffi_backend__target__c__tests__c_class.snap
+++ b/boltffi_backend/src/target/c/snapshots/boltffi_backend__target__c__tests__c_class.snap
@@ -1,0 +1,267 @@
+---
+source: boltffi_backend/src/target/c/mod.rs
+expression: render_header(&output)
+---
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif !defined(__cplusplus)
+#include <stdatomic.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    int32_t code;
+} FfiStatus;
+
+#ifdef __cplusplus
+static inline FfiStatus boltffi_status_from_code(int32_t code) {
+    FfiStatus status = { code };
+    return status;
+}
+#define FFI_STATUS_OK boltffi_status_from_code(0)
+#define FFI_STATUS_NULL_POINTER boltffi_status_from_code(1)
+#define FFI_STATUS_BUFFER_TOO_SMALL boltffi_status_from_code(2)
+#define FFI_STATUS_INVALID_ARG boltffi_status_from_code(3)
+#define FFI_STATUS_CANCELLED boltffi_status_from_code(4)
+#define FFI_STATUS_INTERNAL_ERROR boltffi_status_from_code(100)
+#else
+#define FFI_STATUS_OK ((FfiStatus){0})
+#define FFI_STATUS_NULL_POINTER ((FfiStatus){1})
+#define FFI_STATUS_BUFFER_TOO_SMALL ((FfiStatus){2})
+#define FFI_STATUS_INVALID_ARG ((FfiStatus){3})
+#define FFI_STATUS_CANCELLED ((FfiStatus){4})
+#define FFI_STATUS_INTERNAL_ERROR ((FfiStatus){100})
+#endif
+
+typedef struct {
+    uint8_t *ptr;
+    uintptr_t len;
+    uintptr_t cap;
+    uintptr_t align;
+} FfiBuf_u8;
+
+typedef struct {
+    uint8_t *ptr;
+    uintptr_t len;
+    uintptr_t cap;
+} FfiString;
+
+typedef struct {
+    FfiString message;
+} FfiError;
+
+typedef struct {
+    const uint8_t *ptr;
+    uintptr_t len;
+} FfiSpan;
+
+typedef const void *RustFutureHandle;
+typedef int8_t StreamPollResult;
+typedef int32_t WaitResult;
+typedef void (*RustFutureContinuationCallback)(uint64_t callback_data, int8_t poll_result);
+typedef void (*StreamContinuationCallback)(uint64_t callback_data, StreamPollResult result);
+
+#if defined(_MSC_VER)
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return _InterlockedCompareExchange8((volatile char *)state, (char)desired, (char)expected) == (char)expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return (uint64_t)_InterlockedExchange64((volatile __int64 *)slot, (__int64)value);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, (__int64)desired, (__int64)expected) == expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, 0, 0);
+}
+#elif defined(__cplusplus) && (defined(__clang__) || defined(__GNUC__))
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return __atomic_compare_exchange_n(state, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return __atomic_exchange_n(slot, value, __ATOMIC_ACQ_REL);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return __atomic_compare_exchange_n(slot, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return __atomic_load_n(slot, __ATOMIC_ACQUIRE);
+}
+#elif defined(__cplusplus)
+#error "BoltFFI C++ atomics require GCC, Clang, or MSVC"
+#else
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return atomic_compare_exchange_strong_explicit((_Atomic uint8_t *)state, &expected, desired, memory_order_acq_rel, memory_order_acquire);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return atomic_exchange_explicit((_Atomic uint64_t *)slot, value, memory_order_acq_rel);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return atomic_compare_exchange_strong_explicit((_Atomic uint64_t *)slot, &expected, desired, memory_order_acq_rel, memory_order_acquire);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return atomic_load_explicit((_Atomic uint64_t *)slot, memory_order_acquire);
+}
+#endif
+
+typedef struct {
+    uint64_t handle;
+    const void *vtable;
+} BoltFFICallbackHandle;
+
+void boltffi_free_string(FfiString string);
+void boltffi_free_buf(FfiBuf_u8 buf);
+FfiString boltffi_buf_into_string(FfiBuf_u8 buf);
+FfiBuf_u8 boltffi_buf_from_bytes(const uint8_t *ptr, uintptr_t len);
+FfiBuf_u8 boltffi_buf_with_len(uintptr_t len);
+FfiStatus boltffi_last_error_message(FfiString *out);
+void boltffi_clear_last_error(void);
+typedef struct {
+    double x;
+    double y;
+} ___Point;
+void boltffi_release_class_demo_engine(uint64_t handle);
+uint64_t boltffi_init_class_demo_engine_new(uint64_t seed);
+uint32_t boltffi_method_class_demo_engine_score(uint64_t receiver, ___Point point);
+
+#ifdef __cplusplus
+}
+#endif
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct { const uint8_t *ptr; uintptr_t len; } DemoBytesView;
+typedef struct { const char *ptr; uintptr_t len; } DemoStringView;
+typedef struct { uint8_t *ptr; uintptr_t len; } DemoBytes;
+typedef struct { char *ptr; uintptr_t len; } DemoString;
+typedef struct { bool has_value; uint32_t value; } DemoOptionU32;
+typedef struct { bool has_value; float value; } DemoOptionF32;
+typedef struct { bool has_value; DemoStringView value; } DemoOptionStringView;
+typedef struct { bool has_value; DemoString value; } DemoOptionString;
+typedef struct { const DemoStringView *ptr; uintptr_t len; } DemoStringSlice;
+typedef struct { DemoString *ptr; uintptr_t len; } DemoStringSequence;
+typedef ___Point DemoPoint;
+typedef struct { uint64_t _boltffi_handle; } DemoEngine;
+typedef struct { const bool *ptr; uintptr_t len; } DemoBoolSlice;
+typedef struct { bool *ptr; uintptr_t len; } DemoBoolSequence;
+typedef struct { const int8_t *ptr; uintptr_t len; } DemoI8Slice;
+typedef struct { int8_t *ptr; uintptr_t len; } DemoI8Sequence;
+typedef struct { const uint8_t *ptr; uintptr_t len; } DemoU8Slice;
+typedef struct { uint8_t *ptr; uintptr_t len; } DemoU8Sequence;
+typedef struct { const int16_t *ptr; uintptr_t len; } DemoI16Slice;
+typedef struct { int16_t *ptr; uintptr_t len; } DemoI16Sequence;
+typedef struct { const uint16_t *ptr; uintptr_t len; } DemoU16Slice;
+typedef struct { uint16_t *ptr; uintptr_t len; } DemoU16Sequence;
+typedef struct { const int32_t *ptr; uintptr_t len; } DemoI32Slice;
+typedef struct { int32_t *ptr; uintptr_t len; } DemoI32Sequence;
+typedef struct { const uint32_t *ptr; uintptr_t len; } DemoU32Slice;
+typedef struct { uint32_t *ptr; uintptr_t len; } DemoU32Sequence;
+typedef struct { const int64_t *ptr; uintptr_t len; } DemoI64Slice;
+typedef struct { int64_t *ptr; uintptr_t len; } DemoI64Sequence;
+typedef struct { const uint64_t *ptr; uintptr_t len; } DemoU64Slice;
+typedef struct { uint64_t *ptr; uintptr_t len; } DemoU64Sequence;
+typedef struct { const intptr_t *ptr; uintptr_t len; } DemoISizeSlice;
+typedef struct { intptr_t *ptr; uintptr_t len; } DemoISizeSequence;
+typedef struct { const uintptr_t *ptr; uintptr_t len; } DemoUSizeSlice;
+typedef struct { uintptr_t *ptr; uintptr_t len; } DemoUSizeSequence;
+typedef struct { const float *ptr; uintptr_t len; } DemoF32Slice;
+typedef struct { float *ptr; uintptr_t len; } DemoF32Sequence;
+typedef struct { const double *ptr; uintptr_t len; } DemoF64Slice;
+typedef struct { double *ptr; uintptr_t len; } DemoF64Sequence;
+typedef struct { const DemoPoint *ptr; uintptr_t len; } DemoPointSlice;
+typedef struct { DemoPoint *ptr; uintptr_t len; } DemoPointSequence;
+
+typedef struct { uint8_t *ptr; uintptr_t len; uintptr_t offset; bool ok; } BoltFFICWireWriter;
+typedef struct { const uint8_t *ptr; uintptr_t len; uintptr_t offset; bool ok; } BoltFFICWireReader;
+static inline void boltffi_c_demo_write(BoltFFICWireWriter *w, const void *src, uintptr_t n) {
+    if (!w->ok || n > w->len - w->offset) { w->ok = false; return; }
+    if (n != 0) memcpy(w->ptr + w->offset, src, n);
+    w->offset += n;
+}
+static inline void boltffi_c_demo_read(BoltFFICWireReader *r, void *dst, uintptr_t n) {
+    if (!r->ok || n > r->len - r->offset) { r->ok = false; return; }
+    if (n != 0) memcpy(dst, r->ptr + r->offset, n);
+    r->offset += n;
+}
+static inline void boltffi_c_demo_write_u8(BoltFFICWireWriter *w, uint8_t v) { boltffi_c_demo_write(w, &v, 1); }
+static inline void boltffi_c_demo_write_u32(BoltFFICWireWriter *w, uint32_t v) {
+    uint8_t b[4] = {(uint8_t)v, (uint8_t)(v >> 8), (uint8_t)(v >> 16), (uint8_t)(v >> 24)};
+    boltffi_c_demo_write(w, b, 4);
+}
+static inline uint8_t boltffi_c_demo_read_u8(BoltFFICWireReader *r) { uint8_t v = 0; boltffi_c_demo_read(r, &v, 1); return v; }
+static inline uint32_t boltffi_c_demo_read_u32(BoltFFICWireReader *r) {
+    uint8_t b[4] = {0,0,0,0}; boltffi_c_demo_read(r, b, 4);
+    return (uint32_t)b[0] | ((uint32_t)b[1] << 8) | ((uint32_t)b[2] << 16) | ((uint32_t)b[3] << 24);
+}
+static inline void *boltffi_c_demo_alloc(uintptr_t count, uintptr_t size) {
+    if (count == 0) return NULL;
+    if (size != 0 && count > (uintptr_t)-1 / size) return NULL;
+    return calloc((size_t)count, (size_t)size);
+}
+static inline bool boltffi_c_demo_copy_string(BoltFFICWireReader *r, DemoString *out) {
+    uint32_t n = boltffi_c_demo_read_u32(r); char *copy;
+    if (!r->ok || (uintptr_t)n > r->len - r->offset) return false;
+    copy = (char *)boltffi_c_demo_alloc((uintptr_t)n + 1, 1);
+    if (copy == NULL) { r->ok = false; return false; }
+    boltffi_c_demo_read(r, copy, n); copy[n] = '\0'; out->ptr = copy; out->len = n; return r->ok;
+}
+static inline bool boltffi_c_demo_copy_bytes(BoltFFICWireReader *r, DemoBytes *out) {
+    uint32_t n = boltffi_c_demo_read_u32(r); uint8_t *copy;
+    if (!r->ok || (uintptr_t)n > r->len - r->offset) return false;
+    copy = (uint8_t *)boltffi_c_demo_alloc(n, 1);
+    if (n != 0 && copy == NULL) { r->ok = false; return false; }
+    boltffi_c_demo_read(r, copy, n); out->ptr = copy; out->len = n; return r->ok;
+}
+static inline DemoStringView demo_string_view(const char *ptr, uintptr_t len) { DemoStringView v={ptr,len}; return v; }
+static inline DemoBytesView demo_bytes_view(const uint8_t *ptr, uintptr_t len) { DemoBytesView v={ptr,len}; return v; }
+static inline void demo_string_free(DemoString *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_string_sequence_free(DemoStringSequence *v) { if (v == NULL) return; for (uintptr_t i=0;i<v->len;++i) demo_string_free(&v->ptr[i]); free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_bytes_free(DemoBytes *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_bool_sequence_free(DemoBoolSequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_i8_sequence_free(DemoI8Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_u8_sequence_free(DemoU8Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_i16_sequence_free(DemoI16Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_u16_sequence_free(DemoU16Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_i32_sequence_free(DemoI32Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_u32_sequence_free(DemoU32Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_i64_sequence_free(DemoI64Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_u64_sequence_free(DemoU64Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_isize_sequence_free(DemoISizeSequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_usize_sequence_free(DemoUSizeSequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_f32_sequence_free(DemoF32Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_f64_sequence_free(DemoF64Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_point_sequence_free(DemoPointSequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+static inline DemoEngine demo_engine_new(uint64_t seed) {
+    DemoEngine boltffi_result; boltffi_result._boltffi_handle = boltffi_init_class_demo_engine_new(seed);
+    return boltffi_result;
+}
+static inline uint32_t demo_engine_score(const DemoEngine *receiver, DemoPoint point) {
+    uint32_t boltffi_result = (uint32_t)boltffi_method_class_demo_engine_score(receiver->_boltffi_handle, point);
+    return boltffi_result;
+}
+static inline void demo_engine_free(DemoEngine *value) { if (value == NULL || value->_boltffi_handle == 0) return; boltffi_release_class_demo_engine(value->_boltffi_handle); value->_boltffi_handle=0; }
+
+#ifdef __cplusplus
+}
+#endif

--- a/boltffi_backend/src/target/c/snapshots/boltffi_backend__target__c__tests__c_direct_record_and_enum.snap
+++ b/boltffi_backend/src/target/c/snapshots/boltffi_backend__target__c__tests__c_direct_record_and_enum.snap
@@ -1,0 +1,258 @@
+---
+source: boltffi_backend/src/target/c/mod.rs
+expression: render_header(&output)
+---
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif !defined(__cplusplus)
+#include <stdatomic.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    int32_t code;
+} FfiStatus;
+
+#ifdef __cplusplus
+static inline FfiStatus boltffi_status_from_code(int32_t code) {
+    FfiStatus status = { code };
+    return status;
+}
+#define FFI_STATUS_OK boltffi_status_from_code(0)
+#define FFI_STATUS_NULL_POINTER boltffi_status_from_code(1)
+#define FFI_STATUS_BUFFER_TOO_SMALL boltffi_status_from_code(2)
+#define FFI_STATUS_INVALID_ARG boltffi_status_from_code(3)
+#define FFI_STATUS_CANCELLED boltffi_status_from_code(4)
+#define FFI_STATUS_INTERNAL_ERROR boltffi_status_from_code(100)
+#else
+#define FFI_STATUS_OK ((FfiStatus){0})
+#define FFI_STATUS_NULL_POINTER ((FfiStatus){1})
+#define FFI_STATUS_BUFFER_TOO_SMALL ((FfiStatus){2})
+#define FFI_STATUS_INVALID_ARG ((FfiStatus){3})
+#define FFI_STATUS_CANCELLED ((FfiStatus){4})
+#define FFI_STATUS_INTERNAL_ERROR ((FfiStatus){100})
+#endif
+
+typedef struct {
+    uint8_t *ptr;
+    uintptr_t len;
+    uintptr_t cap;
+    uintptr_t align;
+} FfiBuf_u8;
+
+typedef struct {
+    uint8_t *ptr;
+    uintptr_t len;
+    uintptr_t cap;
+} FfiString;
+
+typedef struct {
+    FfiString message;
+} FfiError;
+
+typedef struct {
+    const uint8_t *ptr;
+    uintptr_t len;
+} FfiSpan;
+
+typedef const void *RustFutureHandle;
+typedef int8_t StreamPollResult;
+typedef int32_t WaitResult;
+typedef void (*RustFutureContinuationCallback)(uint64_t callback_data, int8_t poll_result);
+typedef void (*StreamContinuationCallback)(uint64_t callback_data, StreamPollResult result);
+
+#if defined(_MSC_VER)
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return _InterlockedCompareExchange8((volatile char *)state, (char)desired, (char)expected) == (char)expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return (uint64_t)_InterlockedExchange64((volatile __int64 *)slot, (__int64)value);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, (__int64)desired, (__int64)expected) == expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, 0, 0);
+}
+#elif defined(__cplusplus) && (defined(__clang__) || defined(__GNUC__))
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return __atomic_compare_exchange_n(state, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return __atomic_exchange_n(slot, value, __ATOMIC_ACQ_REL);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return __atomic_compare_exchange_n(slot, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return __atomic_load_n(slot, __ATOMIC_ACQUIRE);
+}
+#elif defined(__cplusplus)
+#error "BoltFFI C++ atomics require GCC, Clang, or MSVC"
+#else
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return atomic_compare_exchange_strong_explicit((_Atomic uint8_t *)state, &expected, desired, memory_order_acq_rel, memory_order_acquire);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return atomic_exchange_explicit((_Atomic uint64_t *)slot, value, memory_order_acq_rel);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return atomic_compare_exchange_strong_explicit((_Atomic uint64_t *)slot, &expected, desired, memory_order_acq_rel, memory_order_acquire);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return atomic_load_explicit((_Atomic uint64_t *)slot, memory_order_acquire);
+}
+#endif
+
+typedef struct {
+    uint64_t handle;
+    const void *vtable;
+} BoltFFICallbackHandle;
+
+void boltffi_free_string(FfiString string);
+void boltffi_free_buf(FfiBuf_u8 buf);
+FfiString boltffi_buf_into_string(FfiBuf_u8 buf);
+FfiBuf_u8 boltffi_buf_from_bytes(const uint8_t *ptr, uintptr_t len);
+FfiBuf_u8 boltffi_buf_with_len(uintptr_t len);
+FfiStatus boltffi_last_error_message(FfiString *out);
+void boltffi_clear_last_error(void);
+typedef struct {
+    double x;
+    double y;
+} ___Point;
+typedef uint8_t ___Mode;
+#define MODE_FAST ((___Mode)1)
+#define MODE_SLOW ((___Mode)2)
+
+#ifdef __cplusplus
+}
+#endif
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct { const uint8_t *ptr; uintptr_t len; } DemoBytesView;
+typedef struct { const char *ptr; uintptr_t len; } DemoStringView;
+typedef struct { uint8_t *ptr; uintptr_t len; } DemoBytes;
+typedef struct { char *ptr; uintptr_t len; } DemoString;
+typedef struct { bool has_value; uint32_t value; } DemoOptionU32;
+typedef struct { bool has_value; float value; } DemoOptionF32;
+typedef struct { bool has_value; DemoStringView value; } DemoOptionStringView;
+typedef struct { bool has_value; DemoString value; } DemoOptionString;
+typedef struct { const DemoStringView *ptr; uintptr_t len; } DemoStringSlice;
+typedef struct { DemoString *ptr; uintptr_t len; } DemoStringSequence;
+typedef ___Point DemoPoint;
+typedef ___Mode DemoMode;
+typedef struct { const bool *ptr; uintptr_t len; } DemoBoolSlice;
+typedef struct { bool *ptr; uintptr_t len; } DemoBoolSequence;
+typedef struct { const int8_t *ptr; uintptr_t len; } DemoI8Slice;
+typedef struct { int8_t *ptr; uintptr_t len; } DemoI8Sequence;
+typedef struct { const uint8_t *ptr; uintptr_t len; } DemoU8Slice;
+typedef struct { uint8_t *ptr; uintptr_t len; } DemoU8Sequence;
+typedef struct { const int16_t *ptr; uintptr_t len; } DemoI16Slice;
+typedef struct { int16_t *ptr; uintptr_t len; } DemoI16Sequence;
+typedef struct { const uint16_t *ptr; uintptr_t len; } DemoU16Slice;
+typedef struct { uint16_t *ptr; uintptr_t len; } DemoU16Sequence;
+typedef struct { const int32_t *ptr; uintptr_t len; } DemoI32Slice;
+typedef struct { int32_t *ptr; uintptr_t len; } DemoI32Sequence;
+typedef struct { const uint32_t *ptr; uintptr_t len; } DemoU32Slice;
+typedef struct { uint32_t *ptr; uintptr_t len; } DemoU32Sequence;
+typedef struct { const int64_t *ptr; uintptr_t len; } DemoI64Slice;
+typedef struct { int64_t *ptr; uintptr_t len; } DemoI64Sequence;
+typedef struct { const uint64_t *ptr; uintptr_t len; } DemoU64Slice;
+typedef struct { uint64_t *ptr; uintptr_t len; } DemoU64Sequence;
+typedef struct { const intptr_t *ptr; uintptr_t len; } DemoISizeSlice;
+typedef struct { intptr_t *ptr; uintptr_t len; } DemoISizeSequence;
+typedef struct { const uintptr_t *ptr; uintptr_t len; } DemoUSizeSlice;
+typedef struct { uintptr_t *ptr; uintptr_t len; } DemoUSizeSequence;
+typedef struct { const float *ptr; uintptr_t len; } DemoF32Slice;
+typedef struct { float *ptr; uintptr_t len; } DemoF32Sequence;
+typedef struct { const double *ptr; uintptr_t len; } DemoF64Slice;
+typedef struct { double *ptr; uintptr_t len; } DemoF64Sequence;
+typedef struct { const DemoPoint *ptr; uintptr_t len; } DemoPointSlice;
+typedef struct { DemoPoint *ptr; uintptr_t len; } DemoPointSequence;
+
+typedef struct { uint8_t *ptr; uintptr_t len; uintptr_t offset; bool ok; } BoltFFICWireWriter;
+typedef struct { const uint8_t *ptr; uintptr_t len; uintptr_t offset; bool ok; } BoltFFICWireReader;
+static inline void boltffi_c_demo_write(BoltFFICWireWriter *w, const void *src, uintptr_t n) {
+    if (!w->ok || n > w->len - w->offset) { w->ok = false; return; }
+    if (n != 0) memcpy(w->ptr + w->offset, src, n);
+    w->offset += n;
+}
+static inline void boltffi_c_demo_read(BoltFFICWireReader *r, void *dst, uintptr_t n) {
+    if (!r->ok || n > r->len - r->offset) { r->ok = false; return; }
+    if (n != 0) memcpy(dst, r->ptr + r->offset, n);
+    r->offset += n;
+}
+static inline void boltffi_c_demo_write_u8(BoltFFICWireWriter *w, uint8_t v) { boltffi_c_demo_write(w, &v, 1); }
+static inline void boltffi_c_demo_write_u32(BoltFFICWireWriter *w, uint32_t v) {
+    uint8_t b[4] = {(uint8_t)v, (uint8_t)(v >> 8), (uint8_t)(v >> 16), (uint8_t)(v >> 24)};
+    boltffi_c_demo_write(w, b, 4);
+}
+static inline uint8_t boltffi_c_demo_read_u8(BoltFFICWireReader *r) { uint8_t v = 0; boltffi_c_demo_read(r, &v, 1); return v; }
+static inline uint32_t boltffi_c_demo_read_u32(BoltFFICWireReader *r) {
+    uint8_t b[4] = {0,0,0,0}; boltffi_c_demo_read(r, b, 4);
+    return (uint32_t)b[0] | ((uint32_t)b[1] << 8) | ((uint32_t)b[2] << 16) | ((uint32_t)b[3] << 24);
+}
+static inline void *boltffi_c_demo_alloc(uintptr_t count, uintptr_t size) {
+    if (count == 0) return NULL;
+    if (size != 0 && count > (uintptr_t)-1 / size) return NULL;
+    return calloc((size_t)count, (size_t)size);
+}
+static inline bool boltffi_c_demo_copy_string(BoltFFICWireReader *r, DemoString *out) {
+    uint32_t n = boltffi_c_demo_read_u32(r); char *copy;
+    if (!r->ok || (uintptr_t)n > r->len - r->offset) return false;
+    copy = (char *)boltffi_c_demo_alloc((uintptr_t)n + 1, 1);
+    if (copy == NULL) { r->ok = false; return false; }
+    boltffi_c_demo_read(r, copy, n); copy[n] = '\0'; out->ptr = copy; out->len = n; return r->ok;
+}
+static inline bool boltffi_c_demo_copy_bytes(BoltFFICWireReader *r, DemoBytes *out) {
+    uint32_t n = boltffi_c_demo_read_u32(r); uint8_t *copy;
+    if (!r->ok || (uintptr_t)n > r->len - r->offset) return false;
+    copy = (uint8_t *)boltffi_c_demo_alloc(n, 1);
+    if (n != 0 && copy == NULL) { r->ok = false; return false; }
+    boltffi_c_demo_read(r, copy, n); out->ptr = copy; out->len = n; return r->ok;
+}
+static inline DemoStringView demo_string_view(const char *ptr, uintptr_t len) { DemoStringView v={ptr,len}; return v; }
+static inline DemoBytesView demo_bytes_view(const uint8_t *ptr, uintptr_t len) { DemoBytesView v={ptr,len}; return v; }
+static inline void demo_string_free(DemoString *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_string_sequence_free(DemoStringSequence *v) { if (v == NULL) return; for (uintptr_t i=0;i<v->len;++i) demo_string_free(&v->ptr[i]); free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_bytes_free(DemoBytes *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_bool_sequence_free(DemoBoolSequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_i8_sequence_free(DemoI8Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_u8_sequence_free(DemoU8Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_i16_sequence_free(DemoI16Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_u16_sequence_free(DemoU16Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_i32_sequence_free(DemoI32Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_u32_sequence_free(DemoU32Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_i64_sequence_free(DemoI64Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_u64_sequence_free(DemoU64Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_isize_sequence_free(DemoISizeSequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_usize_sequence_free(DemoUSizeSequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_f32_sequence_free(DemoF32Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_f64_sequence_free(DemoF64Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_point_sequence_free(DemoPointSequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/boltffi_backend/src/target/c/snapshots/boltffi_backend__target__c__tests__c_primitive_function.snap
+++ b/boltffi_backend/src/target/c/snapshots/boltffi_backend__target__c__tests__c_primitive_function.snap
@@ -1,0 +1,251 @@
+---
+source: boltffi_backend/src/target/c/mod.rs
+expression: render_header(&output)
+---
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif !defined(__cplusplus)
+#include <stdatomic.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    int32_t code;
+} FfiStatus;
+
+#ifdef __cplusplus
+static inline FfiStatus boltffi_status_from_code(int32_t code) {
+    FfiStatus status = { code };
+    return status;
+}
+#define FFI_STATUS_OK boltffi_status_from_code(0)
+#define FFI_STATUS_NULL_POINTER boltffi_status_from_code(1)
+#define FFI_STATUS_BUFFER_TOO_SMALL boltffi_status_from_code(2)
+#define FFI_STATUS_INVALID_ARG boltffi_status_from_code(3)
+#define FFI_STATUS_CANCELLED boltffi_status_from_code(4)
+#define FFI_STATUS_INTERNAL_ERROR boltffi_status_from_code(100)
+#else
+#define FFI_STATUS_OK ((FfiStatus){0})
+#define FFI_STATUS_NULL_POINTER ((FfiStatus){1})
+#define FFI_STATUS_BUFFER_TOO_SMALL ((FfiStatus){2})
+#define FFI_STATUS_INVALID_ARG ((FfiStatus){3})
+#define FFI_STATUS_CANCELLED ((FfiStatus){4})
+#define FFI_STATUS_INTERNAL_ERROR ((FfiStatus){100})
+#endif
+
+typedef struct {
+    uint8_t *ptr;
+    uintptr_t len;
+    uintptr_t cap;
+    uintptr_t align;
+} FfiBuf_u8;
+
+typedef struct {
+    uint8_t *ptr;
+    uintptr_t len;
+    uintptr_t cap;
+} FfiString;
+
+typedef struct {
+    FfiString message;
+} FfiError;
+
+typedef struct {
+    const uint8_t *ptr;
+    uintptr_t len;
+} FfiSpan;
+
+typedef const void *RustFutureHandle;
+typedef int8_t StreamPollResult;
+typedef int32_t WaitResult;
+typedef void (*RustFutureContinuationCallback)(uint64_t callback_data, int8_t poll_result);
+typedef void (*StreamContinuationCallback)(uint64_t callback_data, StreamPollResult result);
+
+#if defined(_MSC_VER)
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return _InterlockedCompareExchange8((volatile char *)state, (char)desired, (char)expected) == (char)expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return (uint64_t)_InterlockedExchange64((volatile __int64 *)slot, (__int64)value);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, (__int64)desired, (__int64)expected) == expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, 0, 0);
+}
+#elif defined(__cplusplus) && (defined(__clang__) || defined(__GNUC__))
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return __atomic_compare_exchange_n(state, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return __atomic_exchange_n(slot, value, __ATOMIC_ACQ_REL);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return __atomic_compare_exchange_n(slot, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return __atomic_load_n(slot, __ATOMIC_ACQUIRE);
+}
+#elif defined(__cplusplus)
+#error "BoltFFI C++ atomics require GCC, Clang, or MSVC"
+#else
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return atomic_compare_exchange_strong_explicit((_Atomic uint8_t *)state, &expected, desired, memory_order_acq_rel, memory_order_acquire);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return atomic_exchange_explicit((_Atomic uint64_t *)slot, value, memory_order_acq_rel);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return atomic_compare_exchange_strong_explicit((_Atomic uint64_t *)slot, &expected, desired, memory_order_acq_rel, memory_order_acquire);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return atomic_load_explicit((_Atomic uint64_t *)slot, memory_order_acquire);
+}
+#endif
+
+typedef struct {
+    uint64_t handle;
+    const void *vtable;
+} BoltFFICallbackHandle;
+
+void boltffi_free_string(FfiString string);
+void boltffi_free_buf(FfiBuf_u8 buf);
+FfiString boltffi_buf_into_string(FfiBuf_u8 buf);
+FfiBuf_u8 boltffi_buf_from_bytes(const uint8_t *ptr, uintptr_t len);
+FfiBuf_u8 boltffi_buf_with_len(uintptr_t len);
+FfiStatus boltffi_last_error_message(FfiString *out);
+void boltffi_clear_last_error(void);
+int32_t boltffi_function_demo_add(int32_t left, int32_t right);
+
+#ifdef __cplusplus
+}
+#endif
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct { const uint8_t *ptr; uintptr_t len; } DemoBytesView;
+typedef struct { const char *ptr; uintptr_t len; } DemoStringView;
+typedef struct { uint8_t *ptr; uintptr_t len; } DemoBytes;
+typedef struct { char *ptr; uintptr_t len; } DemoString;
+typedef struct { bool has_value; uint32_t value; } DemoOptionU32;
+typedef struct { bool has_value; float value; } DemoOptionF32;
+typedef struct { bool has_value; DemoStringView value; } DemoOptionStringView;
+typedef struct { bool has_value; DemoString value; } DemoOptionString;
+typedef struct { const DemoStringView *ptr; uintptr_t len; } DemoStringSlice;
+typedef struct { DemoString *ptr; uintptr_t len; } DemoStringSequence;
+typedef struct { const bool *ptr; uintptr_t len; } DemoBoolSlice;
+typedef struct { bool *ptr; uintptr_t len; } DemoBoolSequence;
+typedef struct { const int8_t *ptr; uintptr_t len; } DemoI8Slice;
+typedef struct { int8_t *ptr; uintptr_t len; } DemoI8Sequence;
+typedef struct { const uint8_t *ptr; uintptr_t len; } DemoU8Slice;
+typedef struct { uint8_t *ptr; uintptr_t len; } DemoU8Sequence;
+typedef struct { const int16_t *ptr; uintptr_t len; } DemoI16Slice;
+typedef struct { int16_t *ptr; uintptr_t len; } DemoI16Sequence;
+typedef struct { const uint16_t *ptr; uintptr_t len; } DemoU16Slice;
+typedef struct { uint16_t *ptr; uintptr_t len; } DemoU16Sequence;
+typedef struct { const int32_t *ptr; uintptr_t len; } DemoI32Slice;
+typedef struct { int32_t *ptr; uintptr_t len; } DemoI32Sequence;
+typedef struct { const uint32_t *ptr; uintptr_t len; } DemoU32Slice;
+typedef struct { uint32_t *ptr; uintptr_t len; } DemoU32Sequence;
+typedef struct { const int64_t *ptr; uintptr_t len; } DemoI64Slice;
+typedef struct { int64_t *ptr; uintptr_t len; } DemoI64Sequence;
+typedef struct { const uint64_t *ptr; uintptr_t len; } DemoU64Slice;
+typedef struct { uint64_t *ptr; uintptr_t len; } DemoU64Sequence;
+typedef struct { const intptr_t *ptr; uintptr_t len; } DemoISizeSlice;
+typedef struct { intptr_t *ptr; uintptr_t len; } DemoISizeSequence;
+typedef struct { const uintptr_t *ptr; uintptr_t len; } DemoUSizeSlice;
+typedef struct { uintptr_t *ptr; uintptr_t len; } DemoUSizeSequence;
+typedef struct { const float *ptr; uintptr_t len; } DemoF32Slice;
+typedef struct { float *ptr; uintptr_t len; } DemoF32Sequence;
+typedef struct { const double *ptr; uintptr_t len; } DemoF64Slice;
+typedef struct { double *ptr; uintptr_t len; } DemoF64Sequence;
+
+typedef struct { uint8_t *ptr; uintptr_t len; uintptr_t offset; bool ok; } BoltFFICWireWriter;
+typedef struct { const uint8_t *ptr; uintptr_t len; uintptr_t offset; bool ok; } BoltFFICWireReader;
+static inline void boltffi_c_demo_write(BoltFFICWireWriter *w, const void *src, uintptr_t n) {
+    if (!w->ok || n > w->len - w->offset) { w->ok = false; return; }
+    if (n != 0) memcpy(w->ptr + w->offset, src, n);
+    w->offset += n;
+}
+static inline void boltffi_c_demo_read(BoltFFICWireReader *r, void *dst, uintptr_t n) {
+    if (!r->ok || n > r->len - r->offset) { r->ok = false; return; }
+    if (n != 0) memcpy(dst, r->ptr + r->offset, n);
+    r->offset += n;
+}
+static inline void boltffi_c_demo_write_u8(BoltFFICWireWriter *w, uint8_t v) { boltffi_c_demo_write(w, &v, 1); }
+static inline void boltffi_c_demo_write_u32(BoltFFICWireWriter *w, uint32_t v) {
+    uint8_t b[4] = {(uint8_t)v, (uint8_t)(v >> 8), (uint8_t)(v >> 16), (uint8_t)(v >> 24)};
+    boltffi_c_demo_write(w, b, 4);
+}
+static inline uint8_t boltffi_c_demo_read_u8(BoltFFICWireReader *r) { uint8_t v = 0; boltffi_c_demo_read(r, &v, 1); return v; }
+static inline uint32_t boltffi_c_demo_read_u32(BoltFFICWireReader *r) {
+    uint8_t b[4] = {0,0,0,0}; boltffi_c_demo_read(r, b, 4);
+    return (uint32_t)b[0] | ((uint32_t)b[1] << 8) | ((uint32_t)b[2] << 16) | ((uint32_t)b[3] << 24);
+}
+static inline void *boltffi_c_demo_alloc(uintptr_t count, uintptr_t size) {
+    if (count == 0) return NULL;
+    if (size != 0 && count > (uintptr_t)-1 / size) return NULL;
+    return calloc((size_t)count, (size_t)size);
+}
+static inline bool boltffi_c_demo_copy_string(BoltFFICWireReader *r, DemoString *out) {
+    uint32_t n = boltffi_c_demo_read_u32(r); char *copy;
+    if (!r->ok || (uintptr_t)n > r->len - r->offset) return false;
+    copy = (char *)boltffi_c_demo_alloc((uintptr_t)n + 1, 1);
+    if (copy == NULL) { r->ok = false; return false; }
+    boltffi_c_demo_read(r, copy, n); copy[n] = '\0'; out->ptr = copy; out->len = n; return r->ok;
+}
+static inline bool boltffi_c_demo_copy_bytes(BoltFFICWireReader *r, DemoBytes *out) {
+    uint32_t n = boltffi_c_demo_read_u32(r); uint8_t *copy;
+    if (!r->ok || (uintptr_t)n > r->len - r->offset) return false;
+    copy = (uint8_t *)boltffi_c_demo_alloc(n, 1);
+    if (n != 0 && copy == NULL) { r->ok = false; return false; }
+    boltffi_c_demo_read(r, copy, n); out->ptr = copy; out->len = n; return r->ok;
+}
+static inline DemoStringView demo_string_view(const char *ptr, uintptr_t len) { DemoStringView v={ptr,len}; return v; }
+static inline DemoBytesView demo_bytes_view(const uint8_t *ptr, uintptr_t len) { DemoBytesView v={ptr,len}; return v; }
+static inline void demo_string_free(DemoString *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_string_sequence_free(DemoStringSequence *v) { if (v == NULL) return; for (uintptr_t i=0;i<v->len;++i) demo_string_free(&v->ptr[i]); free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_bytes_free(DemoBytes *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_bool_sequence_free(DemoBoolSequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_i8_sequence_free(DemoI8Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_u8_sequence_free(DemoU8Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_i16_sequence_free(DemoI16Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_u16_sequence_free(DemoU16Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_i32_sequence_free(DemoI32Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_u32_sequence_free(DemoU32Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_i64_sequence_free(DemoI64Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_u64_sequence_free(DemoU64Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_isize_sequence_free(DemoISizeSequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_usize_sequence_free(DemoUSizeSequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_f32_sequence_free(DemoF32Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+static inline void demo_f64_sequence_free(DemoF64Sequence *v) { if (v == NULL) return; free((void *)v->ptr); v->ptr=NULL; v->len=0; }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+static inline int32_t demo_add(int32_t left, int32_t right) {
+    int32_t boltffi_result = (int32_t)boltffi_function_demo_add(left, right);
+    return boltffi_result;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/boltffi_backend/src/target/c/syntax.rs
+++ b/boltffi_backend/src/target/c/syntax.rs
@@ -1,0 +1,64 @@
+//! C host syntax fragment family.
+//!
+//! The C host renders directly over the shared C ABI (`CBridge`), so its
+//! syntax fragment types are the same C fragments the bridge already emits.
+//! This module re-exposes them under the host's `LanguageSyntax` contract so
+//! host render models can type fragments by grammar role.
+use crate::bridge::c::{ArgumentList, Expression, Identifier, Literal, Statement, TypeFragment};
+use crate::core::LanguageSyntax;
+use crate::core::syntax::sealed;
+
+/// C host syntax marker implementing the host `LanguageSyntax` contract.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub struct Syntax;
+
+impl LanguageSyntax for Syntax {
+    const KEYWORDS: &'static [&'static str] = crate::bridge::c::Syntax::KEYWORDS;
+
+    type Identifier = Identifier;
+    type Type = TypeFragment;
+    type Expr = Expression;
+    type Stmt = Statement;
+    type Literal = Literal;
+    type Arguments = ArgumentList;
+}
+
+impl sealed::LanguageSyntax for Syntax {}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        bridge::c::{Identifier, TypeFragment},
+        core::LanguageSyntax,
+        target::c::Syntax,
+    };
+
+    #[test]
+    fn syntax_reuses_c_keyword_set() {
+        assert!(Syntax::keyword("struct"));
+        assert!(Syntax::keyword("void"));
+        assert!(!Syntax::keyword("point"));
+    }
+
+    #[test]
+    fn reserved_words_are_escaped_with_a_stable_suffix() {
+        assert_eq!(
+            Identifier::escape("struct").expect("escaped").as_str(),
+            "struct_"
+        );
+        assert_eq!(
+            Identifier::escape("case").expect("escaped").as_str(),
+            "case_"
+        );
+    }
+
+    #[test]
+    fn type_fragment_renders_pointer_types() {
+        // Pointer types render as `const <inner> *` through the bridge fragment.
+        let fragment = TypeFragment::anonymous(&crate::bridge::c::Type::ConstPointer(Box::new(
+            crate::bridge::c::Type::Uint8,
+        )))
+        .expect("pointer type fragment");
+        assert_eq!(fragment.to_string(), "const uint8_t *");
+    }
+}

--- a/boltffi_backend/src/target/mod.rs
+++ b/boltffi_backend/src/target/mod.rs
@@ -1,5 +1,6 @@
 //! Host target implementations.
 
+pub mod c;
 pub mod csharp;
 pub mod dart;
 pub mod java;

--- a/boltffi_backend/templates/bridge/c/header.h
+++ b/boltffi_backend/templates/bridge/c/header.h
@@ -3,7 +3,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif !defined(__cplusplus)
 #include <stdatomic.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,12 +17,25 @@ typedef struct {
     int32_t code;
 } FfiStatus;
 
+#ifdef __cplusplus
+static inline FfiStatus boltffi_status_from_code(int32_t code) {
+    FfiStatus status = { code };
+    return status;
+}
+#define FFI_STATUS_OK boltffi_status_from_code(0)
+#define FFI_STATUS_NULL_POINTER boltffi_status_from_code(1)
+#define FFI_STATUS_BUFFER_TOO_SMALL boltffi_status_from_code(2)
+#define FFI_STATUS_INVALID_ARG boltffi_status_from_code(3)
+#define FFI_STATUS_CANCELLED boltffi_status_from_code(4)
+#define FFI_STATUS_INTERNAL_ERROR boltffi_status_from_code(100)
+#else
 #define FFI_STATUS_OK ((FfiStatus){0})
 #define FFI_STATUS_NULL_POINTER ((FfiStatus){1})
 #define FFI_STATUS_BUFFER_TOO_SMALL ((FfiStatus){2})
 #define FFI_STATUS_INVALID_ARG ((FfiStatus){3})
 #define FFI_STATUS_CANCELLED ((FfiStatus){4})
 #define FFI_STATUS_INTERNAL_ERROR ((FfiStatus){100})
+#endif
 
 typedef struct {
     uint8_t *ptr;
@@ -48,6 +65,41 @@ typedef int32_t WaitResult;
 typedef void (*RustFutureContinuationCallback)(uint64_t callback_data, int8_t poll_result);
 typedef void (*StreamContinuationCallback)(uint64_t callback_data, StreamPollResult result);
 
+#if defined(_MSC_VER)
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return _InterlockedCompareExchange8((volatile char *)state, (char)desired, (char)expected) == (char)expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return (uint64_t)_InterlockedExchange64((volatile __int64 *)slot, (__int64)value);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, (__int64)desired, (__int64)expected) == expected;
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)slot, 0, 0);
+}
+#elif defined(__cplusplus) && (defined(__clang__) || defined(__GNUC__))
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return __atomic_compare_exchange_n(state, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return __atomic_exchange_n(slot, value, __ATOMIC_ACQ_REL);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return __atomic_compare_exchange_n(slot, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return __atomic_load_n(slot, __ATOMIC_ACQUIRE);
+}
+#elif defined(__cplusplus)
+#error "BoltFFI C++ atomics require GCC, Clang, or MSVC"
+#else
 static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
     return atomic_compare_exchange_strong_explicit((_Atomic uint8_t *)state, &expected, desired, memory_order_acq_rel, memory_order_acquire);
 }
@@ -63,6 +115,7 @@ static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uin
 static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
     return atomic_load_explicit((_Atomic uint64_t *)slot, memory_order_acquire);
 }
+#endif
 
 typedef struct {
     uint64_t handle;

--- a/boltffi_bindgen/src/generate.rs
+++ b/boltffi_bindgen/src/generate.rs
@@ -6,6 +6,7 @@ use boltffi_backend::bridge::c::CBridge;
 use boltffi_backend::core::bridge::BridgeBackend;
 use boltffi_backend::core::{CoverageMode, bridge, host};
 use boltffi_backend::target::{
+    c::CHost,
     csharp::CSharpHost,
     dart::DartHost,
     java::{JavaDesktopLoader, JavaHost, JavaVersion},
@@ -436,7 +437,11 @@ impl Generation {
             }
             Target::Swift => self.render_swift(),
             Target::TypeScript => self.render_typescript(),
-            Target::Header | Target::C => Err(GenerationError::UnsupportedTarget { target }),
+            Target::C => {
+                let bindings = self.bindings::<Native>()?;
+                self.render_native_bindings(target, &bindings)
+            }
+            Target::Header => Err(GenerationError::UnsupportedTarget { target }),
         }
     }
 
@@ -471,7 +476,8 @@ impl Generation {
             Target::KotlinMultiplatform => self.render_kmp_bindings(bindings),
             Target::CSharp => self.render_csharp_bindings(bindings),
             Target::Dart => self.render_dart_bindings(bindings),
-            Target::Swift | Target::TypeScript | Target::Header | Target::C => {
+            Target::C => self.render_c_bindings(bindings),
+            Target::Swift | Target::TypeScript | Target::Header => {
                 Err(GenerationError::UnsupportedTarget { target })
             }
         }
@@ -648,6 +654,16 @@ impl Generation {
         bridge
             .render_bridge(bindings, &contract)
             .map_err(GenerationError::Render)
+    }
+
+    fn render_c_bindings(
+        &self,
+        bindings: &Bindings<Native>,
+    ) -> Result<GeneratedOutput, GenerationError> {
+        let target = CHost::new()
+            .into_target(bindings)
+            .map_err(GenerationError::Render)?;
+        self.render_backend(&target, bindings)
     }
 
     fn render_csharp_bindings(

--- a/boltffi_cli/src/build/expansion.rs
+++ b/boltffi_cli/src/build/expansion.rs
@@ -356,6 +356,13 @@ impl BindingExpansion {
     pub(crate) fn surface(&self) -> BindingMetadataSurface {
         self.surface
     }
+
+    pub(crate) fn fixture_outputs(mut self, builds_staticlib: bool, builds_cdylib: bool) -> Self {
+        self.library = self
+            .library
+            .fixture_outputs(builds_staticlib, builds_cdylib);
+        self
+    }
 }
 
 #[cfg(test)]

--- a/boltffi_cli/src/cli.rs
+++ b/boltffi_cli/src/cli.rs
@@ -9,9 +9,9 @@ use crate::commands::doctor::{ConfigSummary, DoctorOptions};
 use crate::commands::generate::{GenerateOptions, GenerateTarget, run_generate_with_output};
 use crate::commands::init::InitOptions;
 use crate::commands::pack::{
-    PackAllOptions, PackAndroidOptions, PackAppleOptions, PackCSharpOptions, PackCommand,
-    PackDartOptions, PackExecutionOptions, PackJavaOptions, PackKmpOptions, PackPythonOptions,
-    PackWasmOptions, check_java_packaging_prereqs,
+    PackAllOptions, PackAndroidOptions, PackAppleOptions, PackCOptions, PackCSharpOptions,
+    PackCommand, PackDartOptions, PackExecutionOptions, PackJavaOptions, PackKmpOptions,
+    PackPythonOptions, PackWasmOptions, check_java_packaging_prereqs,
 };
 use crate::commands::verify::VerifyOptions;
 use crate::commands::{run_build, run_check, run_doctor, run_init, run_pack, run_verify};
@@ -366,6 +366,20 @@ pub(crate) enum PackTargetArg {
         #[arg(long)]
         no_build: bool,
     },
+    #[command(
+        about = "Build + package C artifacts (experimental)",
+        long_about = "Build + package C artifacts.\n\nOutputs:\n  - Header: {targets.c.output}/include/<library>.h\n  - Host library: {targets.c.output}/lib/"
+    )]
+    C {
+        #[arg(long)]
+        release: bool,
+
+        #[arg(long)]
+        no_build: bool,
+
+        #[arg(long, help = "Enable experimental targets/features")]
+        experimental: bool,
+    },
 }
 
 #[derive(Clone, Copy, clap::ValueEnum)]
@@ -644,6 +658,20 @@ pub(crate) fn execute_command(
                         ),
                     })
                 }
+                PackTargetArg::C {
+                    release,
+                    no_build,
+                    experimental,
+                } => PackCommand::C(PackCOptions {
+                    execution: pack_execution_options(
+                        release,
+                        regenerate,
+                        no_build,
+                        deny_skipped,
+                        cargo_args,
+                    ),
+                    experimental,
+                }),
             };
             run_pack(&config, command, reporter)
         }
@@ -1435,21 +1463,6 @@ enabled = true
     }
 
     #[test]
-    fn cli_parses_generate_c_target() {
-        let cli = Cli::try_parse_from(["boltffi", "generate", "c", "--experimental"])
-            .expect("cli parse should succeed");
-
-        assert!(matches!(
-            cli.command,
-            Commands::Generate {
-                target: Some(GenerateTargetArg::C),
-                experimental: true,
-                ..
-            }
-        ));
-    }
-
-    #[test]
     fn cli_parses_generate_kmp_target() {
         let cli = Cli::try_parse_from(["boltffi", "generate", "kmp", "--experimental"])
             .expect("cli parse should succeed");
@@ -1470,7 +1483,7 @@ enabled = true
     #[test]
     fn cli_parses_deny_skipped_on_every_pack_target() {
         for target in [
-            "all", "apple", "android", "kmp", "wasm", "python", "csharp", "java", "dart",
+            "all", "apple", "android", "kmp", "wasm", "python", "csharp", "java", "dart", "c",
         ] {
             let default = Cli::try_parse_from(["boltffi", "pack", target])
                 .unwrap_or_else(|error| panic!("pack {target} should parse: {error}"));
@@ -1506,6 +1519,38 @@ enabled = true
     }
 
     #[test]
+    fn cli_parses_pack_c_target() {
+        let cli = Cli::try_parse_from(["boltffi", "pack", "c", "--experimental", "--release"])
+            .expect("cli parse should succeed");
+        assert!(matches!(
+            cli.command,
+            Commands::Pack {
+                target: PackTargetArg::C {
+                    experimental: true,
+                    release: true,
+                    ..
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn cli_parses_generate_c_target() {
+        let cli = Cli::try_parse_from(["boltffi", "generate", "c", "--experimental"])
+            .expect("cli parse should succeed");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Generate {
+                target: Some(GenerateTargetArg::C),
+                experimental: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn cli_parses_pack_python_target() {
         let cli =
             Cli::try_parse_from(["boltffi", "pack", "python"]).expect("cli parse should succeed");
@@ -1538,7 +1583,7 @@ enabled = true
     #[test]
     fn cli_parses_regeneration_selection_for_every_pack_target() {
         [
-            "all", "apple", "android", "kmp", "wasm", "java", "python", "dart", "csharp",
+            "all", "apple", "android", "kmp", "wasm", "java", "python", "dart", "csharp", "c",
         ]
         .into_iter()
         .for_each(|target| {

--- a/boltffi_cli/src/cli.rs
+++ b/boltffi_cli/src/cli.rs
@@ -196,6 +196,8 @@ pub(crate) enum GenerateTargetArg {
     Python,
     #[value(help = "Generate C# bindings")]
     Csharp,
+    #[value(help = "Generate experimental C bindings (sync surface)")]
+    C,
     #[value(help = "Generate all bindings")]
     All,
 }
@@ -479,6 +481,7 @@ pub(crate) fn execute_command(
                         GenerateTargetArg::Dart => GenerateTarget::Dart,
                         GenerateTargetArg::Python => GenerateTarget::Python,
                         GenerateTargetArg::Csharp => GenerateTarget::CSharp,
+                        GenerateTargetArg::C => GenerateTarget::C,
                         GenerateTargetArg::All => GenerateTarget::All,
                     })
                     .unwrap_or(GenerateTarget::All),
@@ -1426,6 +1429,21 @@ enabled = true
             Commands::Generate {
                 target: Some(GenerateTargetArg::Csharp),
                 experimental: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn cli_parses_generate_c_target() {
+        let cli = Cli::try_parse_from(["boltffi", "generate", "c", "--experimental"])
+            .expect("cli parse should succeed");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Generate {
+                target: Some(GenerateTargetArg::C),
+                experimental: true,
                 ..
             }
         ));

--- a/boltffi_cli/src/commands/generate/bindings.rs
+++ b/boltffi_cli/src/commands/generate/bindings.rs
@@ -92,6 +92,7 @@ pub fn run_generation(config: &Config, options: &GenerateOptions) -> Result<()> 
         GenerateTarget::Dart => generate_dart(config, options),
         GenerateTarget::CSharp => generate_csharp(config, options),
         GenerateTarget::Header => generate_header(config, options),
+        GenerateTarget::C => generate_c(config, options),
         other => Err(CliError::CommandFailed {
             command: format!("cannot directly generate {}", target_label(other)),
             status: None,
@@ -457,6 +458,45 @@ fn generate_python(config: &Config, options: &GenerateOptions) -> Result<()> {
         expansion.toolchain_selector().map(str::to_owned),
         options.deny_skipped,
     )
+}
+
+fn generate_c(config: &Config, options: &GenerateOptions) -> Result<()> {
+    if !config.is_c_enabled() {
+        return Err(CliError::CommandFailed {
+            command: "targets.c.enabled = false".to_string(),
+            status: None,
+        });
+    }
+
+    if !config.should_process(Target::C, options.experimental) {
+        return Err(CliError::CommandFailed {
+            command: format!(
+                "{} is experimental, use --experimental flag or add \"{}\" to [experimental]",
+                Target::C.name(),
+                Target::C.name()
+            ),
+            status: None,
+        });
+    }
+
+    let expansion = BindingExpansion::resolve_for_commands(
+        config,
+        &["build", "generate"],
+        &options.cargo_args,
+    )?;
+    let output_directory = options.output.clone().unwrap_or_else(|| config.c_output());
+
+    expansion
+        .generation()
+        .coverage_mode(CoverageMode::Partial)
+        .render(Target::C)
+        .map_err(|error| generation_error(Target::C.name(), error))
+        .and_then(|output| {
+            print_coverage(Target::C.name(), &output, options.deny_skipped)?;
+            Generation::write_output(output, &output_directory)
+                .map(drop)
+                .map_err(|error| generation_error(Target::C.name(), error))
+        })
 }
 
 fn generate_kotlin(config: &Config, options: &GenerateOptions) -> Result<()> {
@@ -856,6 +896,7 @@ fn target_label(target: &GenerateTarget) -> &'static str {
         GenerateTarget::Dart => "dart",
         GenerateTarget::Python => "python",
         GenerateTarget::CSharp => "csharp",
+        GenerateTarget::C => "c",
         GenerateTarget::All => "all",
     }
 }

--- a/boltffi_cli/src/commands/generate/mod.rs
+++ b/boltffi_cli/src/commands/generate/mod.rs
@@ -18,6 +18,7 @@ pub enum GenerateTarget {
     Dart,
     Python,
     CSharp,
+    C,
     All,
 }
 
@@ -41,6 +42,7 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
         GenerateTarget::Dart => bindings::run_generation(config, &options),
         GenerateTarget::Python => bindings::run_generation(config, &options),
         GenerateTarget::CSharp => bindings::run_generation(config, &options),
+        GenerateTarget::C => bindings::run_generation(config, &options),
         GenerateTarget::All => {
             if config.should_process(Target::Swift, options.experimental) {
                 bindings::run_generation(
@@ -125,6 +127,19 @@ pub fn run_generate_with_output(config: &Config, options: GenerateOptions) -> Re
                     config,
                     &GenerateOptions {
                         target: GenerateTarget::Python,
+                        output: options.output.clone(),
+                        experimental: options.experimental,
+                        cargo_args: options.cargo_args.clone(),
+                        deny_skipped: options.deny_skipped,
+                    },
+                )?;
+            }
+
+            if config.should_process(Target::C, options.experimental) {
+                bindings::run_generation(
+                    config,
+                    &GenerateOptions {
+                        target: GenerateTarget::C,
                         output: options.output.clone(),
                         experimental: options.experimental,
                         cargo_args: options.cargo_args.clone(),

--- a/boltffi_cli/src/commands/init.rs
+++ b/boltffi_cli/src/commands/init.rs
@@ -2,10 +2,10 @@ use std::path::{Path, PathBuf};
 
 use crate::cli::Result;
 use crate::config::{
-    AndroidConfig, AndroidPackConfig, AppleConfig, CSharpConfig, CargoConfig, Config, DartConfig,
-    DebugSymbolsConfig, ErrorStyle, HeaderConfig, JavaConfig, KotlinConfig, KotlinFactoryStyle,
-    KotlinMultiplatformConfig, PackageConfig, PythonConfig, SpmConfig, SwiftConfig, TargetsConfig,
-    WasmConfig, XcframeworkConfig,
+    AndroidConfig, AndroidPackConfig, AppleConfig, CConfig, CSharpConfig, CargoConfig, Config,
+    DartConfig, DebugSymbolsConfig, ErrorStyle, HeaderConfig, JavaConfig, KotlinConfig,
+    KotlinFactoryStyle, KotlinMultiplatformConfig, PackageConfig, PythonConfig, SpmConfig,
+    SwiftConfig, TargetsConfig, WasmConfig, XcframeworkConfig,
 };
 
 pub struct InitOptions {
@@ -134,6 +134,7 @@ fn create_default_config(package_name: &str) -> Config {
             dart: DartConfig::default(),
             python: PythonConfig::default(),
             csharp: CSharpConfig::default(),
+            c: CConfig::default(),
         },
     }
 }

--- a/boltffi_cli/src/commands/pack/all.rs
+++ b/boltffi_cli/src/commands/pack/all.rs
@@ -5,10 +5,10 @@ use crate::config::Config;
 use crate::reporter::Reporter;
 
 use super::{
-    PackAllOptions, PackAndroidOptions, PackAppleOptions, PackCSharpOptions, PackDartOptions,
-    PackJavaOptions, PackKmpOptions, PackPythonOptions, PackWasmOptions, pack_android, pack_apple,
-    pack_csharp, pack_dart, pack_kmp, pack_prepared_java, pack_python, pack_wasm,
-    prepare_java_pack,
+    PackAllOptions, PackAndroidOptions, PackAppleOptions, PackCOptions, PackCSharpOptions,
+    PackDartOptions, PackJavaOptions, PackKmpOptions, PackPythonOptions, PackWasmOptions,
+    pack_android, pack_apple, pack_c, pack_csharp, pack_dart, pack_kmp, pack_prepared_java,
+    pack_python, pack_wasm, prepare_java_pack,
 };
 
 pub(super) fn pack_all(
@@ -113,6 +113,18 @@ pub(super) fn pack_all(
         pack_dart(
             config,
             PackDartOptions {
+                execution: options.execution.clone(),
+                experimental: options.experimental,
+            },
+            reporter,
+        )?;
+        packed_any = true;
+    }
+
+    if config.should_process(Target::C, options.experimental) {
+        pack_c(
+            config,
+            PackCOptions {
                 execution: options.execution.clone(),
                 experimental: options.experimental,
             },

--- a/boltffi_cli/src/commands/pack/mod.rs
+++ b/boltffi_cli/src/commands/pack/mod.rs
@@ -6,12 +6,13 @@ use crate::config::Config;
 use crate::reporter::Reporter;
 
 pub use self::request::{
-    PackAllOptions, PackAndroidOptions, PackAppleOptions, PackCSharpOptions, PackCommand,
-    PackDartOptions, PackExecutionOptions, PackJavaOptions, PackKmpOptions, PackPythonOptions,
-    PackWasmOptions,
+    PackAllOptions, PackAndroidOptions, PackAppleOptions, PackCOptions, PackCSharpOptions,
+    PackCommand, PackDartOptions, PackExecutionOptions, PackJavaOptions, PackKmpOptions,
+    PackPythonOptions, PackWasmOptions,
 };
 pub(crate) use crate::pack::android::pack_android;
 pub(crate) use crate::pack::apple::pack_apple;
+pub(crate) use crate::pack::c::pack_c;
 pub(crate) use crate::pack::csharp::pack_csharp;
 pub(crate) use crate::pack::dart::pack_dart;
 pub(crate) use crate::pack::java::{
@@ -33,5 +34,6 @@ pub fn run_pack(config: &Config, command: PackCommand, reporter: &Reporter) -> R
         PackCommand::Python(options) => pack_python(config, options, reporter),
         PackCommand::Dart(options) => pack_dart(config, options, reporter),
         PackCommand::CSharp(options) => pack_csharp(config, options, reporter),
+        PackCommand::C(options) => pack_c(config, options, reporter),
     }
 }

--- a/boltffi_cli/src/commands/pack/request.rs
+++ b/boltffi_cli/src/commands/pack/request.rs
@@ -10,6 +10,7 @@ pub enum PackCommand {
     Python(PackPythonOptions),
     Dart(PackDartOptions),
     CSharp(PackCSharpOptions),
+    C(PackCOptions),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -66,4 +67,9 @@ pub struct PackDartOptions {
 
 pub struct PackCSharpOptions {
     pub execution: PackExecutionOptions,
+}
+
+pub struct PackCOptions {
+    pub execution: PackExecutionOptions,
+    pub experimental: bool,
 }

--- a/boltffi_cli/src/config/experimental.rs
+++ b/boltffi_cli/src/config/experimental.rs
@@ -14,6 +14,7 @@ impl Experimental {
         },
         Experimental::WholeTarget(Target::Dart),
         Experimental::WholeTarget(Target::KotlinMultiplatform),
+        Experimental::WholeTarget(Target::C),
     ];
 
     pub fn is_target_experimental(target: Target) -> bool {

--- a/boltffi_cli/src/config/mod.rs
+++ b/boltffi_cli/src/config/mod.rs
@@ -16,7 +16,7 @@ pub use cargo::{CargoConfig, PackageConfig};
 pub use experimental::Experimental;
 pub use symbols::{DebugSymbolsBundle, DebugSymbolsConfig, DebugSymbolsFormat};
 pub use targets::{
-    AndroidConfig, AndroidPackConfig, AppleConfig, CSharpConfig, DartConfig, HeaderConfig,
+    AndroidConfig, AndroidPackConfig, AppleConfig, CConfig, CSharpConfig, DartConfig, HeaderConfig,
     JavaConfig, KotlinApiStyle, KotlinConfig, KotlinDesktopLoader, KotlinFactoryStyle,
     KotlinMultiplatformConfig, PythonConfig, SpmConfig, SpmDistribution, SpmLayout, SwiftConfig,
     TargetsConfig, WasmConfig, WasmNpmTarget, WasmOptimizeLevel, WasmOptimizeOnMissing,
@@ -401,6 +401,10 @@ impl Config {
         self.targets.csharp.enabled
     }
 
+    pub fn is_c_enabled(&self) -> bool {
+        self.targets.c.enabled
+    }
+
     pub fn is_kotlin_multiplatform_enabled(&self) -> bool {
         self.targets.kotlin_multiplatform.enabled
     }
@@ -757,7 +761,7 @@ impl Config {
             Target::Dart => self.is_dart_enabled(),
             Target::Python => self.is_python_enabled(),
             Target::CSharp => self.is_csharp_enabled(),
-            Target::C => false,
+            Target::C => self.is_c_enabled(),
         }
     }
 
@@ -908,6 +912,10 @@ impl Config {
 
     pub fn csharp_output(&self) -> PathBuf {
         self.targets.csharp.output.clone()
+    }
+
+    pub fn c_output(&self) -> PathBuf {
+        self.targets.c.output.clone()
     }
 
     pub fn csharp_namespace(&self) -> Option<&str> {
@@ -2698,5 +2706,35 @@ runtime_identifiers = ["linux-x64", "linux-x64"]
             Err(ConfigError::Validation(message))
                 if message.contains("targets.csharp.runtime_identifiers contains duplicate runtime identifier")
         ));
+    }
+
+    #[test]
+    fn c_target_is_experimental_and_requires_opt_in() {
+        assert!(Experimental::is_target_experimental(Target::C));
+        let config = parse_config(
+            r#"
+[package]
+name = "my-lib"
+
+[targets.c]
+enabled = true
+"#,
+        );
+        assert!(!config.should_process(Target::C, false));
+        assert!(config.should_process(Target::C, true));
+        // Opt in via [experimental].
+        let config = parse_config(
+            r#"
+experimental = ["c"]
+
+[package]
+name = "my-lib"
+
+[targets.c]
+enabled = true
+"#,
+        );
+        assert!(config.should_process(Target::C, false));
+        assert_eq!(config.c_output(), PathBuf::from("dist/c"));
     }
 }

--- a/boltffi_cli/src/config/targets/c.rs
+++ b/boltffi_cli/src/config/targets/c.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// `[targets.c]` configuration for the experimental C host target.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CConfig {
+    #[serde(default = "default_c_output")]
+    pub output: PathBuf,
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl Default for CConfig {
+    fn default() -> Self {
+        Self {
+            output: default_c_output(),
+            enabled: false,
+        }
+    }
+}
+
+fn default_c_output() -> PathBuf {
+    PathBuf::from("dist/c")
+}

--- a/boltffi_cli/src/config/targets/mod.rs
+++ b/boltffi_cli/src/config/targets/mod.rs
@@ -1,4 +1,5 @@
 pub mod apple;
+pub mod c;
 pub mod c_header;
 pub mod csharp;
 pub mod dart;
@@ -11,6 +12,7 @@ pub mod wasm;
 pub use apple::{
     AppleConfig, SpmConfig, SpmDistribution, SpmLayout, SwiftConfig, XcframeworkConfig,
 };
+pub use c::CConfig;
 pub use c_header::HeaderConfig;
 pub use csharp::CSharpConfig;
 #[cfg(test)]
@@ -49,4 +51,6 @@ pub struct TargetsConfig {
     pub python: PythonConfig,
     #[serde(default)]
     pub csharp: CSharpConfig,
+    #[serde(default)]
+    pub c: CConfig,
 }

--- a/boltffi_cli/src/pack/c/mod.rs
+++ b/boltffi_cli/src/pack/c/mod.rs
@@ -1,0 +1,258 @@
+//! C package assembler.
+//!
+//! The C package is intentionally the simplest in the repository: the
+//! ergonomic header, a shared library, and a static archive. It is build-system
+//! agnostic so downstream users can easily integrate those artifacts into their
+//! own build system.
+//!
+//! ```text
+//! dist/c/
+//! ├── include/<library>.h
+//! └── lib/
+//!     ├── lib<library>.{so,dylib,dll}
+//!     └── lib<library>.a
+//! ```
+//!
+//! A consumer links with `-I dist/c/include -L dist/c/lib -l<library>` and
+//! chooses dynamic or static linking by picking `lib<library>.so` or
+//! `lib<library>.a`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::{
+    build::{BindingExpansion, CargoBuildProfile, resolve_build_profile},
+    cargo::Cargo,
+    cli::{CliError, Result},
+    commands::{
+        generate::{GenerateOptions, GenerateTarget, run_generate_with_output},
+        pack::PackCOptions,
+    },
+    config::Config,
+    pack::resolve_build_cargo_args,
+    reporter::Reporter,
+    target::NativeHostPlatform,
+};
+
+fn ensure_c_pack_cargo_args_supported(cargo: &Cargo) -> Result<()> {
+    if let Some(target) = cargo.target_selector() {
+        return Err(CliError::CommandFailed {
+            command: format!("pack c is host-only; remove cargo --target '{target}'"),
+            status: None,
+        });
+    }
+    if let Some(target) = cargo.configured_build_target() {
+        return Err(CliError::CommandFailed {
+            command: format!("pack c is host-only; remove cargo build.target '{target}'"),
+            status: None,
+        });
+    }
+    Ok(())
+}
+
+fn ensure_c_library_outputs(expansion: &BindingExpansion) -> Result<()> {
+    let library = expansion.selected_library();
+    if library.builds_cdylib() && library.builds_staticlib() {
+        return Ok(());
+    }
+    Err(CliError::CommandFailed {
+        command:
+            "pack c requires the selected Rust library target to build both cdylib and staticlib"
+                .to_owned(),
+        status: None,
+    })
+}
+
+/// Configures the same binding-expansion ABI shim build used by the other
+/// native packers.
+fn host_libraries_command(expansion: &BindingExpansion, release: bool) -> Result<Command> {
+    let mut command = Command::new("cargo");
+    if let Some(toolchain_selector) = expansion.toolchain_selector() {
+        command.arg(toolchain_selector);
+    }
+    command
+        .arg("rustc")
+        .arg("--manifest-path")
+        .arg(expansion.cargo_manifest_path())
+        .arg("-p")
+        .arg(expansion.package_id());
+    if release {
+        command.arg("--release");
+    }
+    command.args(expansion.cargo_args());
+    command.arg("--lib");
+    expansion.configure_rustc(&mut command)?;
+    Ok(command)
+}
+
+/// Builds the same binding-expansion ABI shim used by the other native packers.
+fn build_host_libraries(expansion: &BindingExpansion, release: bool) -> Result<()> {
+    let mut command = host_libraries_command(expansion, release)?;
+    let status = command.status().map_err(|source| CliError::CommandFailed {
+        command: format!("cargo rustc: {source}"),
+        status: None,
+    })?;
+
+    if !status.success() {
+        return Err(CliError::CommandFailed {
+            command: "cargo rustc".to_string(),
+            status: status.code(),
+        });
+    }
+    Ok(())
+}
+
+fn copy_file(source: PathBuf, dest: PathBuf) -> Result<()> {
+    std::fs::copy(&source, &dest)
+        .map(|_| ())
+        .map_err(|source_err| CliError::CopyFailed {
+            from: source,
+            to: dest,
+            source: source_err,
+        })
+}
+
+pub(crate) fn pack_c(config: &Config, options: PackCOptions, reporter: &Reporter) -> Result<()> {
+    if !config.is_c_enabled() {
+        return Err(CliError::CommandFailed {
+            command: "targets.c.enabled = false".to_string(),
+            status: None,
+        });
+    }
+
+    reporter.section("🌐", "Packing C");
+
+    let build_cargo_args = resolve_build_cargo_args(config, &options.execution.cargo_args);
+    let cargo = Cargo::current(&build_cargo_args)?;
+    ensure_c_pack_cargo_args_supported(&cargo)?;
+    let build_profile = resolve_build_profile(options.execution.release, &build_cargo_args);
+    let binding_expansion = BindingExpansion::resolve(config, &build_cargo_args)?;
+    ensure_c_library_outputs(&binding_expansion)?;
+
+    // Generating the header runs a metadata rustc invocation. Build the final
+    // artifacts afterwards so that metadata compilation cannot overwrite the
+    // binding-expansion cdylib/staticlib selected for this package.
+    if options.execution.regenerate {
+        let step = reporter.step("Generating C bindings");
+        run_generate_with_output(
+            config,
+            GenerateOptions {
+                target: GenerateTarget::C,
+                output: Some(config.c_output()),
+                experimental: options.experimental,
+                cargo_args: build_cargo_args.clone(),
+                deny_skipped: options.execution.deny_skipped,
+            },
+        )?;
+        step.finish_success();
+    }
+
+    if !options.execution.no_build {
+        let step = reporter.step("Building Rust shared and static libraries");
+        build_host_libraries(
+            &binding_expansion,
+            matches!(build_profile, CargoBuildProfile::Release),
+        )?;
+        step.finish_success();
+    }
+
+    let step = reporter.step("Packaging header and libraries");
+
+    let output_dir = config.c_output();
+    let include_dir = output_dir.join("include");
+    let lib_dir = output_dir.join("lib");
+    std::fs::create_dir_all(&include_dir).map_err(|source| CliError::CreateDirectoryFailed {
+        path: include_dir.clone(),
+        source,
+    })?;
+    std::fs::create_dir_all(&lib_dir).map_err(|source| CliError::CreateDirectoryFailed {
+        path: lib_dir.clone(),
+        source,
+    })?;
+
+    let library_name = config.library_name().to_string();
+    let artifact_name = binding_expansion.artifact_name();
+    let target_directory = binding_expansion.target_directory();
+    let profile_dir = target_directory.join(build_profile.output_directory_name());
+
+    // Header.
+    let header_source = output_dir.join("boltffi.h");
+    let header_dest = include_dir.join(format!("{library_name}.h"));
+    copy_file(header_source, header_dest)?;
+
+    let platform = NativeHostPlatform::current().ok_or_else(|| CliError::CommandFailed {
+        command: "pack c is unsupported on this host platform".to_owned(),
+        status: None,
+    })?;
+
+    // Shared library.
+    copy_file(
+        profile_dir.join(platform.shared_library_filename(artifact_name)),
+        lib_dir.join(platform.shared_library_filename(&library_name)),
+    )?;
+
+    // Static archive.
+    copy_file(
+        profile_dir.join(platform.static_library_filename(artifact_name)),
+        lib_dir.join(platform.static_library_filename(&library_name)),
+    )?;
+
+    step.finish_success();
+    reporter.finish();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_c_library_outputs, host_libraries_command};
+    use crate::build::BindingExpansion;
+
+    #[test]
+    fn c_pack_requires_shared_and_static_library_outputs() {
+        for (staticlib, cdylib) in [(false, true), (true, false), (false, false)] {
+            let expansion = BindingExpansion::fixture(
+                "/external/workspace/Cargo.toml",
+                "/external/workspace/demo/Cargo.toml",
+                std::iter::empty(),
+            )
+            .fixture_outputs(staticlib, cdylib);
+            let error = ensure_c_library_outputs(&expansion).expect_err("missing output rejects");
+            assert!(format!("{error}").contains("both cdylib and staticlib"));
+        }
+    }
+
+    #[test]
+    fn c_build_uses_the_binding_expansion_abi_shim() {
+        let expansion = BindingExpansion::fixture(
+            "/external/workspace/Cargo.toml",
+            "/external/workspace/demo/Cargo.toml",
+            ["--features".to_string(), "ffi".to_string()],
+        );
+        let package_id = expansion.package_id().to_owned();
+        let command = host_libraries_command(&expansion, true).expect("command");
+        let arguments = command
+            .get_args()
+            .map(|argument| argument.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(arguments.first().map(String::as_str), Some("+nightly"));
+        assert_eq!(arguments.get(1).map(String::as_str), Some("rustc"));
+        assert!(arguments.windows(2).any(|arguments| {
+            arguments == ["--manifest-path", "/external/workspace/Cargo.toml"]
+        }));
+        assert!(
+            arguments
+                .windows(2)
+                .any(|arguments| arguments == ["-p", package_id.as_str()])
+        );
+        assert_eq!(
+            &arguments[arguments.len() - 4..],
+            ["--lib", "--", "--cfg", "boltffi_binding_expansion"]
+        );
+        assert!(
+            command
+                .get_envs()
+                .any(|(key, value)| { key == "BOLTFFI_BINDING_EXPANSION" && value.is_some() })
+        );
+    }
+}

--- a/boltffi_cli/src/pack/mod.rs
+++ b/boltffi_cli/src/pack/mod.rs
@@ -1,5 +1,6 @@
 pub mod android;
 pub mod apple;
+pub mod c;
 pub mod csharp;
 pub mod dart;
 pub mod java;

--- a/boltffi_core/src/types/buf.rs
+++ b/boltffi_core/src/types/buf.rs
@@ -126,6 +126,31 @@ pub extern "C" fn boltffi_free_buf(buf: FfiBuf) {
     drop(buf);
 }
 
+/// Decodes an owned, wire-encoded UTF-8 string buffer into an [`FfiString`].
+///
+/// The returned string is length-delimited and is **not** NUL-terminated.
+#[unsafe(no_mangle)]
+pub extern "C" fn boltffi_buf_into_string(buf: FfiBuf) -> crate::FfiString {
+    let mut bytes = unsafe { buf.into_vec::<u8>() };
+    let Some(length) = bytes
+        .get(..core::mem::size_of::<u32>())
+        .and_then(|prefix| prefix.try_into().ok())
+        .map(u32::from_le_bytes)
+        .and_then(|length| usize::try_from(length).ok())
+    else {
+        return crate::FfiString::default();
+    };
+    let prefix_len = core::mem::size_of::<u32>();
+    if bytes.len() != prefix_len.saturating_add(length) {
+        return crate::FfiString::default();
+    }
+    bytes.copy_within(prefix_len.., 0);
+    bytes.truncate(length);
+    String::from_utf8(bytes)
+        .map(crate::FfiString::from)
+        .unwrap_or_default()
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn boltffi_buf_from_bytes(ptr: *const u8, len: usize) -> FfiBuf {
     if ptr.is_null() || len == 0 {
@@ -247,5 +272,21 @@ mod tests {
         assert_eq!(unsafe { actual.as_byte_slice() }, unsafe {
             expected.as_byte_slice()
         });
+    }
+
+    #[test]
+    fn encoded_string_buffer_converts_to_owned_ffi_string() {
+        let encoded = FfiBuf::wire_encode(&String::from("not NUL-terminated"));
+        let decoded = boltffi_buf_into_string(encoded);
+
+        assert_eq!(decoded.as_str(), Some("not NUL-terminated"));
+    }
+
+    #[test]
+    fn malformed_encoded_string_buffer_converts_to_empty_string() {
+        let malformed = FfiBuf::from_vec(vec![5_u8, 0, 0, 0, b'x']);
+        let decoded = boltffi_buf_into_string(malformed);
+
+        assert!(decoded.is_empty());
     }
 }


### PR DESCRIPTION
Sixth layer of the experimental C target (continuation of #842). Depends on #842.

Adds `boltffi pack c --experimental`: stages the generated `<library>.h` under `include/` and the host shared/static libraries under `lib/`, built from a host-only binding-expansion build that keeps the C ABI surface without cross-compiling. Ensures cdylib + staticlib outputs are produced, and wires the pack command into the CLI and the all-targets path, gated behind the experimental flag.