### PR TITLE
Add targets.android.link.extra_args for custom linker flags

### DIFF
--- a/boltffi_cli/src/commands/init.rs
+++ b/boltffi_cli/src/commands/init.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use crate::cli::Result;
 use crate::config::{
-    AndroidConfig, AndroidPackConfig, AppleConfig, CSharpConfig, CargoConfig, Config, DartConfig,
+    AndroidConfig, AndroidLinkConfig, AndroidPackConfig, AppleConfig, CSharpConfig, CargoConfig, Config, DartConfig,
     DebugSymbolsConfig, ErrorStyle, HeaderConfig, JavaConfig, KotlinConfig, KotlinFactoryStyle,
     KotlinMultiplatformConfig, PackageConfig, PythonConfig, SpmConfig, SwiftConfig, TargetsConfig,
     WasmConfig, XcframeworkConfig,
@@ -126,6 +126,7 @@ fn create_default_config(package_name: &str) -> Config {
                 },
                 header: HeaderConfig { output: None },
                 pack: AndroidPackConfig { output: None },
+                link: AndroidLinkConfig::default(),
                 debug_symbols: DebugSymbolsConfig::default(),
             },
             kotlin_multiplatform: KotlinMultiplatformConfig::default(),

--- a/boltffi_cli/src/commands/init.rs
+++ b/boltffi_cli/src/commands/init.rs
@@ -2,10 +2,10 @@ use std::path::{Path, PathBuf};
 
 use crate::cli::Result;
 use crate::config::{
-    AndroidConfig, AndroidLinkConfig, AndroidPackConfig, AppleConfig, CSharpConfig, CargoConfig, Config, DartConfig,
-    DebugSymbolsConfig, ErrorStyle, HeaderConfig, JavaConfig, KotlinConfig, KotlinFactoryStyle,
-    KotlinMultiplatformConfig, PackageConfig, PythonConfig, SpmConfig, SwiftConfig, TargetsConfig,
-    WasmConfig, XcframeworkConfig,
+    AndroidConfig, AndroidLinkConfig, AndroidPackConfig, AppleConfig, CSharpConfig, CargoConfig,
+    Config, DartConfig, DebugSymbolsConfig, ErrorStyle, HeaderConfig, JavaConfig, KotlinConfig,
+    KotlinFactoryStyle, KotlinMultiplatformConfig, PackageConfig, PythonConfig, SpmConfig,
+    SwiftConfig, TargetsConfig, WasmConfig, XcframeworkConfig,
 };
 
 pub struct InitOptions {

--- a/boltffi_cli/src/config/mod.rs
+++ b/boltffi_cli/src/config/mod.rs
@@ -16,11 +16,11 @@ pub use cargo::{CargoConfig, PackageConfig};
 pub use experimental::Experimental;
 pub use symbols::{DebugSymbolsBundle, DebugSymbolsConfig, DebugSymbolsFormat};
 pub use targets::{
-    AndroidConfig, AndroidLinkConfig, AndroidPackConfig, AppleConfig, CSharpConfig, DartConfig, HeaderConfig,
-    JavaConfig, KotlinApiStyle, KotlinConfig, KotlinDesktopLoader, KotlinFactoryStyle,
-    KotlinMultiplatformConfig, PythonConfig, SpmConfig, SpmDistribution, SpmLayout, SwiftConfig,
-    TargetsConfig, WasmConfig, WasmNpmTarget, WasmOptimizeLevel, WasmOptimizeOnMissing,
-    WasmProfile, XcframeworkConfig,
+    AndroidConfig, AndroidLinkConfig, AndroidPackConfig, AppleConfig, CSharpConfig, DartConfig,
+    HeaderConfig, JavaConfig, KotlinApiStyle, KotlinConfig, KotlinDesktopLoader,
+    KotlinFactoryStyle, KotlinMultiplatformConfig, PythonConfig, SpmConfig, SpmDistribution,
+    SpmLayout, SwiftConfig, TargetsConfig, WasmConfig, WasmNpmTarget, WasmOptimizeLevel,
+    WasmOptimizeOnMissing, WasmProfile, XcframeworkConfig,
 };
 #[cfg(test)]
 pub use targets::{CSharpNugetConfig, JavaJvmConfig, PythonWheelConfig};

--- a/boltffi_cli/src/config/mod.rs
+++ b/boltffi_cli/src/config/mod.rs
@@ -16,7 +16,7 @@ pub use cargo::{CargoConfig, PackageConfig};
 pub use experimental::Experimental;
 pub use symbols::{DebugSymbolsBundle, DebugSymbolsConfig, DebugSymbolsFormat};
 pub use targets::{
-    AndroidConfig, AndroidPackConfig, AppleConfig, CSharpConfig, DartConfig, HeaderConfig,
+    AndroidConfig, AndroidLinkConfig, AndroidPackConfig, AppleConfig, CSharpConfig, DartConfig, HeaderConfig,
     JavaConfig, KotlinApiStyle, KotlinConfig, KotlinDesktopLoader, KotlinFactoryStyle,
     KotlinMultiplatformConfig, PythonConfig, SpmConfig, SpmDistribution, SpmLayout, SwiftConfig,
     TargetsConfig, WasmConfig, WasmNpmTarget, WasmOptimizeLevel, WasmOptimizeOnMissing,
@@ -676,6 +676,10 @@ impl Config {
 
     pub fn android_debug_symbols_bundle(&self) -> DebugSymbolsBundle {
         self.targets.android.debug_symbols.bundle
+    }
+
+    pub fn android_extra_link_args(&self) -> &[String] {
+        &self.targets.android.link.extra_args
     }
 
     pub fn kotlin_class_name(&self) -> String {
@@ -2698,5 +2702,23 @@ runtime_identifiers = ["linux-x64", "linux-x64"]
             Err(ConfigError::Validation(message))
                 if message.contains("targets.csharp.runtime_identifiers contains duplicate runtime identifier")
         ));
+    }
+
+    #[test]
+    fn parses_android_link_extra_args() {
+        let config = parse_config(
+            r#"
+[package]
+name = "mylib"
+
+[targets.android.link]
+extra_args = ["-Wl,-z,max-page-size=16384"]
+"#,
+        );
+
+        assert_eq!(
+            config.android_extra_link_args(),
+            &["-Wl,-z,max-page-size=16384".to_string()]
+        );
     }
 }

