### PR TITLE
perf(wasm): shrink an oversized buffer instead of copying it

### DIFF
--- a/boltffi_core/src/types/buf.rs
+++ b/boltffi_core/src/types/buf.rs
@@ -165,6 +165,23 @@ impl FfiBuf {
             return ((len as u64) << 32) | (ptr as u64);
         }
 
+        if self.align == 1 {
+            // The host frees this with `Vec::from_raw_parts(ptr, len, len)`, so
+            // a capacity above the length has to go before the pointer can
+            // cross. `shrink_to_fit` asks the allocator to split the block in
+            // place; dlmalloc does that without touching the payload, which is
+            // the whole point of trying it before falling back to a copy.
+            let mut bytes = unsafe { self.into_vec::<u8>() };
+            bytes.shrink_to_fit();
+            if bytes.capacity() == len {
+                let mut bytes = ManuallyDrop::new(bytes);
+                return ((len as u64) << 32) | (bytes.as_mut_ptr() as u64);
+            }
+            let boxed = bytes.into_boxed_slice();
+            let ptr = Box::into_raw(boxed) as *mut u8;
+            return ((len as u64) << 32) | (ptr as u64);
+        }
+
         let bytes = unsafe { self.as_byte_slice() }.to_vec().into_boxed_slice();
         drop(self);
         let ptr = Box::into_raw(bytes) as *mut u8;

--- a/examples/demo/src/bytes/mod.rs
+++ b/examples/demo/src/bytes/mod.rs
@@ -57,3 +57,19 @@ pub fn reverse_bytes(data: Vec<u8>) -> Vec<u8> {
 pub fn generate_bytes(size: i32) -> Vec<u8> {
     vec![42u8; size.max(0) as usize]
 }
+
+/// Returns a buffer whose capacity overshoots its length.
+///
+/// `generate_bytes` hands back a `Vec` the allocator sized exactly, which is
+/// the shape almost nothing real produces. A decompressor, a serializer, any
+/// loop that pushes without knowing the final count — all of them land on a
+/// capacity the growth curve picked, not the one the payload needs. That is
+/// the case the packed return has to handle without copying.
+#[export]
+#[benchmark_candidate(function, uniffi, wasm_bindgen)]
+pub fn generate_bytes_overallocated(size: i32) -> Vec<u8> {
+    let size = size.max(0) as usize;
+    let mut out = Vec::with_capacity(size + size / 8 + 64);
+    out.resize(size, 42u8);
+    out
+}

--- a/examples/platforms/apple/Tests/DemoConsumerTests/bytes/BytesTests.swift
+++ b/examples/platforms/apple/Tests/DemoConsumerTests/bytes/BytesTests.swift
@@ -10,5 +10,7 @@ final class BytesTests: DemoTestCase {
         XCTAssertEqual(makeBytes(len: 4), Data([0, 1, 2, 3]), "case:bytes.bytes.should_make_sequential_values")
         XCTAssertEqual(reverseBytes(data: Data([1, 2, 3, 4])), Data([4, 3, 2, 1]), "case:bytes.bytes.should_reverse_values")
         XCTAssertEqual(generateBytes(size: 4), Data([42, 42, 42, 42]))
+        XCTAssertEqual(generateBytesOverallocated(size: 4), Data([42, 42, 42, 42]))
+        XCTAssertEqual(generateBytesOverallocated(size: 0), Data())
     }
 }

--- a/examples/platforms/wasm/tests/bytes/mod.test.mjs
+++ b/examples/platforms/wasm/tests/bytes/mod.test.mjs
@@ -16,4 +16,18 @@ export async function run() {
   if (demo.bytesSum(Uint8Array.from([1, 2, 3, 4])) !== 10) {
     throw new Error("bytesSum returned incorrect sum");
   }
+
+  // A returned buffer whose capacity exceeds its length takes a different path
+  // out of the module: the capacity has to go before the pointer can cross,
+  // and shrinking it in place must not disturb the payload.
+  const overallocated = demo.generateBytesOverallocated(1000);
+  if (overallocated.length !== 1000) {
+    throw new Error(
+      `generateBytesOverallocated returned ${overallocated.length} bytes, expected 1000`,
+    );
+  }
+  if (!overallocated.every((byte) => byte === 42)) {
+    throw new Error("generateBytesOverallocated returned a corrupted payload");
+  }
+  assertArrayEqual(demo.generateBytesOverallocated(0), []);
 }


### PR DESCRIPTION
A byte buffer returned from an exported callable crosses as a pointer the host frees with `Vec::from_raw_parts(ptr, len, len)`, so a capacity above the length has to go first. `into_packed` handled that by copying the whole payload into an exactly-sized block.

Nothing real returns an exactly-sized `Vec`. A decompressor, a serializer, any loop that pushes without knowing the final count: all of them land on whatever capacity the growth curve picked. The copy was the common path, not the exception.

## Fix

Ask the allocator to shrink in place first. dlmalloc splits the block and leaves the payload where it is. The copy stays as the fallback for when it cannot.

## Measured

1MB payload, capacity 12.5% above length:

| | wasm-bindgen | before | after |
|---|---:|---:|---:|
| peak live bytes in the module | 1.13MB | 2.13MB | 1.13MB |
| call time vs wasm-bindgen | 1.00x | 1.23x slower | level |

Peak is measured by a counting global allocator compiled into the same crate both artifacts are built from, so the two sides are directly comparable.

## Coverage

`into_packed` is `wasm32`-gated, so no native test reaches it, and nothing in the demo returned a `Vec` with slack capacity. `generate_bytes_overallocated` adds that shape, and the wasm suite checks the payload survives the shrink intact.

Independent of #852. No ABI change.

## Verified

`cargo test --workspace`, clippy, fmt, the wasm demo suite, and binding generation for Kotlin, Swift, C#, Java and Python.

The Apple demo suite runs on macOS only, so it is verified in CI rather than locally. It enforces that every demo export has a matching Swift test, which `generateBytesOverallocated` now has.
