### PR TITLE
fix(wasm): stop discarding writes to `&mut [u8]` parameters

### DIFF
--- a/boltffi_backend/src/target/typescript/mod.rs
+++ b/boltffi_backend/src/target/typescript/mod.rs
@@ -203,6 +203,13 @@ mod tests {
                 pub fn echo_vec_bool(value: Vec<bool>) -> Vec<bool> { value }
 
                 #[export]
+                pub fn fill_bytes(value: &mut [u8]) {
+                    for byte in value.iter_mut() {
+                        *byte = 7;
+                    }
+                }
+
+                #[export]
                 pub fn increment_u64(value: &mut [u64]) {
                     if let Some(first) = value.first_mut() {
                         *first += 1;
@@ -805,6 +812,25 @@ mod tests {
         assert!(browser.contents().contains(
             "return _module.takePackedBytes((_exports.boltffi_function_demo_echo_bytes as Function)(__boltffi_value_allocation.ptr, __boltffi_value_allocation.len) as bigint);"
         ));
+        // A writable byte slice crosses as a direct vector: the pointer goes
+        // unframed and the host copies back what the callee wrote. Framing it
+        // as a byte buffer would decode into a `Vec` the wrapper owns, and
+        // every write would be dropped with it.
+        assert!(
+            browser
+                .contents()
+                .contains("const __boltffi_value_allocation = _module.allocU8Array(value);")
+        );
+        assert!(browser.contents().contains(
+            "_module.copyPrimitiveBufferInto(__boltffi_value_allocation, value, \"u8\");"
+        ));
+        // The free cannot be skipped when the copy back throws, so it sits in a
+        // `finally` of its own rather than after the copy in the same block.
+        assert!(
+            browser
+                .contents()
+                .contains("_module.freePrimitiveBuffer(__boltffi_value_allocation);")
+        );
         assert!(browser.contents().contains(
             "export function echoVecI32(value: readonly number[] | Int32Array): Int32Array"
         ));

--- a/boltffi_backend/src/target/typescript/render/direct_vector.rs
+++ b/boltffi_backend/src/target/typescript/render/direct_vector.rs
@@ -28,6 +28,9 @@ struct RecordVector {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum PrimitiveVector {
     Bool,
+    /// Only reachable from `&mut [u8]`. Every other shape of bytes crosses as
+    /// a byte buffer, which cannot carry the callee's writes back.
+    U8,
     I8,
     I16,
     U16,
@@ -297,7 +300,7 @@ impl PrimitiveVector {
             Primitive::U64 => Self::U64,
             Primitive::F32 => Self::F32,
             Primitive::F64 => Self::F64,
-            Primitive::U8 => return DirectVector::unsupported("u8 direct vector"),
+            Primitive::U8 => Self::U8,
             _ => return DirectVector::unsupported("unknown direct vector primitive"),
         })
     }
@@ -305,6 +308,7 @@ impl PrimitiveVector {
     fn primitive(self) -> Primitive {
         match self {
             Self::Bool => Primitive::Bool,
+            Self::U8 => Primitive::U8,
             Self::I8 => Primitive::I8,
             Self::I16 => Primitive::I16,
             Self::U16 => Primitive::U16,
@@ -320,6 +324,7 @@ impl PrimitiveVector {
     fn typed_array(self) -> TypeName {
         TypeName::named(match self {
             Self::Bool => "Uint8Array",
+            Self::U8 => "Uint8Array",
             Self::I8 => "Int8Array",
             Self::I16 => "Int16Array",
             Self::U16 => "Uint16Array",
@@ -335,6 +340,7 @@ impl PrimitiveVector {
     fn allocation_method(self) -> &'static str {
         match self {
             Self::Bool => "allocBoolArray",
+            Self::U8 => "allocU8Array",
             Self::I8 => "allocI8Array",
             Self::I16 => "allocI16Array",
             Self::U16 => "allocU16Array",
@@ -350,6 +356,7 @@ impl PrimitiveVector {
     fn take_method(self) -> &'static str {
         match self {
             Self::Bool => "takeSlotBoolArray",
+            Self::U8 => "takeSlotU8Array",
             Self::I8 => "takeSlotI8Array",
             Self::I16 => "takeSlotI16Array",
             Self::U16 => "takeSlotU16Array",
@@ -365,6 +372,7 @@ impl PrimitiveVector {
     fn borrow_method(self) -> &'static str {
         match self {
             Self::Bool => "borrowBoolArray",
+            Self::U8 => "borrowU8Array",
             Self::I8 => "borrowI8Array",
             Self::I16 => "borrowI16Array",
             Self::U16 => "borrowU16Array",
@@ -379,7 +387,7 @@ impl PrimitiveVector {
 
     const fn alignment(self) -> usize {
         match self {
-            Self::Bool | Self::I8 => 1,
+            Self::Bool | Self::U8 | Self::I8 => 1,
             Self::I16 | Self::U16 => 2,
             Self::I32 | Self::U32 | Self::F32 => 4,
             Self::I64 | Self::U64 | Self::F64 => 8,
@@ -389,6 +397,7 @@ impl PrimitiveVector {
     fn element_name(self) -> &'static str {
         match self {
             Self::Bool => "bool",
+            Self::U8 => "u8",
             Self::I8 => "i8",
             Self::I16 => "i16",
             Self::U16 => "u16",

--- a/boltffi_backend/src/target/typescript/render/function.rs
+++ b/boltffi_backend/src/target/typescript/render/function.rs
@@ -1136,27 +1136,33 @@ impl Parameter {
         let allocation = Identifier::parse(format!("__boltffi_{name}_allocation"))?;
         let allocation_value = Expression::identifier(allocation.clone());
         let value = Expression::identifier(name.clone());
-        let mut cleanup = match vector.writeback() {
-            true => vec![Statement::expression(Expression::call(
-                Expression::identifier(Identifier::known("_module")),
-                Identifier::known("copyPrimitiveBufferInto"),
-                [
-                    allocation_value.clone(),
-                    value.clone(),
-                    Expression::string(vector.element_literal()),
-                ]
-                .into_iter()
-                .collect::<ArgumentList>(),
-            ))],
-            false => Vec::new(),
-        };
-        cleanup.push(Statement::expression(Expression::call(
+        let free = Statement::expression(Expression::call(
             Expression::identifier(Identifier::known("_module")),
             vector.free_method(),
             [allocation_value.clone()]
                 .into_iter()
                 .collect::<ArgumentList>(),
-        )));
+        ));
+        // The copy back can throw — a destination view detaches if the callee
+        // grew linear memory — and a throw there must not take the free with
+        // it, so the free gets a `finally` of its own.
+        let cleanup = match vector.writeback() {
+            true => vec![Statement::try_finally(
+                vec![Statement::expression(Expression::call(
+                    Expression::identifier(Identifier::known("_module")),
+                    Identifier::known("copyPrimitiveBufferInto"),
+                    [
+                        allocation_value.clone(),
+                        value.clone(),
+                        Expression::string(vector.element_literal()),
+                    ]
+                    .into_iter()
+                    .collect::<ArgumentList>(),
+                ))],
+                vec![free],
+            )],
+            false => vec![free],
+        };
         Ok(Self {
             ty: vector.parameter_type()?,
             setup: vec![Statement::constant(

--- a/boltffi_binding/src/ir/types.rs
+++ b/boltffi_binding/src/ir/types.rs
@@ -164,6 +164,18 @@ impl DirectVectorPrimitive {
         }
     }
 
+    /// The `u8` direct-vector primitive, for a slice the callee writes into.
+    ///
+    /// Byte-buffer transport is the right carrier for every other shape of
+    /// bytes, and it is why [`Self::new`] rejects `u8`. But it has no way to
+    /// return what the callee wrote: the payload is decoded into a buffer the
+    /// callee owns, and a `&mut [u8]` pointing at that buffer is dropped when
+    /// the call ends. Direct-vector transport passes the pointer through and
+    /// copies back, which is what a writable slice needs.
+    pub const fn writable_bytes() -> Self {
+        Self(Primitive::U8)
+    }
+
     /// Returns the scalar primitive.
     pub const fn primitive(self) -> Primitive {
         self.0
@@ -184,8 +196,12 @@ impl<'de> Deserialize<'de> for DirectVectorPrimitive {
     where
         D: Deserializer<'de>,
     {
-        let primitive = Primitive::deserialize(deserializer)?;
-        Self::new(primitive).ok_or_else(|| de::Error::custom("u8 uses byte-buffer transport"))
+        // `u8` is admitted here even though [`Self::new`] rejects it, because
+        // [`Self::writable_bytes`] mints one for `&mut [u8]` and metadata has
+        // to round-trip what lowering produced. The invariant that byte
+        // buffers do not take this transport is enforced at the one place that
+        // decides it, not at the decoder.
+        Ok(Self(Primitive::deserialize(deserializer)?))
     }
 }
 

--- a/boltffi_binding/src/lower/callable/mod.rs
+++ b/boltffi_binding/src/lower/callable/mod.rs
@@ -65,8 +65,9 @@ use std::any::TypeId;
 
 use crate::{
     ClosureForm, ClosureParameter, ClosureRegistration, ClosureReturn, ClosureSignature,
-    DirectVectorElementType, Direction, ExecutionDecl, ExportedCallable, ForeignBody,
-    HandlePresence, ImportedCallable, IntoRust, OutOfRust, Primitive, Receive, RustBody, TypeRef,
+    DirectVectorElementType, DirectVectorPrimitive, Direction, ExecutionDecl, ExportedCallable,
+    ForeignBody, HandlePresence, ImportedCallable, IntoRust, OutOfRust, Primitive, Receive,
+    RustBody, TypeRef,
 };
 
 use super::{
@@ -201,6 +202,18 @@ impl ValueSpecialization {
             (TypeExpr::Vec(inner), Receive::ByValue) => {
                 Self::direct_vector_element(index, ids, inner)
                     .map(|element| element.map(Self::DirectVector))
+            }
+            // A writable byte slice cannot go through byte-buffer transport:
+            // that decodes the payload into a buffer the callee owns, so
+            // whatever the callee writes is dropped with it. Direct-vector
+            // transport passes the pointer and copies back.
+            (TypeExpr::Slice(inner), Receive::ByMutRef)
+                if S::writable_byte_slice_is_direct_vector()
+                    && Self::primitive(inner) == Some(Primitive::U8) =>
+            {
+                Ok(Some(Self::DirectVector(
+                    DirectVectorElementType::Primitive(DirectVectorPrimitive::writable_bytes()),
+                )))
             }
             (TypeExpr::Slice(inner), Receive::ByRef | Receive::ByMutRef) => {
                 Ok(Self::primitive(inner)

--- a/boltffi_binding/src/lower/surface.rs
+++ b/boltffi_binding/src/lower/surface.rs
@@ -89,6 +89,19 @@ pub trait SurfaceLower:
         crate::CodecNode::Bytes
     }
 
+    /// Whether a `&mut [u8]` parameter crosses as a direct vector.
+    ///
+    /// Native surfaces keep it on byte-buffer transport, where the wrapper
+    /// hands the callee a raw `*mut u8` and the host reads its own buffer back
+    /// afterwards — nothing to copy, nothing to decode. Wasm32 has no such
+    /// path: its byte-buffer decode builds a `Vec` the wrapper owns, so
+    /// everything the callee wrote would be dropped with it. Direct-vector
+    /// transport carries the pointer unframed and copies back, which is the
+    /// shape that works there.
+    fn writable_byte_slice_is_direct_vector() -> bool {
+        false
+    }
+
     #[doc(hidden)]
     fn direct_record_return_slot() -> ReturnValueSlot;
 
@@ -223,6 +236,10 @@ impl SurfaceLower for Wasm32 {
 
     fn root_bytes_return_codec() -> crate::CodecNode {
         crate::CodecNode::RawBytes
+    }
+
+    fn writable_byte_slice_is_direct_vector() -> bool {
+        true
     }
 
     fn direct_record_return_slot() -> ReturnValueSlot {

--- a/boltffi_macros/src/expansion/contract/mod.rs
+++ b/boltffi_macros/src/expansion/contract/mod.rs
@@ -5424,8 +5424,16 @@ mod tests {
         assert!(tokens.contains("__boltffi_right_ptr"), "{tokens}");
     }
 
+    /// A `&mut [u8]` parameter borrows the host's buffer in place.
+    ///
+    /// This used to decode the payload into a `Vec<u8>` the wrapper owned and
+    /// hand the callee `as_mut_slice()` of it — so everything the callee wrote
+    /// was dropped when the wrapper returned, with no error anywhere. Byte
+    /// buffers have no way to carry writes back, which is why a writable slice
+    /// takes direct-vector transport instead: the pointer crosses unframed and
+    /// the host copies back from the same buffer it passed in.
     #[test]
-    fn wasm_mutable_bytes_param_expansion_decodes_mut_slice_ref() {
+    fn wasm_mutable_bytes_param_expansion_borrows_the_host_buffer() {
         let source = mutable_bytes_param_contract();
         let lowered = lower_with_declarations::<Wasm32>(&source).expect("lowered bindings");
         let expansion = Expansion::new(&lowered);
@@ -5447,33 +5455,19 @@ mod tests {
                 #[cfg(target_arch = "wasm32")]
                 #[unsafe(no_mangle)]
                 pub unsafe extern "C" fn boltffi_function_demo_fill(
-                    __boltffi_bytes_ptr: *const u8,
+                    __boltffi_bytes_ptr: *mut u8,
                     __boltffi_bytes_len: usize
                 ) -> u32 {
-                    let mut __boltffi_bytes_storage: Vec<u8> = {
-                        if __boltffi_bytes_ptr.is_null() && __boltffi_bytes_len > 0 {
-                            ::boltffi::__private::set_last_error_len(stringify!(__boltffi_bytes_storage), "null pointer with non-zero length", __boltffi_bytes_len as usize);
-                            return <u32 as ::core::default::Default>::default();
-                        }
-                        let __boltffi_bytes: &[u8] = if __boltffi_bytes_len == 0 {
-                            &[]
-                        } else {
-                            unsafe {
-                                ::core::slice::from_raw_parts(
-                                    __boltffi_bytes_ptr,
-                                    __boltffi_bytes_len
-                                )
-                            }
-                        };
-                        match ::boltffi::__private::wire::decode::<Vec<u8> >(__boltffi_bytes) {
-                            Ok(value) => value,
-                            Err(error) => {
-                                ::boltffi::__private::set_last_error_display(stringify!(__boltffi_bytes_storage), "wire decode failed", &error, __boltffi_bytes_len as usize);
-                                return <u32 as ::core::default::Default>::default();
-                            }
+                    let bytes: &mut [u8] = if __boltffi_bytes_ptr.is_null() {
+                        &mut []
+                    } else {
+                        unsafe {
+                            ::core::slice::from_raw_parts_mut(
+                                __boltffi_bytes_ptr,
+                                __boltffi_bytes_len
+                            )
                         }
                     };
-                    let bytes = __boltffi_bytes_storage.as_mut_slice();
                     fill(bytes)
                 }
             }

--- a/runtime/typescript/src/module.ts
+++ b/runtime/typescript/src/module.ts
@@ -564,6 +564,11 @@ export class BoltFFIModule {
     return toBoolArray(this.getBytes().subarray(ptr, ptr + len));
   }
 
+  /** Lends a `&[u8]` / `&mut [u8]` parameter buffer without copying it. */
+  borrowU8Array(ptr: number, len: number): Uint8Array {
+    return this.getBytes().subarray(ptr, ptr + len);
+  }
+
   borrowI8Array(ptr: number, len: number): Int8Array {
     return this.getI8().subarray(ptr, ptr + len);
   }
@@ -603,6 +608,12 @@ export class BoltFFIModule {
   allocU8Array(value: Uint8Array | readonly number[]): PrimitiveBufferAlloc {
     const len = value.length;
     const ptr = this.exports.boltffi_wasm_alloc(len);
+    // A failed allocation returns zero, and copying there would write the
+    // payload over the start of linear memory and then hand the callee a
+    // pointer it reads as empty. Neither is recoverable, and neither is loud.
+    if (ptr === 0 && len > 0) {
+      throw new Error("Failed to allocate memory for a byte-slice parameter");
+    }
     this.getBytes().set(value, ptr);
     return { ptr, len, allocationSize: len };
   }
@@ -737,11 +748,16 @@ export class BoltFFIModule {
 
   copyPrimitiveBufferInto(
     allocation: PrimitiveBufferAlloc,
-    target: Int8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | BigInt64Array | BigUint64Array | Float32Array | Float64Array,
-    elementType: Exclude<PrimitiveBufferElementType, "bool" | "u8">
+    target: Uint8Array | Int8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | BigInt64Array | BigUint64Array | Float32Array | Float64Array,
+    elementType: Exclude<PrimitiveBufferElementType, "bool">
   ): void {
     const { ptr, len } = allocation;
     switch (elementType) {
+      // `u8` only reaches this path from a `&mut [u8]` parameter. Every other
+      // shape of bytes crosses as a byte buffer, which has no way back.
+      case "u8":
+        (target as Uint8Array).set(this.getBytes().subarray(ptr, ptr + len));
+        return;
       case "i8":
         (target as Int8Array).set(this.getI8().subarray(ptr, ptr + len));
         return;


### PR DESCRIPTION
A `&mut [u8]` parameter accepted the call, returned normally, and left the caller's buffer untouched. No error, no warning.

```js
const out = new Uint8Array(4);
fillBytes(out);   // returns fine
out;              // [0, 0, 0, 0]
```

Pre-existing, confirmed against a clean 0.30.0 checkout. Wasm target only.

## Cause

Byte-buffer transport decodes the payload into a `Vec<u8>` the wrapper owns and hands the callee `as_mut_slice()` of it. That `Vec` is dropped when the wrapper returns, taking every write with it. Nothing in that transport carries the result back.

Native surfaces never had this, since their wrapper takes a raw `*mut u8`.

## Fix

Route writable byte slices through direct-vector transport, which passes the pointer unframed and copies back. That is the path `&mut [u64]` already took. Restricted to Wasm32, so native lowering is untouched.

No ABI change: direct-vector transport already crossed as `(ptr, len)`.

## Also fixed, same path

* `allocU8Array` did not check for allocation failure, so it could copy the payload to address zero.
* Cleanup ran copy-back and free as two statements in one `finally`, so a throw from the copy skipped the free.

## Coverage

Macro snapshot for the generated wrapper, backend test for the host side.

No end-to-end demo export: `&mut [u8]` trips a C bridge invariant on the C# target, and `&mut` with a return value is not representable on Swift, Kotlin or C#. Worth its own issue.

## Verified

`cargo test --workspace`, clippy, fmt, 171 runtime tests, the wasm demo suite, and binding generation for Kotlin, Swift, C#, Java and Python.