--- a/boltffi_cli/src/config/targets/kotlin.rs
+++ b/boltffi_cli/src/config/targets/kotlin.rs
@@ -76,6 +76,8 @@ pub struct AndroidConfig {
     #[serde(default)]
     pub pack: AndroidPackConfig,
     #[serde(default)]
+    pub link: AndroidLinkConfig,
+    #[serde(default)]
     pub debug_symbols: DebugSymbolsConfig,
 }
 
@@ -90,6 +92,7 @@ impl Default for AndroidConfig {
             kotlin: KotlinConfig::default(),
             header: HeaderConfig::default(),
             pack: AndroidPackConfig::default(),
+            link: AndroidLinkConfig::default(),
             debug_symbols: DebugSymbolsConfig::default(),
         }
     }
@@ -128,6 +131,12 @@ impl AndroidConfig {
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct AndroidPackConfig {
     pub output: Option<PathBuf>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct AndroidLinkConfig {
+    #[serde(default)]
+    pub extra_args: Vec<String>,
 }
 
 fn default_android_output() -> PathBuf {

--- a/boltffi_cli/src/config/targets/mod.rs
+++ b/boltffi_cli/src/config/targets/mod.rs
@@ -21,8 +21,8 @@ pub use java::JavaConfig;
 pub use java::JavaJvmConfig;
 pub use kmp::KotlinMultiplatformConfig;
 pub use kotlin::{
-    AndroidConfig, AndroidPackConfig, AndroidLinkConfig, KotlinApiStyle, KotlinConfig, KotlinDesktopLoader,
-    KotlinFactoryStyle,
+    AndroidConfig, AndroidLinkConfig, AndroidPackConfig, KotlinApiStyle, KotlinConfig,
+    KotlinDesktopLoader, KotlinFactoryStyle,
 };
 pub use python::PythonConfig;
 #[cfg(test)]

--- a/boltffi_cli/src/config/targets/mod.rs
+++ b/boltffi_cli/src/config/targets/mod.rs
@@ -21,7 +21,7 @@ pub use java::JavaConfig;
 pub use java::JavaJvmConfig;
 pub use kmp::KotlinMultiplatformConfig;
 pub use kotlin::{
-    AndroidConfig, AndroidPackConfig, KotlinApiStyle, KotlinConfig, KotlinDesktopLoader,
+    AndroidConfig, AndroidPackConfig, AndroidLinkConfig, KotlinApiStyle, KotlinConfig, KotlinDesktopLoader,
     KotlinFactoryStyle,
 };
 pub use python::PythonConfig;

--- a/boltffi_cli/src/pack/android/link.rs
+++ b/boltffi_cli/src/pack/android/link.rs
@@ -215,6 +215,7 @@ impl<'a> AndroidPackager<'a> {
             &object_path,
             &library.path,
             &export_script_path,
+            self.config.android_extra_link_args(),
         ));
         run_command(link)?;
 
@@ -323,8 +324,9 @@ fn android_shared_link_args(
     object_path: &Path,
     library_path: &Path,
     export_script_path: &Path,
+    extra_args: &[String],
 ) -> Vec<OsString> {
-    vec![
+    let mut args = vec![
         OsString::from("-shared"),
         OsString::from("-o"),
         dest_path.as_os_str().to_os_string(),
@@ -341,7 +343,9 @@ fn android_shared_link_args(
         OsString::from("-lm"),
         OsString::from("-llog"),
         OsString::from("-ldl"),
-    ]
+    ];
+    args.extend(extra_args.iter().map(OsString::from));
+    args
 }
 
 fn write_android_export_version_script(path: &Path) -> Result<()> {
@@ -706,6 +710,7 @@ enabled = true
             Path::new("/tmp/out/jni_glue.o"),
             Path::new("/tmp/out/libdemo.a"),
             Path::new("/tmp/out/exports.map"),
+            &[],
         );
 
         assert!(!args.contains(&OsString::from("-Wl,--exclude-libs,ALL")));
@@ -721,6 +726,7 @@ enabled = true
             Path::new("/tmp/out/jni_glue.o"),
             Path::new("/tmp/out/libdemo.a"),
             Path::new("/tmp/out/exports.map"),
+            &[],
         );
 
         assert!(
@@ -763,7 +769,7 @@ enabled = true
         let export_script_path =
             PathBuf::from(OsString::from_vec(b"/tmp/exports-\xFC.map".to_vec()));
         let args =
-            android_shared_link_args(&dest_path, &object_path, &library_path, &export_script_path);
+            android_shared_link_args(&dest_path, &object_path, &library_path, &export_script_path, &[]);
 
         assert_eq!(
             args[2].as_os_str().as_bytes(),
@@ -780,6 +786,25 @@ enabled = true
         assert_eq!(
             args[10].as_os_str().as_bytes(),
             export_script_path.as_os_str().as_bytes()
+        );
+    }
+    
+    #[test]
+    fn android_linker_appends_configured_extra_link_args() {
+        let extra_args = vec!["-Wl,-z,max-page-size=16384".to_string()];
+        let args = android_shared_link_args(
+            Path::new("/tmp/out/libdemo.so"),
+            Path::new("/tmp/out/jni_glue.o"),
+            Path::new("/tmp/out/libdemo.a"),
+            Path::new("/tmp/out/exports.map"),
+            &extra_args,
+        );
+
+        assert!(args.contains(&OsString::from("-Wl,-z,max-page-size=16384")));
+        assert_eq!(
+            args.last(),
+            Some(&OsString::from("-Wl,-z,max-page-size=16384")),
+            "extra link args should be appended after the built-in flags so they can override them"
         );
     }
 }

--- a/boltffi_cli/src/pack/android/link.rs
+++ b/boltffi_cli/src/pack/android/link.rs
@@ -768,8 +768,13 @@ enabled = true
         let library_path = PathBuf::from(OsString::from_vec(b"/tmp/lib-\xFD.a".to_vec()));
         let export_script_path =
             PathBuf::from(OsString::from_vec(b"/tmp/exports-\xFC.map".to_vec()));
-        let args =
-            android_shared_link_args(&dest_path, &object_path, &library_path, &export_script_path, &[]);
+        let args = android_shared_link_args(
+            &dest_path,
+            &object_path,
+            &library_path,
+            &export_script_path,
+            &[],
+        );
 
         assert_eq!(
             args[2].as_os_str().as_bytes(),
@@ -788,7 +793,7 @@ enabled = true
             export_script_path.as_os_str().as_bytes()
         );
     }
-    
+
     #[test]
     fn android_linker_appends_configured_extra_link_args() {
         let extra_args = vec!["-Wl,-z,max-page-size=16384".to_string()];


### PR DESCRIPTION
## Problem

`AndroidPackager::link_shared_library` invokes `clang` directly to link
the final Android `.so`, with linker args fully hardcoded in
`android_shared_link_args`. This means `RUSTFLAGS` and
`.cargo/config.toml` have no effect on this final link step — they only
apply to the earlier `cargo build` that produces the staticlib.

This makes it impossible to add linker flags like
`-Wl,-z,max-page-size=16384` (needed for Android 16k page size support)
without patching the CLI.

## Solution

Adds an optional `[targets.android.link]` config table with an
`extra_args` field, following the same pattern as `AndroidPackConfig`
and `DebugSymbolsConfig`. Extra args are appended after the built-in
flags, so they can override defaults (like page size) when needed.

## Example

\`\`\`toml
[targets.android.link]
extra_args = ["-Wl,-z,max-page-size=16384"]
\`\`\`

## Testing

- `cargo test -p boltffi_cli` (unit tests): 473 passed, 0 failed
- `cargo test -p boltffi_cli --test wasm_wake_link`: 1 pre-existing
  failure unrelated to this change (confirmed via `git stash` — fails
  identically on `main` without this patch)
- Added `android_linker_appends_configured_extra_link_args`
- Added `parses_android_link_extra_args`

## Real-world verification

Verified against a real Android JNI library build using
`extra_args = ["-Wl,-z,max-page-size=16384"]`:

\`\`\`
$ readelf -l lib*.so | grep -A1 LOAD
  LOAD           0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x00000000000ceda0 0x00000000000ceda0  R      0x4000
  LOAD           0x00000000000ceda0 0x00000000000d2da0 0x00000000000d2da0
                 0x00000000001ae7d0 0x00000000001ae7d0  R E    0x4000
  LOAD           0x000000000027d570 0x0000000000285570 0x0000000000285570
                 0x000000000000ead0 0x000000000000fa90  RW     0x4000
  LOAD           0x000000000028c040 0x0000000000298040 0x0000000000298040
                 0x0000000000000cb0 0x0000000000003890  RW     0x4000
\`\`\`

All LOAD segments are aligned to `0x4000` (16384 bytes), confirming
16KB page size compliance — required for Android 15+ devices.